### PR TITLE
Fix bug#11142 - At times, undefined variable warning in agent interface

### DIFF
--- a/Kernel/System/Web/InterfaceAgent.pm
+++ b/Kernel/System/Web/InterfaceAgent.pm
@@ -769,8 +769,8 @@ sub Run {
                             Secure   => scalar $CookieSecureAttribute,
                             HTTPOnly => 1,
                         ),
-                        %Param,
                     },
+                    %Param,
                     }
             );
 


### PR DESCRIPTION
This PR is fix for bug#11142 - At times, undefined variable warning in agent interface.
See http://bugs.otrs.org/show_bug.cgi?id=11142 .
