### PR TITLE
Link ticket queue overview in dashboard to ticket queue view

### DIFF
--- a/Kernel/Output/HTML/DashboardTicketQueueOverview.pm
+++ b/Kernel/Output/HTML/DashboardTicketQueueOverview.pm
@@ -182,6 +182,7 @@ sub Run {
         $LayoutObject->Block(
             Name => 'ContentLargeTicketQueueOverviewQueueName',
             Data => {
+                QueueID   => $QueueToID{$Queue},
                 QueueName => $Queue,
                 }
         );

--- a/Kernel/Output/HTML/Standard/AgentDashboardTicketQueueOverview.tt
+++ b/Kernel/Output/HTML/Standard/AgentDashboardTicketQueueOverview.tt
@@ -19,7 +19,7 @@
     <tbody>
 [% RenderBlockStart("ContentLargeTicketQueueOverviewQueueName") %]
         <tr class="Row">
-            <td>[% Data.QueueName | html %]</td>
+            <td><a class="AsBlock" href="[% Env("Baselink") %]Action=AgentTicketQueue;QueueID=[% Data.QueueID | uri %]">[% Data.QueueName | html %]</a></td>
 [% RenderBlockStart("ContentLargeTicketQueueOverviewQueueResults") %]
             <td><a class="AsBlock" href="[% Env("Baselink") %]Action=AgentTicketSearch;Subaction=Search;[% Env("ChallengeTokenParam") | html %];StateIDs=[% Data.StateID | uri %];QueueIDs=[% Data.QueueID | uri %];[% Data.Sort | html %]">[% Translate(Data.Number) | html %]</a></td>
 [% RenderBlockEnd("ContentLargeTicketQueueOverviewQueueResults") %]


### PR DESCRIPTION
This PR is minor change in dashboard.  Link ticket queue overview in dashboard to ticket queue view.  It will improve the accessibility to the ticket queue.
