### PR TITLE
More Company related columns in ticker related dashboard widgets

### DIFF
--- a/Kernel/Config/Files/Ticket.xml
+++ b/Kernel/Config/Files/Ticket.xml
@@ -5821,6 +5821,10 @@
                         <Item Key="CustomerID">1</Item>
                         <Item Key="CustomerName">1</Item>
                         <Item Key="CustomerUserID">1</Item>
+                        <Item Key="CompanyName">1</Item>
+                        <Item Key="CompanyCity">0</Item>
+                        <Item Key="CompanyCountry">0</Item>
+                        <Item Key="CompanyComment">0</Item>
                         <Item Key="EscalationResponseTime">1</Item>
                         <Item Key="EscalationSolutionTime">1</Item>
                         <Item Key="EscalationTime">1</Item>
@@ -5867,6 +5871,10 @@
                         <Item Key="CustomerID">1</Item>
                         <Item Key="CustomerName">1</Item>
                         <Item Key="CustomerUserID">1</Item>
+                        <Item Key="CompanyName">1</Item>
+                        <Item Key="CompanyCity">0</Item>
+                        <Item Key="CompanyCountry">0</Item>
+                        <Item Key="CompanyComment">0</Item>
                         <Item Key="EscalationResponseTime">1</Item>
                         <Item Key="EscalationSolutionTime">1</Item>
                         <Item Key="EscalationTime">1</Item>
@@ -5913,6 +5921,10 @@
                         <Item Key="CustomerID">1</Item>
                         <Item Key="CustomerName">1</Item>
                         <Item Key="CustomerUserID">1</Item>
+                        <Item Key="CompanyName">1</Item>
+                        <Item Key="CompanyCity">0</Item>
+                        <Item Key="CompanyCountry">0</Item>
+                        <Item Key="CompanyComment">0</Item>
                         <Item Key="EscalationResponseTime">1</Item>
                         <Item Key="EscalationSolutionTime">1</Item>
                         <Item Key="EscalationTime">1</Item>
@@ -5959,6 +5971,10 @@
                         <Item Key="CustomerID">1</Item>
                         <Item Key="CustomerName">1</Item>
                         <Item Key="CustomerUserID">1</Item>
+                        <Item Key="CompanyName">1</Item>
+                        <Item Key="CompanyCity">0</Item>
+                        <Item Key="CompanyCountry">0</Item>
+                        <Item Key="CompanyComment">0</Item>
                         <Item Key="EscalationResponseTime">1</Item>
                         <Item Key="EscalationSolutionTime">1</Item>
                         <Item Key="EscalationTime">1</Item>
@@ -6177,6 +6193,10 @@
                         <Item Key="CustomerID">1</Item>
                         <Item Key="CustomerName">1</Item>
                         <Item Key="CustomerUserID">1</Item>
+                        <Item Key="CompanyName">1</Item>
+                        <Item Key="CompanyCity">0</Item>
+                        <Item Key="CompanyCountry">0</Item>
+                        <Item Key="CompanyComment">0</Item>
                         <Item Key="EscalationResponseTime">1</Item>
                         <Item Key="EscalationSolutionTime">1</Item>
                         <Item Key="EscalationTime">1</Item>
@@ -6223,6 +6243,10 @@
                         <Item Key="CustomerID">1</Item>
                         <Item Key="CustomerName">1</Item>
                         <Item Key="CustomerUserID">1</Item>
+                        <Item Key="CompanyName">1</Item>
+                        <Item Key="CompanyCity">0</Item>
+                        <Item Key="CompanyCountry">0</Item>
+                        <Item Key="CompanyComment">0</Item>
                         <Item Key="EscalationResponseTime">1</Item>
                         <Item Key="EscalationSolutionTime">1</Item>
                         <Item Key="EscalationTime">1</Item>
@@ -6269,6 +6293,10 @@
                         <Item Key="CustomerID">1</Item>
                         <Item Key="CustomerName">1</Item>
                         <Item Key="CustomerUserID">1</Item>
+                        <Item Key="CompanyName">1</Item>
+                        <Item Key="CompanyCity">0</Item>
+                        <Item Key="CompanyCountry">0</Item>
+                        <Item Key="CompanyComment">0</Item>
                         <Item Key="EscalationResponseTime">1</Item>
                         <Item Key="EscalationSolutionTime">1</Item>
                         <Item Key="EscalationTime">1</Item>

--- a/Kernel/Output/HTML/DashboardTicketGeneric.pm
+++ b/Kernel/Output/HTML/DashboardTicketGeneric.pm
@@ -1338,6 +1338,16 @@ sub Run {
         my $BackendObject = $Kernel::OM->Get('Kernel::System::DynamicField::Backend');
         my $UserObject    = $Kernel::OM->Get('Kernel::System::User');
 
+        # get customer company data if CustomerCompanySupport is enabled
+        my %CompanyData;
+        if ( $ConfigObject->Get('CustomerUser')->{CustomerCompanySupport} ) {
+            if ( $Ticket{CustomerID} ) {
+                %CompanyData = $Kernel::OM->Get('Kernel::System::CustomerCompany')->CustomerCompanyGet(
+                    CustomerID => $Ticket{CustomerID},
+                );
+            }
+        }
+
         # show all needed columns
         COLUMN:
         for my $Column (@Columns) {
@@ -1492,6 +1502,30 @@ sub Run {
                         );
                     }
                     $DataValue = $CustomerName;
+                }
+                elsif ( $Column eq 'CompanyName' && $ConfigObject->Get('CustomerUser')->{CustomerCompanySupport} ) {
+                    # get customer company name
+                    if ( IsHashRefWithData(\%CompanyData ) ) {
+                        $DataValue = $CompanyData{CustomerCompanyName};
+                    }
+                }
+                elsif ( $Column eq 'CompanyCity' && $ConfigObject->Get('CustomerUser')->{CustomerCompanySupport} ) {
+                    # get customer company city
+                    if ( IsHashRefWithData(\%CompanyData ) ) {
+                        $DataValue = $CompanyData{CustomerCompanyCity};
+                    }
+                }
+                elsif ( $Column eq 'CompanyCountry' && $ConfigObject->Get('CustomerUser')->{CustomerCompanySupport} ) {
+                    # get customer company country
+                    if ( IsHashRefWithData(\%CompanyData ) ) {
+                        $DataValue = $CompanyData{CustomerCompanyCountry};
+                    }
+                }
+                elsif ( $Column eq 'CompanyComment' && $ConfigObject->Get('CustomerUser')->{CustomerCompanySupport} ) {
+                    # get customer company comment
+                    if ( IsHashRefWithData(\%CompanyData ) ) {
+                        $DataValue = $CompanyData{CustomerCompanyComment};
+                    }
                 }
                 else {
                     $DataValue = $Ticket{$Column};


### PR DESCRIPTION
Added more Company related columns like CompanyName, CompanyCountry... in ticket related dashboard widgets. But Columns are only available if CustomerCompanySupport is enabled.