### PR TITLE
Fixed duble sessionID parameter in some links

### DIFF
--- a/Kernel/Output/HTML/LayoutTemplate.pm
+++ b/Kernel/Output/HTML/LayoutTemplate.pm
@@ -215,7 +215,7 @@ sub Output {
             my $RealEnd = $4;
             if ( lc $Target =~ /^(http:|https:|#|ftp:)/ ||
                 $Target !~ /\.(pl|php|cgi|fcg|fcgi|fpl)(\?|$)/ ||
-                $Target =~ /(\?|&)\Q$Self->{SessionName}\E=/) {
+                $Target =~ /(\?|&|;)\Q$Self->{SessionName}\E=/) {
                 $AHref.$Target.$End.$RealEnd;
             }
             else {


### PR DESCRIPTION
Hi,

While I worked on the bug http://bugs.otrs.org/show_bug.cgi?id=10962 I saw that there is issue on some links if it is set https protocol. The problem is that in some link is added double SessionID value. There are wrong links on Dashboard and AgentTicketOverview  screens (Queue, Status, Escalation...).
I had fixed this when I made the first PR for the bug 10962. Becouse of that I have just made new PR for this bug in FAQ repository, I fixed here the issue with double SessionID value.

Regards
Zoran
