### PR TITLE
Dashlet: Filter Attributes with more then one CustomerID doesn't work

### DIFF
--- a/Kernel/Output/HTML/DashboardTicketGeneric.pm
+++ b/Kernel/Output/HTML/DashboardTicketGeneric.pm
@@ -1978,6 +1978,10 @@ sub _SearchParamsGet {
         next STRING if !$String;
         my ( $Key, $Value ) = split /=/, $String;
 
+        if ( $Key eq 'CustomerID' ) {
+            $Key = "CustomerIDRaw";
+        }
+
         # push ARRAYREF attributes directly in an ARRAYREF
         if (
             $Key


### PR DESCRIPTION
http://bugs.otrs.org/show_bug.cgi?id=10968