### PR TITLE
[Master Bug - 11156 ] - No translated headers in Excel output in AgentTicketSearch 

### DIFF
--- a/Kernel/Output/HTML/Standard/AAATicket.tt
+++ b/Kernel/Output/HTML/Standard/AAATicket.tt
@@ -169,6 +169,7 @@
 [% Translate("Phone-Ticket") | html %]
 [% Translate("Search Tickets") | html %]
 [% Translate("Customer") | html %]
+[% Translate("Customer Realname") | html %]
 [% Translate("Customer History") | html %]
 [% Translate("Edit Customer Users") | html %]
 [% Translate("Edit Customer") | html %]


### PR DESCRIPTION
http://bugs.otrs.org/show_bug.cgi?id=11156

Hi @mgruner ,

In the bug report, reporter mentioned problem in exporting to Excel with "Artictle Tree" and 
"Customer Realname". 
Actualy, "ArtictleTree" is translated, and here I wanted to fix only translation for "Customer Realname". I did not call translate update comand.

I am not sure is it the best solution, let me know if I can do on different way.


Regards
Zoran