### PR TITLE
fixed typo for "exept=>except" and improved datepicker for validation future date

### DIFF
--- a/Kernel/Modules/AdminSystemMaintenance.pm
+++ b/Kernel/Modules/AdminSystemMaintenance.pm
@@ -243,7 +243,7 @@ sub Run {
             # add notification
             push @NotifyData, {
                 Priority => 'Notice',
-                Info     => 'All sessions has been killed, exept the current one!',
+                Info     => 'All sessions has been killed, except the current one!',
             };
 
             # set class for expanding sessions widget
@@ -462,24 +462,26 @@ sub _ShowEdit {
     $Param{StartDateString} = $Self->{LayoutObject}->BuildDateSelection(
         %{$SystemMaintenanceData},
         %{ $TimeConfig{StartDate} },
-        Prefix           => 'StartDate',
-        Format           => 'DateInputFormatLong',
-        YearPeriodPast   => 0,
-        YearPeriodFuture => 0,
-        StartDateClass   => $Param{StartDateInvalid} || ' ',
-        Validate         => 1,
+        Prefix               => 'StartDate',
+        Format               => 'DateInputFormatLong',
+        YearPeriodPast       => 0,
+        YearPeriodFuture     => 1,
+        StartDateClass       => $Param{StartDateInvalid} || ' ',
+        Validate             => 1,
+        ValidateDateInFuture => 1,
     );
 
     # stop date info
     $Param{StopDateString} = $Self->{LayoutObject}->BuildDateSelection(
         %{$SystemMaintenanceData},
         %{ $TimeConfig{StopDate} },
-        Prefix           => 'StopDate',
-        Format           => 'DateInputFormatLong',
-        YearPeriodPast   => 0,
-        YearPeriodFuture => 0,
-        StopDateClass    => $Param{StopDateInvalid} || ' ',
-        Validate         => 1,
+        Prefix               => 'StopDate',
+        Format               => 'DateInputFormatLong',
+        YearPeriodPast       => 0,
+        YearPeriodFuture     => 1,
+        StopDateClass        => $Param{StopDateInvalid} || ' ',
+        Validate             => 1,
+        ValidateDateInFuture => 1,
     );
 
     # get valid list

--- a/Kernel/Output/HTML/Standard/AdminSystemMaintenanceEdit.tt
+++ b/Kernel/Output/HTML/Standard/AdminSystemMaintenanceEdit.tt
@@ -197,7 +197,7 @@
                         <div class="Clear"></div>
 
                         <div class="Field SpacingTop">
-                            <a href="[% Env("Baselink") %]Action=[% Env("Action") %];Subaction=KillAll;WantSessionID=[% Env("SessionID") %];[% Env("ChallengeTokenParam") | html %];SystemMaintenanceID=[% Data.SystemMaintenanceID | html %]" id="KillAllSessions" class="CallForAction LittleSpacingTop Fullsize Center"><span><i class="fa fa-trash-o"></i> [% Translate("Kill all Sessions, exept current") | html %]</span></a>
+                            <a href="[% Env("Baselink") %]Action=[% Env("Action") %];Subaction=KillAll;WantSessionID=[% Env("SessionID") %];[% Env("ChallengeTokenParam") | html %];SystemMaintenanceID=[% Data.SystemMaintenanceID | html %]" id="KillAllSessions" class="CallForAction LittleSpacingTop Fullsize Center"><span><i class="fa fa-trash-o"></i> [% Translate("Kill all Sessions, except current") | html %]</span></a>
                         </div>
 
                     </fieldset>


### PR DESCRIPTION
Hi @mrcbnsls,

I again saw something wrong while I tested code by Selenium and ported to OM. In my opinion there was type with "exept", it should be "except".
And when we tested AdminSystemMaintenance screen, we saw that it could be a problem with datepicker. There was only current year in datepicker. If someone want to create system SystemMaintenance on the end of year, it will not be possible.Also we add validation for future year. 
Maybe it is not so important, because of that it is only my proposal for fix.

What do you think about it? If you mean that it have a sense, I can make another PR for rel-4_0.

Regards
Zoran

  