### PR TITLE
Added generic redirect module to redirect agents to external URLs with optional ticket parameters

### DIFF
--- a/Kernel/Config/Files/Framework.xml
+++ b/Kernel/Config/Files/Framework.xml
@@ -4332,6 +4332,18 @@ via the Preferences button after logging in.
             </Hash>
         </Setting>
     </ConfigItem>
+    <ConfigItem Name="Frontend::Module###Redirect" Required="0" Valid="1">
+        <Description Translatable="1">Frontend module registration for the agent interface.</Description>
+        <Group>Ticket</Group>
+        <SubGroup>Frontend::Agent::ModuleRegistration</SubGroup>
+        <Setting>
+            <FrontendModuleReg>
+                <Description></Description>
+                <NavBarName></NavBarName>
+                <Title></Title>
+            </FrontendModuleReg>
+        </Setting>
+    </ConfigItem>
     <ConfigItem Name="Frontend::Module###Logout" Required="0" Valid="1">
         <Description Translatable="1">Frontend module registration for the agent interface.</Description>
         <Group>Framework</Group>

--- a/Kernel/Config/Files/Ticket.xml
+++ b/Kernel/Config/Files/Ticket.xml
@@ -5517,15 +5517,15 @@
         </Setting>
     </ConfigItem>
     <ConfigItem Name="Ticket::Frontend::MenuModule###510-Redirect" Required="0" Valid="0">
-        <Description Translatable="1">Shows a link in the menu to redirect the agent in the ticket zoom view of the agent interface.</Description>
+        <Description Translatable="1">Shows a link in the ticket action row to redirect the agent in the ticket zoom view of the agent interface. "Module" defines the HTML module to prepare the ticket action row item. "Name" defines the ticket action row item name. "Descripton" defines the ticket action row item tool-tip content. "Action" defines the action name for the ticket action row item. "Link" defines the link parameters to call the redirect module and may contain extra parameters. E.g. "[% Data.Ticket.State | html %]" adds the current ticket state to the "href" parameter (E.g. "http://www.example.com/search?query=[% Data.Ticket.State | html %])" may result into "http://www.example.com/search?query=pending+reminder". "Target" defines the hyper link target. If "PopUpType" is left empty, "_new" as value for "Target" will open the new page in a new browser window or browser tab.</Description>
         <Group>Ticket</Group>
         <SubGroup>Frontend::Agent::Ticket::MenuModule</SubGroup>
         <Setting>
             <Hash>
                 <Item Key="Module">Kernel::Output::HTML::TicketMenuGeneric</Item>
-                <Item Key="Name">Redirect</Item>
+                <Item Key="Name" Translatable="1">Redirect</Item>
                 <Item Key="Description" Translatable="1">Redirect</Item>
-                <Item Key="Action"></Item>
+                <Item Key="Action">Redirect</Item>
                 <Item Key="Link">Action=Redirect;Url=[% "http://www.example.com" | html %]</Item>
                 <Item Key="Target"></Item>
                 <Item Key="PopupType">TicketAction</Item>

--- a/Kernel/Config/Files/Ticket.xml
+++ b/Kernel/Config/Files/Ticket.xml
@@ -5516,6 +5516,22 @@
             </Hash>
         </Setting>
     </ConfigItem>
+    <ConfigItem Name="Ticket::Frontend::MenuModule###510-Redirect" Required="0" Valid="0">
+        <Description Translatable="1">Shows a link in the menu to redirect the agent in the ticket zoom view of the agent interface.</Description>
+        <Group>Ticket</Group>
+        <SubGroup>Frontend::Agent::Ticket::MenuModule</SubGroup>
+        <Setting>
+            <Hash>
+                <Item Key="Module">Kernel::Output::HTML::TicketMenuGeneric</Item>
+                <Item Key="Name">Redirect</Item>
+                <Item Key="Description" Translatable="1">Redirect</Item>
+                <Item Key="Action"></Item>
+                <Item Key="Link">Action=Redirect;Url=[% "http://www.example.com" | html %]</Item>
+                <Item Key="Target"></Item>
+                <Item Key="PopupType">TicketAction</Item>
+            </Hash>
+        </Setting>
+    </ConfigItem>
     <ConfigItem Name="Ticket::Frontend::OverviewMenuModule###001-Sort" Required="0" Valid="1">
         <Description Translatable="1">Shows a select of ticket attributes to order the queue view ticket list. The possible selections can be configured via 'TicketOverviewMenuSort###SortAttributes'.</Description>
         <Group>Ticket</Group>

--- a/Kernel/Modules/Redirect.pm
+++ b/Kernel/Modules/Redirect.pm
@@ -1,0 +1,44 @@
+# --
+# Kernel/Modules/Redirect.pm - redirect module
+# Copyright (C) 2001-2014 OTRS AG, http://otrs.com/
+# --
+# This software comes with ABSOLUTELY NO WARRANTY. For details, see
+# the enclosed file COPYING for license information (AGPL). If you
+# did not receive this file, see http://www.gnu.org/licenses/agpl.txt.
+# --
+
+package Kernel::Modules::Redirect;
+
+use strict;
+use warnings;
+
+#use Kernel::System::CustomerUser;
+
+sub new {
+    my ( $Type, %Param ) = @_;
+
+    # allocate new hash for object
+    my $Self = {%Param};
+    bless( $Self, $Type );
+
+    # check needed objects
+    for (qw(ParamObject DBObject LayoutObject LogObject ConfigObject )) {
+        if ( !$Self->{$_} ) {
+            $Self->{LayoutObject}->FatalError( Message => "Got no $_!" );
+        }
+    }
+
+    return $Self;
+}
+
+sub Run {
+    my ( $Self, %Param ) = @_;
+
+    # get requested URL from parameters
+    my $Redirect = $Self->{ParamObject}->GetParam( Param => 'Url' );
+
+    # redirect to requested URL
+    return $Self->{LayoutObject}->Redirect( ExtURL => $Redirect );
+}
+
+1;

--- a/Kernel/Modules/Redirect.pm
+++ b/Kernel/Modules/Redirect.pm
@@ -12,8 +12,6 @@ package Kernel::Modules::Redirect;
 use strict;
 use warnings;
 
-#use Kernel::System::CustomerUser;
-
 sub new {
     my ( $Type, %Param ) = @_;
 
@@ -22,7 +20,7 @@ sub new {
     bless( $Self, $Type );
 
     # check needed objects
-    for (qw(ParamObject DBObject LayoutObject LogObject ConfigObject )) {
+    for (qw(ParamObject LayoutObject)) {
         if ( !$Self->{$_} ) {
             $Self->{LayoutObject}->FatalError( Message => "Got no $_!" );
         }


### PR DESCRIPTION
Added generic redirect module to redirect agents to external URLs with optional ticket parameters.

This is very useful if you want to redirect your agents to other pages including OTRS internal parameters. The very typical use case is to open another ticket system and providing the OTRS ticket number in the URL.

-- Cheers, Nils 