### PR TITLE
TicketSearch: Implement search by article flag

### DIFF
--- a/Kernel/System/Ticket/TicketSearch.pm
+++ b/Kernel/System/Ticket/TicketSearch.pm
@@ -153,12 +153,7 @@ To find tickets in your system.
         # search for tickets by the presence of flags on articles
         ArticleFlag => {
             Important => 1,
-        }
-
-        # search for tickets by the absence of flags on articles
-        NotArticleFlag => {
-            Important => 1,
-        }
+        },
 
         # article stuff (optional)
         From    => '%spam@example.com%',
@@ -1141,27 +1136,6 @@ sub TicketSearch {
             $Index++;
         }
     }
-
-    if ( $Param{NotArticleFlag} ) {
-        my $ArticleFlagUserID = $Param{ArticleFlagUserID} // $Param{UserID};
-        my $Index = 1;
-        for my $Key ( sort keys %{ $Param{NotArticleFlag} } ) {
-            my $Value = $Param{NotArticleFlag}->{$Key};
-            return if !defined $Value;
-
-            $SQLExt .= " AND NOT EXISTS (SELECT na$Index.id "
-                        . " FROM article na$Index"
-                        . " JOIN article_flag naf$Index "
-                        . " WHERE naf$Index.article_key = '" . $DBObject->Quote($Key) . "' "
-                        . " AND naf$Index.article_value = '" . $DBObject->Quote($Value) . "' "
-                        . " AND naf$Index.create_by = "
-                            . $DBObject->Quote($ArticleFlagUserID, 'Integer')
-                        . " AND na$Index.ticket_id = st.id) ";
-
-            $Index++;
-        }
-    }
-
 
     # other ticket stuff
     my %FieldSQLMap = (

--- a/scripts/test/Ticket/ArticleFlags.t
+++ b/scripts/test/Ticket/ArticleFlags.t
@@ -264,6 +264,98 @@ for my $Test (@Tests) {
     );
 }
 
+# test searching for article flags
+
+my @SearchTestFlagsSet = qw( f1 f2 f3 );
+my @SearchTestFlagsNotSet = qw( f4 f5 );
+
+for my $Flag (@SearchTestFlagsSet) {
+    my $Set = $TicketObject->ArticleFlagSet(
+        ArticleID => $ArticleID,
+        Key       => $Flag,
+        Value     => 42,
+        UserID    => 1,
+    );
+
+    $Self->True(
+        $Set,
+        "Can set article flag $Flag",
+    );
+}
+
+my @FlagSearchTests = (
+    {
+        Search  => {
+            ArticleFlag => {
+                f1      => 42,
+                f2      => 42,
+            },
+        },
+        Expected    => 1,
+        Name        => "Can find ticket when searching for two article flags",
+    },
+    {
+        Search  => {
+            ArticleFlag => {
+                f1      => 42,
+                f2      => 1,
+            },
+        },
+        Expected    => 0,
+        Name        => "Wrong flag value leads to no match",
+    },
+    {
+        Search  => {
+            NotArticleFlag => {
+                f1      => 23,
+                f4      => 42,
+                f5      => 'nothing much',
+            },
+        },
+        Expected    => 1,
+        Name        => "Non-matching NotArticleFlag do not prevent finding of ticket",
+    },
+    {
+        Search  => {
+            NotArticleFlag => {
+                f1      => 42,
+            },
+        },
+        Expected    => 0,
+        Name        => "NotArticleFlag can prevent tickets from being found",
+    },
+    {
+        Search  => {
+            ArticleFlag => {
+                f2      => 42,
+            },
+            NotArticleFlag => {
+                f1      => 23,
+                f4      => 42,
+                f5      => 'nothing much',
+            },
+        },
+        Expected    => 1,
+        Name        => "Combining ArticleFlag and NotArticleFlag",
+    },
+);
+
+for my $Test (@FlagSearchTests) {
+    my $Found = $TicketObject->TicketSearch(
+        TicketID    => $TicketID,
+        Result      => 'COUNT',
+        UserID      => 1,
+        %{ $Test->{Search} },
+    );
+
+    $Self->Is(
+        $Found,
+        $Test->{Expected},
+        $Test->{Name},
+    );
+}
+
+
 # the ticket is no longer needed
 $TicketObject->TicketDelete(
     TicketID => $TicketID,

--- a/scripts/test/Ticket/ArticleFlags.t
+++ b/scripts/test/Ticket/ArticleFlags.t
@@ -304,40 +304,6 @@ my @FlagSearchTests = (
         Expected    => 0,
         Name        => "Wrong flag value leads to no match",
     },
-    {
-        Search  => {
-            NotArticleFlag => {
-                f1      => 23,
-                f4      => 42,
-                f5      => 'nothing much',
-            },
-        },
-        Expected    => 1,
-        Name        => "Non-matching NotArticleFlag do not prevent finding of ticket",
-    },
-    {
-        Search  => {
-            NotArticleFlag => {
-                f1      => 42,
-            },
-        },
-        Expected    => 0,
-        Name        => "NotArticleFlag can prevent tickets from being found",
-    },
-    {
-        Search  => {
-            ArticleFlag => {
-                f2      => 42,
-            },
-            NotArticleFlag => {
-                f1      => 23,
-                f4      => 42,
-                f5      => 'nothing much',
-            },
-        },
-        Expected    => 1,
-        Name        => "Combining ArticleFlag and NotArticleFlag",
-    },
 );
 
 for my $Test (@FlagSearchTests) {


### PR DESCRIPTION
... including negation.
For example this could be used to search for tickets containing important
articles, or those without.

Tests included.