### PR TITLE
[Rel-3_3 Bug 11080] Ticketfilter doesn' t work - maximum number of expressions reach

### DIFF
--- a/Kernel/System/TicketSearch.pm
+++ b/Kernel/System/TicketSearch.pm
@@ -1890,11 +1890,36 @@ sub _InConditionGet {
     my @SortedIDs = sort { $a <=> $b } @{ $Param{IDRef} };
 
     # quote values
+    SORTEDID:
     for my $Value (@SortedIDs) {
-        return if !defined $Self->{DBObject}->Quote( $Value, 'Integer' );
+        next SORTEDID if !defined $Self->{DBObject}->Quote( $Value, 'Integer' );
     }
 
-    return " AND $Param{TableColumn} IN (" . ( join ',', @SortedIDs ) . ")";
+    # split IN statement with more than 900 elements in more statements combined with OR
+    # because Oracle doesn't support more than 1000 elements for one IN statement.
+    my @SQLStrings;
+    while ( scalar @SortedIDs ) {
+
+        # remove section in the array
+        my @SortedIDsPart = splice @SortedIDs, 0, 900;
+
+        # link together IDs
+        my $IDString = join ', ', @SortedIDsPart;
+
+        # add new statement
+        push @SQLStrings, " $Param{TableColumn} IN ($IDString) ";
+    }
+
+    my $SQL = '';
+    if (@SQLStrings) {
+
+        # combine statements
+        $SQL = join ' OR ', @SQLStrings;
+
+        # encapsulate conditions
+        $SQL = ' AND ( ' . $SQL . ' ) ';
+    }
+    return $SQL;
 }
 
 1;


### PR DESCRIPTION
http://bugs.otrs.org/show_bug.cgi?id=11080

Hi,
In this PR is maybe fixed the bug (11080). I had a problem with reproducing and configuring environment for Oracle DB. While I was comparing code in the newer versions of OTRS, I saw that this issue is solved in TicketSearch(). Because of that I made this PR, maybe it will be helpful, but QA and follow-up is necessary and welcomed.
I am looking forward for any feedback.

Regards
Zoran  