### PR TITLE
Don't display 0 accounted time in articles (IB#1040541)

### DIFF
--- a/Kernel/Modules/AgentTicketZoom.pm
+++ b/Kernel/Modules/AgentTicketZoom.pm
@@ -1,6 +1,7 @@
 # --
 # Kernel/Modules/AgentTicketZoom.pm - to get a closer view
 # Copyright (C) 2001-2014 OTRS AG, http://otrs.com/
+# Copyright (C) 2015 Informatyka Boguslawski sp. z o.o. sp.k., http://www.ib.pl/
 # --
 # This software comes with ABSOLUTELY NO WARRANTY. For details, see
 # the enclosed file COPYING for license information (AGPL). If you
@@ -2302,13 +2303,16 @@ sub _ArticleItem {
         my $ArticleTime = $Self->{TicketObject}->ArticleAccountedTimeGet(
             ArticleID => $Article{ArticleID}
         );
-        $Self->{LayoutObject}->Block(
-            Name => 'ArticleAccountedTime',
-            Data => {
-                Key   => 'Time',
-                Value => $ArticleTime,
-            },
-        );
+
+        if ($ArticleTime) {
+            $Self->{LayoutObject}->Block(
+                Name => 'ArticleAccountedTime',
+                Data => {
+                    Key   => 'Time',
+                    Value => $ArticleTime,
+                },
+            );
+        };
     }
 
     # get the dynamic fields for article object


### PR DESCRIPTION
https://dev.ib.pl/ib/otrs-ib/issues/13

Please merge to master if you find it useful (we still use 3.3 for devel now and will try to be more compatible in the future).

Other ideas:
* adding extra parameter in sysconfig might be better for hiding 0 accounted times in articles and in tickets maybe,
* consider adding indexes on article.create_time and time_accounting.create_time columns in db schema to allow optimal searching (in custom queries/stats for example) for accounting data in given period and for articles without accounting time defined by mistake). 

Regards,
Pawel