### PR TITLE
Fix bug#11106 - Owner type is ignored if set previous owner to brank Age...

### DIFF
--- a/Kernel/Modules/AgentTicketActionCommon.pm
+++ b/Kernel/Modules/AgentTicketActionCommon.pm
@@ -684,7 +684,7 @@ sub Run {
                     push @NotifyDone, $GetParam{OldOwnerID};
                 }
             }
-            elsif ( $GetParam{NewOwnerID} ) {
+            elsif ( $GetParam{NewOwnerType} eq 'New' && $GetParam{NewOwnerID} ) {
                 $Self->{TicketObject}->TicketLockSet(
                     TicketID => $Self->{TicketID},
                     Lock     => 'lock',


### PR DESCRIPTION
Fix bug#11106 - Owner type is ignored if set previous owner to brank AgentTicketOwner.
See http://bugs.otrs.org/show_bug.cgi?id=11106 .
