### PR TITLE
Do not distinguish KeepChildren if Valid is 0 in ServiceList

### DIFF
--- a/Kernel/System/Service.pm
+++ b/Kernel/System/Service.pm
@@ -101,7 +101,7 @@ sub ServiceList {
     # read cache
     my $CacheKey = 'ServiceList::Valid::' . $Param{Valid};
 
-    if ( defined $Param{KeepChildren} && $Param{KeepChildren} eq '1' ) {
+    if ( $Param{Valid} && defined $Param{KeepChildren} && $Param{KeepChildren} eq '1' ) {
         $CacheKey .= '::KeepChildren::' . $Param{KeepChildren};
     }
 


### PR DESCRIPTION
In Kernel::System::Service::ServiceList, if $Param{Valid} is 0, KeepChildren is not used,
so we use one cache for both 0 and 1 of KeepChildren.
