### PR TITLE
Removed VariableWidth CSS class from Postmaster filter table.

### DIFF
--- a/Kernel/Output/HTML/Standard/AdminPostMasterFilter.tt
+++ b/Kernel/Output/HTML/Standard/AdminPostMasterFilter.tt
@@ -61,7 +61,7 @@
                 <h2>[% Translate("List") | html %]</h2>
             </div>
             <div class="Content">
-                <table class="DataTable VariableWidth">
+                <table class="DataTable">
                     <thead>
                         <tr>
                             <th>[% Translate("Name") | html %]</th>


### PR DESCRIPTION
The variable postmaster filter table width is more or less unique in the admin interface. All other tables are width 100%, so should the postmaster filter table :-)