### PR TITLE
Fix bug#11128 - Uninitialized variable warning in dashboard after additi...

### DIFF
--- a/Kernel/Output/HTML/DashboardTicketGeneric.pm
+++ b/Kernel/Output/HTML/DashboardTicketGeneric.pm
@@ -1880,8 +1880,10 @@ sub _SearchParamsGet {
     }
     if ($PreferencesColumn) {
         if ( $PreferencesColumn->{Columns} && %{$PreferencesColumn->{Columns}}) {
-            @Columns = grep { $PreferencesColumn->{Columns}->{$_} eq '1' }
-                sort { $Self->_DefaultColumnSort() } keys %{ $Self->{Config}->{DefaultColumns} };
+            @Columns = grep {
+                defined $PreferencesColumn->{Columns}->{$_}
+                && $PreferencesColumn->{Columns}->{$_} eq '1'
+            } sort { $Self->_DefaultColumnSort() } keys %{ $Self->{Config}->{DefaultColumns} };
         }
         if ( $PreferencesColumn->{Order} && @{ $PreferencesColumn->{Order} } ) {
             @Columns = @{ $PreferencesColumn->{Order} };


### PR DESCRIPTION
This PR fixes bug#11128 - Uninitialized variable warning in dashboard after addition of new dynamic field.
See http://bugs.otrs.org/show_bug.cgi?id=11128 .
