### PR TITLE
Fix bug#11135 - Use of uninitialized value warning in CustomerCompanyLis...

### DIFF
--- a/Kernel/System/CustomerCompany/DB.pm
+++ b/Kernel/System/CustomerCompany/DB.pm
@@ -173,7 +173,7 @@ sub CustomerCompanyList {
     while ( my @Row = $Self->{DBObject}->FetchrowArray() ) {
 
         my $CustomerCompanyID = shift @Row;
-        $List{$CustomerCompanyID} = join( ' ', @Row );
+        $List{$CustomerCompanyID} = join( ' ', map { defined($_) ? $_ : '' } @Row );
     }
 
     # cache request


### PR DESCRIPTION
This PR is fix for bug#11135 - Use of uninitialized value warning in CustomerCompanyList.
See http://bugs.otrs.org/show_bug.cgi?id=11135 .
