### PR TITLE
Patch Oracle connection in WebInstaller

### DIFF
--- a/Kernel/Modules/Installer.pm
+++ b/Kernel/Modules/Installer.pm
@@ -599,7 +599,7 @@ sub Run {
 
             # set DSN for Config.pm
             $DB{ConfigDSN} = 'DBI:Oracle://$Self->{DatabaseHost}:' . $DB{DBPort} . '/' . $DB{DBSID};
-            $DB{DSN}       = "DBI:Oracle://$Self->{DBHost}:$DB{DBPort}/$Self->{DBSID}";
+            $DB{DSN}       = "DBI:Oracle://$DB{DBHost}:$DB{DBPort}/$DB{DBSID}";
             $Self->{ConfigObject}->Set(
                 Key   => 'Database::Connect',
                 Value => "ALTER SESSION SET NLS_DATE_FORMAT = 'YYYY-MM-DD HH24:MI:SS'",
@@ -1170,7 +1170,7 @@ sub ConnectToDB {
         $Param{DSN} = "DBI:Pg:host=$Param{DBHost};dbname=$Param{DBName}";
     }
     elsif ( $Param{DBType} eq 'oracle' ) {
-        $Param{DSN} = "DBI:Oracle:host=$Param{DBHost};sid=$Param{DBSID};port=$Param{DBPort};"
+        $Param{DSN} = "DBI:Oracle://$Param{DBHost}:$Param{DBPort}/$Param{DBSID}";
     }
 
     # extract driver to load for install test

--- a/Kernel/Modules/Installer.pm
+++ b/Kernel/Modules/Installer.pm
@@ -598,7 +598,7 @@ sub Run {
         elsif ( $DB{DBType} eq 'oracle' ) {
 
             # set DSN for Config.pm
-            $DB{ConfigDSN} = 'DBI:Oracle://$Self->{DatabaseHost}/$Self->{Database}';
+            $DB{ConfigDSN} = 'DBI:Oracle://$Self->{DatabaseHost}:' . $DB{DBPort} . '/$Self->{Database}';
             $DB{DSN}       = "DBI:Oracle://$DB{DBHost}:$DB{DBPort}/$DB{DBSID}";
             $Self->{ConfigObject}->Set(
                 Key   => 'Database::Connect',
@@ -654,7 +654,7 @@ sub Run {
         if ( $DB{DBType} eq 'oracle' ) {
             $ReConfigure = $Self->ReConfigure(
                 DatabaseDSN  => $DB{ConfigDSN},
-                DatabaseHost => $DB{DBHost} . ':' . $DB{DBPort},
+                DatabaseHost => $DB{DBHost},
                 Database     => $DB{DBSID},
                 DatabaseUser => $DB{OTRSDBUser},
                 DatabasePw   => $DB{OTRSDBPassword},

--- a/Kernel/Modules/Installer.pm
+++ b/Kernel/Modules/Installer.pm
@@ -598,7 +598,7 @@ sub Run {
         elsif ( $DB{DBType} eq 'oracle' ) {
 
             # set DSN for Config.pm
-            $DB{ConfigDSN} = 'DBI:Oracle://$Self->{DatabaseHost}:' . $DB{DBPort} . '/' . $DB{DBSID};
+            $DB{ConfigDSN} = 'DBI:Oracle://$Self->{DatabaseHost}/$Self->{Database}';
             $DB{DSN}       = "DBI:Oracle://$DB{DBHost}:$DB{DBPort}/$DB{DBSID}";
             $Self->{ConfigObject}->Set(
                 Key   => 'Database::Connect',
@@ -650,13 +650,25 @@ sub Run {
         }
 
         # ReConfigure Config.pm
-        my $ReConfigure = $Self->ReConfigure(
-            DatabaseDSN  => $DB{ConfigDSN},
-            DatabaseHost => $DB{DBHost},
-            Database     => $DB{DBName},
-            DatabaseUser => $DB{OTRSDBUser},
-            DatabasePw   => $DB{OTRSDBPassword},
-        );
+        my $ReConfigure;
+        if ( $DB{DBType} eq 'oracle' ) {
+            $ReConfigure = $Self->ReConfigure(
+                DatabaseDSN  => $DB{ConfigDSN},
+                DatabaseHost => $DB{DBHost} . ':' . $DB{DBPort},
+                Database     => $DB{DBSID},
+                DatabaseUser => $DB{OTRSDBUser},
+                DatabasePw   => $DB{OTRSDBPassword},
+            );
+        }
+        else {
+            $ReConfigure = $Self->ReConfigure(
+                DatabaseDSN  => $DB{ConfigDSN},
+                DatabaseHost => $DB{DBHost},
+                Database     => $DB{DBName},
+                DatabaseUser => $DB{OTRSDBUser},
+                DatabasePw   => $DB{OTRSDBPassword},
+            );
+        }
 
         if ($ReConfigure) {
             my $Output =


### PR DESCRIPTION
WebInstaller was unable to create Oracle database.
I found the wrong usage of "$Self->{}" instead of "$DB{}" for DBHost and DBSID, which broke connection to Oracle. On the other hand the correct connection string was stored in ConfigDSN.
Second, the "test database connection" used another naming, requiring the short "SID" in config parameter "DBSID", but the resulting ConfigDSN used the Service Name (in my case the SID extended by or domain name). It should be unique for connection test and real connection and I prefer the Service Name, so I changed the DSN for the connection string.

Maybe someone should care about the naming "SID" now, but I'm fine since it at least works now.

Further, the separate commit will store DBPort and DBSID inside DatabaseHost and Database(name) to avoid having them only in the DSN.