### PR TITLE
 [Rel-4_0 Bug 11118]  Function NotificationCustomer always get DefaultLanguage to send notification

### DIFF
--- a/Kernel/System/TemplateGenerator.pm
+++ b/Kernel/System/TemplateGenerator.pm
@@ -912,7 +912,9 @@ sub NotificationCustomer {
         %Queue = $QueueObject->QueueGet( ID => $Param{QueueID} );
     }
 
-    my %User;
+    my %User = $Kernel::OM->Get('Kernel::System::CustomerUser')->GetPreferences(
+        UserID => $Ticket{CustomerUserID},
+    );
 
     # get user language
     my $Language = $User{UserLanguage} || $Kernel::OM->Get('Kernel::Config')->Get('DefaultLanguage') || 'en';


### PR DESCRIPTION
http://bugs.otrs.org/show_bug.cgi?id=11118

While researching this bug, we found out that there has been some misleading parts of code. In module TemplateGenerator.pm - sub NotificationCustomer() is no longer used. Correct, if this is wrong thinking. For sending customer notification Kernel::System::Ticket::Event::NotificationEvent module is responsible.

Furthermore in Kernel::System::Ticket::Article in comment for sub SendCustomerNotification() it is clearly stated that this function is DEPRECATED due to usage of RichText editor and should not be used anymore. Additionally in Kernel::System::Notification (line 180 & 206) in sub NotificationList() also states that customer notification should be handled by NotificationEvent.

We added a fix for reporter bug. We tested it by forcing it to enter desired sub function, but in real environment this could not be reproduced because of above mentioned details. In order for customer to receive translated tags with NotificationEvent, it would require writing additional function similar to _Replace() from TemplateGenerator.pm but this is something to be discussed further on.

Please, one more time correct if these are all wrong assumptions.

Regards,
S7
