### PR TITLE
Master - Selenium tests replaced go_back function

### DIFF
--- a/scripts/test/Selenium/Agent/Admin/AdminAttachment.t
+++ b/scripts/test/Selenium/Agent/Admin/AdminAttachment.t
@@ -96,7 +96,9 @@ $Selenium->RunTest(
                 'Selenium test attachment',
                 "#Comment updated value",
             );
-            $Selenium->go_back();
+
+            # go back to AdminAttachment overview screen
+            $Selenium->get("${ScriptAlias}index.pl?Action=AdminAttachment");
 
             # check delete button
             my $ID = $Kernel::OM->Get('Kernel::System::StdAttachment')->StdAttachmentLookup(
@@ -105,7 +107,7 @@ $Selenium->RunTest(
             $Selenium->find_element("//a[contains(\@href, \'Subaction=Delete;ID=$ID' )]")->click();
 
         }
-    }
+        }
 );
 
 1;

--- a/scripts/test/Selenium/Agent/Admin/AdminDynamicField.t
+++ b/scripts/test/Selenium/Agent/Admin/AdminDynamicField.t
@@ -106,9 +106,8 @@ $Selenium->RunTest(
                     "#ValidID stored value",
                 );
 
-                $Selenium->go_back();
-
                 # delete DynamicFields, check button for deleting Dynamic Field
+                $Selenium->get("${ScriptAlias}index.pl?Action=AdminDynamicField");
                 my $DynamicFieldID = $Kernel::OM->Get('Kernel::System::DynamicField')->DynamicFieldGet(
                     Name => $RandomID
                 )->{ID};
@@ -150,7 +149,7 @@ $Selenium->RunTest(
             # Make sure the cache is correct.
             $Kernel::OM->Get('Kernel::System::Cache')->CleanUp( Type => "DynamicField" );
         }
-    }
+        }
 );
 
 1;

--- a/scripts/test/Selenium/Agent/Admin/AdminNotificationEvent.t
+++ b/scripts/test/Selenium/Agent/Admin/AdminNotificationEvent.t
@@ -170,7 +170,8 @@ $Selenium->RunTest(
             "#ValidID updated value",
         );
 
-        $Selenium->go_back();
+        # go back to AdminNotificationEvent overview screen
+        $Selenium->get("${ScriptAlias}index.pl?Action=AdminNotificationEvent");
 
         # get NotificationEventID
         my %NotifEventID = $Kernel::OM->Get('Kernel::System::NotificationEvent')->NotificationGet(
@@ -180,7 +181,7 @@ $Selenium->RunTest(
         # delete test SLA with delete button
         $Selenium->find_element("//a[contains(\@href, \'Subaction=Delete;ID=$NotifEventID{ID}' )]")->click();
 
-    }
+        }
 
 );
 

--- a/scripts/test/Selenium/Agent/Admin/AdminPostMasterFilter.t
+++ b/scripts/test/Selenium/Agent/Admin/AdminPostMasterFilter.t
@@ -167,12 +167,13 @@ $Selenium->RunTest(
             "#SetValue1 updated value",
         );
 
-        $Selenium->go_back();
+        # go back to AdminPostMasterFilter screen
+        $Selenium->get("${ScriptAlias}index.pl?Action=AdminPostMasterFilter");
 
         # delete test PostMasterFilter with delete button
         $Selenium->find_element("//a[contains(\@href, \'Subaction=Delete;Name=$PostMasterRandomID' )]")->click();
 
-    }
+        }
 
 );
 

--- a/scripts/test/Selenium/Agent/Admin/AdminRoleGroup.t
+++ b/scripts/test/Selenium/Agent/Admin/AdminRoleGroup.t
@@ -130,7 +130,9 @@ $Selenium->RunTest(
             0,
             "priority permission for group $GroupRandomID is disabled",
         );
-        $Selenium->go_back();
+
+        # go back to AdminRoleGroup screen
+        $Selenium->get("${ScriptAlias}index.pl?Action=AdminRoleGroup");
 
         # edit role relations for test group
         $Selenium->find_element( $GroupRandomID, 'link_text' )->click();
@@ -215,7 +217,7 @@ $Selenium->RunTest(
         $Kernel::OM->Get('Kernel::System::Cache')->CleanUp( Type => 'Group' );
         $Kernel::OM->Get('Kernel::System::Cache')->CleanUp( Type => 'Role' );
 
-    }
+        }
 );
 
 1;

--- a/scripts/test/Selenium/Agent/Admin/AdminTemplate.t
+++ b/scripts/test/Selenium/Agent/Admin/AdminTemplate.t
@@ -145,7 +145,8 @@ $Selenium->RunTest(
             "#ValidID updated value",
         );
 
-        $Selenium->go_back();
+        # go back to AdminTemplate screen
+        $Selenium->get("${ScriptAlias}index.pl?Action=AdminTemplate");
 
         # test template delete button
         my $TemplateID = $Kernel::OM->Get('Kernel::System::StandardTemplate')->StandardTemplateLookup(
@@ -154,7 +155,7 @@ $Selenium->RunTest(
 
         $Selenium->find_element("//a[contains(\@href, \'Subaction=Delete;ID=$TemplateID' )]")->click();
 
-    }
+        }
 );
 
 1;

--- a/scripts/test/Selenium/Agent/Admin/AdminUserGroup.t
+++ b/scripts/test/Selenium/Agent/Admin/AdminUserGroup.t
@@ -125,7 +125,8 @@ $Selenium->RunTest(
             "rw permission for group $RandomID is disabled",
         );
 
-        $Selenium->go_back();
+        # go back to AdminUserGroup screen
+        $Selenium->get("${ScriptAlias}index.pl?Action=AdminUserGroup");
 
         # edit test agent permission for test group
         my $TestGroupID = $Kernel::OM->Get('Kernel::System::Group')->GroupLookup(
@@ -189,7 +190,7 @@ $Selenium->RunTest(
         # Make sure the cache is correct.
         $Kernel::OM->Get('Kernel::System::Cache')->CleanUp( Type => 'Group' );
 
-    }
+        }
 
 );
 

--- a/scripts/test/Selenium/Agent/AdminDynamicField/AdminDynamicFieldCheckbox.t
+++ b/scripts/test/Selenium/Agent/AdminDynamicField/AdminDynamicFieldCheckbox.t
@@ -120,7 +120,8 @@ $Selenium->RunTest(
                 "#DefaultValue updated value",
             );
 
-            $Selenium->go_back();
+            # go back to AdminDynamicField screen
+            $Selenium->get("${ScriptAlias}index.pl?Action=AdminDynamicField");
 
             # delete DynamicFields
             my $DynamicFieldObject = $Kernel::OM->Get('Kernel::System::DynamicField');
@@ -143,7 +144,7 @@ $Selenium->RunTest(
         # delete cache
         $Kernel::OM->Get('Kernel::System::Cache')->CleanUp( Type => "DynamicField" );
 
-    }
+        }
 
 );
 

--- a/scripts/test/Selenium/Agent/AdminDynamicField/AdminDynamicFieldDateTime.t
+++ b/scripts/test/Selenium/Agent/AdminDynamicField/AdminDynamicFieldDateTime.t
@@ -154,7 +154,8 @@ $Selenium->RunTest(
                 "#ValidID updated value",
             );
 
-            $Selenium->go_back();
+            # go back to AdminDynamicField screen
+            $Selenium->get("${ScriptAlias}index.pl?Action=AdminDynamicField");
 
             # delete DynamicFields
             my $DynamicFieldObject = $Kernel::OM->Get('Kernel::System::DynamicField');
@@ -177,7 +178,7 @@ $Selenium->RunTest(
         # make sure cache is correct
         $Kernel::OM->Get('Kernel::System::Cache')->CleanUp( Type => "DynamicField" );
 
-    }
+        }
 
 );
 

--- a/scripts/test/Selenium/Agent/AdminDynamicField/AdminDynamicFieldDropdown.t
+++ b/scripts/test/Selenium/Agent/AdminDynamicField/AdminDynamicFieldDropdown.t
@@ -170,7 +170,8 @@ $Selenium->RunTest(
                 "#ValidID updated value",
             );
 
-            $Selenium->go_back();
+            # go back to AdminDynamicField screen
+            $Selenium->get("${ScriptAlias}index.pl?Action=AdminDynamicField");
 
             # delete DynamicFields
             my $DynamicFieldObject = $Kernel::OM->Get('Kernel::System::DynamicField');
@@ -193,7 +194,7 @@ $Selenium->RunTest(
         # make sure cache is correct
         $Kernel::OM->Get('Kernel::System::Cache')->CleanUp( Type => "DynamicField" );
 
-    }
+        }
 
 );
 

--- a/scripts/test/Selenium/Agent/AdminDynamicField/AdminDynamicFieldMultiselect.t
+++ b/scripts/test/Selenium/Agent/AdminDynamicField/AdminDynamicFieldMultiselect.t
@@ -170,7 +170,8 @@ $Selenium->RunTest(
                 "#ValidID updated value",
             );
 
-            $Selenium->go_back();
+            # go back to AdminDynamicField screen
+            $Selenium->get("${ScriptAlias}index.pl?Action=AdminDynamicField");
 
             # delete DynamicFields
             my $DynamicFieldObject = $Kernel::OM->Get('Kernel::System::DynamicField');
@@ -193,7 +194,7 @@ $Selenium->RunTest(
         # make sure cache is correct
         $Kernel::OM->Get('Kernel::System::Cache')->CleanUp( Type => "DynamicField" );
 
-    }
+        }
 
 );
 

--- a/scripts/test/Selenium/Agent/AdminDynamicField/AdminDynamicFieldText.t
+++ b/scripts/test/Selenium/Agent/AdminDynamicField/AdminDynamicFieldText.t
@@ -130,7 +130,8 @@ $Selenium->RunTest(
                 "#ValidID updated value",
             );
 
-            $Selenium->go_back();
+            # go back to AdminDynamicField screen
+            $Selenium->get("${ScriptAlias}index.pl?Action=AdminDynamicField");
 
             # delete DynamicFields
             my $DynamicFieldObject = $Kernel::OM->Get('Kernel::System::DynamicField');
@@ -153,7 +154,7 @@ $Selenium->RunTest(
         # make sure cache is correct
         $Kernel::OM->Get('Kernel::System::Cache')->CleanUp( Type => "DynamicField" );
 
-    }
+        }
 
 );
 

--- a/scripts/test/Selenium/Agent/AdminDynamicField/AdminDynamicFieldTextArea.t
+++ b/scripts/test/Selenium/Agent/AdminDynamicField/AdminDynamicFieldTextArea.t
@@ -144,7 +144,8 @@ $Selenium->RunTest(
                 "#ValidID updated value",
             );
 
-            $Selenium->go_back();
+            # go back to AdminDynamicField screen
+            $Selenium->get("${ScriptAlias}index.pl?Action=AdminDynamicField");
 
             # delete DynamicFields
             my $DynamicFieldObject = $Kernel::OM->Get('Kernel::System::DynamicField');
@@ -167,7 +168,7 @@ $Selenium->RunTest(
         # make sure cache is correct
         $Kernel::OM->Get('Kernel::System::Cache')->CleanUp( Type => "DynamicField" );
 
-    }
+        }
 
 );
 


### PR DESCRIPTION
Hi @mgruner,

We replaced go_back function in the Selenium tests with exact URL of screens that we expected next in a test case.
I saw that you did this in AgentTicketMerge, maybe it could be better that we use something that we suggest in this PR because in this way test scripts are more readable, but of course behavior and test case is the same.
If you mean that it is good, you can merge it.

Regards
Zoran