### PR TITLE
Fix bug#11219 - Uninitialized warning in Kernel::Output::HTML::Dashboard...

### DIFF
--- a/Kernel/Output/HTML/DashboardCalendar.pm
+++ b/Kernel/Output/HTML/DashboardCalendar.pm
@@ -127,6 +127,10 @@ sub Run {
             my $TimeStamp;
             my $TimeTill;
             if ( $Type eq 'Escalation' ) {
+
+                next TICKETID if !$Ticket{EscalationTime};
+                next TICKETID if !$Ticket{EscalationDestinationDate};
+
                 $TimeTill  = $Ticket{EscalationTime};
                 $TimeStamp = $Ticket{EscalationDestinationDate};
             }


### PR DESCRIPTION
This PR is the fix for bug#11219.
See http://bugs.otrs.org/show_bug.cgi?id=11219.
