### PR TITLE
[Rel-4_0 - Bug 10895] Dynamic Field shown in ticket information although it isn' t used

### DIFF
--- a/Kernel/Modules/CustomerTicketZoom.pm
+++ b/Kernel/Modules/CustomerTicketZoom.pm
@@ -1169,7 +1169,7 @@ sub _Mask {
             ObjectID           => $Param{TicketID},
         );
 
-        next DYNAMICFIELD if !$Value;
+        next DYNAMICFIELD if !defined $Value;
         next DYNAMICFIELD if $Value eq "";
 
         # get print string for this dynamic field


### PR DESCRIPTION
Hi men,

I fixed it here for customer like Carlos suggested. Now, we have unique behavior for all screens.
There is the same situation in Ticket overview medium  and large as well.
I believe that in this moment it is better solution.
If we have any suggestion let me know.

Regards
Zoran