### PR TITLE
Fix bug#11226 - Update Base.pm

### DIFF
--- a/Kernel/System/ProcessManagement/TransitionAction/Base.pm
+++ b/Kernel/System/ProcessManagement/TransitionAction/Base.pm
@@ -80,13 +80,14 @@ sub _ReplaceTicketAttributes {
         # replace ticket attributes such as <OTRS_Ticket_Dynamic_Field_Name1> or
         # <OTRS_TICKET_Dynamic_Field_Name1>
         # <OTRS_Ticket_*> is deprecated and should be removed in further versions of OTRS
-        while (
-            $Param{Config}->{$Attribute}
-            && $Param{Config}->{$Attribute} =~ m{<OTRS_(?i:TICKET)_([A-Za-z0-9_]+)>}msx
-            )
+        for ( my $replacement = 0;
+            $replacement <= 1000 
+            && $Param{Config}->{$Attribute}
+            && $Param{Config}->{$Attribute} =~ m{<OTRS_TICKET_([A-Za-z0-9_]+)>}misx;
+            $replacement++ )
         {
             my $TicketAttribute = $1;
-            $Param{Config}->{$Attribute} =~ s/<OTRS_(?i:TICKET)_$1>/$Param{Ticket}->{$TicketAttribute}/msxg // '';
+            $Param{Config}->{$Attribute} =~ s/<OTRS_TICKET_$1>/$Param{Ticket}->{$TicketAttribute}/misxg // '';
         }
     }
 

--- a/Kernel/System/ProcessManagement/TransitionAction/Base.pm
+++ b/Kernel/System/ProcessManagement/TransitionAction/Base.pm
@@ -80,13 +80,13 @@ sub _ReplaceTicketAttributes {
         # replace ticket attributes such as <OTRS_Ticket_Dynamic_Field_Name1> or
         # <OTRS_TICKET_Dynamic_Field_Name1>
         # <OTRS_Ticket_*> is deprecated and should be removed in further versions of OTRS
-        if (
+        while (
             $Param{Config}->{$Attribute}
-            && $Param{Config}->{$Attribute} =~ m{\A<OTRS_(?:Ticket|TICKET)_([A-Za-z0-9_]+)>\z}msx
+            && $Param{Config}->{$Attribute} =~ m{<OTRS_(?i:TICKET)_([A-Za-z0-9_]+)>}msx
             )
         {
             my $TicketAttribute = $1;
-            $Param{Config}->{$Attribute} = $Param{Ticket}->{$TicketAttribute} //= '';
+            $Param{Config}->{$Attribute} =~ s/<OTRS_(?i:TICKET)_$1>/$Param{Ticket}->{$TicketAttribute}/msxg; #//= '';
         }
     }
 

--- a/Kernel/System/ProcessManagement/TransitionAction/Base.pm
+++ b/Kernel/System/ProcessManagement/TransitionAction/Base.pm
@@ -86,7 +86,7 @@ sub _ReplaceTicketAttributes {
             )
         {
             my $TicketAttribute = $1;
-            $Param{Config}->{$Attribute} =~ s/<OTRS_(?i:TICKET)_$1>/$Param{Ticket}->{$TicketAttribute}/msxg; #//= '';
+            $Param{Config}->{$Attribute} =~ s/<OTRS_(?i:TICKET)_$1>/$Param{Ticket}->{$TicketAttribute}/msxg // '';
         }
     }
 


### PR DESCRIPTION
1. why use __|__ for case in __?:__ instead of just __?i:__ ?
2. Without following changes the tag is replaced only if there is nothing but it in the field.
 1. changed regexp (deleted __\A__ and __\z__), so it would work also if there something except a tag in the field. Without this change the tag is replaced only if there is nothing but it in the field.
 2. replaced the __if__ statement with a __while__ cycle, so multiple tags may be processed
    1. added __g__ key in __s///__ in case some tags are repeating multiple times.

* http://forums.otterhub.org/viewtopic.php?f=62&t=22916&p=116147#p116147 - related forum thread
* http://otrs.ru/forum/viewtopic.php?f=5&t=3042&p=15896#p15896 - related russian forum thread
* http://bugs.otrs.org/show__bug.cgi?id=11226 - related bug