### PR TITLE
[Rel-4_0 - Bug 10809] OTRS tags aren't working within the bounce function

### DIFF
--- a/Kernel/Modules/AgentTicketBounce.pm
+++ b/Kernel/Modules/AgentTicketBounce.pm
@@ -220,7 +220,7 @@ sub Run {
         if ( $Self->{LayoutObject}->{BrowserRichText} ) {
 
             # prepare bounce tags
-            $Param{BounceText} =~ s/<OTRS_TICKET>/&lt;OTRS_TICKET&gt;/g;
+            $Param{BounceText} =~ s/<OTRS_TICKET>/$Ticket{TicketNumber}/g;
             $Param{BounceText} =~ s/<OTRS_BOUNCE_TO>/&lt;OTRS_BOUNCE_TO&gt;/g;
 
             $Param{BounceText} = $Self->{LayoutObject}->Ascii2RichText(
@@ -404,7 +404,7 @@ $Param{Signature}";
             if ( $Self->{LayoutObject}->{BrowserRichText} ) {
 
                 # prepare bounce tags
-                $Param{Body} =~ s/&lt;OTRS_TICKET&gt;/&amp;lt;OTRS_TICKET&amp;gt;/gi;
+                $Param{Body} =~ s/&lt;OTRS_TICKET&gt;/&amp;$Ticket{TicketNumber}/gi;
                 $Param{Body} =~ s/&lt;OTRS_BOUNCE_TO&gt;/&amp;lt;OTRS_BOUNCE_TO&amp;gt;/gi;
             }
 

--- a/Kernel/Modules/AgentTicketBounce.pm
+++ b/Kernel/Modules/AgentTicketBounce.pm
@@ -404,7 +404,7 @@ $Param{Signature}";
             if ( $Self->{LayoutObject}->{BrowserRichText} ) {
 
                 # prepare bounce tags
-                $Param{Body} =~ s/&lt;OTRS_TICKET&gt;/&amp;$Ticket{TicketNumber}/gi;
+                $Param{Body} =~ s/&lt;OTRS_TICKET&gt;/$Ticket{TicketNumber}/gi;
                 $Param{Body} =~ s/&lt;OTRS_BOUNCE_TO&gt;/&amp;lt;OTRS_BOUNCE_TO&amp;gt;/gi;
             }
 


### PR DESCRIPTION
http://bugs.otrs.org/show_bug.cgi?id=10809

In bounce function tags are little bit different then in other modules. We think that for TicketNumber it is possible to have right away replaced value, yet that is not the case for <OTRS_BOUNCE_TO> since bounce receiver isn't known until completion of request.