### PR TITLE
Fixed overflow of table in ticket overview screens

### DIFF
--- a/var/httpd/htdocs/skins/Agent/default/css/Core.Table.css
+++ b/var/httpd/htdocs/skins/Agent/default/css/Core.Table.css
@@ -566,6 +566,10 @@ thead .headerSortDown a {
  * @subsection  Ticket List Tables
  */
 
+.TicketList {
+    overflow: auto;
+}
+
 .TicketList table {
     border-collapse: separate;
     position: relative;


### PR DESCRIPTION
Hi @mrcbnsls, 

While I worked on something else I saw that there is a bug with overflow ticket list table in ticket overview screens (e.g. AgentTicketQueue,AgentTicketStatus,AgentTicketResponsibleView ... actually all small overview screens ). You can reproduce this bug if add all column in "Visible Columns". In case that resolution of display is small or if resize window on smaller resolution you could see overflow of table.
I saw that when I work on a small monitor.
There is different case in dashboard ticket lists because there is in Content class for DachboardBox overview properties set to auto.
I have done something similar in this PR.
I did not open bug report for this, if you think that I should open it or if you have any suggestions let me know, please.

Regards
Zoran
