### PR TITLE
Spelling check: false string is not an error

### DIFF
--- a/Kernel/System/Spelling.pm
+++ b/Kernel/System/Spelling.pm
@@ -82,7 +82,7 @@ sub Check {
 
     # check needed stuff
     for (qw(Text)) {
-        if ( !$Param{$_} ) {
+        if ( !defined $Param{$_} ) {
             $Kernel::OM->Get('Kernel::System::Log')->Log(
                 Priority => 'error',
                 Message  => "Need $_!"


### PR DESCRIPTION
Spell-checking a text area with an empty string or the string "0"
should not be considered an error worthy of a log file entry.