### PR TITLE
SASL authentication for LDAP

### DIFF
--- a/Kernel/Config/Defaults.pm
+++ b/Kernel/Config/Defaults.pm
@@ -174,7 +174,7 @@ sub LoadDefaults {
         'hr' => 'Hrvatski',
         'hu' => 'Magyar',
         'it' => 'Italiano',
-        'ja' => 'Japanese (&#x65e5;&#x672c;&#x8a9e)',
+        'ja' => 'Japanese (&#x65e5;&#x672c;&#x8a9e;)',
         'lt' => 'Lietuvių kalba',
         'lv' => 'Latvijas',
         'ms' => 'Malay',

--- a/Kernel/Config/Defaults.pm
+++ b/Kernel/Config/Defaults.pm
@@ -360,6 +360,10 @@ sub LoadDefaults {
     # for non ldap posixGroups objectclass (with full user dn)
 #    $Self->{'AuthModule::LDAP::UserAttr'} = 'DN';
 
+    # The SASL authentication mechanism to bind to the LDAP server
+    # examples: GSSAPI DIGEST-MD5 PLAIN CRAM-MD5 EXTERNAL ANONYMOUS
+#    $Self->{'AuthModule::LDAP::SASL'} = '';
+
     # The following is valid but would only be necessary if the
     # anonymous user do NOT have permission to read from the LDAP tree
 #    $Self->{'AuthModule::LDAP::SearchUserDN'} = '';
@@ -432,6 +436,10 @@ sub LoadDefaults {
 #    $Self->{'AuthSyncModule::LDAP::Host'} = 'ldap.example.com';
 #    $Self->{'AuthSyncModule::LDAP::BaseDN'} = 'dc=example,dc=com';
 #    $Self->{'AuthSyncModule::LDAP::UID'} = 'uid';
+
+    # The SASL authentication mechanism to bind to the LDAP server
+    # examples: GSSAPI DIGEST-MD5 PLAIN CRAM-MD5 EXTERNAL ANONYMOUS
+#    $Self->{'AuthSyncModule::LDAP::SASL'} = '';
 
     # The following is valid but would only be necessary if the
     # anonymous user do NOT have permission to read from the LDAP tree
@@ -1260,6 +1268,10 @@ via the Preferences button after logging in.
     # for non ldap posixGroups objectclass (full user dn)
 #    $Self->{'Customer::AuthModule::LDAP::UserAttr'} = 'DN';
 
+    # The SASL authentication mechanism to bind to the LDAP server
+    # examples: GSSAPI DIGEST-MD5 PLAIN CRAM-MD5 EXTERNAL ANONYMOUS
+#    $Self->{'Customer::AuthModule::LDAP::SASL'} = '';
+
     # The following is valid but would only be necessary if the
     # anonymous user do NOT have permission to read from the LDAP tree
 #    $Self->{'Customer::AuthModule::LDAP::SearchUserDN'} = '';
@@ -1416,6 +1428,8 @@ via the Preferences button after logging in.
 #            BaseDN => 'ou=seas,o=csuh',
 #            # search scope (one|sub)
 #            SSCOPE => 'sub',
+#            # the SASL authentication mechanism to bind to the LDAP server
+#            SASL => '', # ie: DIGEST-MD5 PLAIN CRAM-MD5 EXTERNAL ANONYMOUS GSSAPI
 #            # The following is valid but would only be necessary if the
 #            # anonymous user does NOT have permission to read from the LDAP tree
 #            UserDN => '',

--- a/Kernel/Config/Files/Framework.xml
+++ b/Kernel/Config/Files/Framework.xml
@@ -152,7 +152,7 @@
                 <Item Key="hr">Hrvatski</Item>
                 <Item Key="hu">Magyar</Item>
                 <Item Key="it">Italiano</Item>
-                <Item Key="ja">Japanese (&amp;#x65e5;&amp;#x672c;&amp;#x8a9e)</Item>
+                <Item Key="ja">Japanese (&amp;#x65e5;&amp;#x672c;&amp;#x8a9e;)</Item>
                 <Item Key="lt">Lietuvi&#371; kalba</Item>
                 <Item Key="lv">Latvijas</Item>
                 <Item Key="ms">Malay</Item>

--- a/Kernel/Config/Files/Framework.xml
+++ b/Kernel/Config/Files/Framework.xml
@@ -4132,6 +4132,14 @@ via the Preferences button after logging in.
             </Option>
         </Setting>
     </ConfigItem>
+    <ConfigItem Name="Customer::AuthModule::LDAP::SASL" Required="0" Valid="0" ConfigLevel="200">
+        <Description Translatable="1">If "LDAP" was selected for Customer::AuthModule and your users have only anonymous access to the LDAP tree, but you want to search through the data, you can do this with a user who has access to the LDAP directory. Specify the SASL authentication mechanism here.</Description>
+        <Group>Framework</Group>
+        <SubGroup>Frontend::Customer::Auth</SubGroup>
+        <Setting>
+            <String Regex="">GSSAPI</String>
+        </Setting>
+    </ConfigItem>
     <ConfigItem Name="Customer::AuthModule::LDAP::SearchUserDN" Required="0" Valid="0" ConfigLevel="200">
         <Description Translatable="1">If "LDAP" was selected for Customer::AuthModule and your users have only anonymous access to the LDAP tree, but you want to search through the data, you can do this with a user who has access to the LDAP directory. Specify the username for this special user here.</Description>
         <Group>Framework</Group>

--- a/Kernel/Modules/AdminCustomerUser.pm
+++ b/Kernel/Modules/AdminCustomerUser.pm
@@ -815,6 +815,7 @@ sub _Edit {
     ENTRY:
     for my $Entry ( @{ $ConfigObject->Get( $Param{Source} )->{Map} } ) {
         next ENTRY if !$Entry->[0];
+	next ENTRY if $Entry->[5] =~ /^image\//;
 
         my $Block = 'Input';
 

--- a/Kernel/Output/HTML/LayoutTicket.pm
+++ b/Kernel/Output/HTML/LayoutTicket.pm
@@ -117,6 +117,15 @@ sub AgentCustomerViewTable {
                 Key   => $Field->[1],
                 Value => $Param{Data}->{ $Field->[0] },
             );
+
+            if ($Field->[5] =~ /^image\/.+/) {
+                    use MIME::Base64;
+                    $Record{LinkStart} = "<img style=\"max-width:96px;max-height:96px;\" src=\"data:$Field->[5];base64," .
+                                         MIME::Base64::encode_base64($Param{Data}->{ $Field->[0] }, '') .
+                                         "\" alt=\"$Field->[1]\" />";
+                    $Record{Value} = "";
+            }
+
             if ( $Field->[6] ) {
                 $Record{LinkStart} = "<a href=\"$Field->[6]\"";
                 if ( $Field->[8] ) {

--- a/Kernel/System/Auth/LDAP.pm
+++ b/Kernel/System/Auth/LDAP.pm
@@ -66,6 +66,7 @@ sub new {
         );
         return;
     }
+    $Self->{SASL}         = $ConfigObject->Get( 'AuthModule::LDAP::SASL' . $Param{Count} ) || '';
     $Self->{SearchUserDN} = $ConfigObject->Get( 'AuthModule::LDAP::SearchUserDN' . $Param{Count} ) || '';
     $Self->{SearchUserPw} = $ConfigObject->Get( 'AuthModule::LDAP::SearchUserPw' . $Param{Count} ) || '';
     $Self->{GroupDN}      = $ConfigObject->Get( 'AuthModule::LDAP::GroupDN' . $Param{Count} )
@@ -179,14 +180,33 @@ sub Auth {
         }
     }
     my $Result = '';
-    if ( $Self->{SearchUserDN} && $Self->{SearchUserPw} ) {
-        $Result = $LDAP->bind(
-            dn       => $Self->{SearchUserDN},
-            password => $Self->{SearchUserPw}
-        );
-    }
-    else {
-        $Result = $LDAP->bind();
+    if ($Self->{SASL}) {
+        eval 'use Authen::SASL';
+        if ($@) {
+            $Kernel::OM->Get('Kernel::System::Log')->Log(
+                Priority => 'error',
+                Message  => $@,
+            );
+        }
+        my $SASL = Authen::SASL->new(mechanism => $Self->{SASL});
+        # sasl bind with username and password
+        if ( $Self->{SearchUserDN} && $Self->{SearchUserPw} ) {
+            $SASL->callback(user => $Self->{SearchUserDN} );
+            $SASL->callback(pass => $Self->{SearchUserPw} );
+            $Result = $Self->{LDAP}->bind( $Self->{SearchUserDN}, sasl => $SASL );
+        } else {
+            $Result = $Self->{LDAP}->bind(sasl => $SASL);
+        }
+    } else {
+        if ( $Self->{SearchUserDN} && $Self->{SearchUserPw} ) {
+            $Result = $LDAP->bind(
+                dn       => $Self->{SearchUserDN},
+                password => $Self->{SearchUserPw}
+            );
+        }
+        else {
+            $Result = $LDAP->bind();
+        }
     }
     if ( $Result->code() ) {
         $Kernel::OM->Get('Kernel::System::Log')->Log(

--- a/bin/otrs.CheckModules.pl
+++ b/bin/otrs.CheckModules.pl
@@ -175,6 +175,28 @@ my @NeededModules = (
         },
     },
     {
+        Module    => 'Authen::SASL',
+        Required  => 0,
+        Comment   => 'Required for SASL authentication to LDAP server.',
+        InstTypes => {
+            aptget => 'libauthen-sasl-perl',
+            ppm    => 'Authen-SASL',
+            zypper => 'perl-Authen-SASL',
+        },
+        Depends => [
+            {
+                Module    => 'GSSAPI',
+                Required  => 0,
+                Comment   => 'Required for the GSSAPI SASL authentication mechanism.',
+                InstTypes => {
+                    aptget => 'libgssapi-perl',
+                    ppm    => 'GSSAPI',
+                    zypper => 'perl-GSSAPI',
+                },
+            },
+        ],
+    },
+    {
         Module    => 'Crypt::Eksblowfish::Bcrypt',
         Required  => 0,
         Comment   => 'For strong password hashing.',


### PR DESCRIPTION
This patch implements (optional) SASL authentication in all LDAP binds:
I tested it with GSSAPI (Kerberos) only, but I have no reason to think it won't work with the other mechanisms.
I also added new optional dependencies in otrs.CheckModules.pl:
- Authen::SASL
- GSSAPI

There is also a typo fix in the language list in preferences, for Japanese.
