### PR TITLE
show 'add agent' and 'add group' action in UserGroup overview

### DIFF
--- a/Kernel/Modules/AdminUserGroup.pm
+++ b/Kernel/Modules/AdminUserGroup.pm
@@ -287,8 +287,8 @@ sub _Overview {
 
     $Self->{LayoutObject}->Block( Name => 'Overview' );
 
-    # no "actions list" block because no actions now
-    #    $Self->{LayoutObject}->Block( Name => 'ActionList' );
+    $Self->{LayoutObject}->Block( Name => 'ActionList' );
+    $Self->{LayoutObject}->Block( Name => 'NewActions' );
 
     $Self->{LayoutObject}->Block( Name => 'UserFilter' );
     $Self->{LayoutObject}->Block( Name => 'GroupFilter' );

--- a/Kernel/Output/HTML/Standard/AdminRoleUser.tt
+++ b/Kernel/Output/HTML/Standard/AdminRoleUser.tt
@@ -11,6 +11,23 @@
 <div class="MainBox ARIARoleMain LayoutFixedSidebar SidebarFirst">
     <h1>[% Translate("Manage Agent-Role Relations") | html %]</h1>
     <div class="SidebarColumn">
+
+        <div class="WidgetSimple">
+            <div class="Header">
+                <h2>[% Translate("Actions") | html %]</h2>
+            </div>
+            <div class="Content">
+                <ul class="ActionList">
+                    <li>
+                        <a href="[% Env("Baselink") %]Action=AdminUser;Subaction=Add" class="CallForAction Fullsize Center"><span><i class="fa fa-plus-square"></i>[% Translate("Add agent") | html %]</span></a>
+                    </li>
+                    <li>
+                        <a href="[% Env("Baselink") %]Action=AdminRole;Subaction=Add" class="CallForAction Fullsize Center"><span><i class="fa fa-plus-square"></i>[% Translate("Add role") | html %]</span></a>
+                    </li>
+                </ul>
+            </div>
+        </div>
+
         <div class="WidgetSimple">
             <div class="Header">
                 <h2><label for="FilterUsers">[% Translate("Filter for Agents") | html %]</label></h2>

--- a/Kernel/Output/HTML/Standard/AdminUserGroup.tt
+++ b/Kernel/Output/HTML/Standard/AdminUserGroup.tt
@@ -25,6 +25,14 @@
                         <a href="[% Env("Baselink") %]Action=[% Env("Action") %]" class="CallForAction Fullsize Center"><span><i class="fa fa-caret-left"></i>[% Translate("Go to overview") | html %]</span></a>
                     </li>
 [% RenderBlockEnd("ActionOverview") %]
+[% RenderBlockStart("NewActions") %]
+                    <li>
+                        <a href="[% Env("Baselink") %]Action=AdminUser;Subaction=Add" class="CallForAction Fullsize Center"><span><i class="fa fa-plus-square"></i>[% Translate("Add agent") | html %]</span></a>
+                    </li>
+                    <li>
+                        <a href="[% Env("Baselink") %]Action=AdminGroup;Subaction=Add" class="CallForAction Fullsize Center"><span><i class="fa fa-plus-square"></i>[% Translate("Add group") | html %]</span></a>
+                    </li>
+[% RenderBlockEnd("NewActions") %]
                 </ul>
             </div>
         </div>


### PR DESCRIPTION
I find it always annoying when I have to add several agents via web-gui that I always have to go the "full path" for adding agents. With these to actions shown in the overview, it's just one click...