### PR TITLE
AgentTicketBulk: Redirect to Zoom if only one Ticket comes out

### DIFF
--- a/Kernel/Modules/AgentTicketBulk.pm
+++ b/Kernel/Modules/AgentTicketBulk.pm
@@ -317,6 +317,7 @@ sub Run {
 
     # process tickets
     my @TicketIDSelected;
+    my @ResultTicketIDs;
     my $LockedTickets = '';
     my $ActionFlag    = 0;
     my $Counter       = 1;
@@ -429,6 +430,7 @@ sub Run {
 
         # do some actions on tickets
         if ( ( $Self->{Subaction} eq 'Do' ) && ( !%Error ) ) {
+            push @ResultTicketIDs, $TicketID;
 
             # challenge token check for write action
             $Self->{LayoutObject}->ChallengeTokenCheck();
@@ -695,6 +697,7 @@ sub Run {
                     MergeTicketID => $TicketID,
                     UserID        => $Self->{UserID},
                 );
+                @ResultTicketIDs = ( $MainTicketID );
             }
 
             # link all tickets to a parent
@@ -750,8 +753,12 @@ sub Run {
 
     # redirect
     if ($ActionFlag) {
+        my $DestURL = @ResultTicketIDs == 1
+            ? "Action=AgentTicketZoom;TicketID=$ResultTicketIDs[0]"
+            : ( $Self->{LastScreenOverview} || 'Action=AgentDashboard' );
+
         return $Self->{LayoutObject}->PopupClose(
-            URL => ( $Self->{LastScreenOverview} || 'Action=AgentDashboard' ),
+            URL => $DestURL,
         );
     }
 

--- a/Kernel/Modules/AgentTicketBulk.pm
+++ b/Kernel/Modules/AgentTicketBulk.pm
@@ -317,7 +317,6 @@ sub Run {
 
     # process tickets
     my @TicketIDSelected;
-    my @ResultTicketIDs;
     my $LockedTickets = '';
     my $ActionFlag    = 0;
     my $Counter       = 1;
@@ -430,8 +429,6 @@ sub Run {
 
         # do some actions on tickets
         if ( ( $Self->{Subaction} eq 'Do' ) && ( !%Error ) ) {
-            push @ResultTicketIDs, $TicketID;
-
             # challenge token check for write action
             $Self->{LayoutObject}->ChallengeTokenCheck();
 
@@ -697,7 +694,6 @@ sub Run {
                     MergeTicketID => $TicketID,
                     UserID        => $Self->{UserID},
                 );
-                @ResultTicketIDs = ( $MainTicketID );
             }
 
             # link all tickets to a parent
@@ -753,8 +749,8 @@ sub Run {
 
     # redirect
     if ($ActionFlag) {
-        my $DestURL = @ResultTicketIDs == 1
-            ? "Action=AgentTicketZoom;TicketID=$ResultTicketIDs[0]"
+        my $DestURL = defined $MainTicketID
+            ? "Action=AgentTicketZoom;TicketID=$MainTicketID"
             : ( $Self->{LastScreenOverview} || 'Action=AgentDashboard' );
 
         return $Self->{LayoutObject}->PopupClose(


### PR DESCRIPTION
if the bulk action involves only one ticket, or one of the action is to
merge all tickets into one, redirect to the AgentTicketZoom view of
that one ticket after successfully doing the bulk action.

This makes for a much smoother user experience, since usually people
want to actually work with the ticket that they just merged.