### PR TITLE
Deny customer access to tickets in some queues

### DIFF
--- a/Kernel/Config/Files/Ticket.xml
+++ b/Kernel/Config/Files/Ticket.xml
@@ -1714,6 +1714,15 @@
             </Option>
         </Setting>
     </ConfigItem>
+    <ConfigItem Name="Ticket::Frontend::CustomerDenyQueuesTicketAccess" Required="0" Valid="1">
+        <Description Translatable="1">Deny customer access to tickets in the specified queues.</Description>
+        <Group>Ticket</Group>
+        <SubGroup>Frontend::Customer</SubGroup>
+        <Setting>
+            <Array>
+            </Array>
+        </Setting>
+    </ConfigItem>
     <ConfigItem Name="Ticket::Frontend::CustomerTicketOverviewCustomEmptyText" Required="0" Valid="0">
         <Description Translatable="1">Custom text for the page shown to customers that have no tickets yet (if you need those text translated add them to a custom translation module).</Description>
         <Group>Ticket</Group>

--- a/Kernel/System/Ticket/CustomerPermission/CustomerIDCheck.pm
+++ b/Kernel/System/Ticket/CustomerPermission/CustomerIDCheck.pm
@@ -17,6 +17,7 @@ our @ObjectDependencies = (
     'Kernel::Config',
     'Kernel::System::CustomerUser',
     'Kernel::System::Log',
+    'Kernel::System::Queue',
     'Kernel::System::Ticket',
 );
 
@@ -53,6 +54,15 @@ sub Run {
         TicketID      => $Param{TicketID},
         DynamicFields => 0,
     );
+
+    # Deny access if ticket queue is in Ticket::Frontend::CustomerDenyQueuesTicketAccess
+    for my $Queue (
+        @{ $Kernel::OM->Get('Kernel::Config')->Get('Ticket::Frontend::CustomerDenyQueuesTicketAccess') }
+        )
+    {
+        # no access because ticket queue is in Ticket::Frontend::CustomerDenyQueuesTicketAccess
+        return if ( $Ticket{Queue} eq $Queue );
+    }
 
     # get customer user object
     my $CustomerUserObject = $Kernel::OM->Get('Kernel::System::CustomerUser');

--- a/Kernel/System/Ticket/CustomerPermission/CustomerUserIDCheck.pm
+++ b/Kernel/System/Ticket/CustomerPermission/CustomerUserIDCheck.pm
@@ -14,6 +14,7 @@ use strict;
 use warnings;
 
 our @ObjectDependencies = (
+    'Kernel::Config',
     'Kernel::System::CustomerUser',
     'Kernel::System::Log',
     'Kernel::System::Ticket',
@@ -48,6 +49,15 @@ sub Run {
         TicketID      => $Param{TicketID},
         DynamicFields => 0,
     );
+
+    # Deny access if ticket queue is in Ticket::Frontend::CustomerDenyQueuesTicketAccess
+    for my $Queue (
+        @{ $Kernel::OM->Get('Kernel::Config')->Get('Ticket::Frontend::CustomerDenyQueuesTicketAccess') }
+        )
+    {
+        # no access because ticket queue is in Ticket::Frontend::CustomerDenyQueuesTicketAccess
+        return if ( $Ticket{Queue} eq $Queue );
+    }
 
     # get user data
     my %CustomerData = $Kernel::OM->Get('Kernel::System::CustomerUser')->CustomerUserDataGet(

--- a/Kernel/System/Ticket/TicketSearch.pm
+++ b/Kernel/System/Ticket/TicketSearch.pm
@@ -339,6 +339,11 @@ sub TicketSearch {
         return;
     }
 
+    # if this is a customer search: delete $Param{QueueIDs} if it's empty
+    if ( $Param{CustomerUserID} && ref $Param{QueueIDs} eq 'ARRAY' && !@{ $Param{QueueIDs} } ) {
+        delete $Param{QueueIDs};
+    }
+
     # check types of given arguments
     ARGUMENT:
     for my $Key (
@@ -823,10 +828,21 @@ sub TicketSearch {
 
     # current queue ids
     if ( $Param{QueueIDs} ) {
-        $SQLExt .= $Self->_InConditionGet(
-            TableColumn => 'st.queue_id',
-            IDRef       => $Param{QueueIDs},
-        );
+
+        # this is a user search
+        if ( $Param{UserID} ) {
+            $SQLExt .= $Self->_InConditionGet(
+                TableColumn => 'st.queue_id',
+                IDRef       => $Param{QueueIDs},
+            );
+        }
+        else {
+            # this is a customer search
+            $SQLExt .= $Self->_InConditionGet(
+                TableColumn => 'st.queue_id NOT',
+                IDRef       => $Param{QueueIDs},
+            );
+        }
     }
 
     # created queue lookup


### PR DESCRIPTION
Hello,

in our company we would like to hide some tickets from the customer.
The best solution seems to be hiding the tickets in some queues.
This way the agent will be able to hide or unhide the tickets simply by moving them from one queue to another one.
The queue names for hiding should be changeable via sysconfig.
This pull requeust contains the needed changes.

Could you please check if it makes sense to include this function and could you please review the code changes.

Thanks.
Albrecht