### PR TITLE
Enable to disable to force to rewrap a text input in text area

### DIFF
--- a/Kernel/Config/Files/Framework.xml
+++ b/Kernel/Config/Files/Framework.xml
@@ -384,6 +384,17 @@
             </Option>
         </Setting>
     </ConfigItem>
+    <ConfigItem Name="Frontend::WrapText" Required="1" Valid="1">
+        <Description Translatable="1">Enables or disables to force to rewrap a text input in text area.</Description>
+        <Group>Framework</Group>
+        <SubGroup>Core::Web</SubGroup>
+        <Setting>
+            <Option SelectedID="1">
+                <Item Key="0">No</Item>
+                <Item Key="1">Yes</Item>
+            </Option>
+        </Setting>
+    </ConfigItem>
     <ConfigItem Name="DisableMSIFrameSecurityRestricted" Required="0" Valid="1">
         <Description Translatable="1">Disable restricted security for IFrames in IE. May be required for SSO to work in IE8.</Description>
         <Group>Framework</Group>

--- a/Kernel/Modules/AgentTicketPrint.pm
+++ b/Kernel/Modules/AgentTicketPrint.pm
@@ -1351,9 +1351,10 @@ sub _HTMLMask {
 
                 # html quoting
                 $Article{Body} = $Self->{LayoutObject}->Ascii2Html(
-                    NewLine => $Self->{ConfigObject}->Get('DefaultViewNewLine'),
-                    Text    => $Article{Body},
-                    VMax    => $Self->{ConfigObject}->Get('DefaultViewLines') || 5000,
+                    NewLine        => $Self->{ConfigObject}->Get('DefaultViewNewLine'),
+                    Text           => $Article{Body},
+                    VMax           => $Self->{ConfigObject}->Get('DefaultViewLines') || 5000,
+                    HTMLResultMode => 1,
                 );
             }
         }

--- a/Kernel/Modules/CustomerTicketPrint.pm
+++ b/Kernel/Modules/CustomerTicketPrint.pm
@@ -1083,9 +1083,10 @@ sub _HTMLMask {
 
                 # html quoting
                 $Article{Body} = $Self->{LayoutObject}->Ascii2Html(
-                    NewLine => $Self->{ConfigObject}->Get('DefaultViewNewLine'),
-                    Text    => $Article{Body},
-                    VMax    => $Self->{ConfigObject}->Get('DefaultViewLines') || 5000,
+                    NewLine        => $Self->{ConfigObject}->Get('DefaultViewNewLine'),
+                    Text           => $Article{Body},
+                    VMax           => $Self->{ConfigObject}->Get('DefaultViewLines') || 5000,
+                    HTMLResultMode => 1,
                 );
             }
         }

--- a/Kernel/Output/HTML/Layout.pm
+++ b/Kernel/Output/HTML/Layout.pm
@@ -1650,7 +1650,12 @@ sub Ascii2Html {
     }
 
     # newline
-    if ( $Param{NewLine} && length( ${$Text} ) < 140_000 ) {
+    if (
+        $Self->{ConfigObject}->Get('Frontend::WrapText')
+        && $Param{NewLine}
+        && length( ${$Text} ) < 140_000
+        )
+    {
         ${$Text} =~ s/(\n\r|\r\r\n|\r\n)/\n/g;
         ${$Text} =~ s/\r/\n/g;
         ${$Text} =~ s/(.{4,$Param{NewLine}})(?:\s|\z)/$1\n/gm;
@@ -5028,7 +5033,11 @@ sub WrapPlainText {
     }
 
     # Return PlainText if we have less than MaxCharacters
-    if ( length $Param{PlainText} < $Param{MaxCharacters} ) {
+    if (
+        !$Self->{ConfigObject}->Get('Frontend::WrapText')
+        || length $Param{PlainText} < $Param{MaxCharacters}
+        )
+    {
         return $Param{PlainText};
     }
 

--- a/Kernel/Output/HTML/Standard/AgentTicketPrint.tt
+++ b/Kernel/Output/HTML/Standard/AgentTicketPrint.tt
@@ -248,9 +248,9 @@
 [% IF Data.IsChat == 1 %]
 [% INCLUDE "ChatDisplay.tt" %]
 [% ELSE %]
-                                    <pre>
+                                    <div class="ArticleBody">
 [% Data.Body %]
-                                    </pre>
+                                    </div>
 [% END %]
                                 </td>
                             </tr>

--- a/Kernel/Output/HTML/Standard/CustomerTicketPrint.tt
+++ b/Kernel/Output/HTML/Standard/CustomerTicketPrint.tt
@@ -212,9 +212,9 @@
 [% INCLUDE "ChatDisplay.tt" %]
 [% ELSE %]
 [% Data.TextNote %]
-                                    <pre>
+                                    <div class="ArticleBody">
 [% Data.Body %]
-                                    </pre>
+                                    </div>
 [% END %]
                                 </td>
                             </tr>

--- a/Kernel/System/HTMLUtils.pm
+++ b/Kernel/System/HTMLUtils.pm
@@ -96,6 +96,7 @@ sub ToAscii {
 
     # pre-process <blockquote> and <div style=\"cite\"
     my %Cite;
+     my $WrapText = $Kernel::OM->Get('Kernel::Config')->Get('Filter::Output::WrapText');
     $Counter = 0;
     $Param{String} =~ s{
         <blockquote(.*?)>(.+?)</blockquote>
@@ -105,7 +106,7 @@ sub ToAscii {
             String => $2,
         );
         # force line breaking
-        if ( length $Ascii > $LineLength ) {
+        if ( $WrapText && length $Ascii > $LineLength ) {
             $Ascii =~ s/(.{4,$LineLength})(?:\s|\z)/$1\n/gm;
         }
         $Ascii =~ s/^(.*?)$/> $1/gm;
@@ -122,7 +123,7 @@ sub ToAscii {
             String => $1,
         );
         # force line breaking
-        if ( length $Ascii > $LineLength ) {
+        if ( $WrapText && length $Ascii > $LineLength ) {
             $Ascii =~ s/(.{4,$LineLength})(?:\s|\z)/$1\n/gm;
         }
         $Ascii =~ s/^(.*?)$/> $1/gm;
@@ -526,7 +527,7 @@ sub ToAscii {
     $Param{String} =~ s/^\s*\n\s*\n/\n/mg;
 
     # force line breaking
-    if ( length $Param{String} > $LineLength ) {
+    if ( $WrapText && length $Param{String} > $LineLength ) {
         $Param{String} =~ s/(.{4,$LineLength})(?:\s|\z)/$1\n/gm;
     }
 

--- a/Kernel/System/TemplateGenerator.pm
+++ b/Kernel/System/TemplateGenerator.pm
@@ -555,7 +555,11 @@ sub AutoResponse {
     }
 
     # format body (only if longer than 86 chars)
-    if ( $Param{OrigHeader}->{Body} ) {
+    if (
+        $Kernel::OM->Get('Kernel::Config')->Get('Frontend::WrapText')
+        && $Param{OrigHeader}->{Body}
+        )
+    {
         if ( length $Param{OrigHeader}->{Body} > 86 ) {
             my @Lines = split /\n/, $Param{OrigHeader}->{Body};
             LINE:
@@ -735,7 +739,11 @@ sub NotificationAgent {
     }
 
     # format body (only if longer the 86 chars)
-    if ( $Param{CustomerMessageParams}->{Body} ) {
+    if (
+        $Kernel::OM->Get('Kernel::Config')->Get('Frontend::WrapText')
+        && $Param{CustomerMessageParams}->{Body}
+        )
+    {
         if ( length $Param{CustomerMessageParams}->{Body} > 86 ) {
             my @Lines = split /\n/, $Param{CustomerMessageParams}->{Body};
             LINE:

--- a/Kernel/System/Ticket/Article.pm
+++ b/Kernel/System/Ticket/Article.pm
@@ -3058,7 +3058,7 @@ sub SendCustomerNotification {
     $Notification{Subject} =~ s/<OTRS_CUSTOMER_DATA_.+?>/-/gi;
 
     # format body
-    if ( $Article{Body} ) {
+    if ( $ConfigObject->Get('Frontend::WrapText') && $Article{Body} ) {
         $Article{Body} =~ s/(^>.+|.{4,72})(?:\s|\z)/$1\n/gm;
     }
     for ( sort keys %Article ) {

--- a/Kernel/System/Ticket/Event/NotificationEvent.pm
+++ b/Kernel/System/Ticket/Event/NotificationEvent.pm
@@ -970,7 +970,7 @@ sub _SendNotification {
 
         if (%Article) {
 
-            if ( $Article{Body} ) {
+            if ( $ConfigObject->Get('Frontend::WrapText') && $Article{Body} ) {
 
                 # Use the same line length as HTMLUtils::toAscii to avoid
                 #   line length problems.

--- a/var/httpd/htdocs/skins/Customer/default/css/Core.Default.css
+++ b/var/httpd/htdocs/skins/Customer/default/css/Core.Default.css
@@ -354,6 +354,7 @@ form select.Error {
  */
 .ArticleBody{
     font-family: monospace,fixed;
+    word-wrap: break-word;
 }
 
 


### PR DESCRIPTION
In recent years, we don't have to rewrap the text in many cases by
following reasons.  This PR enables to disable to force to rewrap a text
in text area as article body.

  - Recent screen is large.  It can display more than 150 characters of
    a line without scroll.
  - Even when send email, body text is encoded quoted-printable or
    base64.  It means that we don't have to mind "Line Length Limits"
    written in RFC 5322 Section 2.1.1.
  - Japanese and Chinese does not use spaces to separate between words
    in locale.  It causes to ignore hard wrap trick in these locales.
    By the way, I confirmed Firefox and Internet Explorer expectly wrap
    a text even in these locales with "word-wrap: break-word".
  - If Frontend::RichText is not "0", a text is not rewrapped.

By the way, I see that the feature to rewrap a text in text area is
introduced in fix for bug#526.  At first "hard" attributes of textarea
is used, it is changed into Perl code in the fix.  However, now, if
"word-wrap: break-word" works correctly, a horizontal scrollbar will be
not caused for a long line, and the line will be wrapped expectedly by
browser's feature.