### PR TITLE
TicketSearch by array reference of TicketIDs

### DIFF
--- a/Kernel/System/Ticket/TicketSearch.pm
+++ b/Kernel/System/Ticket/TicketSearch.pm
@@ -520,7 +520,7 @@ sub TicketSearch {
     if ( $Param{TicketID} ) {
         $SQLExt .= $Self->_InConditionGet(
             TableColumn => 'st.id',
-            IDRef       => ref($Param{TicketID})
+            IDRef       => ref($Param{TicketID}) && ref($Param{TicketID}) eq 'ARRAY'
                            ? $Param{TicketID}
                            : [ $DBObject->Quote($Param{TicketID}, 'Integer') ],
         );

--- a/Kernel/System/Ticket/TicketSearch.pm
+++ b/Kernel/System/Ticket/TicketSearch.pm
@@ -37,8 +37,10 @@ To find tickets in your system.
         # result limit
         Limit => 100,
 
-        # Use TicketSearch as a ticket filter on a single ticket
+        # Use TicketSearch as a ticket filter on a single ticket,
+        # or a predefined ticket list
         TicketID     => 1234,
+        TicketID     => [1234, 1235],
 
         # ticket number (optional) as STRING or as ARRAYREF
         TicketNumber => '%123546%',
@@ -513,10 +515,15 @@ sub TicketSearch {
 
     my $SQLExt = ' WHERE 1=1';
 
-    # Limit the search to just one TicketID (used by the GenericAgent
+    # Limit the search to just one (or a list) TicketID (used by the GenericAgent
     #   to filter for events on single tickets with the job's ticket filter).
     if ( $Param{TicketID} ) {
-        $SQLExt .= ' AND st.id = ' . $DBObject->Quote( $Param{TicketID}, 'Integer' );
+        $SQLExt .= $Self->_InConditionGet(
+            TableColumn => 'st.id',
+            IDRef       => ref($Param{TicketID})
+                           ? $Param{TicketID}
+                           : [ $DBObject->Quote($Param{TicketID}, 'Integer') ],
+        );
     }
 
     # add ticket flag table

--- a/scripts/test/Ticket.t
+++ b/scripts/test/Ticket.t
@@ -301,6 +301,33 @@ $Self->True(
     'TicketSearch() (HASH:TicketNumber)',
 );
 
+%TicketIDs = $TicketObject->TicketSearch(
+    Result       => 'HASH',
+    Limit        => 100,
+    TicketID     => $TicketID,
+    UserID       => 1,
+    Permission   => 'rw',
+);
+
+$Self->True(
+    $TicketIDs{$TicketID},
+    'TicketSearch() (HAHS:TicketID)',
+);
+
+%TicketIDs = $TicketObject->TicketSearch(
+    Result       => 'HASH',
+    Limit        => 100,
+    TicketID     => [$TicketID, 42],
+    UserID       => 1,
+    Permission   => 'rw',
+);
+
+$Self->True(
+    $TicketIDs{$TicketID},
+    'TicketSearch() (HAHS:TicketID as ARRAYREF)',
+);
+
+
 my $Count = $TicketObject->TicketSearch(
     Result       => 'COUNT',
     TicketNumber => $Ticket{TicketNumber},


### PR DESCRIPTION
Most other search options for IDs already accept array refs, so it is only
consistent to accept array refs for TicketID too. Plus, we have a good use
case at my employer for that (filtering a pre-existing list of tickets).