### PR TITLE
Master port to OM  - Kernel/Output/Article

### DIFF
--- a/Kernel/Config/Files/Ticket.xml
+++ b/Kernel/Config/Files/Ticket.xml
@@ -5906,7 +5906,7 @@
         <SubGroup>Frontend::Agent::Ticket::ArticleViewModule</SubGroup>
         <Setting>
             <Hash>
-                <Item Key="Module">Kernel::Output::HTML::ArticleCheckPGP</Item>
+                <Item Key="Module">Kernel::Output::HTML::Article::CheckPGP</Item>
             </Hash>
         </Setting>
     </ConfigItem>
@@ -5916,7 +5916,7 @@
         <SubGroup>Frontend::Agent::Ticket::ArticleViewModule</SubGroup>
         <Setting>
             <Hash>
-                <Item Key="Module">Kernel::Output::HTML::ArticleCheckSMIME</Item>
+                <Item Key="Module">Kernel::Output::HTML::Article::CheckSMIME</Item>
             </Hash>
         </Setting>
     </ConfigItem>
@@ -5936,7 +5936,7 @@
         <SubGroup>Frontend::Agent::Ticket::ArticleViewModulePre</SubGroup>
         <Setting>
             <Hash>
-                <Item Key="Module">Kernel::Output::HTML::ArticleCheckSMIME</Item>
+                <Item Key="Module">Kernel::Output::HTML::Article::CheckSMIME</Item>
             </Hash>
         </Setting>
     </ConfigItem>
@@ -5946,7 +5946,7 @@
         <SubGroup>Frontend::Agent::Ticket::ArticleComposeModule</SubGroup>
         <Setting>
             <Hash>
-                <Item Key="Module">Kernel::Output::HTML::ArticleComposeSign</Item>
+                <Item Key="Module">Kernel::Output::HTML::Article::ComposeSign</Item>
             </Hash>
         </Setting>
     </ConfigItem>
@@ -5956,7 +5956,7 @@
         <SubGroup>Frontend::Agent::Ticket::ArticleComposeModule</SubGroup>
         <Setting>
             <Hash>
-                <Item Key="Module">Kernel::Output::HTML::ArticleComposeCrypt</Item>
+                <Item Key="Module">Kernel::Output::HTML::Article::ComposeCrypt</Item>
             </Hash>
         </Setting>
     </ConfigItem>
@@ -5966,7 +5966,7 @@
         <SubGroup>Frontend::Agent::Ticket::ArticleAttachmentModule</SubGroup>
         <Setting>
             <Hash>
-                <Item Key="Module">Kernel::Output::HTML::ArticleAttachmentDownload</Item>
+                <Item Key="Module">Kernel::Output::HTML::Article::AttachmentDownload</Item>
             </Hash>
         </Setting>
     </ConfigItem>
@@ -5976,7 +5976,7 @@
         <SubGroup>Frontend::Agent::Ticket::ArticleAttachmentModule</SubGroup>
         <Setting>
             <Hash>
-                <Item Key="Module">Kernel::Output::HTML::ArticleAttachmentHTMLViewer</Item>
+                <Item Key="Module">Kernel::Output::HTML::Article::AttachmentHTMLViewer</Item>
             </Hash>
         </Setting>
     </ConfigItem>

--- a/Kernel/Output/HTML/Article/AttachmentDownload.pm
+++ b/Kernel/Output/HTML/Article/AttachmentDownload.pm
@@ -1,5 +1,4 @@
 # --
-# Kernel/Output/HTML/Article/AttachmentDownload.pm
 # Copyright (C) 2001-2015 OTRS AG, http://otrs.com/
 # --
 # This software comes with ABSOLUTELY NO WARRANTY. For details, see
@@ -35,7 +34,7 @@ sub Run {
     for my $Needed (qw(File Article)) {
         if ( !$Param{$Needed} ) {
             $Kernel::OM->Get('Kernel::System::Log')->Log(
-                 Priority => 'error',
+                Priority => 'error',
                 Message  => "Need $Needed!"
             );
             return;

--- a/Kernel/Output/HTML/Article/AttachmentHTMLViewer.pm
+++ b/Kernel/Output/HTML/Article/AttachmentHTMLViewer.pm
@@ -1,5 +1,4 @@
 # --
-# Kernel/Output/HTML/Article/AttachmentHTMLViewer.pm
 # Copyright (C) 2001-2015 OTRS AG, http://otrs.com/
 # --
 # This software comes with ABSOLUTELY NO WARRANTY. For details, see
@@ -35,7 +34,7 @@ sub Run {
     for my $Needed (qw(File Article)) {
         if ( !$Param{$Needed} ) {
             $Kernel::OM->Get('Kernel::System::Log')->Log(
-                    Priority => 'error',
+                Priority => 'error',
                 Message  => "Need $Needed!"
             );
             return;

--- a/Kernel/Output/HTML/Article/CheckPGP.pm
+++ b/Kernel/Output/HTML/Article/CheckPGP.pm
@@ -1,5 +1,4 @@
 # --
-# Kernel/Output/HTML/Article/CheckPGP.pm
 # Copyright (C) 2001-2015 OTRS AG, http://otrs.com/
 # --
 # This software comes with ABSOLUTELY NO WARRANTY. For details, see
@@ -37,7 +36,7 @@ sub new {
         }
         else {
             $Kernel::OM->Get('Kernel::System::Log')->Log(
-                     Priority => 'error',
+                Priority => 'error',
                 Message  => "Need $Needed!"
             );
         }

--- a/Kernel/Output/HTML/Article/CheckSMIME.pm
+++ b/Kernel/Output/HTML/Article/CheckSMIME.pm
@@ -1,5 +1,4 @@
 # --
-# Kernel/Output/HTML/ArticleCheckSMIME.pm
 # Copyright (C) 2001-2015 OTRS AG, http://otrs.com/
 # --
 # This software comes with ABSOLUTELY NO WARRANTY. For details, see
@@ -7,7 +6,7 @@
 # did not receive this file, see http://www.gnu.org/licenses/agpl.txt.
 # --
 
-package Kernel::Output::HTML::ArticleCheckSMIME;
+package Kernel::Output::HTML::Article::CheckSMIME;
 
 use strict;
 use warnings;

--- a/Kernel/Output/HTML/Article/ComposeCrypt.pm
+++ b/Kernel/Output/HTML/Article/ComposeCrypt.pm
@@ -1,5 +1,4 @@
 # --
-# Kernel/Output/HTML/Article/ComposeCrypt.pm
 # Copyright (C) 2001-2015 OTRS AG, http://otrs.com/
 # --
 # This software comes with ABSOLUTELY NO WARRANTY. For details, see
@@ -63,7 +62,7 @@ sub Run {
     }
     my @SearchAddress = ();
     if ($Recipient) {
-        @SearchAddress =    Mail::Address->parse($Recipient);
+        @SearchAddress = Mail::Address->parse($Recipient);
     }
 
     my $Class;

--- a/Kernel/Output/HTML/ArticleAttachmentDownload.pm
+++ b/Kernel/Output/HTML/ArticleAttachmentDownload.pm
@@ -12,6 +12,12 @@ package Kernel::Output::HTML::ArticleAttachmentDownload;
 use strict;
 use warnings;
 
+our @ObjectDependencies = (
+    'Kernel::System::Log',
+    'Kernel::Config',
+    'Kernel::Output::HTML::Layout',
+);
+
 sub new {
     my ( $Type, %Param ) = @_;
 
@@ -19,10 +25,6 @@ sub new {
     my $Self = {};
     bless( $Self, $Type );
 
-    # get needed objects
-    for (qw(ConfigObject LogObject DBObject LayoutObject UserID TicketObject ArticleID)) {
-        $Self->{$_} = $Param{$_} || die "Got no $_!";
-    }
     return $Self;
 }
 
@@ -32,7 +34,7 @@ sub Run {
     # check needed stuff
     for (qw(File Article)) {
         if ( !$Param{$_} ) {
-            $Self->{LogObject}->Log(
+            $Kernel::OM->Get('Kernel::System::Log')->Log(
                 Priority => 'error',
                 Message  => "Need $_!"
             );
@@ -41,7 +43,7 @@ sub Run {
     }
 
     # download type
-    my $Type = $Self->{ConfigObject}->Get('AttachmentDownloadType') || 'attachment';
+    my $Type = $Kernel::OM->Get('Kernel::Config')->Get('AttachmentDownloadType') || 'attachment';
 
     # if attachment will be forced to download, don't open a new download window!
     my $Target = 'target="AttachmentWindow" ';
@@ -52,7 +54,7 @@ sub Run {
     return (
         %{ $Param{File} },
         Action => 'Download',
-        Link   => $Self->{LayoutObject}->{Baselink} .
+        Link   => $Kernel::OM->Get('Kernel::Output::HTML::Layout')->{Baselink} .
             "Action=AgentTicketAttachment;ArticleID=$Param{Article}->{ArticleID};FileID=$Param{File}->{FileID}",
         Image  => 'disk-s.png',
         Target => $Target,

--- a/Kernel/Output/HTML/ArticleAttachmentDownload.pm
+++ b/Kernel/Output/HTML/ArticleAttachmentDownload.pm
@@ -32,11 +32,11 @@ sub Run {
     my ( $Self, %Param ) = @_;
 
     # check needed stuff
-    for (qw(File Article)) {
-        if ( !$Param{$_} ) {
+    for my $Needed (qw(File Article)) {
+        if ( !$Param{$Needed} ) {
             $Kernel::OM->Get('Kernel::System::Log')->Log(
                 Priority => 'error',
-                Message  => "Need $_!"
+                Message  => "Need $Needed!"
             );
             return;
         }

--- a/Kernel/Output/HTML/ArticleAttachmentHTMLViewer.pm
+++ b/Kernel/Output/HTML/ArticleAttachmentHTMLViewer.pm
@@ -32,11 +32,11 @@ sub Run {
     my ( $Self, %Param ) = @_;
 
     # check needed stuff
-    for (qw(File Article)) {
-        if ( !$Param{$_} ) {
+    for my $Needed (qw(File Article)) {
+        if ( !$Param{$Needed} ) {
             $Kernel::OM->Get('Kernel::System::Log')->Log(
                 Priority => 'error',
-                Message  => "Need $_!"
+                Message  => "Need $Needed!"
             );
             return;
         }

--- a/Kernel/Output/HTML/ArticleCheckPGP.pm
+++ b/Kernel/Output/HTML/ArticleCheckPGP.pm
@@ -282,7 +282,6 @@ sub Check {
                 my $EntityCopy = $Entity->dup();
 
                 my $ParserObject = Kernel::System::EmailParser->new(
-                    %{$Self},
                     Entity => $EntityCopy,
                 );
 

--- a/Kernel/Output/HTML/ArticleCheckPGP.pm
+++ b/Kernel/Output/HTML/ArticleCheckPGP.pm
@@ -67,7 +67,7 @@ sub Check {
 
     # get needed objects
     my $TicketObject = $Param{TicketObject} || $Kernel::OM->Get('Kernel::System::Ticket');
-    my $PGPObject          = $Kernel::OM->Get('Kernel::System::Crypt::PGP');
+    my $PGPObject = $Kernel::OM->Get('Kernel::System::Crypt::PGP');
 
     # check inline pgp crypt
     if ( $Param{Article}->{Body} =~ /\A[\s\n]*^-----BEGIN PGP MESSAGE-----/m ) {

--- a/Kernel/Output/HTML/ArticleCheckPGP.pm
+++ b/Kernel/Output/HTML/ArticleCheckPGP.pm
@@ -190,7 +190,6 @@ sub Check {
 
         # create local email parser object
         my $ParserObject = Kernel::System::EmailParser->new(
-            %{$Self},
             Email => $Message,
         );
 

--- a/Kernel/Output/HTML/ArticleCheckPGP.pm
+++ b/Kernel/Output/HTML/ArticleCheckPGP.pm
@@ -32,6 +32,19 @@ sub new {
     my $Self = {};
     bless( $Self, $Type );
 
+    # get needed params
+    for my $Needed (qw(UserID ArticleID)) {
+        if ( $Param{$Needed} ) {
+            $Self->{$Needed} = $Param{$Needed};
+        }
+        else {
+            $Kernel::OM->Get('Kernel::System::Log')->Log(
+                Priority => 'error',
+                Message  => "Need $Needed!"
+            );
+        }
+    }
+
     return $Self;
 }
 
@@ -51,24 +64,10 @@ sub Check {
     return if $Param{Article}->{ArticleType} !~ /email/i;
 
     my $StoreDecryptedData = $ConfigObject->Get('PGP::StoreDecryptedData');
-    my $PGPObject          = $Kernel::OM->Get('Kernel::System::Crypt::PGP');
 
     # get needed objects
     my $TicketObject = $Param{TicketObject} || $Kernel::OM->Get('Kernel::System::Ticket');
-    my $LogObject    = $Param{LogObject}    || $Kernel::OM->Get('Kernel::System::Log');
-
-    # get needed params
-    for (qw(UserID ArticleID)) {
-        if ( $Param{$_} ) {
-            $Self->{$_} = $Param{$_};
-        }
-        else {
-            $Kernel::OM->Get('Kernel::System::Log')->Log(
-                Priority => 'error',
-                Message  => "Need $_!"
-            );
-        }
-    }
+    my $PGPObject          = $Kernel::OM->Get('Kernel::System::Crypt::PGP');
 
     # check inline pgp crypt
     if ( $Param{Article}->{Body} =~ /\A[\s\n]*^-----BEGIN PGP MESSAGE-----/m ) {

--- a/Kernel/Output/HTML/ArticleCheckSMIME.pm
+++ b/Kernel/Output/HTML/ArticleCheckSMIME.pm
@@ -28,6 +28,19 @@ sub new {
     my $Self = {};
     bless( $Self, $Type );
 
+    # get needed params
+    for my $Needed (qw(UserID ArticleID)) {
+        if ( $Param{$Needed} ) {
+            $Self->{$Needed} = $Param{$Needed};
+        }
+        else {
+            $Kernel::OM->Get('Kernel::System::Log')->Log(
+                Priority => 'error',
+                Message  => "Need $Needed!"
+            );
+        }
+    }
+
     return $Self;
 }
 
@@ -47,24 +60,10 @@ sub Check {
     return if $Param{Article}->{ArticleType} !~ /email/i;
 
     my $StoreDecryptedData = $ConfigObject->Get('SMIME::StoreDecryptedData');
-    my $SMIMEObject        = $Kernel::OM->Get('Kernel::System::Crypt::SMIME');
 
     # get needed objects
-    my $LogObject    = $Param{LogObject}    || $Kernel::OM->Get('Kernel::System::Log');
+    my $SMIMEObject        = $Kernel::OM->Get('Kernel::System::Crypt::SMIME');
     my $TicketObject = $Param{TicketObject} || $Kernel::OM->Get('Kernel::System::Ticket');
-
-    # get needed params
-    for (qw(UserID ArticleID)) {
-        if ( $Param{$_} ) {
-            $Self->{$_} = $Param{$_};
-        }
-        else {
-            $LogObject->Log(
-                Priority => 'error',
-                Message  => "Need $_!"
-            );
-        }
-    }
 
     # check inline smime
     if ( $Param{Article}->{Body} =~ /^-----BEGIN PKCS7-----/ ) {

--- a/Kernel/Output/HTML/ArticleCheckSMIME.pm
+++ b/Kernel/Output/HTML/ArticleCheckSMIME.pm
@@ -240,7 +240,6 @@ sub Check {
 
                 # parse the decrypted email body
                 my $ParserObject = Kernel::System::EmailParser->new(
-                    %{$Self},
                     Email => $EmailContent
                 );
                 my $Body = $ParserObject->GetMessageBody();
@@ -268,7 +267,6 @@ sub Check {
                 # get original sender from email
                 my @OrigEmail = map {"$_\n"} split( /\n/, $Message );
                 my $ParserObjectOrig = Kernel::System::EmailParser->new(
-                    %{$Self},
                     Email => \@OrigEmail,
                 );
 
@@ -370,7 +368,6 @@ sub Check {
                     push( @Email, $_ . "\n" );
                 }
                 my $ParserObject = Kernel::System::EmailParser->new(
-                    %{$Self},
                     Email => \@Email,
                 );
                 my $Body = $ParserObject->GetMessageBody();
@@ -398,7 +395,6 @@ sub Check {
                 # get original sender from email
                 my @OrigEmail = map {"$_\n"} split( /\n/, $Message );
                 my $ParserObjectOrig = Kernel::System::EmailParser->new(
-                    %{$Self},
                     Email => \@OrigEmail,
                 );
 

--- a/Kernel/Output/HTML/ArticleCheckSMIME.pm
+++ b/Kernel/Output/HTML/ArticleCheckSMIME.pm
@@ -102,7 +102,6 @@ sub Check {
         }
 
         my $ParserObject = Kernel::System::EmailParser->new(
-            %{$Self},
             Email => \@Email,
         );
 

--- a/Kernel/Output/HTML/ArticleCheckSMIME.pm
+++ b/Kernel/Output/HTML/ArticleCheckSMIME.pm
@@ -62,7 +62,7 @@ sub Check {
     my $StoreDecryptedData = $ConfigObject->Get('SMIME::StoreDecryptedData');
 
     # get needed objects
-    my $SMIMEObject        = $Kernel::OM->Get('Kernel::System::Crypt::SMIME');
+    my $SMIMEObject = $Kernel::OM->Get('Kernel::System::Crypt::SMIME');
     my $TicketObject = $Param{TicketObject} || $Kernel::OM->Get('Kernel::System::Ticket');
 
     # check inline smime

--- a/Kernel/Output/HTML/ArticleComposeSign.pm
+++ b/Kernel/Output/HTML/ArticleComposeSign.pm
@@ -1,5 +1,5 @@
 # --
-# Kernel/Output/HTML/ArticleComposeSign.pm
+# Kernel/Output/HTML/Article/ComposeSign.pm
 # Copyright (C) 2001-2015 OTRS AG, http://otrs.com/
 # --
 # This software comes with ABSOLUTELY NO WARRANTY. For details, see
@@ -7,7 +7,7 @@
 # did not receive this file, see http://www.gnu.org/licenses/agpl.txt.
 # --
 
-package Kernel::Output::HTML::ArticleComposeSign;
+package Kernel::Output::HTML::Article::ComposeSign;
 
 use strict;
 use warnings;
@@ -74,7 +74,7 @@ sub Run {
     my $LayoutObject = $Kernel::OM->Get('Kernel::Output::HTML::Layout');
 
     my $List = $LayoutObject->BuildSelection(
-        Data       => \%KeyList,
+        Data            => \%KeyList,
         Name       => 'SignKeyID',
         SelectedID => $Param{SignKeyID},
     );

--- a/scripts/test/PGP/EmailHandling.t
+++ b/scripts/test/PGP/EmailHandling.t
@@ -1,5 +1,4 @@
 # --
-# EmailHandling.t - PGP email handling tests
 # Copyright (C) 2001-2015 OTRS AG, http://otrs.com/
 # --
 # This software comes with ABSOLUTELY NO WARRANTY. For details, see
@@ -13,7 +12,7 @@ use utf8;
 
 use vars (qw($Self));
 
-use Kernel::Output::HTML::ArticleCheckPGP;
+use Kernel::Output::HTML::Article::CheckPGP;
 use Kernel::System::PostMaster;
 
 use Kernel::System::VariableCheck qw(:all);
@@ -244,8 +243,8 @@ for my $Test (@Tests) {
             UserID        => 1,
         );
 
-        # use ArticleCheckPGP to decript the article
-        my $CheckObject = Kernel::Output::HTML::ArticleCheckPGP->new(
+        # use Article::CheckPGP to decript the article
+        my $CheckObject = Kernel::Output::HTML::Article::CheckPGP->new(
             ArticleID => $ArticleIDs[0],
             UserID    => 1,
         );
@@ -530,7 +529,7 @@ for my $Test (@TestVariations) {
         ArticleID => $ArticleID,
     );
 
-    my $CheckObject = Kernel::Output::HTML::ArticleCheckPGP->new(
+    my $CheckObject = Kernel::Output::HTML::Article::CheckPGP->new(
         ArticleID => $ArticleID,
         UserID    => 1,
     );

--- a/scripts/test/SMIME/EmailHandling.t
+++ b/scripts/test/SMIME/EmailHandling.t
@@ -1,5 +1,4 @@
 # --
-# EmailHandling.t - SMIME email handling tests
 # Copyright (C) 2001-2015 OTRS AG, http://otrs.com/
 # --
 # This software comes with ABSOLUTELY NO WARRANTY. For details, see
@@ -13,7 +12,7 @@ use utf8;
 
 use vars (qw($Self));
 
-use Kernel::Output::HTML::ArticleCheckSMIME;
+use Kernel::Output::HTML::Article::CheckSMIME;
 
 # get needed objects
 my $ConfigObject    = $Kernel::OM->Get('Kernel::Config');
@@ -484,7 +483,7 @@ for my $Test (@TestVariations) {
         ArticleID => $ArticleID,
     );
 
-    my $CheckObject = Kernel::Output::HTML::ArticleCheckSMIME->new(
+    my $CheckObject = Kernel::Output::HTML::Article::CheckSMIME->new(
         ArticleID => $ArticleID,
         UserID    => 1,
     );

--- a/scripts/test/Selenium/Output/ArticleAttachmentHTMLViewer.t
+++ b/scripts/test/Selenium/Output/ArticleAttachmentHTMLViewer.t
@@ -31,211 +31,138 @@ $Selenium->RunTest(
         );
         my $Helper = $Kernel::OM->Get('Kernel::System::UnitTest::Helper');
 
-        # get sysconfig object
-        my $SysConfigObject = $Kernel::OM->Get('Kernel::System::SysConfig');
-
-        # do not check RichText
-        $SysConfigObject->ConfigItemUpdate(
-            Valid => 1,
-            Key   => 'Frontend::RichText',
-            Value => 0
-        );
-
-        # do not check service and type
-        $SysConfigObject->ConfigItemUpdate(
-            Valid => 1,
-            Key   => 'Ticket::Service',
-            Value => 0
-        );
-        $SysConfigObject->ConfigItemUpdate(
-            Valid => 1,
-            Key   => 'Ticket::Type',
-            Value => 0
-        );
-
-        $SysConfigObject->ConfigItemUpdate(
-            Valid => 1,
-            Key   => 'PDF',
-            Value => 0
-        );
-
-        # enable MIME-Viewer for PDF attachment
-        $SysConfigObject->ConfigItemUpdate(
-            Valid => 1,
-            Key   => 'MIME-Viewer###application/pdf',
-            Value => "pdftohtml -stdout -i",
-        );
-
-        # create test user and login
-        my $TestUserLogin = $Helper->TestUserCreate(
-            Groups => [ 'admin', 'users' ],
-        ) || die "Did not get test user";
-
-        $Selenium->Login(
-            Type     => 'Agent',
-            User     => $TestUserLogin,
-            Password => $TestUserLogin,
-        );
-
-        # get test user ID
-        my $TestUserID = $Kernel::OM->Get('Kernel::System::User')->UserLookup(
-            UserLogin => $TestUserLogin,
-        );
-
-        # create test company
-        my $TestCustomerID    = $Helper->GetRandomID() . "CID";
-        my $TestCompanyName   = "Company" . $Helper->GetRandomID();
-        my $CustomerCompanyID = $Kernel::OM->Get('Kernel::System::CustomerCompany')->CustomerCompanyAdd(
-            CustomerID             => $TestCustomerID,
-            CustomerCompanyName    => $TestCompanyName,
-            CustomerCompanyStreet  => '5201 Blue Lagoon Drive',
-            CustomerCompanyZIP     => '33126',
-            CustomerCompanyCity    => 'Miami',
-            CustomerCompanyCountry => 'USA',
-            CustomerCompanyURL     => 'http://www.example.org',
-            CustomerCompanyComment => 'some comment',
-            ValidID                => 1,
-            UserID                 => $TestUserID,
-        );
-
-        # add test customer for testing
-        my $TestCustomer = 'Customer' . $Helper->GetRandomID();
-        my $UserLogin    = $Kernel::OM->Get('Kernel::System::CustomerUser')->CustomerUserAdd(
-            Source         => 'CustomerUser',
-            UserFirstname  => $TestCustomer,
-            UserLastname   => $TestCustomer,
-            UserCustomerID => $TestCustomerID,
-            UserLogin      => $TestCustomer,
-            UserEmail      => "$TestCustomer\@localhost.com",
-            ValidID        => 1,
-            UserID         => $TestUserID,
-        );
-
-        # create test phone ticket with PDF attachment
-        my $ScriptAlias = $Kernel::OM->Get('Kernel::Config')->Get('ScriptAlias');
-        $Selenium->get("${ScriptAlias}index.pl?Action=AgentTicketPhone");
-
-        # create test phone ticket
-        my $AutoCompleteString = "\"$TestCustomer $TestCustomer\" <$TestCustomer\@localhost.com> ($TestCustomer)";
-        my $AttachmentName     = "StdAttachment-Test1.pdf";
-        my $Location           = $Kernel::OM->Get('Kernel::Config')->Get('Home')
-            . "/scripts/test/sample/StdAttachment/$AttachmentName";
-        $Selenium->find_element( "#FromCustomer", 'css' )->send_keys($TestCustomer);
-        sleep 1;
-        $Selenium->find_element("//*[text()='$AutoCompleteString']")->click();
-        sleep 1;
-        $Selenium->find_element( "#Dest option[value='4||Misc']", 'css' )->click();
-        $Selenium->find_element( "#Subject",                      'css' )->send_keys("Selenium Ticket");
-        $Selenium->find_element( "#RichText",                     'css' )->send_keys("Selenium body test");
-        $Selenium->find_element( "#FileUpload",                   'css' )->send_keys($Location);
-
-        # wait until attachment is upoading
-        ACTIVESLEEP:
-        for my $Second ( 1 .. 20 ) {
-            if ( index( $Selenium->get_page_source(), $AttachmentName ) > -1 ) {
-                last ACTIVESLEEP;
-            }
-            sleep 1;
-        }
-
-        $Selenium->find_element( "#Subject", 'css' )->submit();
-
-        # get ticket object
-        my $TicketObject = $Kernel::OM->Get('Kernel::System::Ticket');
-
-        # search for new created ticket on AgentTicketZoom screen
-        my %TicketIDs = $TicketObject->TicketSearch(
-            Result         => 'HASH',
-            Limit          => 1,
-            CustomerUserID => $TestCustomer,
-            UserID         => $TestUserID,
-        );
-        my $TicketNumber = (%TicketIDs)[1];
-        my $TicketID     = (%TicketIDs)[0];
-
-        my @ArticleIDs = $TicketObject->ArticleIndex(
-            TicketID => (%TicketIDs)[0],
-        );
-
-        # wait until ticket is created
-        ACTIVESLEEP:
-        for my $Second ( 1 .. 20 ) {
-            if ( index( $Selenium->get_page_source(), $TicketNumber ) > -1 ) {
-                last ACTIVESLEEP;
-            }
-            sleep 1;
-        }
-
-        $Self->True(
-            index( $Selenium->get_page_source(), $TicketNumber ) > -1,
-            "Ticket with ticket id $TicketID is created"
-        );
-
-        # go to ticket zoom page of created test ticket
-        $Selenium->find_element("//a[contains(\@href, \'Action=AgentTicketZoom' )]")->click();
-
-        # check are there Downlaod and Viewer liks for test attachment
-        $Self->True(
-            $Selenium->find_element("//a[contains(\@title, \'Download' )]"),
-            "Download link for attachment is founded"
-        );
-
-        $Self->True(
-            $Selenium->find_element("//a[contains(\@title, \'Viewer' )]"),
-            "Viewer link for attachment is founded"
-        );
-
-        # check test attachment in MIME-Viwer
-        $Selenium->find_element("//a[contains(\@title, \'Viewer' )]")->click();
-
-        my $Handles = $Selenium->get_window_handles();
-        $Selenium->switch_to_window( $Handles->[1] );
-
-        # check expexted values in PDF test attachment
-        for my $ExpextedValue (qw( OTRS.org TEST )) {
-            $Self->True(
-                index( $Selenium->get_page_source(), $ExpextedValue ) > -1,
-                "Value is founded on screen - $ExpextedValue"
+        # check if MIME-Viewer exists in file system
+        my $Exist = -e '/usr/bin/pdftohtml';
+        if ( !$Exist ) {
+            $Self->False(
+                $Exist,
+                "Can't find MIME-Viewer for PDF, please install pdftohtml"
             );
         }
-        $Selenium->close();
+        else {
 
-        # delete created test ticket
-        my $Success = $TicketObject->TicketDelete(
-            TicketID => $TicketID,
-            UserID   => 1,
-        );
-        $Self->True(
-            $Success,
-            "Ticket with ticket id $TicketID is deleted"
-        );
+            # get sysconfig object
+            my $SysConfigObject = $Kernel::OM->Get('Kernel::System::SysConfig');
 
-        # delete test customer company
-        my $DBObject = $Kernel::OM->Get('Kernel::System::DB');
-        $Success = $DBObject->Do(
-            SQL  => "DELETE FROM customer_company WHERE customer_id = ?",
-            Bind => [ \$CustomerCompanyID ],
-        );
-        $Self->True(
-            $Success,
-            "Deleted CustomerCompany - $CustomerCompanyID",
-        );
+            # disable  PDF output
+            $SysConfigObject->ConfigItemUpdate(
+                Valid => 1,
+                Key   => 'PDF',
+                Value => 0
+            );
 
-        # delete created test customer user
-        $Success = $DBObject->Do(
-            SQL  => "DELETE FROM customer_user WHERE login = ?",
-            Bind => [ \$TestCustomer ],
-        );
-        $Self->True(
-            $Success,
-            "Deleted CustomerUser - $TestCustomer",
-        );
+            # enable MIME-Viewer for PDF attachment
+            $SysConfigObject->ConfigItemUpdate(
+                Valid => 1,
+                Key   => 'MIME-Viewer###application/pdf',
+                Value => "pdftohtml -stdout -i",
+            );
 
-        # make sure the cache is correct.
-        for my $Cache (qw( Ticket CustomerUser CustomerCompany)) {
-            $Kernel::OM->Get('Kernel::System::Cache')->CleanUp( Type => $Cache );
+            # create test user and login
+            my $TestUserLogin = $Helper->TestUserCreate(
+                Groups => [ 'admin', 'users' ],
+            ) || die "Did not get test user";
+
+            $Selenium->Login(
+                Type     => 'Agent',
+                User     => $TestUserLogin,
+                Password => $TestUserLogin,
+            );
+
+            # get test user ID
+            my $TestUserID = $Kernel::OM->Get('Kernel::System::User')->UserLookup(
+                UserLogin => $TestUserLogin,
+            );
+
+            # get ticket object
+            my $TicketObject = $Kernel::OM->Get('Kernel::System::Ticket');
+
+            # create test ticket
+            my $TicketID = $TicketObject->TicketCreate(
+                Title        => 'Some Ticket Title',
+                Queue        => 'Raw',
+                Lock         => 'unlock',
+                Priority     => '3 normal',
+                State        => 'new',
+                CustomerID   => '123465',
+                CustomerUser => 'customer@example.com',
+                OwnerID      => $TestUserID,
+                UserID       => $TestUserID,
+            );
+
+            # add article to test ticket with PDF test attachment
+            my $Location = $Kernel::OM->Get('Kernel::Config')->Get('Home')
+                . "/scripts/test/sample/StdAttachment/StdAttachment-Test1.pdf";
+
+            my $ContentRef = $Kernel::OM->Get('Kernel::System::Main')->FileRead(
+                Location => $Location,
+                Mode     => 'binmode',
+            );
+            my $Content = ${$ContentRef};
+
+            my $ArticleID = $TicketObject->ArticleCreate(
+                TicketID       => $TicketID,
+                ArticleType    => 'note-internal',
+                SenderType     => 'agent',
+                Subject        => 'some short description',
+                Body           => 'the message text',
+                ContentType    => 'text/html; charset=ISO-8859-15',
+                HistoryType    => 'AddNote',
+                HistoryComment => 'Some free text!',
+                UserID         => $TestUserID,
+                Attachment     => [
+                    {
+                        Content     => $Content,
+                        ContentType => 'application/pdf',
+                        Filename    => 'StdAttachment-Test1.pdf',
+                    },
+                ],
+            );
+
+            # go to ticket zoom page of created test ticket
+            my $ScriptAlias = $Kernel::OM->Get('Kernel::Config')->Get('ScriptAlias');
+            $Selenium->get("${ScriptAlias}index.pl?Action=AgentTicketZoom;TicketID=$TicketID");
+
+            # check are there Downlaod and Viewer liks for test attachment
+            $Self->True(
+                $Selenium->find_element("//a[contains(\@title, \'Download' )]"),
+                "Download link for attachment is founded"
+            );
+            $Self->True(
+                $Selenium->find_element("//a[contains(\@title, \'Viewer' )]"),
+                "Viewer link for attachment is founded"
+            );
+
+            # check test attachment in MIME-Viwer
+            $Selenium->find_element("//a[contains(\@title, \'Viewer' )]")->click();
+
+            my $Handles = $Selenium->get_window_handles();
+            $Selenium->switch_to_window( $Handles->[1] );
+
+            # check expexted values in PDF test attachment
+            for my $ExpextedValue (qw(OTRS.org TEST)) {
+                $Self->True(
+                    index( $Selenium->get_page_source(), $ExpextedValue ) > -1,
+                    "Value is founded on screen - $ExpextedValue"
+                );
+            }
+            $Selenium->close();
+
+            # delete created test ticket
+            my $Success = $TicketObject->TicketDelete(
+                TicketID => $TicketID,
+                UserID   => 1,
+            );
+            $Self->True(
+                $Success,
+                "Ticket with ticket id $TicketID is deleted"
+            );
+
+            # make sure the cache is correct.
+            $Kernel::OM->Get('Kernel::System::Cache')->CleanUp(
+                Type => 'Ticket'
+            );
         }
-
         }
 );
 

--- a/scripts/test/Selenium/Output/ArticleAttachmentHTMLViewer.t
+++ b/scripts/test/Selenium/Output/ArticleAttachmentHTMLViewer.t
@@ -193,7 +193,7 @@ $Selenium->RunTest(
         $Selenium->switch_to_window( $Handles->[1] );
 
         # check expexted values in PDF test attachment
-        for my $ExpextedValue ( qw( OTRS.org TEST ) ) {
+        for my $ExpextedValue (qw( OTRS.org TEST )) {
             $Self->True(
                 index( $Selenium->get_page_source(), $ExpextedValue ) > -1,
                 "Value is founded on screen - $ExpextedValue"
@@ -223,7 +223,7 @@ $Selenium->RunTest(
         );
 
         # delete created test customer user
-        $Success      = $DBObject->Do(
+        $Success = $DBObject->Do(
             SQL  => "DELETE FROM customer_user WHERE login = ?",
             Bind => [ \$TestCustomer ],
         );
@@ -233,11 +233,11 @@ $Selenium->RunTest(
         );
 
         # make sure the cache is correct.
-        for my $Cache ( qw( Ticket CustomerUser CustomerCompany) ){
+        for my $Cache (qw( Ticket CustomerUser CustomerCompany)) {
             $Kernel::OM->Get('Kernel::System::Cache')->CleanUp( Type => $Cache );
         }
 
-    }
+        }
 );
 
 1;

--- a/scripts/test/Selenium/Output/ArticleAttachmentHTMLViewer.t
+++ b/scripts/test/Selenium/Output/ArticleAttachmentHTMLViewer.t
@@ -1,5 +1,4 @@
 # --
-# ArticleAttachmentHTMLViewer.t - frontend tests for ArticleAttachmentHTMLViewer
 # Copyright (C) 2001-2015 OTRS AG, http://otrs.com/
 # --
 # This software comes with ABSOLUTELY NO WARRANTY. For details, see

--- a/scripts/test/Selenium/Output/ArticleAttachmentHTMLViewer.t
+++ b/scripts/test/Selenium/Output/ArticleAttachmentHTMLViewer.t
@@ -1,0 +1,243 @@
+# --
+# ArticleAttachmentHTMLViewer.t - frontend tests for ArticleAttachmentHTMLViewer
+# Copyright (C) 2001-2015 OTRS AG, http://otrs.com/
+# --
+# This software comes with ABSOLUTELY NO WARRANTY. For details, see
+# the enclosed file COPYING for license information (AGPL). If you
+# did not receive this file, see http://www.gnu.org/licenses/agpl.txt.
+# --
+
+use strict;
+use warnings;
+use utf8;
+
+use vars (qw($Self));
+
+# get selenium object
+$Kernel::OM->ObjectParamAdd(
+    'Kernel::System::UnitTest::Selenium' => {
+        Verbose => 1,
+        }
+);
+my $Selenium = $Kernel::OM->Get('Kernel::System::UnitTest::Selenium');
+
+$Selenium->RunTest(
+    sub {
+
+        # get helper object
+        $Kernel::OM->ObjectParamAdd(
+            'Kernel::System::UnitTest::Helper' => {
+                RestoreSystemConfiguration => 1,
+                }
+        );
+        my $Helper = $Kernel::OM->Get('Kernel::System::UnitTest::Helper');
+
+        # get sysconfig object
+        my $SysConfigObject = $Kernel::OM->Get('Kernel::System::SysConfig');
+
+        # do not check RichText
+        $SysConfigObject->ConfigItemUpdate(
+            Valid => 1,
+            Key   => 'Frontend::RichText',
+            Value => 0
+        );
+
+        # do not check service and type
+        $SysConfigObject->ConfigItemUpdate(
+            Valid => 1,
+            Key   => 'Ticket::Service',
+            Value => 0
+        );
+        $SysConfigObject->ConfigItemUpdate(
+            Valid => 1,
+            Key   => 'Ticket::Type',
+            Value => 0
+        );
+
+        $SysConfigObject->ConfigItemUpdate(
+            Valid => 1,
+            Key   => 'PDF',
+            Value => 0
+        );
+
+        # enable MIME-Viewer for PDF attachment
+        $SysConfigObject->ConfigItemUpdate(
+            Valid => 1,
+            Key   => 'MIME-Viewer###application/pdf',
+            Value => "pdftohtml -stdout -i",
+        );
+
+        # create test user and login
+        my $TestUserLogin = $Helper->TestUserCreate(
+            Groups => [ 'admin', 'users' ],
+        ) || die "Did not get test user";
+
+        $Selenium->Login(
+            Type     => 'Agent',
+            User     => $TestUserLogin,
+            Password => $TestUserLogin,
+        );
+
+        # get test user ID
+        my $TestUserID = $Kernel::OM->Get('Kernel::System::User')->UserLookup(
+            UserLogin => $TestUserLogin,
+        );
+
+        # create test company
+        my $TestCustomerID    = $Helper->GetRandomID() . "CID";
+        my $TestCompanyName   = "Company" . $Helper->GetRandomID();
+        my $CustomerCompanyID = $Kernel::OM->Get('Kernel::System::CustomerCompany')->CustomerCompanyAdd(
+            CustomerID             => $TestCustomerID,
+            CustomerCompanyName    => $TestCompanyName,
+            CustomerCompanyStreet  => '5201 Blue Lagoon Drive',
+            CustomerCompanyZIP     => '33126',
+            CustomerCompanyCity    => 'Miami',
+            CustomerCompanyCountry => 'USA',
+            CustomerCompanyURL     => 'http://www.example.org',
+            CustomerCompanyComment => 'some comment',
+            ValidID                => 1,
+            UserID                 => $TestUserID,
+        );
+
+        # add test customer for testing
+        my $TestCustomer = 'Customer' . $Helper->GetRandomID();
+        my $UserLogin    = $Kernel::OM->Get('Kernel::System::CustomerUser')->CustomerUserAdd(
+            Source         => 'CustomerUser',
+            UserFirstname  => $TestCustomer,
+            UserLastname   => $TestCustomer,
+            UserCustomerID => $TestCustomerID,
+            UserLogin      => $TestCustomer,
+            UserEmail      => "$TestCustomer\@localhost.com",
+            ValidID        => 1,
+            UserID         => $TestUserID,
+        );
+
+        # create test phone ticket with PDF attachment
+        my $ScriptAlias = $Kernel::OM->Get('Kernel::Config')->Get('ScriptAlias');
+        $Selenium->get("${ScriptAlias}index.pl?Action=AgentTicketPhone");
+
+        # create test phone ticket
+        my $AutoCompleteString = "\"$TestCustomer $TestCustomer\" <$TestCustomer\@localhost.com> ($TestCustomer)";
+        my $AttachmentName     = "StdAttachment-Test1.pdf";
+        my $Location           = $Kernel::OM->Get('Kernel::Config')->Get('Home')
+            . "/scripts/test/sample/StdAttachment/$AttachmentName";
+        $Selenium->find_element( "#FromCustomer", 'css' )->send_keys($TestCustomer);
+        sleep 1;
+        $Selenium->find_element("//*[text()='$AutoCompleteString']")->click();
+        sleep 1;
+        $Selenium->find_element( "#Dest option[value='4||Misc']", 'css' )->click();
+        $Selenium->find_element( "#Subject",                      'css' )->send_keys("Selenium Ticket");
+        $Selenium->find_element( "#RichText",                     'css' )->send_keys("Selenium body test");
+        $Selenium->find_element( "#FileUpload",                   'css' )->send_keys($Location);
+
+        # wait until attachment is upoading
+        ACTIVESLEEP:
+        for my $Second ( 1 .. 20 ) {
+            if ( index( $Selenium->get_page_source(), $AttachmentName ) > -1 ) {
+                last ACTIVESLEEP;
+            }
+            sleep 1;
+        }
+
+        $Selenium->find_element( "#Subject", 'css' )->submit();
+
+        # get ticket object
+        my $TicketObject = $Kernel::OM->Get('Kernel::System::Ticket');
+
+        # search for new created ticket on AgentTicketZoom screen
+        my %TicketIDs = $TicketObject->TicketSearch(
+            Result         => 'HASH',
+            Limit          => 1,
+            CustomerUserID => $TestCustomer,
+            UserID         => $TestUserID,
+        );
+        my $TicketNumber = (%TicketIDs)[1];
+        my $TicketID     = (%TicketIDs)[0];
+
+        my @ArticleIDs = $TicketObject->ArticleIndex(
+            TicketID => (%TicketIDs)[0],
+        );
+
+        # wait until ticket is created
+        ACTIVESLEEP:
+        for my $Second ( 1 .. 20 ) {
+            if ( index( $Selenium->get_page_source(), $TicketNumber ) > -1 ) {
+                last ACTIVESLEEP;
+            }
+            sleep 1;
+        }
+
+        $Self->True(
+            index( $Selenium->get_page_source(), $TicketNumber ) > -1,
+            "Ticket with ticket id $TicketID is created"
+        );
+
+        # go to ticket zoom page of created test ticket
+        $Selenium->find_element("//a[contains(\@href, \'Action=AgentTicketZoom' )]")->click();
+
+        # check are there Downlaod and Viewer liks for test attachment
+        $Self->True(
+            $Selenium->find_element("//a[contains(\@title, \'Download' )]"),
+            "Download link for attachment is founded"
+        );
+
+        $Self->True(
+            $Selenium->find_element("//a[contains(\@title, \'Viewer' )]"),
+            "Viewer link for attachment is founded"
+        );
+
+        # check test attachment in MIME-Viwer
+        $Selenium->find_element("//a[contains(\@title, \'Viewer' )]")->click();
+
+        my $Handles = $Selenium->get_window_handles();
+        $Selenium->switch_to_window( $Handles->[1] );
+
+        # check expexted values in PDF test attachment
+        for my $ExpextedValue ( qw( OTRS.org TEST ) ) {
+            $Self->True(
+                index( $Selenium->get_page_source(), $ExpextedValue ) > -1,
+                "Value is founded on screen - $ExpextedValue"
+            );
+        }
+        $Selenium->close();
+
+        # delete created test ticket
+        my $Success = $TicketObject->TicketDelete(
+            TicketID => $TicketID,
+            UserID   => 1,
+        );
+        $Self->True(
+            $Success,
+            "Ticket with ticket id $TicketID is deleted"
+        );
+
+        # delete test customer company
+        my $DBObject = $Kernel::OM->Get('Kernel::System::DB');
+        $Success = $DBObject->Do(
+            SQL  => "DELETE FROM customer_company WHERE customer_id = ?",
+            Bind => [ \$CustomerCompanyID ],
+        );
+        $Self->True(
+            $Success,
+            "Deleted CustomerCompany - $CustomerCompanyID",
+        );
+
+        # delete created test customer user
+        $Success      = $DBObject->Do(
+            SQL  => "DELETE FROM customer_user WHERE login = ?",
+            Bind => [ \$TestCustomer ],
+        );
+        $Self->True(
+            $Success,
+            "Deleted CustomerUser - $TestCustomer",
+        );
+
+        # make sure the cache is correct.
+        for my $Cache ( qw( Ticket CustomerUser CustomerCompany) ){
+            $Kernel::OM->Get('Kernel::System::Cache')->CleanUp( Type => $Cache );
+        }
+
+    }
+);
+
+1;


### PR DESCRIPTION
Hi,

There are ported Article modules from Kernel/Output/HTML.
We added only one Selenium test, to be honest I don't know how to test these modules for SMIME/PGP/Sign/Crypt with Selenium, and I think that test for ArticleAttachmentDownload is not needed here, because there is test for AgentTicketAttachment. Here is test for ArticleAttachmentHTMLViewer. There is checked how  MIME-Viwer works, if it is enabled. 

In some modules is used EmailParser.pm (ArticleCheckPGP and ArticleCheckSMIME), and I am not sure if we used it well. We had such dilemma only in this PR https://github.com/OTRS/otrs/pull/521 (line 3053 - AgentTicketZoom.pm). I saw that in  Kernel::System::EmailParser there is  $ObjectManagerDisabled = 1;, maybe because of that we cannot use it with OM.
Also, I delete %{$Self}, from constructor for EmailParser. I think it is not necessary anymore.

And one more thing, I saw that in some modules is used for checking needed prams the flowing
    # check needed stuff
     for (qw(File Article)) { 
... and then in body of for loop is used $_

and in the others also is used 
    # check needed stuff
    for my $Needed (qw(File Article)) {

In my opinion the second one is better and I feel free to fix it in these ported modules. 
As I said it is my opinion, and your follow up is welcome in any of these question and dilemmas.

Regards
Zoran 



