### PR TITLE
Fix bug#11178 - Undefined variable warning with "Reply to note" in Agent...

### DIFF
--- a/Kernel/Modules/AgentTicketActionCommon.pm
+++ b/Kernel/Modules/AgentTicketActionCommon.pm
@@ -1964,7 +1964,7 @@ sub _Mask {
         my %ReplyToUserIDs;
         if ( $Self->{ReplyToArticle} ) {
             my @ReplyToParts = $Self->{EmailParserObject}->SplitAddressLine(
-                Line => $Self->{ReplyToArticleContent}->{To},
+                Line => $Self->{ReplyToArticleContent}->{To} || '',
             );
 
             REPLYTOPART:


### PR DESCRIPTION
This PR is fix for bug#11178.
See http://bugs.otrs.org/show_bug.cgi?id=11178 .
