### PR TITLE
[Rel-4_0 - Bug 10995] Characters not correctly managed by OTRS scripts.

### DIFF
--- a/bin/otrs.AddService.pl
+++ b/bin/otrs.AddService.pl
@@ -23,6 +23,7 @@ use strict;
 use warnings;
 
 use File::Basename;
+use Encode;
 use FindBin qw($RealBin);
 use lib dirname($RealBin);
 use lib dirname($RealBin) . '/Kernel/cpan-lib';
@@ -73,6 +74,7 @@ if ( $Opts{p} ) {
 }
 
 $ServiceName .= $Opts{n};
+$ServiceName = decode_utf8($ServiceName);
 
 # check if service already exists
 my %ServiceList = $Kernel::OM->Get('Kernel::System::Service')->ServiceList(


### PR DESCRIPTION
Hi @mrcbnsls,

There was a problem only in command line printing. Service was added well in DB (I use mysql utf-8 encoding, and I tested there).

I tested it with something like this:
     bin/otrs.AddService.pl -n 'Açãošđčćžшђчћжüöä-Test_Service' -c '3 normal'

I hope it is fixed well. If you have any suggestion, please let me know. If you agree with me, we could solve, in the same way, the others scrips in /bin directory (e.gotrs.AddRole, otrs.AddGroup.... ) 
I will make another PR for the others scripts.

Regards
Zoran

