### PR TITLE
Added support for regular expressions in event based notifications

### DIFF
--- a/Kernel/System/Ticket/Event/NotificationEvent.pm
+++ b/Kernel/System/Ticket/Event/NotificationEvent.pm
@@ -179,6 +179,13 @@ sub Run {
                         $Match = 1;
                         last VALUE;
                     }
+                    elsif ( lc substr( $Value, 0, 8 ) eq '[regexp]' ) {
+                        my $RegExp = substr $Value, 8;
+                        if ( $Ticket{$Key} =~ /$RegExp/i ) {
+                            $Match = 1;
+                            last;
+                        }
+                    }
                 }
             }
 


### PR DESCRIPTION
Added support for regular expressions for event based notifications.

Usecase: send a notification if "To-Field" contains .*@company.com OR .*companyB.com 
via: "\[regexp\](.*@companyA.com|.*companyB.com)"

[regexp] behaviour is used in the ACL's too in the same way. 

regards