### PR TITLE
Converting email addresses to html

### DIFF
--- a/Kernel/System/Ticket/Event/NotificationEvent.pm
+++ b/Kernel/System/Ticket/Event/NotificationEvent.pm
@@ -643,6 +643,9 @@ sub _SendNotification {
         for my $Key ( sort keys %Recipient ) {
 
             next KEY if !$Recipient{$Key};
+            
+            # do not convert email addresses to HTML
+            next KEY if ($Key eq 'Email');
 
             $Recipient{$Key} = $HTMLUtilsObject->ToHTML(
                 String => $Recipient{$Key},


### PR DESCRIPTION
I had problems with recipient emails being converted to HTML. For example, email address in format like `"John Smith <john.smith@domain.tld>"` got converted to `"John Smith &lt;john.smith@domain.tld&gt;"` in table.field ARTICLE.A_TO using event notification. This PR solved that problem.

![vco7txi](https://cloud.githubusercontent.com/assets/419794/5755251/8f21b6aa-9ca2-11e4-80de-4cc3372cefb2.png)