### PR TITLE
Add ticket owner view in custom queues

### DIFF
--- a/Kernel/Config/Files/Ticket.xml
+++ b/Kernel/Config/Files/Ticket.xml
@@ -6016,7 +6016,7 @@
             </Hash>
         </Setting>
     </ConfigItem>
-     <ConfigItem Name="DashboardBackend###0270-TicketQueueOverview" Required="0" Valid="1">
+    <ConfigItem Name="DashboardBackend###0270-TicketQueueOverview" Required="0" Valid="1">
         <Description Translatable="1">Parameters for the dashboard backend of the queue overview widget of the agent interface. "Group" is used to restrict the access to the plugin (e. g. Group: admin;group1;group2;). "QueuePermissionGroup" is not mandatory, queues are only listed if they belong to this permission group if you enable it. "States" is a list of states, the key is the sort order of the state in the widget. "Default" determines if the plugin is enabled by default or if the user needs to enable it manually. "CacheTTLLocal" is the cache time in minutes for the plugin.</Description>
         <Group>Ticket</Group>
         <SubGroup>Frontend::Agent::Dashboard</SubGroup>
@@ -6027,6 +6027,31 @@
                 <Item Key="Description" Translatable="1">Provides a matrix overview of the tickets per state per queue.</Item>
                 <Item Key="Permission">rw</Item>
                 <Item Key="QueuePermissionGroup">users</Item>
+                <Item Key="Block">ContentLarge</Item>
+                <Item Key="Group"></Item>
+                <Item Key="Default">1</Item>
+                <Item Key="Sort">SortBy=Age;OrderBy=Up</Item>
+                <Item Key="CacheTTLLocal">0.5</Item>
+                <Item Key="States">
+                    <Hash>
+                        <Item Key="1">new</Item>
+                        <Item Key="4">open</Item>
+                        <Item Key="6">pending reminder</Item>
+                    </Hash>
+                </Item>
+            </Hash>
+        </Setting>
+    </ConfigItem>
+    <ConfigItem Name="DashboardBackend###0280-TicketOwnerOverview" Required="0" Valid="1">
+        <Description Translatable="1">Parameters for the dashboard backend of the owner overview widget of the agent interface. "Group" is used to restrict the access to the plugin (e. g. Group: admin;group1;group2;). "States" is a list of states, the key is the sort order of the state in the widget. "Default" determines if the plugin is enabled by default or if the user needs to enable it manually. "CacheTTLLocal" is the cache time in minutes for the plugin.</Description>
+        <Group>Ticket</Group>
+        <SubGroup>Frontend::Agent::Dashboard</SubGroup>
+        <Setting>
+            <Hash>
+                <Item Key="Module">Kernel::Output::HTML::DashboardTicketOwnerOverview</Item>
+                <Item Key="Title" Translatable="1">Ticket Owner Overview</Item>
+                <Item Key="Description" Translatable="1">Provides a matrix overview of the tickets per state per owner.</Item>
+                <Item Key="Permission">rw</Item>
                 <Item Key="Block">ContentLarge</Item>
                 <Item Key="Group"></Item>
                 <Item Key="Default">1</Item>

--- a/Kernel/Output/HTML/DashboardTicketOwnerOverview.pm
+++ b/Kernel/Output/HTML/DashboardTicketOwnerOverview.pm
@@ -1,0 +1,245 @@
+# --
+# Kernel/Output/HTML/DashboardTicketOwnerOverview.pm
+# Copyright (C) 2001-2014 OTRS AG, http://otrs.com/
+# --
+# This software comes with ABSOLUTELY NO WARRANTY. For details, see
+# the enclosed file COPYING for license information (AGPL). If you
+# did not receive this file, see http://www.gnu.org/licenses/agpl.txt.
+# --
+
+package Kernel::Output::HTML::DashboardTicketOwnerOverview;
+
+use strict;
+use warnings;
+
+our $ObjectManagerDisabled = 1;
+
+sub new {
+    my ( $Type, %Param ) = @_;
+
+    # allocate new hash for object
+    my $Self = {%Param};
+    bless( $Self, $Type );
+
+    # get needed parameters
+    for my $Object (qw( Config Name UserID )) {
+        die "Got no $Object!" if ( !$Self->{$Object} );
+    }
+
+    $Self->{PrefKey}  = 'UserDashboardPref' . $Self->{Name} . '-Shown';
+    $Self->{CacheKey} = $Self->{Name} . '-' . $Self->{UserID};
+
+    return $Self;
+}
+
+sub Preferences {
+    my ( $Self, %Param ) = @_;
+
+    return;
+}
+
+sub Config {
+    my ( $Self, %Param ) = @_;
+
+    return (
+        %{ $Self->{Config} },
+
+        # remember, do not allow to use page cache
+        # (it's not working because of internal filter)
+        CacheKey => undef,
+        CacheTTL => undef,
+    );
+}
+
+sub Run {
+    my ( $Self, %Param ) = @_;
+
+    my $CacheKey = 'User' . '-' . $Self->{UserID};
+
+    my $Content = $Self->{CacheObject}->Get(
+        Type => 'DashboardOwnerOverview',
+        Key  => $CacheKey,
+    );
+    return $Content if defined $Content;
+
+    # get configured states, get their state ID and test if they exist while we do it
+    my %States;
+    my $StateIDURL;
+    my %ConfiguredStates = %{ $Self->{Config}->{States} };
+    for my $StateOrder ( sort { $a <=> $b } keys %ConfiguredStates ) {
+        my $State = $ConfiguredStates{$StateOrder};
+
+        # check if state is found, to record StateID
+        my $StateID = $Kernel::OM->Get('Kernel::System::State')->StateLookup(
+            State => $State,
+        ) || '';
+        if ($StateID) {
+            $States{$State} = $StateID;
+
+            # append StateID to URL for search string
+            $StateIDURL .= "StateIDs=$StateID;";
+        }
+        else {
+
+            # state does not exist, skipping
+            delete $ConfiguredStates{$StateOrder};
+        }
+    }
+
+
+    # get custom queues
+    my @ViewableQueueIDs = $Self->{QueueObject}->GetAllCustomQueues(
+        UserID => $Self->{UserID},
+    );
+
+    my $Sort = $Self->{Config}->{Sort} || '';
+
+    # search ticket
+    my @TicketIDs;
+    if ( @ViewableQueueIDs ) {
+        @TicketIDs = $Self->{TicketObject}->TicketSearch(
+            Result     => 'ARRAY',
+            Limit      => 1000,
+            States     => [ values %ConfiguredStates ],
+            QueueIDs   => \@ViewableQueueIDs,
+            UserID     => 1,
+            Permission => 'ro',
+        );
+    }
+
+    # count ticket by user and state
+    my ( %Count, %StatusTotal );
+    my %OwnerList;
+    for my $TicketID ( @TicketIDs ) {
+        my %Ticket = $Self->{TicketObject}->TicketGet(
+            TicketID => $TicketID,
+        );
+        next if ( !%Ticket );
+        if ( ref $Count{ $Ticket{OwnerID} } ne 'HASH' ) {
+            my %State;
+            $Count{ $Ticket{OwnerID} } = {};
+        }
+        if ( !$OwnerList{ $Ticket{OwnerID} } ) {
+            my %UserInfo = $Self->{UserObject}->GetUserData(
+                UserID => $Ticket{OwnerID},
+            );
+            $OwnerList{ $Ticket{OwnerID} } = \%UserInfo;
+        }
+        $Count{ $Ticket{OwnerID} }->{ $Ticket{StateID} }++;
+        $StatusTotal{ $Ticket{StateID} }++;
+    }
+
+    # build header
+    my @Headers = ( 'Owner', );
+    for my $StateOrder ( sort { $a <=> $b } keys %ConfiguredStates ) {
+        push @Headers, $ConfiguredStates{$StateOrder};
+    }
+
+    # get layout object
+    my $LayoutObject = $Kernel::OM->Get('Kernel::Output::HTML::Layout');
+
+    for my $HeaderItem (@Headers) {
+        $LayoutObject->Block(
+            Name => 'ContentLargeTicketOwnerOverviewHeaderStatus',
+            Data => {
+                Text => $HeaderItem,
+            },
+        );
+    }
+
+    my $OwnerIDURL;
+
+    # iterate over all owners, print results;
+    OWNER:
+    for my $OwnerID ( sort {
+        ( $OwnerList{$a}->{UserTitle} || '' ) cmp ( $OwnerList{$b}->{UserTitle} || '' )
+        || $OwnerList{$a}->{UserLogin} cmp $OwnerList{$b}->{UserLogin}
+        } keys %OwnerList )
+    {
+        $LayoutObject->Block(
+            Name => 'ContentLargeTicketOwnerOverviewOwnerName',
+            Data => {
+                OwnerName => $OwnerList{$OwnerID}->{UserFullname},
+            }
+        );
+
+        # iterate over states
+        my $RowTotal = 0;
+        for my $StateOrderID ( sort { $a <=> $b } keys %ConfiguredStates ) {
+            if ( ref $Count{ $OwnerID } eq 'HASH' ) {
+                $LayoutObject->Block(
+                    Name => 'ContentLargeTicketOwnerOverviewOwnerResults',
+                    Data => {
+                        Number   => $Count{ $OwnerID }->{ $States{ $ConfiguredStates{$StateOrderID} } } || 0,
+                        OwnerID  => $OwnerID,
+                        StateID  => $States{ $ConfiguredStates{$StateOrderID} },
+                        State    => $ConfiguredStates{$StateOrderID},
+                        Sort     => $Sort,
+                    },
+                );
+                $RowTotal += $Count{ $OwnerID }->{ $States{ $ConfiguredStates{$StateOrderID} } } || 0;
+            }
+            else {
+                $Self->{LayoutObject}->Block(
+                    Name => 'CountRow',
+                    Data => {
+                        Count => 0,
+                    },
+                );
+            }
+        }
+
+        # print row (owner) total
+        $LayoutObject->Block(
+            Name => 'ContentLargeTicketOwnerOverviewOwnerTotal',
+            Data => {
+                Number   => $RowTotal,
+                OwnerID  => $OwnerID,
+                StateIDs => $StateIDURL,
+                Sort     => $Sort,
+            },
+        );
+
+        # add owner to SearchURL
+        $OwnerIDURL .= "OwnerIDs=$OwnerID;";
+    }
+
+    $LayoutObject->Block(
+        Name => 'ContentLargeTicketOwnerOverviewStatusTotalRow',
+    );
+
+    for my $StateOrderID ( sort { $a <=> $b } keys %ConfiguredStates ) {
+        $LayoutObject->Block(
+            Name => 'ContentLargeTicketOwnerOverviewStatusTotal',
+            Data => {
+                Number   => $StatusTotal{ $States{ $ConfiguredStates{$StateOrderID} } } || 0,
+                OnwerIDs => $OwnerIDURL,
+                StateID  => $States{ $ConfiguredStates{$StateOrderID} },
+                Sort     => $Sort,
+            },
+        );
+    }
+
+    $Content = $LayoutObject->Output(
+        TemplateFile => 'AgentDashboardTicketOwnerOverview',
+        Data         => {
+            %{ $Self->{Config} },
+            Name => $Self->{Name},
+        },
+        KeepScriptTags => $Param{AJAX},
+    );
+
+    # cache result
+    if ( $Self->{Config}->{CacheTTLLocal} ) {
+        $Self->{CacheObject}->Set(
+            Type  => 'DashboardOwnerOverview',
+            Key   => $CacheKey,
+            Value => $Content || '',
+            TTL   => 2 * 60,
+        );
+    }
+
+    return $Content;
+}
+
+1;

--- a/Kernel/Output/HTML/DashboardTicketOwnerOverview.pm
+++ b/Kernel/Output/HTML/DashboardTicketOwnerOverview.pm
@@ -102,7 +102,7 @@ sub Run {
             Limit      => 1000,
             States     => [ values %ConfiguredStates ],
             QueueIDs   => \@ViewableQueueIDs,
-            UserID     => 1,
+            UserID     => $Self->{UserID},
             Permission => 'ro',
         );
     }

--- a/Kernel/Output/HTML/Standard/AgentDashboardTicketOwnerOverview.tt
+++ b/Kernel/Output/HTML/Standard/AgentDashboardTicketOwnerOverview.tt
@@ -1,0 +1,69 @@
+# --
+# AgentDashboardTicketOwnerOverview.tt - provides HTML for Ticket Owner Overview
+# Copyright (C) 2001-2014 OTRS AG, http://otrs.com/
+# --
+# This software comes with ABSOLUTELY NO WARRANTY. For details, see
+# the enclosed file COPYING for license information (AGPL). If you
+# did not receive this file, see http://www.gnu.org/licenses/agpl.txt.
+# --
+
+<table class="DataTable">
+    <thead>
+        <tr>
+[% RenderBlockStart("ContentLargeTicketOwnerOverviewHeaderStatus") %]
+            <th>[% Translate(Data.Text) | html %]</th>
+[% RenderBlockEnd("ContentLargeTicketOwnerOverviewHeaderStatus") %]
+            <th class="OwnerOverviewTotals">[% Translate("Totals") | html %]</th>
+        </tr>
+    </thead>
+    <tbody>
+[% RenderBlockStart("ContentLargeTicketOwnerOverviewOwnerName") %]
+        <tr class="Row">
+            <td>[% Data.OwnerName | html %]</td>
+[% RenderBlockStart("ContentLargeTicketOwnerOverviewOwnerResults") %]
+            <td><a class="AsBlock" href="[% Env("Baselink") %]Action=AgentTicketSearch;Subaction=Search;[% Env("ChallengeTokenParam") | html %];StateIDs=[% Data.StateID | uri %];OwnerIDs=[% Data.OwnerID | uri %];[% Data.Sort | html %]">[% Translate(Data.Number) | html %]</a></td>
+[% RenderBlockEnd("ContentLargeTicketOwnerOverviewOwnerResults") %]
+[% RenderBlockStart("ContentLargeTicketOwnerOverviewOwnerTotal") %]
+            <td><a class="OwnerOverviewTotals AsBlock" href="[% Env("Baselink") %]Action=AgentTicketSearch;Subaction=Search;[% Env("ChallengeTokenParam") | html %];OwnerIDs=[% Data.OwnerID | uri %];[% Data.StateIDs | html %];[% Data.Sort | html %]">[% Translate(Data.Number) | html %]</a></td>
+[% RenderBlockEnd("ContentLargeTicketOwnerOverviewOwnerTotal") %]
+        </tr>
+[% RenderBlockEnd("ContentLargeTicketOwnerOverviewOwnerName") %]
+[% RenderBlockStart("ContentLargeTicketOwnerOverviewStatusTotalRow") %]
+        <tr class="Row">
+            <td class="OwnerOverviewTotals">[% Translate("Totals") | html %]</td>
+[% RenderBlockStart("ContentLargeTicketOwnerOverviewStatusTotal") %]
+            <td class="OwnerOverviewTotals"><a class="AsBlock" href="[% Env("Baselink") %]Action=AgentTicketSearch;Subaction=Search;[% Env("ChallengeTokenParam") | html %];StateIDs=[% Data.StateID | uri %];[% Data.OwnerIDs | html %];[% Data.Sort | html %]">[% Translate(Data.Number) | html %]</a></td>
+[% RenderBlockEnd("ContentLargeTicketOwnerOverviewStatusTotal") %]
+            <td class="OwnerOverviewTotals"></td>
+        </tr>
+[% RenderBlockEnd("ContentLargeTicketOwnerOverviewStatusTotalRow") %]
+[% RenderBlockStart("ContentLargeTicketOwnerOverviewNone") %]
+        <tr>
+            <td colspan="[% Data.ColumnCount | html %]">
+                [% Translate("No data found.") | html %]
+            </td>
+        </tr>
+[% RenderBlockEnd("ContentLargeTicketOwnerOverviewNone") %]
+    </tbody>
+</table>
+
+[% RenderBlockStart("ContentLargeTicketOwnerOverviewRefresh") %]
+[% WRAPPER JSOnDocumentComplete %]
+<script type="text/javascript">//<![CDATA[
+Core.Config.Set('RefreshSeconds_[% Data.NameHTML | html %]', parseInt("[% Data.RefreshTime | html %]", 10) || 0);
+if (Core.Config.Get('RefreshSeconds_[% Data.NameHTML | html %]')) {
+    Core.Config.Set('Timer_[% Data.NameHTML | html %]', window.setTimeout(function() {
+
+        // get active filter
+        var Filter = $('#Dashboard[% Data.Name | html %]-box').find('.Tab.Actions li.Selected a').attr('data-filter');
+        $('#Dashboard[% Data.Name | html %]-box').addClass('Loading');
+        Core.AJAX.ContentUpdate($('#Dashboard[% Data.Name | html %]'), '[% Env("Baselink") %]Action=[% Env("Action") %];Subaction=Element;Name=[% Data.Name | html %];Filter=' + Filter + ';CustomerID=[% Data.CustomerID | html %]', function () {
+            Core.UI.Table.InitCSSPseudoClasses($('#Dashboard[% Data.Name | html %]'));
+            $('#Dashboard[% Data.Name | html %]-box').removeClass('Loading');
+        });
+        clearTimeout(Core.Config.Get('Timer_[% Data.NameHTML | html %]'));
+    }, Core.Config.Get('RefreshSeconds_[% Data.NameHTML | html %]') * 1000));
+}
+//]]></script>
+[% END %]
+[% RenderBlockEnd("ContentLargeTicketOwnerOverviewRefresh") %]

--- a/Kernel/System/Ticket/TicketSearch.pm
+++ b/Kernel/System/Ticket/TicketSearch.pm
@@ -797,6 +797,23 @@ sub TicketSearch {
         }
     }
 
+    # custom queue ids
+    QUEUE:
+    for my $QueueID ( @{ $Param{QueueIDs} } ) {
+        next QUEUE if $QueueID ne '0';
+
+        # get queue object
+        my $QueueObject = $Kernel::OM->Get('Kernel::System::Queue');
+
+        # add custom queue ids
+        my @ViewableQueueIDs = $QueueObject->GetAllCustomQueues(
+            UserID => $Param{UserID},
+        );
+        push @{ $Param{QueueIDs} }, @ViewableQueueIDs;
+
+        last;
+    }
+
     # current sub queue ids
     if ( $Param{UseSubQueues} && $Param{QueueIDs} ) {
 

--- a/var/httpd/htdocs/skins/Agent/default/css/Core.Table.css
+++ b/var/httpd/htdocs/skins/Agent/default/css/Core.Table.css
@@ -242,6 +242,22 @@ table tr.MasterAction {
 }
 
 /**
+ * @subsection  OwnerOverviewTotals DataTable
+ */
+
+.DataTable thead th.OwnerOverviewTotals,
+.Row td.OwnerOverviewTotals,
+.Row a.OwnerOverviewTotals {
+    font-weight: bold;
+}
+
+.DataTable .Row td.OwnerOverviewTotals {
+    text-transform: uppercase;
+    color: #4B4B4B;
+    border-top: 1px dotted #CCCCCC;
+}
+
+/**
  * @subsection  Sortable DataTable
  */
 


### PR DESCRIPTION
Ticket queue view is very useful, but we also want to look at number of tickets ownered by each member in custom queues.  Especially, a manager of a queue will need it.  So I wrote Ticket Owner Overview to fill that by customization of Ticket Queue Overview.
