### PR TITLE
Fixed some mistakes in Selenium tests and add checks screens in Admin.t

### DIFF
--- a/scripts/test/Selenium/Agent/Admin/Admin.t
+++ b/scripts/test/Selenium/Agent/Admin/Admin.t
@@ -43,29 +43,35 @@ $Selenium->RunTest(
         my $ScriptAlias = $ConfigObject->Get('ScriptAlias');
 
         my @AdminModules = qw(
+            AdminACL
             AdminAttachment
             AdminAutoResponse
             AdminCustomerCompany
             AdminCustomerUser
             AdminCustomerUserGroup
             AdminCustomerUserService
+            AdminDynamicField
             AdminEmail
             AdminGenericAgent
+            AdminGenericInterfaceWebservice
             AdminGroup
             AdminLog
             AdminMailAccount
             AdminNotification
             AdminNotificationEvent
+            AdminOTRSBusiness
             AdminPGP
             AdminPackageManager
             AdminPerformanceLog
             AdminPostMasterFilter
             AdminPriority
+            AdminProcessManagement
             AdminQueue
             AdminQueueAutoResponse
             AdminQueueTemplates
             AdminTemplate
             AdminTemplateAttachment
+            AdminRegistration
             AdminRole
             AdminRoleGroup
             AdminRoleUser
@@ -74,11 +80,13 @@ $Selenium->RunTest(
             AdminSalutation
             AdminSelectBox
             AdminService
+            AdminServiceCenter
             AdminSession
             AdminSignature
             AdminState
             AdminSysConfig
             AdminSystemAddress
+            AdminSystemMaintenance
             AdminType
             AdminUser
             AdminUserGroup

--- a/scripts/test/Selenium/Agent/Admin/AdminACL.t
+++ b/scripts/test/Selenium/Agent/Admin/AdminACL.t
@@ -48,7 +48,7 @@ JAVASCRIPT
 
         my $TestUserLogin = $Helper->TestUserCreate(
             Groups   => ['admin'],
-            Language => 'de',
+            Language => 'en',
         ) || die "Did not get test user";
 
         $Selenium->Login(
@@ -148,9 +148,9 @@ JAVASCRIPT
         # now we should not be able to add the same element again, an alert box should appear
         $Selenium->execute_script($CheckAlertJS);
         $Selenium->find_element( ".ItemAddLevel1 option[value='Properties']", 'css' )->click();
-        my $LanguageObject = Kernel::Language->new(
-            UserLanguage => 'de',
-        );
+
+        my $LanguageObject = $Kernel::OM->Get('Kernel::Language');
+
         $Self->Is(
             $Selenium->execute_script(
                 "return window.getLastAlert()"

--- a/scripts/test/Selenium/Agent/Admin/AdminACL.t
+++ b/scripts/test/Selenium/Agent/Admin/AdminACL.t
@@ -46,9 +46,12 @@ $Selenium->RunTest(
 }());
 JAVASCRIPT
 
+        # defined user language for testing if message is being translated correctly
+        my $Language = "de";
+
         my $TestUserLogin = $Helper->TestUserCreate(
             Groups   => ['admin'],
-            Language => 'en',
+            Language => $Language,
         ) || die "Did not get test user";
 
         $Selenium->Login(
@@ -149,7 +152,9 @@ JAVASCRIPT
         $Selenium->execute_script($CheckAlertJS);
         $Selenium->find_element( ".ItemAddLevel1 option[value='Properties']", 'css' )->click();
 
-        my $LanguageObject = $Kernel::OM->Get('Kernel::Language');
+        my $LanguageObject = Kernel::Language->new(
+            UserLanguage => $Language,
+        );
 
         $Self->Is(
             $Selenium->execute_script(

--- a/scripts/test/Selenium/Agent/Admin/AdminQueue.t
+++ b/scripts/test/Selenium/Agent/Admin/AdminQueue.t
@@ -1,5 +1,5 @@
 # --
-# AdminQueue.t - frontend tests for AdminState
+# AdminQueue.t - frontend tests for AdminQueue
 # Copyright (C) 2001-2015 OTRS AG, http://otrs.com/
 # --
 # This software comes with ABSOLUTELY NO WARRANTY. For details, see

--- a/scripts/test/Selenium/Agent/Admin/AdminSelectBox.t
+++ b/scripts/test/Selenium/Agent/Admin/AdminSelectBox.t
@@ -26,10 +26,18 @@ my $Selenium = Kernel::System::UnitTest::Selenium->new(
 $Selenium->RunTest(
     sub {
 
+        my $Helper = Kernel::System::UnitTest::Helper->new(
+            RestoreSystemConfiguration => 0,
+        );
+
+        my $TestUserLogin = $Helper->TestUserCreate(
+            Groups => ['admin'],
+        ) || die "Did not get test user";
+
         $Selenium->Login(
             Type     => 'Agent',
-            User     => 'root@localhost',
-            Password => 'root',
+            User     => $TestUserLogin,
+            Password => $TestUserLogin,
         );
 
         my $ScriptAlias = $ConfigObject->Get('ScriptAlias');


### PR DESCRIPTION
Hi @mrcbnsls ,

I saw while we tested existed Selenium test that there are some mistakes. I feel free to fix it. I fix following:

-Admin.t : add check for screens that is not exist
-AdminACL: change that default language is English. In my opinion it is better because this is case in the rest of system
- AdminQueue.t: There was a copy/paste mistake from AdminState.t
-AdminSelectBox.t: add Test User instead fixed root user. In this case there is unique test like in another Selenium tests, and also maybe in some OTRS test systems there is no root@localhost agent.

Regards
Zoran