### PR TITLE
TransitionAction - TicketArticleCreate - Create article and set "From" to the current agent email

### DIFF
--- a/Kernel/System/ProcessManagement/TransitionAction/TicketArticleCreate.pm
+++ b/Kernel/System/ProcessManagement/TransitionAction/TicketArticleCreate.pm
@@ -158,7 +158,17 @@ sub Run {
 
     # get ticket object
     my $TicketObject = $Kernel::OM->Get('Kernel::System::Ticket');
-
+    
+	if( !$Param{Config}->{From} ) {	
+		# Get current user data
+		my %User = $Kernel::OM->Get('Kernel::System::User')->GetUserData(
+			UserID => $Param{UserID},
+		);
+		
+		# Set "From" field according to his account - UserFirstname, UserLastname, UserEmail
+		$Param{Config}->{From} = $User{UserFirstname} . ' ' . $User{UserLastname} . ' <' . $User{UserEmail} . '>';
+	}
+	
     my $ArticleID = $TicketObject->ArticleCreate(
         %{ $Param{Config} },
         TicketID => $Param{Ticket}->{TicketID},


### PR DESCRIPTION
TransitionAction - TicketArticleCreate
Right now there is no possibility to set the "From" field of the article to the user that made change. Process creator can just set fixed email address.

This patch allows tracking who created this article without going to the ticket history. If "From" field is not assigned, it will use current user.

