### PR TITLE
WA 4 SMIMEv3 (Content-Type: application/octet-stream)

### DIFF
--- a/Kernel/Output/HTML/ArticleCheckSMIME.pm
+++ b/Kernel/Output/HTML/ArticleCheckSMIME.pm
@@ -123,6 +123,18 @@ sub Check {
         $Head->combine('Content-Type');
         my $ContentType = $Head->get('Content-Type');
 
+        # workaround for handling SMIME v3 messages (Content-Type: application/octet-stream; name="smime.p7m")
+        if (
+            $ContentType
+            && $ContentType =~ /application\/octet-stream;\s+name="smime.p7m"/i
+            )
+        {
+            $Message =~ s/application\/octet-stream;/application\/pkcs7-mime;/g
+            $ContentType =~ s/application\/octet-stream;/application\/pkcs7-mime;/g
+        }
+        # EO workaround for handling SMIME v3 messages (Content-Type: application/octet-stream; name="smime.p7m")
+
+
         if (
             $ContentType
             && $ContentType =~ /application\/(x-pkcs7|pkcs7)-mime/i


### PR DESCRIPTION
This PR provides a simple (and maybe dirty, but working) work around for decrypting SMIMEv3 messages. OTRS as openssl cannot handle messages with content type application/octet-stream; name="smime.p7m" resulting in not being able to decrypt messages from Lotus Notes and some MS Outlook Versions, probably depending on the way the PKI is set up. If the incoming messages content type is manipulated in the suggested way, decrypting works as desired.