### PR TITLE
Let LWP::UserAgent handle https-proxy commands

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,4 +1,5 @@
 #4.0.4 2015-??-??
+ - 2015-01-04 Fixed SSL connections certificate checking through HTTP Proxy servers.
  - 2014-12-22 Fixed bug#[10551](http://bugs.otrs.org/show_bug.cgi?id=10551) - Error: No Process configured! - Agent interface.
  - 2014-12-18 Added Invoker name requirement in Generic Interface Invoker constructor.
  - 2014-12-18 Fixed bug#[10954](http://bugs.otrs.org/show_bug.cgi?id=10954) - Column title disappear  in list for CustumerCompany.

--- a/Kernel/System/WebUserAgent.pm
+++ b/Kernel/System/WebUserAgent.pm
@@ -137,77 +137,75 @@ sub Request {
 
     my $Response;
 
-    {
+    # init agent
+    my $UserAgent = LWP::UserAgent->new();
 
-        # init agent
-        my $UserAgent = LWP::UserAgent->new();
-
-        # In some scenarios like transparent HTTPS proxies, it can be neccessary to turn off
-        #   SSL certificate validation.
-        if ( $Kernel::OM->Get('Kernel::Config')->Get('WebUserAgent::DisableSSLVerification') ) {
-            $UserAgent->ssl_opts(
-                verify_hostname => 0,
-            );
-        }
-
-        # set credentials
-        if ( $Param{Credentials} ) {
-            my %CredentialParams    = %{ $Param{Credentials} || {} };
-            my @Keys                = qw(Location Realm User Password);
-            my $AllCredentialParams = !first { !defined $_ } @CredentialParams{@Keys};
-
-            if ($AllCredentialParams) {
-                $UserAgent->credentials(
-                    @CredentialParams{@Keys},
-                );
-            }
-        }
-
-        # set headers
-        if ( $Param{Header} ) {
-            $UserAgent->default_headers(
-                HTTP::Headers->new( %{ $Param{Header} } ),
-            );
-        }
-
-        # set timeout
-        $UserAgent->timeout( $Self->{Timeout} );
-
-        # get database object
-        my $ConfigObject = $Kernel::OM->Get('Kernel::Config');
-
-        # set user agent
-        $UserAgent->agent(
-            $ConfigObject->Get('Product') . ' ' . $ConfigObject->Get('Version')
+    # In some scenarios like transparent HTTPS proxies, it can be neccessary to turn off
+    #   SSL certificate validation.
+    if ( $Kernel::OM->Get('Kernel::Config')->Get('WebUserAgent::DisableSSLVerification') ) {
+        $UserAgent->ssl_opts(
+            verify_hostname => 0,
         );
+    }
 
-        # set proxy
-        if ( $Self->{Proxy} ) {
-            $UserAgent->proxy( [ 'http', 'https', 'ftp' ], $Self->{Proxy} );
-        }
+    # set credentials
+    if ( $Param{Credentials} ) {
+        my %CredentialParams    = %{ $Param{Credentials} || {} };
+        my @Keys                = qw(Location Realm User Password);
+        my $AllCredentialParams = !first { !defined $_ } @CredentialParams{@Keys};
 
-        if ( $Param{Type} eq 'GET' ) {
-
-            # perform get request on URL
-            $Response = $UserAgent->get( $Param{URL} );
-        }
-
-        else {
-
-            # check for Data param
-            if ( !IsArrayRefWithData( $Param{Data} ) && !IsHashRefWithData( $Param{Data} ) ) {
-                $Kernel::OM->Get('Kernel::System::Log')->Log(
-                    Priority => 'error',
-                    Message =>
-                        'WebUserAgent POST: Need Data param containing a hashref or arrayref with data.',
-                );
-                return ( Status => 0 );
-            }
-
-            # perform post request plus data
-            $Response = $UserAgent->post( $Param{URL}, $Param{Data} );
+        if ($AllCredentialParams) {
+            $UserAgent->credentials(
+                @CredentialParams{@Keys},
+            );
         }
     }
+
+    # set headers
+    if ( $Param{Header} ) {
+        $UserAgent->default_headers(
+            HTTP::Headers->new( %{ $Param{Header} } ),
+        );
+    }
+
+    # set timeout
+    $UserAgent->timeout( $Self->{Timeout} );
+
+    # get database object
+    my $ConfigObject = $Kernel::OM->Get('Kernel::Config');
+
+    # set user agent
+    $UserAgent->agent(
+        $ConfigObject->Get('Product') . ' ' . $ConfigObject->Get('Version')
+    );
+
+    # set proxy
+    if ( $Self->{Proxy} ) {
+        $UserAgent->proxy( [ 'http', 'https', 'ftp' ], $Self->{Proxy} );
+    }
+
+    if ( $Param{Type} eq 'GET' ) {
+
+        # perform get request on URL
+        $Response = $UserAgent->get( $Param{URL} );
+    }
+
+    else {
+
+        # check for Data param
+        if ( !IsArrayRefWithData( $Param{Data} ) && !IsHashRefWithData( $Param{Data} ) ) {
+            $Kernel::OM->Get('Kernel::System::Log')->Log(
+                Priority => 'error',
+                Message =>
+                    'WebUserAgent POST: Need Data param containing a hashref or arrayref with data.',
+            );
+            return ( Status => 0 );
+        }
+
+        # perform post request plus data
+        $Response = $UserAgent->post( $Param{URL}, $Param{Data} );
+    }
+
     if ( !$Response->is_success() ) {
         $Kernel::OM->Get('Kernel::System::Log')->Log(
             Priority => 'error',


### PR DESCRIPTION
This also makes it possible to do proper SSL certifcate verification when https URLs are used and a proxy is configured.

For accessing HTTPS resources via a proxy server, HTTP CONNECT is used only LWP did not support this properly. See https://en.wikipedia.org/wiki/HTTP_tunnel#HTTP_CONNECT_tunneling This is why we had the workaround of using Net::SSL in place.

Only, since LWP 6.06 LWP now supports this properly. See https://metacpan.org/changes/distribution/libwww-perl 
OTRS already ships LWP 6.06. This means the whole Net::SSL workaround, and the cruft around this, can be removed!