### PR TITLE
Use `CustomerID` param when creating new CustomerUser.

### DIFF
--- a/Kernel/Modules/AdminCustomerUser.pm
+++ b/Kernel/Modules/AdminCustomerUser.pm
@@ -936,6 +936,9 @@ sub _Edit {
                 Class      => $Param{RequiredClass} . ' ' . $Param{Errors}->{ $Entry->[0] . 'Invalid' },
             );
         }
+        elsif ( $Param{Action} eq 'Add' && $Entry->[0] =~ /^UserCustomerID$/i ) {
+            $Param{Value} = $Param{CustomerID};
+        }
         else {
             $Param{Value} = $Param{ $Entry->[0] } || '';
         }


### PR DESCRIPTION
When creating a new user by clicking on `+ Add Customer` in the
CustomerInformationCenter, the param `CustomerID` isn't re-used which
requires the user to fill this field manually which is cumbersome and
error-prone.

In the case of `CustomerCompanySupport` being enabled, the param
`CustomerID` is re-used to set the default selection of the
`CustomerID` drop down.

When `CustomerCompanySupport` is not enabled, the `CustomerID` field
remained empty so far. This patch improves this behaviour and
pre-populates the `CustomerID` field based on the `CustomerID` param
value.