### PR TITLE
Improvment in Selenium testing

### DIFF
--- a/Kernel/cpan-lib/Selenium/Remote/Driver.pm
+++ b/Kernel/cpan-lib/Selenium/Remote/Driver.pm
@@ -1299,7 +1299,7 @@ sub set_window_size {
     }
     my $res = { 'command' => 'setWindowSize', 'window_handle' => $window };
     my $params = { 'height' => $height, 'width' => $width };
-    my $ret = $self->_execute_command($res, $params);
+    my $ret = $self->_execute_command($res, $params) // '';
     if ($ret =~ m/204/g) {
         return 1;
     }


### PR DESCRIPTION
Hi,

While we tested some tests, we saw that there is a issue if it is used Firefox.
In command setWindowSize, there is the following message
<pre><code>
[Thu Apr 30 15:52:12 2015] otrs.Console.pl: Use of uninitialized value $ret in pattern match (m//) at /opt/otrs/Kernel/cpan-lib/Selenium/Remote/Driver.pm line 1303.
</pre></code>

It seems that there is a bug, and I felt free to fix it. Maybe there is better solution if I can solve this on another way please let me now.

P.S. You can check it with AdminType.t but only with Firefox the bug occurs.

Regards
Zoran
