### PR TITLE
add new config option and change redirect after a user was created

### DIFF
--- a/Kernel/Config/Files/Framework.xml
+++ b/Kernel/Config/Files/Framework.xml
@@ -6833,4 +6833,16 @@ via the Preferences button after logging in.
             </Option>
         </Setting>
     </ConfigItem>
+    <ConfigItem Name="AddUserNextScreen" Required="0" Valid="0">
+        <Description Translatable="1"></Description>
+        <Group>Framework</Group>
+        <SubGroup>Core</SubGroup>
+        <Setting>
+            <Option SelectedID="UserGroup">
+                <Item Key="UserGroup">User &lt;-&gt; Group</Item>
+                <Item Key="RoleUser">User &lt;-&gt; Role</Item>
+                <Item Key="AddUser">Users</Item>
+            </Option>
+        </Setting>
+    </ConfigItem>
 </otrs_config>

--- a/Kernel/Modules/AdminUser.pm
+++ b/Kernel/Modules/AdminUser.pm
@@ -404,16 +404,21 @@ sub Run {
                 }
 
                 # redirect
+                my $NextScreen = $Self->{ConfigObject}->Get('AddUserNextScreen') || '';
                 if (
-                    !$Self->{ConfigObject}->Get('Frontend::Module')->{AdminUserGroup}
-                    && $Self->{ConfigObject}->Get('Frontend::Module')->{AdminRoleUser}
+                    ( !$Self->{ConfigObject}->Get('Frontend::Module')->{AdminUserGroup}
+                    && $Self->{ConfigObject}->Get('Frontend::Module')->{AdminRoleUser} 
+                    && !$NextScreen ) ||
+                    $NextScreen eq 'RoleUser'
                     )
                 {
                     return $Self->{LayoutObject}->Redirect(
                         OP => "Action=AdminRoleUser;Subaction=User;ID=$UserID",
                     );
                 }
-                if ( $Self->{ConfigObject}->Get('Frontend::Module')->{AdminUserGroup} ) {
+                elsif (
+                    ( $Self->{ConfigObject}->Get('Frontend::Module')->{AdminUserGroup} && !$NextScreen )
+                    || $NextScreen eq 'UserGroup' ) {
                     return $Self->{LayoutObject}->Redirect(
                         OP => "Action=AdminUserGroup;Subaction=User;ID=$UserID",
                     );


### PR DESCRIPTION
Currently the "next screen" after a user was created is determined by the activated frontend modules. But this is sometimes not sufficient as an admin wants to create several users before he assigns them to groups/roles or the user<->group frontend is active but permissions are regulated *mainly* with roles.

This patch adds a new config option to define which screen should be redirected to.