### PR TITLE
Create rhel7-otrs-systemd.spec

### DIFF
--- a/scripts/rhel7-otrs-systemd.spec
+++ b/scripts/rhel7-otrs-systemd.spec
@@ -72,6 +72,8 @@ install -m 644 scripts/apache2-httpd.include.conf $RPM_BUILD_ROOT/etc/httpd/conf
 if test -e /opt/otrs/RELEASE; then
     cat /opt/otrs/RELEASE|grep VERSION|sed 's/VERSION = //'|sed 's/ /-/g' > /tmp/otrs-old.tmp
 fi
+
+%post
 # useradd
 export OTRSUSER=otrs
 echo -n "Check OTRS user ... "
@@ -82,8 +84,6 @@ if id $OTRSUSER >/dev/null 2>&1; then
 else
     useradd $OTRSUSER -d /opt/otrs/ -s /bin/false -g apache -c 'OTRS System User' && echo "$OTRSUSER added."
 fi
-
-%post
 # run OTRS permission setting.
 /opt/otrs/bin/otrs.SetPermissions.pl --web-group=apache
 # if it's a major-update backup old version templates (maybe not compatible!)

--- a/scripts/rhel7-otrs-systemd.spec
+++ b/scripts/rhel7-otrs-systemd.spec
@@ -1,0 +1,156 @@
+# --
+# RPM spec file for RHEL7 of the OTRS package with systemd
+# Copyright (C) 2001-2012 OTRS AG, http://otrs.org/
+# --
+# This software comes with ABSOLUTELY NO WARRANTY. For details, see
+# the enclosed file COPYING for license information (AGPL). If you
+# did not receive this file, see http://www.gnu.org/licenses/agpl.txt.
+# --
+#
+# please file bugfixes or comments on http://bugs.otrs.org
+#
+# --
+Summary:      OTRS Help Desk.
+Name:         otrs
+Version:      0.0
+License:    GNU AFFERO GENERAL PUBLIC LICENSE Version 3, 19 November 2007
+#Copyright:    GNU AFFERO GENERAL PUBLIC LICENSE Version 3, 19 November 2007
+Group:        Applications/Mail
+Provides:     otrs
+# mod_perl removed for now, not available
+Requires:     cronie httpd perl perl(Archive::Zip) perl(Crypt::SSLeay) perl(Date::Format) perl(DBI) perl(Digest::SHA) perl(IO::Socket::SSL) perl(LWP::UserAgent) perl(Net::DNS) perl(Net::LDAP) perl(Template) perl(URI) perl(XML::Parser) perl-core procmail
+#Requires:     cronie httpd mod_perl perl perl(Archive::Zip) perl(Crypt::SSLeay) perl(Date::Format) perl(DBI) perl(Digest::SHA) perl(IO::Socket::SSL) perl(LWP::UserAgent) perl(Net::DNS) perl(Net::LDAP) perl(Template) perl(URI) perl(XML::Parser) perl-core procmail
+Autoreqprov:  no
+Release:      01
+Source0:      otrs-%{version}.tar.bz2
+BuildArch:    noarch
+BuildRoot:    %{_tmppath}/%{name}-%{version}-build
+
+%description
+<DESCRIPTION>
+
+%prep
+%setup
+
+%build
+# copy config file
+cp Kernel/Config.pm.dist Kernel/Config.pm
+cd Kernel/Config/ && for foo in *.dist; do cp $foo `basename $foo .dist`; done && cd ../../
+# copy all crontab dist files
+for foo in var/cron/*.dist; do mv $foo var/cron/`basename $foo .dist`; done
+# copy all .dist files
+cp .procmailrc.dist .procmailrc
+cp .fetchmailrc.dist .fetchmailrc
+cp .mailfilter.dist .mailfilter
+
+%install
+# delete old RPM_BUILD_ROOT
+rm -rf $RPM_BUILD_ROOT
+# set DESTROOT
+export DESTROOT="/opt/otrs/"
+# create RPM_BUILD_ROOT DESTROOT
+mkdir -p $RPM_BUILD_ROOT/$DESTROOT/
+# copy files
+cp -R . $RPM_BUILD_ROOT/$DESTROOT
+# install systemd-script
+install -d -m 755 $RPM_BUILD_ROOT/usr/lib/systemd/system
+install -d -m 755 $RPM_BUILD_ROOT/etc/sysconfig
+install -d -m 755 $RPM_BUILD_ROOT/etc/httpd/conf.d
+
+install -m 644 scripts/redhat-systemd-otrs.dist $RPM_BUILD_ROOT/usr/lib/systemd/system/otrs.service
+install -m 644 scripts/redhat-systemd-otrs.dist $RPM_BUILD_ROOT/$DESTROOT/scripts/otrs.service.dist
+install -m 644 scripts/redhat-systemd-otrs.mariadb $RPM_BUILD_ROOT/$DESTROOT/scripts/otrs.service.mariadb
+install -m 644 scripts/redhat-systemd-otrs.oracle $RPM_BUILD_ROOT/$DESTROOT/scripts/otrs.service.oracle
+install -m 644 scripts/redhat-systemd-otrs.postgresql $RPM_BUILD_ROOT/$DESTROOT/scripts/otrs.service.postgresql
+install -m 644 scripts/redhat-rcotrs-config $RPM_BUILD_ROOT/etc/sysconfig/otrs
+
+# copy apache2-httpd.include.conf to /etc/httpd/conf.d/zzz_otrs.conf
+install -m 644 scripts/apache2-httpd.include.conf $RPM_BUILD_ROOT/etc/httpd/conf.d/zzz_otrs.conf
+
+%pre
+# remember about the installed version
+if test -e /opt/otrs/RELEASE; then
+    cat /opt/otrs/RELEASE|grep VERSION|sed 's/VERSION = //'|sed 's/ /-/g' > /tmp/otrs-old.tmp
+fi
+# useradd
+export OTRSUSER=otrs
+echo -n "Check OTRS user ... "
+if id $OTRSUSER >/dev/null 2>&1; then
+    echo "$OTRSUSER exists."
+    # update home dir
+    usermod -d /opt/otrs $OTRSUSER
+else
+    useradd $OTRSUSER -d /opt/otrs/ -s /bin/false -g apache -c 'OTRS System User' && echo "$OTRSUSER added."
+fi
+
+%post
+# run OTRS permission setting.
+/opt/otrs/bin/otrs.SetPermissions.pl --web-group=apache
+# if it's a major-update backup old version templates (maybe not compatible!)
+if test -e /tmp/otrs-old.tmp; then
+    TOINSTALL=`echo %{version}| sed 's/..$//'`
+    OLDOTRS=`cat /tmp/otrs-old.tmp`
+    if echo $OLDOTRS | grep -v "$TOINSTALL" > /dev/null; then
+        echo "backup old (maybe not compatible) templates (of $OLDOTRS)"
+        for i in /opt/otrs/Kernel/Output/HTML/Standard/*.rpmnew;
+            do BF=`echo $i|sed 's/.rpmnew$//'`; mv -v $BF $BF.backup_maybe_not_compat_to.$OLDOTRS; mv $i $BF;
+        done
+    fi
+    rm -rf /tmp/otrs-old.tmp
+fi
+# run OTRS rebuild config, delete cache, if the system was already in use (i.e. upgrade).
+export OTRSUSER=otrs
+if test -e /opt/otrs/Kernel/Config/Files/ZZZAAuto.pm; then
+    su $OTRSUSER -s /bin/bash -c /opt/otrs/bin/otrs.RebuildConfig.pl;
+    su $OTRSUSER -s /bin/bash -c /opt/otrs/bin/otrs.DeleteCache.pl;
+fi
+
+# note
+HOST=`hostname -f`
+echo ""
+echo "Next steps: "
+echo ""
+echo "[httpd services]"
+echo " Restart httpd 'systemctl restart httpd'"
+echo ""
+echo "[install the OTRS database]"
+echo " Make sure your database server is running."
+echo " Use a web browser and open this link:"
+echo " http://$HOST/otrs/installer.pl"
+echo ""
+echo "[OTRS services]"
+echo " Start OTRS 'systemctl start otrs' (systemctl {start|stop|status|restart} otrs)."
+echo " If start OTRS everytime, enable OTRS 'systemctl enable otrs' (disable to not to start)."
+echo ""
+echo "[change related database on OTRS]"
+echo " Replace '/opt/otrs/scripts/otrs.service.*' onto '/usr/lib/systemd/system/otrs.service'."
+echo " ('*' means {dist|mariadb|oracle|postgresql})"
+echo " Recognize changes of setting 'systemctl daemon-reload'."
+echo ""
+echo "((enjoy))"
+echo ""
+echo " Your OTRS Team"
+echo ""
+
+%clean
+rm -rf $RPM_BUILD_ROOT
+
+%files
+%exclude /opt/otrs/scripts/*.spec
+%exclude /opt/otrs/scripts/suse-*
+%exclude /opt/otrs/scripts/redhat-*
+%config(noreplace) /etc/sysconfig/otrs
+%config(noreplace) /usr/lib/systemd/system/otrs.service
+%config /etc/httpd/conf.d/zzz_otrs.conf
+/opt/otrs/
+
+%changelog
+* Sat Jan 31 2015 - hisatoshi.onishi@gmail.com
+- Relisted target files. Created/added of systemd, removed of initd.
+- Rewritten messages for systemd commands.
+- Excluded unnecessary files. (i.e. configuration files for other distributions)
+* Mon Dec 17 2012 - mb@otrs.com
+- Added dependencies to Digest::SHA, Net::LDAP and Crypt::SSLeay, available from base repositories.
+- Removed dependency on Time::HiRes in favor of perl-core package.
+* Tue Dec 12 2012 - mb@otrs.com
+- spec for RHEL6 created.


### PR DESCRIPTION
Created as RPM spec file for using systemd.

This file depands on some other systemd script files (Also I created).
When reviewing this, please evaluate them (list below) at the same time.
- scripts/redhat-systemd-otrs.dist
- scripts/redhat-systemd-otrs.mariadb
- scripts/redhat-systemd-otrs.oracle
- scripts/redhat-systemd-otrs.postgresql