### PR TITLE
Replaced hardcoded SQL limit with config parameter

### DIFF
--- a/Kernel/System/CustomerCompany/DB.pm
+++ b/Kernel/System/CustomerCompany/DB.pm
@@ -165,7 +165,7 @@ sub CustomerCompanyList {
     $Self->{DBObject}->Prepare(
         SQL   => $CompleteSQL,
         Bind  => \@Bind,
-        Limit => 50000,
+        Limit => $Self->{SearchListLimit},
     );
 
     # fetch the result


### PR DESCRIPTION
The SQL limit value is hardcoded to 50000 although there is a corresponding config parameter.