### PR TITLE
Fix bug#11078 - Extra newline is inserted in the text wrapping

### DIFF
--- a/Kernel/Output/HTML/Layout.pm
+++ b/Kernel/Output/HTML/Layout.pm
@@ -5001,6 +5001,8 @@ sub WrapPlainText {
         return;
     }
 
+    $Param{PlainText} =~ s/\r\n?/\n/g;
+
     # Return PlainText if we have less than MaxCharacters
     if ( length $Param{PlainText} < $Param{MaxCharacters} ) {
         return $Param{PlainText};


### PR DESCRIPTION
This PR changes CR+LF and CR into LF before wrapping.
