### PR TITLE
Inline compression and better compression etc

### DIFF
--- a/scripts/backup.pl
+++ b/scripts/backup.pl
@@ -78,7 +78,7 @@ if ( $Opts{c} ) {
     elsif ( $Opts{c} =~ m/bzip2/i ) {
     	$Compress    = 'j';
     	$CompressCMD = 'bzip2';
-    	$CompressEXT = 'bz';
+    	$CompressEXT = 'bz2';
     }
     else {
     	print STDERR "ERROR: Invalid compression algorithm: $Opts{c}\n";

--- a/scripts/backup.pl
+++ b/scripts/backup.pl
@@ -41,11 +41,13 @@ my $CompressINL = 0; # Compress inline using pipes
 my $DB          = '';
 my $DBDump      = '';
 
-getopt( 'hcrtdi', \%Opts );
+#getopts( 'c:d:hir:t:', \%Opts );
+#getopt( 'hrtdi', \%Opts );
+getopt( 'chrtdiq', \%Opts );
 if ( exists $Opts{h} ) {
     print "backup.pl - backup script\n";
     print "Copyright (C) 2001-2014 OTRS AG, http://otrs.com/\n";
-    print "usage: backup.pl -d /data_backup_dir/ [-c gzip|bzip2|xz] [ -i ] [-r 30] [-t fullbackup|nofullbackup|dbonly]\n";
+    print "usage: backup.pl -d /data_backup_dir/ [-c gzip|bzip2|xz] [ -i ] [ -r 30 ] [-t fullbackup|nofullbackup|dbonly]\n";
     exit 1;
 }
 
@@ -60,6 +62,7 @@ elsif ( !-d $Opts{d} ) {
 }
 
 # check compress mode
+#if ( $Opts{c} ) {
 if ( $Opts{c} ) {
     if ( $Opts{i} ) {
     	$CompressINL = 1;
@@ -72,7 +75,7 @@ if ( $Opts{c} ) {
     elsif ( $Opts{c} =~ m/xz/i ) {
     	$Compress    = 'J';
     	$CompressCMD = 'xz';
-    	$CompressEXT = 'bz';
+    	$CompressEXT = 'xz';
     }
     elsif ( $Opts{c} =~ m/bzip2/i ) {
     	$Compress    = 'j';
@@ -170,7 +173,7 @@ if ( !mkdir($Directory) ) {
 # backup Kernel/Config.pm
 my $BackupFN = "$Directory/Config.tar.$CompressEXT";
 print "Backup $BackupFN ... ";
-if ( !system("tar -cf$Compress $BackupFN Kernel/Config*") ) {
+if ( !system("tar -c -$Compress -f $BackupFN Kernel/Config*") ) {
     print "done\n";
 }
 else {
@@ -185,10 +188,10 @@ if ($DBOnlyBackup) {
 }
 else {
     if ($FullBackup) {
-        $BackupFN = "Backup $Directory/Application.tar.$CompressEXT";
+        $BackupFN = "$Directory/Application.tar.$CompressEXT";
         print "Backup $BackupFN ... ";
         my $Excludes = "--exclude=var/tmp --exclude=js-cache --exclude=css-cache --exclude=.git";
-        if ( !system("tar $Excludes -cf$Compress $BackupFN .") ) {
+        if ( !system("tar -c $Excludes -$Compress -f $BackupFN .") ) {
             print "done\n";
         }
         else {
@@ -200,9 +203,9 @@ else {
 
     # backup vardir
     else {
-        $BackupFN = "Backup $Directory/VarDir.tar.$CompressEXT";
+        $BackupFN = "$Directory/VarDir.tar.$CompressEXT";
         print "Backup $BackupFN ... ";
-        if ( !system("tar -cf$Compress $BackupFN var/") ) {
+        if ( !system("tar -c -$Compress -f $BackupFN var/") ) {
             print "done\n";
         }
         else {
@@ -214,9 +217,9 @@ else {
 
     # backup datadir
     if ( $ArticleDir !~ m/\Q$Home\E/ ) {
-        $BackupFN = "Backup $Directory/DataDir.tar.$CompressEXT";
+        $BackupFN = "$Directory/DataDir.tar.$CompressEXT";
         print "Backup $BackupFN ... ";
-        if ( !system("tar -cf$Compress $BackupFN $ArticleDir") ) {
+        if ( !system("tar -c -$Compress -f $BackupFN $ArticleDir") ) {
             print "done\n";
         }
         else {

--- a/scripts/backup.pl
+++ b/scripts/backup.pl
@@ -41,8 +41,6 @@ my $CompressINL = 0; # Compress inline using pipes
 my $DB          = '';
 my $DBDump      = '';
 
-#getopts( 'c:d:hir:t:', \%Opts );
-#getopt( 'hrtdi', \%Opts );
 getopt( 'chrtdiq', \%Opts );
 if ( exists $Opts{h} ) {
     print "backup.pl - backup script\n";

--- a/scripts/backup.pl
+++ b/scripts/backup.pl
@@ -232,14 +232,16 @@ else {
 my $DBDumpCMD;
 if ( $DB =~ m/mysql/i ) {
     print "Dump $DB rdbms ... ";
-    if ($DatabasePw) {
+    if ( $DatabasePw ) {
         $DatabasePw = "-p'$DatabasePw'";
     }
-    if ($CompressINL) {
+    if ( $CompressINL ) {
         $DBDumpCMD = "$DBDump -u $DatabaseUser $DatabasePw -h $DatabaseHost $Database | $CompressCMD -c > $Directory/DatabaseBackup.sql.$CompressEXT";
-    } else {
+    }
+    else {
         $DBDumpCMD = "$DBDump -u $DatabaseUser $DatabasePw -h $DatabaseHost $Database > $Directory/DatabaseBackup.sql"
     }
+
     if ( !system($DBDumpCMD) ) {
         print "done\n";
     }
@@ -253,17 +255,18 @@ else {
     print "Dump $DB rdbms ... ";
 
     # set password via environment variable if there is one
-    if ($DatabasePw) {
+    if ( $DatabasePw ) {
         $ENV{'PGPASSWORD'} = $DatabasePw;
     }
 
-    if ($DatabaseHost) {
+    if ( $DatabaseHost ) {
         $DatabaseHost = "-h $DatabaseHost"
     }
 
-    if ($CompressINL) {
+    if ( $CompressINL ) {
         $DBDumpCMD = "$DBDump $DatabaseHost -U $DatabaseUser $Database | $CompressCMD -c > $Directory/DatabaseBackup.sql.$CompressEXT";
-    } else {
+    }
+    else {
         $DBDumpCMD = "$DBDump -f $Directory/DatabaseBackup.sql $DatabaseHost -U $DatabaseUser $Database";
     }
 
@@ -388,3 +391,4 @@ sub RemoveIncompleteBackup {
         print STDERR "failed\n";
     }
 }
+

--- a/scripts/backup.pl
+++ b/scripts/backup.pl
@@ -63,26 +63,26 @@ elsif ( !-d $Opts{d} ) {
 #if ( $Opts{c} ) {
 if ( $Opts{c} ) {
     if ( $Opts{i} ) {
-    	$CompressINL = 1;
+        $CompressINL = 1;
     }
     if ( $Opts{c} =~ m/gzip/i ) {
-    	$Compress    = 'z';
-    	$CompressCMD = 'gzip';
-    	$CompressEXT = 'gz';
+        $Compress    = 'z';
+        $CompressCMD = 'gzip';
+        $CompressEXT = 'gz';
     }
     elsif ( $Opts{c} =~ m/xz/i ) {
-    	$Compress    = 'J';
-    	$CompressCMD = 'xz';
-    	$CompressEXT = 'xz';
+        $Compress    = 'J';
+        $CompressCMD = 'xz';
+        $CompressEXT = 'xz';
     }
     elsif ( $Opts{c} =~ m/bzip2/i ) {
-    	$Compress    = 'j';
-    	$CompressCMD = 'bzip2';
-    	$CompressEXT = 'bz2';
+        $Compress    = 'j';
+        $CompressCMD = 'bzip2';
+        $CompressEXT = 'bz2';
     }
     else {
-    	print STDERR "ERROR: Invalid compression algorithm: $Opts{c}\n";
-    	exit 1;
+        print STDERR "ERROR: Invalid compression algorithm: $Opts{c}\n";
+        exit 1;
     }
 }
 
@@ -236,9 +236,9 @@ if ( $DB =~ m/mysql/i ) {
         $DatabasePw = "-p'$DatabasePw'";
     }
     if ($CompressINL) {
-    	$DBDumpCMD = "$DBDump -u $DatabaseUser $DatabasePw -h $DatabaseHost $Database | $CompressCMD -c > $Directory/DatabaseBackup.sql.$CompressEXT";
+        $DBDumpCMD = "$DBDump -u $DatabaseUser $DatabasePw -h $DatabaseHost $Database | $CompressCMD -c > $Directory/DatabaseBackup.sql.$CompressEXT";
     } else {
-    	$DBDumpCMD = "$DBDump -u $DatabaseUser $DatabasePw -h $DatabaseHost $Database > $Directory/DatabaseBackup.sql"
+        $DBDumpCMD = "$DBDump -u $DatabaseUser $DatabasePw -h $DatabaseHost $Database > $Directory/DatabaseBackup.sql"
     }
     if ( !system($DBDumpCMD) ) {
         print "done\n";
@@ -262,9 +262,9 @@ else {
     }
 
     if ($CompressINL) {
-    	$DBDumpCMD = "$DBDump $DatabaseHost -U $DatabaseUser $Database | $CompressCMD -c > $Directory/DatabaseBackup.sql.$CompressEXT";
+        $DBDumpCMD = "$DBDump $DatabaseHost -U $DatabaseUser $Database | $CompressCMD -c > $Directory/DatabaseBackup.sql.$CompressEXT";
     } else {
-    	$DBDumpCMD = "$DBDump -f $Directory/DatabaseBackup.sql $DatabaseHost -U $DatabaseUser $Database";
+        $DBDumpCMD = "$DBDump -f $Directory/DatabaseBackup.sql $DatabaseHost -U $DatabaseUser $Database";
     }
 
     if ( !system($DBDumpCMD) ) {
@@ -281,12 +281,12 @@ else {
 unless ($CompressINL) {
     print "Compress SQL-file... ";
     if ( !system("$CompressCMD $Directory/DatabaseBackup.sql") ) {
-    	print "done\n";
+        print "done\n";
     }
     else {
-    	print "failed\n";
-    	RemoveIncompleteBackup($Directory);
-    	die "Backup failed\n";
+        print "failed\n";
+        RemoveIncompleteBackup($Directory);
+        die "Backup failed\n";
     }
 }
 

--- a/scripts/restore.pl
+++ b/scripts/restore.pl
@@ -200,8 +200,7 @@ if ( $DB =~ m/mysql/i ) {
         );
         print "compress SQL-file...\n";
         system("gzip $Opts{b}/DatabaseBackup.sql");
-    }
-    elsif ( -e "$Opts{b}/DatabaseBackup.sql.bz2" ) {
+    } elsif ( -e "$Opts{b}/DatabaseBackup.sql.bz2" ) {
         print "decompresses SQL-file ...\n";
         system("bunzip2 $Opts{b}/DatabaseBackup.sql.bz2");
         print "cat SQL-file into $DB database\n";
@@ -210,9 +209,17 @@ if ( $DB =~ m/mysql/i ) {
         );
         print "compress SQL-file...\n";
         system("bzip2 $Opts{b}/DatabaseBackup.sql");
+    } elsif ( -e "$Opts{b}/DatabaseBackup.sql.xz" ) {
+        print "decompresses SQL-file ...\n";
+        system("unxz $Opts{b}/DatabaseBackup.sql.bz2");
+        print "cat SQL-file into $DB database\n";
+        system(
+            "mysql -f -u$DatabaseUser $DatabasePw -h$DatabaseHost $Database < $Opts{b}/DatabaseBackup.sql"
+        );
+        print "compress SQL-file...\n";
+        system("unxz $Opts{b}/DatabaseBackup.sql");
     }
-}
-else {
+} else {
     if ($DatabaseHost) {
         $DatabaseHost = "-h $DatabaseHost"
     }
@@ -231,8 +238,7 @@ else {
         );
         print "compress SQL-file...\n";
         system("gzip $Opts{b}/DatabaseBackup.sql");
-    }
-    elsif ( -e "$Opts{b}/DatabaseBackup.sql.bz2" ) {
+    } elsif ( -e "$Opts{b}/DatabaseBackup.sql.bz2" ) {
         print "decompresses SQL-file ...\n";
         system("bunzip2 $Opts{b}/DatabaseBackup.sql.bz2");
 
@@ -246,5 +252,20 @@ else {
         );
         print "compress SQL-file...\n";
         system("bzip2 $Opts{b}/DatabaseBackup.sql");
+    } elsif ( -e "$Opts{b}/DatabaseBackup.sql.xz" ) {
+        print "decompresses SQL-file ...\n";
+        system("unxz $Opts{b}/DatabaseBackup.sql.xz");
+
+        # set password via environment variable if there is one
+        if ($DatabasePw) {
+            $ENV{'PGPASSWORD'} = $DatabasePw;
+        }
+        print "cat SQL-file into $DB database\n";
+        system(
+            "cat $Opts{b}/DatabaseBackup.sql | psql -U$DatabaseUser $DatabaseHost $Database"
+        );
+        print "compress SQL-file...\n";
+        system("xz $Opts{b}/DatabaseBackup.sql");
     }
 }
+

--- a/scripts/restore.pl
+++ b/scripts/restore.pl
@@ -37,6 +37,7 @@ my %Opts;
 my $DB     = '';
 my $DBDump = '';
 my $DecompressINL = 0; # Decompress database inline using pipes
+
 getopt( 'hbdi', \%Opts );
 if ( exists $Opts{h} ) {
     print "restore.pl - restore script\n";
@@ -60,8 +61,8 @@ elsif ( !-d $Opts{d} ) {
     print STDERR "ERROR: No such directory: $Opts{d}\n";
     exit 1;
 }
-if ( $Opts{i} )
-	$DecompressINL = 1;
+if ( $Opts{i} ) {
+    $DecompressINL = 1;
 }
 
 # restore config
@@ -192,7 +193,7 @@ if ( -e "$Opts{b}/DataDir.tar.gz" ) {
 # import database
 my $dbdumpopencmd = undef;
 if ($DecompressINL) {
-    if ( $db =~ m/mysql/i ) {
+    if ( $DB =~ m/mysql/i ) {
         print "create $DB\n";
         if ($DatabasePw) {
             $DatabasePw = "-p'$DatabasePw'";
@@ -237,7 +238,7 @@ if ($DecompressINL) {
         system("$dbdumpopencmd | psql -U$DatabaseUser $DatabaseHost $Database");
     }
 } else {
-    if ( $db =~ m/mysql/i ) {
+    if ( $DB =~ m/mysql/i ) {
         print "create $DB\n";
         if ($DatabasePw) {
             $DatabasePw = "-p'$DatabasePw'";

--- a/scripts/restore.pl
+++ b/scripts/restore.pl
@@ -158,10 +158,12 @@ chdir($Home);
 if ( -e "$Opts{b}/Application.tar.gz" ) {
     print "Restore $Opts{b}/Application.tar.gz ...\n";
     system("tar -xzf $Opts{b}/Application.tar.gz");
-} elsif ( -e "$Opts{b}/Application.tar.bz2" ) {
+}
+elsif ( -e "$Opts{b}/Application.tar.bz2" ) {
     print "Restore $Opts{b}/Application.tar.bz2 ...\n";
     system("tar -xjf $Opts{b}/Application.tar.bz2");
-} elsif ( -e "$Opts{b}/Application.tar.xz" ) {
+}
+elsif ( -e "$Opts{b}/Application.tar.xz" ) {
     print "Restore $Opts{b}/Application.tar.xz ...\n";
     system("tar -xJf $Opts{b}/Application.tar.xz");
 }
@@ -170,10 +172,12 @@ if ( -e "$Opts{b}/Application.tar.gz" ) {
 if ( -e "$Opts{b}/VarDir.tar.gz" ) {
     print "Restore $Opts{b}/VarDir.tar.gz ...\n";
     system("tar -xzf $Opts{b}/VarDir.tar.gz");
-} elsif ( -e "$Opts{b}/VarDir.tar.bz2" ) {
+}
+elsif ( -e "$Opts{b}/VarDir.tar.bz2" ) {
     print "Restore $Opts{b}/VarDir.tar.bz2 ...\n";
     system("tar -xjf $Opts{b}/VarDir.tar.bz2");
-} elsif ( -e "$Opts{b}/VarDir.tar.xz" ) {
+}
+elsif ( -e "$Opts{b}/VarDir.tar.xz" ) {
     print "Restore $Opts{b}/VarDir.tar.xz ...\n";
     system("tar -xJf $Opts{b}/VarDir.tar.xz");
 }
@@ -182,10 +186,12 @@ if ( -e "$Opts{b}/VarDir.tar.gz" ) {
 if ( -e "$Opts{b}/DataDir.tar.gz" ) {
     print "Restore $Opts{b}/DataDir.tar.gz ...\n";
     system("tar -xzf $Opts{b}/DataDir.tar.gz");
-} elsif ( -e "$Opts{b}/DataDir.tar.bz2" ) {
+}
+elsif ( -e "$Opts{b}/DataDir.tar.bz2" ) {
     print "Restore $Opts{b}/DataDir.tar.bz2 ...\n";
     system("tar -xjf $Opts{b}/DataDir.tar.bz2");
-} elsif ( -e "$Opts{b}/DataDir.tar.xz" ) {
+}
+elsif ( -e "$Opts{b}/DataDir.tar.xz" ) {
     print "Restore $Opts{b}/DataDir.tar.xz ...\n";
     system("tar -xJf $Opts{b}/DataDir.tar.xz");
 }
@@ -202,17 +208,21 @@ if ($DecompressINL) {
         # Get the right file
         if ( -e "$Opts{b}/DatabaseBackup.sql.gz" ) {
             $dbdumpopencmd = "zcat $Opts{b}/DatabaseBackup.sql.gz";
-        } elsif ( -e "$Opts{b}/DatabaseBackup.sql.bz2" ) {
+        }
+        elsif ( -e "$Opts{b}/DatabaseBackup.sql.bz2" ) {
             $dbdumpopencmd = "bzcat $Opts{b}/DatabaseBackup.sql.bz2";
-        } elsif ( -e "$Opts{b}/DatabaseBackup.sql.xz" ) {
+        }
+        elsif ( -e "$Opts{b}/DatabaseBackup.sql.xz" ) {
             $dbdumpopencmd = "xzcat $Opts{b}/DatabaseBackup.sql.xz";
-        } else {
+        }
+        else {
             print STDERR "Can't find database dump file";
             exit 1;
         }
         print "decompresses and import SQL-file ...\n";
         system("$dbdumpopencmd | mysql -f -u$DatabaseUser $DatabasePw -h$DatabaseHost $Database");
-    } else {
+    }
+    else {
         if ($DatabaseHost) {
             $DatabaseHost = "-h $DatabaseHost"
         }
@@ -225,11 +235,14 @@ if ($DecompressINL) {
         # Get the right file
         if ( -e "$Opts{b}/DatabaseBackup.sql.gz" ) {
             $dbdumpopencmd = "zcat $Opts{b}/DatabaseBackup.sql.gz";
-        } elsif ( -e "$Opts{b}/DatabaseBackup.sql.bz2" ) {
+        }
+        elsif ( -e "$Opts{b}/DatabaseBackup.sql.bz2" ) {
             $dbdumpopencmd = "bzcat $Opts{b}/DatabaseBackup.sql.bz2";
-        } elsif ( -e "$Opts{b}/DatabaseBackup.sql.xz" ) {
+        }
+        elsif ( -e "$Opts{b}/DatabaseBackup.sql.xz" ) {
             $dbdumpopencmd = "xzcat $Opts{b}/DatabaseBackup.sql.xz";
-        } else {
+        }
+        else {
             print STDERR "Can't find database dump file";
             exit 1;
         }
@@ -237,7 +250,8 @@ if ($DecompressINL) {
         print "decompresses and import SQL-file ...\n";
         system("$dbdumpopencmd | psql -U$DatabaseUser $DatabaseHost $Database");
     }
-} else {
+}
+else {
     if ( $DB =~ m/mysql/i ) {
         print "create $DB\n";
         if ($DatabasePw) {
@@ -252,7 +266,8 @@ if ($DecompressINL) {
             );
             print "compress SQL-file...\n";
             system("gzip $Opts{b}/DatabaseBackup.sql");
-        } elsif ( -e "$Opts{b}/DatabaseBackup.sql.bz2" ) {
+        }
+        elsif ( -e "$Opts{b}/DatabaseBackup.sql.bz2" ) {
             print "decompresses SQL-file ...\n";
             system("bunzip2 $Opts{b}/DatabaseBackup.sql.bz2");
             print "cat SQL-file into $DB database\n";
@@ -261,7 +276,8 @@ if ($DecompressINL) {
             );
             print "compress SQL-file...\n";
             system("bzip2 $Opts{b}/DatabaseBackup.sql");
-        } elsif ( -e "$Opts{b}/DatabaseBackup.sql.xz" ) {
+        }
+        elsif ( -e "$Opts{b}/DatabaseBackup.sql.xz" ) {
             print "decompresses SQL-file ...\n";
             system("unxz $Opts{b}/DatabaseBackup.sql.bz2");
             print "cat SQL-file into $DB database\n";
@@ -271,7 +287,8 @@ if ($DecompressINL) {
             print "compress SQL-file...\n";
             system("unxz $Opts{b}/DatabaseBackup.sql");
         }
-    } else {
+    }
+    else {
         if ($DatabaseHost) {
             $DatabaseHost = "-h $DatabaseHost"
         }
@@ -290,7 +307,8 @@ if ($DecompressINL) {
             );
             print "compress SQL-file...\n";
             system("gzip $Opts{b}/DatabaseBackup.sql");
-        } elsif ( -e "$Opts{b}/DatabaseBackup.sql.bz2" ) {
+        }
+        elsif ( -e "$Opts{b}/DatabaseBackup.sql.bz2" ) {
             print "decompresses SQL-file ...\n";
             system("bunzip2 $Opts{b}/DatabaseBackup.sql.bz2");
 
@@ -304,7 +322,8 @@ if ($DecompressINL) {
             );
             print "compress SQL-file...\n";
             system("bzip2 $Opts{b}/DatabaseBackup.sql");
-        } elsif ( -e "$Opts{b}/DatabaseBackup.sql.xz" ) {
+        }
+        elsif ( -e "$Opts{b}/DatabaseBackup.sql.xz" ) {
             print "decompresses SQL-file ...\n";
             system("unxz $Opts{b}/DatabaseBackup.sql.xz");
 

--- a/scripts/restore.pl
+++ b/scripts/restore.pl
@@ -65,6 +65,10 @@ print "Restore $Opts{b}/Config.tar.gz ...\n";
 chdir( $Opts{d} );
 if ( -e "$Opts{b}/Config.tar.gz" ) {
     system("tar -xzf $Opts{b}/Config.tar.gz");
+} elsif ( -e "$Opts{b}/Config.tar.bz2" ) {
+    system("tar -xjf $Opts{b}/Config.tar.bz2");
+} elsif ( -e "$Opts{b}/Config.tar.xz" ) {
+    system("tar -xJf $Opts{b}/Config.tar.xz");
 }
 
 # create common objects
@@ -149,18 +153,36 @@ chdir($Home);
 if ( -e "$Opts{b}/Application.tar.gz" ) {
     print "Restore $Opts{b}/Application.tar.gz ...\n";
     system("tar -xzf $Opts{b}/Application.tar.gz");
+} elsif ( -e "$Opts{b}/Application.tar.bz2" ) {
+    print "Restore $Opts{b}/Application.tar.bz2 ...\n";
+    system("tar -xjf $Opts{b}/Application.tar.bz2");
+} elsif ( -e "$Opts{b}/Application.tar.xz" ) {
+    print "Restore $Opts{b}/Application.tar.xz ...\n";
+    system("tar -xJf $Opts{b}/Application.tar.xz");
 }
 
 # extract vardir
 if ( -e "$Opts{b}/VarDir.tar.gz" ) {
     print "Restore $Opts{b}/VarDir.tar.gz ...\n";
     system("tar -xzf $Opts{b}/VarDir.tar.gz");
+} elsif ( -e "$Opts{b}/VarDir.tar.bz2" ) {
+    print "Restore $Opts{b}/VarDir.tar.bz2 ...\n";
+    system("tar -xjf $Opts{b}/VarDir.tar.bz2");
+} elsif ( -e "$Opts{b}/VarDir.tar.xz" ) {
+    print "Restore $Opts{b}/VarDir.tar.xz ...\n";
+    system("tar -xJf $Opts{b}/VarDir.tar.xz");
 }
 
 # extract datadir
 if ( -e "$Opts{b}/DataDir.tar.gz" ) {
     print "Restore $Opts{b}/DataDir.tar.gz ...\n";
     system("tar -xzf $Opts{b}/DataDir.tar.gz");
+} elsif ( -e "$Opts{b}/DataDir.tar.bz2" ) {
+    print "Restore $Opts{b}/DataDir.tar.bz2 ...\n";
+    system("tar -xjf $Opts{b}/DataDir.tar.bz2");
+} elsif ( -e "$Opts{b}/DataDir.tar.xz" ) {
+    print "Restore $Opts{b}/DataDir.tar.xz ...\n";
+    system("tar -xJf $Opts{b}/DataDir.tar.xz");
 }
 
 # import database


### PR DESCRIPTION
The current backup.pl script dumps the whole database in cleartext and the compresses it. This uses a lot of disk space, and if I/O is a bandwidth, not CPU, it will slow down the backup. This patch adds the -i flag to allow for inline compression using pipes. It also adds xz compression which is better than gzip and bzip2 for some use.