### PR TITLE
Master - Selenium sleep improvement

### DIFF
--- a/scripts/test/Selenium/Agent/Admin/AdminCustomerUserGroup.t
+++ b/scripts/test/Selenium/Agent/Admin/AdminCustomerUserGroup.t
@@ -116,7 +116,6 @@ $Selenium->RunTest(
 
         # test Filter for Groups
         $Selenium->find_element( "#FilterGroups", 'css' )->send_keys($GroupRandomID);
-        sleep 1;
 
         $Self->True(
             $Selenium->find_element( "$GroupRandomID", 'link_text' )->is_displayed(),
@@ -180,7 +179,7 @@ $Selenium->RunTest(
             $Kernel::OM->Get('Kernel::System::Cache')->CleanUp( Type => $Cache );
         }
 
-    }
+        }
 
 );
 

--- a/scripts/test/Selenium/Agent/Admin/AdminCustomerUserGroup.t
+++ b/scripts/test/Selenium/Agent/Admin/AdminCustomerUserGroup.t
@@ -179,7 +179,7 @@ $Selenium->RunTest(
             $Kernel::OM->Get('Kernel::System::Cache')->CleanUp( Type => $Cache );
         }
 
-        }
+    }
 
 );
 

--- a/scripts/test/Selenium/Agent/Admin/AdminCustomerUserService.t
+++ b/scripts/test/Selenium/Agent/Admin/AdminCustomerUserService.t
@@ -85,11 +85,13 @@ $Selenium->RunTest(
 
         # filter for service. It is autocomplete, submit is not necessary
         $Selenium->find_element( "#FilterServices", 'css' )->send_keys($RandomID2);
+        sleep 1;
         $Self->True(
             $Selenium->find_element( "$RandomID2", 'link_text' )->is_displayed(),
             "$RandomID2 service found on page",
         );
         $Selenium->find_element( "#FilterServices", 'css' )->clear();
+        sleep 1;
 
         # allocate test service to test customer user
         $Selenium->find_element("//a[contains(\@href, \'CustomerUserLogin=$RandomID' )]")->click();

--- a/scripts/test/Selenium/Agent/Admin/AdminCustomerUserService.t
+++ b/scripts/test/Selenium/Agent/Admin/AdminCustomerUserService.t
@@ -166,7 +166,7 @@ $Selenium->RunTest(
             Type => 'Service',
         );
 
-        }
+    }
 
 );
 

--- a/scripts/test/Selenium/Agent/Admin/AdminCustomerUserService.t
+++ b/scripts/test/Selenium/Agent/Admin/AdminCustomerUserService.t
@@ -85,13 +85,11 @@ $Selenium->RunTest(
 
         # filter for service. It is autocomplete, submit is not necessary
         $Selenium->find_element( "#FilterServices", 'css' )->send_keys($RandomID2);
-        sleep 1;
         $Self->True(
             $Selenium->find_element( "$RandomID2", 'link_text' )->is_displayed(),
             "$RandomID2 service found on page",
         );
         $Selenium->find_element( "#FilterServices", 'css' )->clear();
-        sleep 1;
 
         # allocate test service to test customer user
         $Selenium->find_element("//a[contains(\@href, \'CustomerUserLogin=$RandomID' )]")->click();
@@ -168,7 +166,7 @@ $Selenium->RunTest(
             Type => 'Service',
         );
 
-    }
+        }
 
 );
 

--- a/scripts/test/Selenium/Agent/Admin/AdminDynamicField.t
+++ b/scripts/test/Selenium/Agent/Admin/AdminDynamicField.t
@@ -74,13 +74,15 @@ $Selenium->RunTest(
                 $Selenium->find_element( "#Name",                      'css' )->submit();
 
                 # check if test DynamicField show on AdminDynamicField screen
+                $Selenium->WaitFor( JavaScript => "return \$('.DynamicFieldsContent').length" );
                 $Self->True(
                     index( $Selenium->get_page_source(), $RandomID ) > -1,
-                    "$RandomID $Type DynamicField found on page",
+                    "$RandomID $ID $Type DynamicField found on page",
                 );
 
                 # go to new DynamicField again
                 $Selenium->find_element( $RandomID,                    'link_text' )->click();
+                $Selenium->WaitFor( JavaScript => "return \$('#Label').length" );
                 $Selenium->find_element( "#Label",                     'css' )->clear();
                 $Selenium->find_element( "#Label",                     'css' )->send_keys( $RandomID . "-update" );
                 $Selenium->find_element( "#ValidID option[value='2']", 'css' )->click();
@@ -88,6 +90,7 @@ $Selenium->RunTest(
 
                 # go to new DynamicField again after update and check values
                 $Selenium->find_element( $RandomID, 'link_text' )->click();
+                $Selenium->WaitFor( JavaScript => "return \$('#Name').length" );
 
                 # check new DynamicField values
                 $Self->Is(

--- a/scripts/test/Selenium/Agent/Admin/AdminDynamicField.t
+++ b/scripts/test/Selenium/Agent/Admin/AdminDynamicField.t
@@ -132,7 +132,8 @@ $Selenium->RunTest(
 
                 $Selenium->accept_alert();
 
-                sleep 1;    # allow some time for field deletion
+                # allow some time for field deletion
+                $Selenium->WaitFor( JavaScript => "return !\$('#DynamicFieldID_$DynamicFieldID').length" );
 
                 $Selenium->refresh();
                 my $Success;
@@ -150,7 +151,7 @@ $Selenium->RunTest(
             # Make sure the cache is correct.
             $Kernel::OM->Get('Kernel::System::Cache')->CleanUp( Type => "DynamicField" );
         }
-    }
+        }
 );
 
 1;

--- a/scripts/test/Selenium/Agent/Admin/AdminDynamicField.t
+++ b/scripts/test/Selenium/Agent/Admin/AdminDynamicField.t
@@ -151,7 +151,7 @@ $Selenium->RunTest(
             # Make sure the cache is correct.
             $Kernel::OM->Get('Kernel::System::Cache')->CleanUp( Type => "DynamicField" );
         }
-        }
+    }
 );
 
 1;

--- a/scripts/test/Selenium/Agent/Admin/AdminGenericInterfaceWebservice.t
+++ b/scripts/test/Selenium/Agent/Admin/AdminGenericInterfaceWebservice.t
@@ -136,7 +136,7 @@ $Selenium->RunTest(
             );
         }
 
-        }
+    }
 );
 
 1;

--- a/scripts/test/Selenium/Agent/Admin/AdminGenericInterfaceWebservice.t
+++ b/scripts/test/Selenium/Agent/Admin/AdminGenericInterfaceWebservice.t
@@ -123,16 +123,7 @@ $Selenium->RunTest(
             $Selenium->find_element( "#DialogButton2", 'css' )->click();
 
             # wait until delete dialog has closed an action performed
-            ACTIVESLEEP:
-            for my $Second ( 1 .. 20 ) {
-
-                # Test dialog buttons are present
-                if ( !$Selenium->execute_script("return \$('#DialogButton2').length") ) {
-                    last ACTIVESLEEP;
-                }
-                print "Waiting to delete web service $Second second(s)...\n\n";
-                sleep 1;
-            }
+            $Selenium->WaitFor( JavaScript => "return !\$('#DialogButton2').length" );
 
             my $Success;
             eval {
@@ -145,7 +136,7 @@ $Selenium->RunTest(
             );
         }
 
-    }
+        }
 );
 
 1;

--- a/scripts/test/Selenium/Agent/Admin/AdminNotification.t
+++ b/scripts/test/Selenium/Agent/Admin/AdminNotification.t
@@ -51,7 +51,6 @@ $Selenium->RunTest(
 
         # test filter for Notification
         $Selenium->find_element( "#FilterNotification", 'css' )->send_keys("Agent::AddNote");
-        sleep 1;
 
         $Self->True(
             $Selenium->find_element( "Agent::AddNote", 'link_text' )->is_displayed(),
@@ -70,7 +69,6 @@ $Selenium->RunTest(
 
         # clear test filter for Notification
         $Selenium->find_element( "#FilterNotification", 'css' )->clear();
-        sleep 1;
 
         # check defoult notification
         for my $Notification (
@@ -102,7 +100,7 @@ $Selenium->RunTest(
 
         }
 
-    }
+        }
 );
 
 1;

--- a/scripts/test/Selenium/Agent/Admin/AdminNotification.t
+++ b/scripts/test/Selenium/Agent/Admin/AdminNotification.t
@@ -100,7 +100,7 @@ $Selenium->RunTest(
 
         }
 
-        }
+    }
 );
 
 1;

--- a/scripts/test/Selenium/Agent/Admin/AdminNotification.t
+++ b/scripts/test/Selenium/Agent/Admin/AdminNotification.t
@@ -76,7 +76,10 @@ $Selenium->RunTest(
             )
         {
 
+            # wait for notification overview
+            $Selenium->WaitFor( JavaScript => "return \$('#Notifications').length" );
             $Selenium->find_element( "Agent::$Notification", 'link_text' )->click();
+            $Selenium->WaitFor( JavaScript => "return \$('#Subject').length" );
 
             # edit notification
             my $CurrentNotificationSubject = $Selenium->find_element( "#Subject", 'css' )->get_value();

--- a/scripts/test/Selenium/Agent/Admin/AdminPGP.t
+++ b/scripts/test/Selenium/Agent/Admin/AdminPGP.t
@@ -71,13 +71,8 @@ $Selenium->RunTest(
         $Selenium->find_element( "#FileUpload", 'css' )->send_keys($Location1);
         $Selenium->find_element("//button[\@type='submit']")->click();
 
-        ACTIVESLEEP:
-        for my $Second ( 1 .. 20 ) {
-            if ( $Selenium->execute_script("return \$('tr.Last').length") ) {
-                last ACTIVESLEEP;
-            }
-            sleep 1;
-        }
+        # wait for key to upload
+        $Selenium->WaitFor( JavaScript => "return \$('tr.Last').length" );
 
         # add second test PGP key
         $Selenium->find_element("//a[contains(\@href, \'Action=AdminPGP;Subaction=Add' )]")->click();
@@ -87,13 +82,8 @@ $Selenium->RunTest(
         $Selenium->find_element( "#FileUpload", 'css' )->send_keys($Location2);
         $Selenium->find_element("//button[\@type='submit']")->click();
 
-        ACTIVESLEEP:
-        for my $Second ( 1 .. 20 ) {
-            if ( $Selenium->execute_script("return \$('tr.Last').length") ) {
-                last ACTIVESLEEP;
-            }
-            sleep 1;
-        }
+        # wait for key to upload
+        $Selenium->WaitFor( JavaScript => "return \$('tr.Last').length" );
 
         # check if test PGP keys show on AdminPGP screen
         my %PGPKey = (
@@ -174,7 +164,7 @@ $Selenium->RunTest(
             "Directory deleted - '$PGPPath'",
         );
 
-    }
+        }
 
 );
 

--- a/scripts/test/Selenium/Agent/Admin/AdminPGP.t
+++ b/scripts/test/Selenium/Agent/Admin/AdminPGP.t
@@ -164,7 +164,7 @@ $Selenium->RunTest(
             "Directory deleted - '$PGPPath'",
         );
 
-        }
+    }
 
 );
 

--- a/scripts/test/Selenium/Agent/Admin/AdminQueueAutoResponse.t
+++ b/scripts/test/Selenium/Agent/Admin/AdminQueueAutoResponse.t
@@ -279,7 +279,7 @@ $Selenium->RunTest(
             );
         }
 
-        }
+    }
 
 );
 

--- a/scripts/test/Selenium/Agent/Admin/AdminQueueAutoResponse.t
+++ b/scripts/test/Selenium/Agent/Admin/AdminQueueAutoResponse.t
@@ -157,7 +157,6 @@ $Selenium->RunTest(
 
         # test search filter auto response
         $Selenium->find_element( "#FilterAutoResponses", 'css' )->send_keys( $AutoResponseIDs[1]->{Name} );
-        sleep 1;
         $Self->True(
             $Selenium->find_element(
                 "//a[contains(\@href, 'Action=AdminAutoResponse;Subaction=Change;ID=$AutoResponseIDs[1]->{ID}' )]"
@@ -179,16 +178,12 @@ $Selenium->RunTest(
         $Selenium->find_element( "#FilterAutoResponses", 'css' )->clear();
 
         # test search filter queue
-
         $Selenium->find_element( "#FilterQueues", 'css' )->send_keys($QueueRandomID);
-        sleep 1;
-
         $Self->True(
             $Selenium->find_element( $QueueRandomID, 'link_text' )->is_displayed(),
             "$QueueRandomID found on screen",
         );
         $Selenium->find_element( "#FilterQueues", 'css' )->clear();
-        sleep 1;
 
         # check auto response relation for queue screen
         $Selenium->find_element( $QueueRandomID, 'link_text' )->click();
@@ -284,7 +279,7 @@ $Selenium->RunTest(
             );
         }
 
-    }
+        }
 
 );
 

--- a/scripts/test/Selenium/Agent/Admin/AdminQueueTemplates.t
+++ b/scripts/test/Selenium/Agent/Admin/AdminQueueTemplates.t
@@ -155,7 +155,7 @@ $Selenium->RunTest(
             Type => "Queue",
         );
 
-        }
+    }
 
 );
 

--- a/scripts/test/Selenium/Agent/Admin/AdminQueueTemplates.t
+++ b/scripts/test/Selenium/Agent/Admin/AdminQueueTemplates.t
@@ -97,7 +97,6 @@ $Selenium->RunTest(
         # test search filters
         $Selenium->find_element( "#FilterTemplates", 'css' )->send_keys($TemplateRandomID);
         $Selenium->find_element( "#FilterQueues",    'css' )->send_keys($QueueRandomID);
-        sleep 1;
 
         $Self->True(
             $Selenium->find_element("//a[contains(\@href, \'Subaction=Template;ID=$TemplateID' )]")->is_displayed(),
@@ -156,7 +155,7 @@ $Selenium->RunTest(
             Type => "Queue",
         );
 
-    }
+        }
 
 );
 

--- a/scripts/test/Selenium/Agent/Admin/AdminRoleGroup.t
+++ b/scripts/test/Selenium/Agent/Admin/AdminRoleGroup.t
@@ -76,7 +76,6 @@ $Selenium->RunTest(
 
         # test filter for Roles
         $Selenium->find_element( "#FilterRoles", 'css' )->send_keys($RoleRandomID);
-        sleep 1;
         $Self->True(
             $Selenium->find_element( "$RoleRandomID", 'link_text' )->is_displayed(),
             "$RoleRandomID role found on page",
@@ -84,7 +83,6 @@ $Selenium->RunTest(
 
         # test filter for Groups
         $Selenium->find_element( "#FilterGroups", 'css' )->send_keys($GroupRandomID);
-        sleep 1;
         $Self->True(
             $Selenium->find_element( "$GroupRandomID", 'link_text' )->is_displayed(),
             "$GroupRandomID group found on page",
@@ -93,7 +91,6 @@ $Selenium->RunTest(
         # clear test filter for Roles and Groups
         $Selenium->find_element( "#FilterRoles",  'css' )->clear();
         $Selenium->find_element( "#FilterGroups", 'css' )->clear();
-        sleep 1;
 
         # edit group relations for test role
         $Selenium->find_element( $RoleRandomID, 'link_text' )->click();
@@ -215,7 +212,7 @@ $Selenium->RunTest(
         $Kernel::OM->Get('Kernel::System::Cache')->CleanUp( Type => 'Group' );
         $Kernel::OM->Get('Kernel::System::Cache')->CleanUp( Type => 'Role' );
 
-    }
+        }
 );
 
 1;

--- a/scripts/test/Selenium/Agent/Admin/AdminRoleGroup.t
+++ b/scripts/test/Selenium/Agent/Admin/AdminRoleGroup.t
@@ -212,7 +212,7 @@ $Selenium->RunTest(
         $Kernel::OM->Get('Kernel::System::Cache')->CleanUp( Type => 'Group' );
         $Kernel::OM->Get('Kernel::System::Cache')->CleanUp( Type => 'Role' );
 
-        }
+    }
 );
 
 1;

--- a/scripts/test/Selenium/Agent/Admin/AdminRoleUser.t
+++ b/scripts/test/Selenium/Agent/Admin/AdminRoleUser.t
@@ -135,7 +135,7 @@ $Selenium->RunTest(
             Type => 'Group'
         );
 
-        }
+    }
 
 );
 

--- a/scripts/test/Selenium/Agent/Admin/AdminRoleUser.t
+++ b/scripts/test/Selenium/Agent/Admin/AdminRoleUser.t
@@ -77,7 +77,6 @@ $Selenium->RunTest(
 
         # test filter for Users
         $Selenium->find_element( "#FilterUsers", 'css' )->send_keys($TestUserLogin);
-        sleep 1;
 
         $Self->True(
             $Selenium->find_element( "$FullUserID", 'link_text' )->is_displayed(),
@@ -86,7 +85,6 @@ $Selenium->RunTest(
 
         # test filter for Roles
         $Selenium->find_element( "#FilterRoles", 'css' )->send_keys($RoleRandomID);
-        sleep 1;
 
         $Self->True(
             $Selenium->find_element( "$RoleRandomID", 'link_text' )->is_displayed(),
@@ -137,7 +135,7 @@ $Selenium->RunTest(
             Type => 'Group'
         );
 
-    }
+        }
 
 );
 

--- a/scripts/test/Selenium/Agent/Admin/AdminSystemAddress.t
+++ b/scripts/test/Selenium/Agent/Admin/AdminSystemAddress.t
@@ -100,13 +100,8 @@ $Selenium->RunTest(
         $Selenium->find_element( "#Comment",                          'css' )->send_keys($SysAddComment);
         $Selenium->find_element( "#Name",                             'css' )->submit();
 
-        ACTIVESLEEP:
-        for my $Second ( 1 .. 20 ) {
-            if ( $Selenium->execute_script("return \$('.MasterAction').length") ) {
-                last ACTIVESLEEP;
-            }
-            sleep 1;
-        }
+        # wait for SystemAddress create
+        $Selenium->WaitFor( JavaScript => "return \$('.MasterAction').length" );
 
         # check for created test SystemAddress
         $Self->True(
@@ -148,13 +143,8 @@ $Selenium->RunTest(
         $Selenium->find_element( "#Comment",                   'css' )->clear();
         $Selenium->find_element( "#Name",                      'css' )->submit();
 
-        ACTIVESLEEP:
-        for my $Second ( 1 .. 20 ) {
-            if ( $Selenium->execute_script("return \$('.MasterAction').length") ) {
-                last ACTIVESLEEP;
-            }
-            sleep 1;
-        }
+        # wait for SystemAddress edit
+        $Selenium->WaitFor( JavaScript => "return \$('.MasterAction').length" );
 
         # check edited test SystemAddress values
         $Selenium->find_element( $SysAddRandom, 'link_text' )->click();
@@ -198,7 +188,7 @@ $Selenium->RunTest(
             );
         }
 
-    }
+        }
 
 );
 

--- a/scripts/test/Selenium/Agent/Admin/AdminSystemAddress.t
+++ b/scripts/test/Selenium/Agent/Admin/AdminSystemAddress.t
@@ -188,7 +188,7 @@ $Selenium->RunTest(
             );
         }
 
-        }
+    }
 
 );
 

--- a/scripts/test/Selenium/Agent/Admin/AdminTemplate.t
+++ b/scripts/test/Selenium/Agent/Admin/AdminTemplate.t
@@ -52,6 +52,7 @@ $Selenium->RunTest(
 
         # click 'Add template'
         $Selenium->find_element("//a[contains(\@href, \'Subaction=Add' )]")->click();
+        $Selenium->WaitFor( JavaScript => "return \$('#TemplateType').length" );
 
         for my $ID (
             qw(TemplateType Name IDs ValidID Comment)

--- a/scripts/test/Selenium/Agent/Admin/AdminTemplate.t
+++ b/scripts/test/Selenium/Agent/Admin/AdminTemplate.t
@@ -153,7 +153,7 @@ $Selenium->RunTest(
 
         $Selenium->find_element("//a[contains(\@href, \'Subaction=Delete;ID=$TemplateID' )]")->click();
 
-        }
+    }
 );
 
 1;

--- a/scripts/test/Selenium/Agent/Admin/AdminTemplate.t
+++ b/scripts/test/Selenium/Agent/Admin/AdminTemplate.t
@@ -89,7 +89,6 @@ $Selenium->RunTest(
 
         # test search filter
         $Selenium->find_element( "#Filter", 'css' )->send_keys($TemplateRandomID);
-        sleep 1;
 
         $Self->True(
             $Selenium->find_element( $TemplateRandomID, 'link_text' )->is_displayed(),
@@ -154,7 +153,7 @@ $Selenium->RunTest(
 
         $Selenium->find_element("//a[contains(\@href, \'Subaction=Delete;ID=$TemplateID' )]")->click();
 
-    }
+        }
 );
 
 1;

--- a/scripts/test/Selenium/Agent/Admin/AdminTemplateAttachment.t
+++ b/scripts/test/Selenium/Agent/Admin/AdminTemplateAttachment.t
@@ -110,7 +110,6 @@ $Selenium->RunTest(
         # test search filters
         $Selenium->find_element( "#FilterTemplates",   'css' )->send_keys($TemplateRandomID);
         $Selenium->find_element( "#FilterAttachments", 'css' )->send_keys($AttachmentRandomID);
-        sleep 1;
 
         $Self->True(
             $Selenium->find_element("//a[contains(\@href, \'Subaction=Template;ID=$TemplateID' )]")->is_displayed(),
@@ -167,7 +166,7 @@ $Selenium->RunTest(
             "StandardTemplateDelete() for Attachment -> Template tests | with True",
         );
 
-    }
+        }
 
 );
 

--- a/scripts/test/Selenium/Agent/Admin/AdminTemplateAttachment.t
+++ b/scripts/test/Selenium/Agent/Admin/AdminTemplateAttachment.t
@@ -166,7 +166,7 @@ $Selenium->RunTest(
             "StandardTemplateDelete() for Attachment -> Template tests | with True",
         );
 
-        }
+    }
 
 );
 

--- a/scripts/test/Selenium/Agent/Admin/AdminUserGroup.t
+++ b/scripts/test/Selenium/Agent/Admin/AdminUserGroup.t
@@ -186,7 +186,7 @@ $Selenium->RunTest(
         # Make sure the cache is correct.
         $Kernel::OM->Get('Kernel::System::Cache')->CleanUp( Type => 'Group' );
 
-        }
+    }
 
 );
 

--- a/scripts/test/Selenium/Agent/Admin/AdminUserGroup.t
+++ b/scripts/test/Selenium/Agent/Admin/AdminUserGroup.t
@@ -77,7 +77,6 @@ $Selenium->RunTest(
 
         # test filter for Users
         $Selenium->find_element( "#FilterUsers", 'css' )->send_keys($FullTestUserLogin);
-        sleep 1;
         $Self->True(
             $Selenium->find_element( "$FullTestUserLogin", 'link_text' )->is_displayed(),
             "$FullTestUserLogin user found on page",
@@ -85,7 +84,6 @@ $Selenium->RunTest(
 
         # test filter for groups
         $Selenium->find_element( "#FilterGroups", 'css' )->send_keys($RandomID);
-        sleep 1;
         $Self->True(
             $Selenium->find_element( "$RandomID", 'link_text' )->is_displayed(),
             "$RandomID group found on page",
@@ -94,7 +92,6 @@ $Selenium->RunTest(
         # clear test filter for Users and Groups
         $Selenium->find_element( "#FilterUsers",  'css' )->clear();
         $Selenium->find_element( "#FilterGroups", 'css' )->clear();
-        sleep 1;
 
         # edit test group permission for test agent
         $Selenium->find_element( $RandomID, 'link_text' )->click();
@@ -189,7 +186,7 @@ $Selenium->RunTest(
         # Make sure the cache is correct.
         $Kernel::OM->Get('Kernel::System::Cache')->CleanUp( Type => 'Group' );
 
-    }
+        }
 
 );
 

--- a/scripts/test/Selenium/Agent/Admin/ProcessManagement/AdminProcessManagementActivity.t
+++ b/scripts/test/Selenium/Agent/Admin/ProcessManagement/AdminProcessManagementActivity.t
@@ -94,6 +94,7 @@ $Selenium->RunTest(
         $Selenium->switch_to_window( $Handles->[0] );
 
         # check for created test activity using filter on AdminProcessManagement screen
+        $Selenium->WaitFor( JavaScript => 'return $("#ActivityFilter").length' );
         $Selenium->find_element( "#ActivityFilter", 'css' )->send_keys($ActivityRandom);
 
         $Self->True(

--- a/scripts/test/Selenium/Agent/Admin/ProcessManagement/AdminProcessManagementActivity.t
+++ b/scripts/test/Selenium/Agent/Admin/ProcessManagement/AdminProcessManagementActivity.t
@@ -54,7 +54,9 @@ $Selenium->RunTest(
         $Selenium->find_element( "#Name",        'css' )->send_keys($ProcessRandom);
         $Selenium->find_element( "#Description", 'css' )->send_keys("Selenium Test Process");
         $Selenium->find_element( "#Name",        'css' )->submit();
-        sleep 1;
+
+        # wait for Process create
+        $Selenium->WaitFor( JavaScript => "return \$('.Last').length" );
 
         # create new test Activity
         $Selenium->find_element("//a[contains(\@href, \'Subaction=ActivityNew' )]")->click();
@@ -87,14 +89,12 @@ $Selenium->RunTest(
         # input name field and submit
         $Selenium->find_element( "#Name", 'css' )->send_keys($ActivityRandom);
         $Selenium->find_element( "#Name", 'css' )->submit();
-        sleep 2;
 
         # switch back to main window
         $Selenium->switch_to_window( $Handles->[0] );
 
         # check for created test activity using filter on AdminProcessManagement screen
         $Selenium->find_element( "#ActivityFilter", 'css' )->send_keys($ActivityRandom);
-        sleep 1;
 
         $Self->True(
             $Selenium->find_element("//*[text()=\"$ActivityRandom\"]")->is_displayed(),
@@ -126,7 +126,6 @@ $Selenium->RunTest(
 
         $Selenium->find_element( "#Name", 'css' )->send_keys("edit");
         $Selenium->find_element( "#Name", 'css' )->submit();
-        sleep 2;
 
         # return to main window
         $Selenium->switch_to_window( $Handles->[0] );
@@ -159,7 +158,7 @@ $Selenium->RunTest(
             Type => 'ProcessManagement_Activity',
         );
 
-    }
+        }
 );
 
 1;

--- a/scripts/test/Selenium/Agent/Admin/ProcessManagement/AdminProcessManagementActivity.t
+++ b/scripts/test/Selenium/Agent/Admin/ProcessManagement/AdminProcessManagementActivity.t
@@ -158,7 +158,7 @@ $Selenium->RunTest(
             Type => 'ProcessManagement_Activity',
         );
 
-        }
+    }
 );
 
 1;

--- a/scripts/test/Selenium/Agent/Admin/ProcessManagement/AdminProcessManagementActivityDialog.t
+++ b/scripts/test/Selenium/Agent/Admin/ProcessManagement/AdminProcessManagementActivityDialog.t
@@ -57,10 +57,10 @@ $Selenium->RunTest(
         $Selenium->find_element( "#Name",        'css' )->submit();
 
         # click on ActivityDialog dropdown, wait to load it and "Create New Activity Dialog"
-        $Selenium->find_element( "Activity Dialogs", 'link_text' )->click();
-
         $Selenium->WaitFor( JavaScript => 'return $("a.PopupType_ActivityDialog:visible").length' );
-
+        $Selenium->find_element( "Activity Dialogs", 'link_text' )->click();
+        # wait to toggle element
+        sleep 1;
         $Selenium->find_element("//a[contains(\@href, \'Subaction=ActivityDialogNew' )]")->click();
 
         # switch to pop up window
@@ -100,6 +100,7 @@ $Selenium->RunTest(
         $Selenium->switch_to_window( $Handles->[0] );
 
         # check for created test activity dialog using filter on AdminProcessManagement screen
+        $Selenium->WaitFor( JavaScript => 'return $("#ActivityDialogFilter").length' );
         $Selenium->find_element( "Activity Dialogs",      'link_text' )->click();
         $Selenium->find_element( "#ActivityDialogFilter", 'css' )->send_keys($ActivityDialogRandom);
 
@@ -161,6 +162,7 @@ $Selenium->RunTest(
         # check for edited test ActivityDialog using filter on AdminProcessManagement screen
         my $ActivityDialogRandomEdit = $ActivityDialogRandom . "edit";
         my $DescriptionShortEdit     = $DescriptionShort . " Edit";
+        $Selenium->WaitFor( JavaScript => 'return $("#ActivityDialogFilter").length' );
         $Selenium->find_element( "Activity Dialogs",      'link_text' )->click();
         $Selenium->find_element( "#ActivityDialogFilter", 'css' )->send_keys($ActivityDialogRandomEdit);
 

--- a/scripts/test/Selenium/Agent/Admin/ProcessManagement/AdminProcessManagementActivityDialog.t
+++ b/scripts/test/Selenium/Agent/Admin/ProcessManagement/AdminProcessManagementActivityDialog.t
@@ -56,9 +56,11 @@ $Selenium->RunTest(
         $Selenium->find_element( "#Description", 'css' )->send_keys("Selenium Test Process");
         $Selenium->find_element( "#Name",        'css' )->submit();
 
-        # click on ActivityDialog dropdown and "Create New Activity Dialog"
+        # click on ActivityDialog dropdown, wait to load it and "Create New Activity Dialog"
         $Selenium->find_element( "Activity Dialogs", 'link_text' )->click();
-        sleep 1;
+
+        $Selenium->WaitFor( JavaScript => 'return $("a.PopupType_ActivityDialog:visible").length' );
+
         $Selenium->find_element("//a[contains(\@href, \'Subaction=ActivityDialogNew' )]")->click();
 
         # switch to pop up window
@@ -98,10 +100,8 @@ $Selenium->RunTest(
         $Selenium->switch_to_window( $Handles->[0] );
 
         # check for created test activity dialog using filter on AdminProcessManagement screen
-        $Selenium->find_element( "Activity Dialogs", 'link_text' )->click();
-        sleep 1;
+        $Selenium->find_element( "Activity Dialogs",      'link_text' )->click();
         $Selenium->find_element( "#ActivityDialogFilter", 'css' )->send_keys($ActivityDialogRandom);
-        sleep 1;
 
         $Self->True(
             $Selenium->find_element("//*[text()=\"$ActivityDialogRandom\"]")->is_displayed(),
@@ -161,10 +161,8 @@ $Selenium->RunTest(
         # check for edited test ActivityDialog using filter on AdminProcessManagement screen
         my $ActivityDialogRandomEdit = $ActivityDialogRandom . "edit";
         my $DescriptionShortEdit     = $DescriptionShort . " Edit";
-        $Selenium->find_element( "Activity Dialogs", 'link_text' )->click();
-        sleep 1;
+        $Selenium->find_element( "Activity Dialogs",      'link_text' )->click();
         $Selenium->find_element( "#ActivityDialogFilter", 'css' )->send_keys($ActivityDialogRandomEdit);
-        sleep 1;
 
         $Self->True(
             $Selenium->find_element("//*[text()=\"$ActivityDialogRandomEdit\"]")->is_displayed(),
@@ -230,7 +228,7 @@ $Selenium->RunTest(
             Type => 'ProcessManagement_ActivityDialog',
         );
 
-    }
+        }
 
 );
 

--- a/scripts/test/Selenium/Agent/Admin/ProcessManagement/AdminProcessManagementActivityDialog.t
+++ b/scripts/test/Selenium/Agent/Admin/ProcessManagement/AdminProcessManagementActivityDialog.t
@@ -57,7 +57,7 @@ $Selenium->RunTest(
         $Selenium->find_element( "#Name",        'css' )->submit();
 
         # click on ActivityDialog dropdown, wait to load it and "Create New Activity Dialog"
-        $Selenium->WaitFor( JavaScript => 'return $("a.PopupType_ActivityDialog:visible").length' );
+        $Selenium->WaitFor( JavaScript => 'return $("#ActivityFilter").length' );
         $Selenium->find_element( "Activity Dialogs", 'link_text' )->click();
 
         # wait to toggle element

--- a/scripts/test/Selenium/Agent/Admin/ProcessManagement/AdminProcessManagementActivityDialog.t
+++ b/scripts/test/Selenium/Agent/Admin/ProcessManagement/AdminProcessManagementActivityDialog.t
@@ -228,7 +228,7 @@ $Selenium->RunTest(
             Type => 'ProcessManagement_ActivityDialog',
         );
 
-        }
+    }
 
 );
 

--- a/scripts/test/Selenium/Agent/Admin/ProcessManagement/AdminProcessManagementActivityDialog.t
+++ b/scripts/test/Selenium/Agent/Admin/ProcessManagement/AdminProcessManagementActivityDialog.t
@@ -59,6 +59,7 @@ $Selenium->RunTest(
         # click on ActivityDialog dropdown, wait to load it and "Create New Activity Dialog"
         $Selenium->WaitFor( JavaScript => 'return $("a.PopupType_ActivityDialog:visible").length' );
         $Selenium->find_element( "Activity Dialogs", 'link_text' )->click();
+
         # wait to toggle element
         sleep 1;
         $Selenium->find_element("//a[contains(\@href, \'Subaction=ActivityDialogNew' )]")->click();

--- a/scripts/test/Selenium/Agent/Admin/ProcessManagement/AdminProcessManagementTransition.t
+++ b/scripts/test/Selenium/Agent/Admin/ProcessManagement/AdminProcessManagementTransition.t
@@ -58,6 +58,7 @@ $Selenium->RunTest(
         # click on Transitions dropdown and "Create New Transition"
         $Selenium->WaitFor( JavaScript => 'return $("a.PopupType_Transition").length' );
         $Selenium->find_element( "Transitions", 'link_text' )->click();
+
         # wait to toggle element
         sleep 1;
         $Selenium->find_element("//a[contains(\@href, \'Subaction=TransitionNew' )]")->click();
@@ -116,7 +117,7 @@ $Selenium->RunTest(
 
         # check for created test Transition using filter on AdminProcessManagement screen
         $Selenium->WaitFor( JavaScript => 'return $("#TransitionFilter").length' );
-        $Selenium->find_element( "Transitions", 'link_text' )->click();
+        $Selenium->find_element( "Transitions",       'link_text' )->click();
         $Selenium->find_element( "#TransitionFilter", 'css' )->send_keys($TransitionRandom);
 
         $Self->True(
@@ -193,7 +194,7 @@ $Selenium->RunTest(
         # check for edited test Transition using filter on AdminProcessManagement screen
         my $TransitionRandomEdit = $TransitionRandom . "edit";
         $Selenium->WaitFor( JavaScript => 'return $("#TransitionFilter").length' );
-        $Selenium->find_element( "Transitions", 'link_text' )->click();
+        $Selenium->find_element( "Transitions",       'link_text' )->click();
         $Selenium->find_element( "#TransitionFilter", 'css' )->send_keys($TransitionRandomEdit);
 
         $Self->True(

--- a/scripts/test/Selenium/Agent/Admin/ProcessManagement/AdminProcessManagementTransition.t
+++ b/scripts/test/Selenium/Agent/Admin/ProcessManagement/AdminProcessManagementTransition.t
@@ -56,9 +56,10 @@ $Selenium->RunTest(
         $Selenium->find_element( "#Name",        'css' )->submit();
 
         # click on Transitions dropdown and "Create New Transition"
+        $Selenium->WaitFor( JavaScript => 'return $("a.PopupType_Transition").length' );
         $Selenium->find_element( "Transitions", 'link_text' )->click();
-        $Selenium->WaitFor( JavaScript => 'return $("a.PopupType_Transition:visible").length' );
-
+        # wait to toggle element
+        sleep 1;
         $Selenium->find_element("//a[contains(\@href, \'Subaction=TransitionNew' )]")->click();
 
         # Wait until form has loaded, if neccessary
@@ -114,9 +115,8 @@ $Selenium->RunTest(
         $Selenium->switch_to_window( $Handles->[0] );
 
         # check for created test Transition using filter on AdminProcessManagement screen
+        $Selenium->WaitFor( JavaScript => 'return $("#TransitionFilter").length' );
         $Selenium->find_element( "Transitions", 'link_text' )->click();
-        $Selenium->WaitFor( JavaScript => 'return $("a.PopupType_Transition:visible").length' );
-
         $Selenium->find_element( "#TransitionFilter", 'css' )->send_keys($TransitionRandom);
 
         $Self->True(
@@ -192,9 +192,8 @@ $Selenium->RunTest(
 
         # check for edited test Transition using filter on AdminProcessManagement screen
         my $TransitionRandomEdit = $TransitionRandom . "edit";
+        $Selenium->WaitFor( JavaScript => 'return $("#TransitionFilter").length' );
         $Selenium->find_element( "Transitions", 'link_text' )->click();
-        $Selenium->WaitFor( JavaScript => 'return $("a.PopupType_Transition:visible").length' );
-
         $Selenium->find_element( "#TransitionFilter", 'css' )->send_keys($TransitionRandomEdit);
 
         $Self->True(

--- a/scripts/test/Selenium/Agent/Admin/ProcessManagement/AdminProcessManagementTransition.t
+++ b/scripts/test/Selenium/Agent/Admin/ProcessManagement/AdminProcessManagementTransition.t
@@ -261,7 +261,7 @@ $Selenium->RunTest(
             Type => 'ProcessManagement_Transition',
         );
 
-        }
+    }
 
 );
 

--- a/scripts/test/Selenium/Agent/Admin/ProcessManagement/AdminProcessManagementTransition.t
+++ b/scripts/test/Selenium/Agent/Admin/ProcessManagement/AdminProcessManagementTransition.t
@@ -56,7 +56,7 @@ $Selenium->RunTest(
         $Selenium->find_element( "#Name",        'css' )->submit();
 
         # click on Transitions dropdown and "Create New Transition"
-        $Selenium->WaitFor( JavaScript => 'return $("a.PopupType_Transition").length' );
+        $Selenium->WaitFor( JavaScript => "return \$('#ActivityFilter').length" );
         $Selenium->find_element( "Transitions", 'link_text' )->click();
 
         # wait to toggle element

--- a/scripts/test/Selenium/Agent/Admin/ProcessManagement/AdminProcessManagementTransition.t
+++ b/scripts/test/Selenium/Agent/Admin/ProcessManagement/AdminProcessManagementTransition.t
@@ -57,8 +57,12 @@ $Selenium->RunTest(
 
         # click on Transitions dropdown and "Create New Transition"
         $Selenium->find_element( "Transitions", 'link_text' )->click();
-        sleep 1;
+        $Selenium->WaitFor( JavaScript => 'return $("a.PopupType_Transition:visible").length' );
+
         $Selenium->find_element("//a[contains(\@href, \'Subaction=TransitionNew' )]")->click();
+
+        # Wait until form has loaded, if neccessary
+        $Selenium->WaitFor( JavaScript => 'return $("#Name").length' );
 
         # switch to pop up window
         my $Handles = $Selenium->get_window_handles();
@@ -111,9 +115,9 @@ $Selenium->RunTest(
 
         # check for created test Transition using filter on AdminProcessManagement screen
         $Selenium->find_element( "Transitions", 'link_text' )->click();
-        sleep 1;
+        $Selenium->WaitFor( JavaScript => 'return $("a.PopupType_Transition:visible").length' );
+
         $Selenium->find_element( "#TransitionFilter", 'css' )->send_keys($TransitionRandom);
-        sleep 1;
 
         $Self->True(
             $Selenium->find_element("//*[text()=\"$TransitionRandom\"]")->is_displayed(),
@@ -189,9 +193,9 @@ $Selenium->RunTest(
         # check for edited test Transition using filter on AdminProcessManagement screen
         my $TransitionRandomEdit = $TransitionRandom . "edit";
         $Selenium->find_element( "Transitions", 'link_text' )->click();
-        sleep 1;
+        $Selenium->WaitFor( JavaScript => 'return $("a.PopupType_Transition:visible").length' );
+
         $Selenium->find_element( "#TransitionFilter", 'css' )->send_keys($TransitionRandomEdit);
-        sleep 1;
 
         $Self->True(
             $Selenium->find_element("//*[text()=\"$TransitionRandomEdit\"]")->is_displayed(),
@@ -257,7 +261,7 @@ $Selenium->RunTest(
             Type => 'ProcessManagement_Transition',
         );
 
-    }
+        }
 
 );
 

--- a/scripts/test/Selenium/Agent/Admin/ProcessManagement/AdminProcessManagementTransitionAction.t
+++ b/scripts/test/Selenium/Agent/Admin/ProcessManagement/AdminProcessManagementTransitionAction.t
@@ -59,6 +59,7 @@ $Selenium->RunTest(
         # wait to load element ( in some case with FireFox)
         sleep 1;
         $Selenium->find_element( "Transition Actions", 'link_text' )->click();
+
         # wait to togle element
         sleep 1;
         $Selenium->find_element(".//a[contains(\@href, \'Subaction=TransitionActionNew' )]")->click();
@@ -176,6 +177,7 @@ $Selenium->RunTest(
 
         # check for edited test TransitionAction using filter on AdminProcessManagement screen
         my $TransitionActionRandomEdit = $TransitionActionRandom . "edit";
+
         # wait to load element ( in some case with FireFox)
         sleep 1;
         $Selenium->find_element( "Transition Actions", 'link_text' )->click();

--- a/scripts/test/Selenium/Agent/Admin/ProcessManagement/AdminProcessManagementTransitionAction.t
+++ b/scripts/test/Selenium/Agent/Admin/ProcessManagement/AdminProcessManagementTransitionAction.t
@@ -56,10 +56,12 @@ $Selenium->RunTest(
         $Selenium->find_element( "#Name",        'css' )->submit();
 
         # click on Transition Actions dropdown and "Create New Transition Action"
+        # wait to load element ( in some case with FireFox)
+        sleep 1;
         $Selenium->find_element( "Transition Actions", 'link_text' )->click();
-        $Selenium->WaitFor( JavaScript => 'return $("a.PopupType_TransitionAction:visible").length' );
-
-        $Selenium->find_element("//a[contains(\@href, \'Subaction=TransitionActionNew' )]")->click();
+        # wait to togle element
+        sleep 1;
+        $Selenium->find_element(".//a[contains(\@href, \'Subaction=TransitionActionNew' )]")->click();
 
         # switch to pop up window
         my $Handles = $Selenium->get_window_handles();
@@ -104,9 +106,10 @@ $Selenium->RunTest(
         $Selenium->switch_to_window( $Handles->[0] );
 
         # check for created test TransitionAction using filter on AdminProcessManagement screen
+        # wait to load element ( in some case with FireFox)
+        sleep 1;
         $Selenium->find_element( "Transition Actions", 'link_text' )->click();
-        $Selenium->WaitFor( JavaScript => 'return $("a.PopupType_TransitionAction:visible").length' );
-
+        $Selenium->WaitFor( JavaScript => 'return $("#TransitionActionFilter:visible").length' );
         $Selenium->find_element( "#TransitionActionFilter", 'css' )->send_keys($TransitionActionRandom);
 
         $Self->True(
@@ -129,6 +132,7 @@ $Selenium->RunTest(
         # go to edit test TransitionAction screen
         $Selenium->find_element("//a[contains(\@href, \'Subaction=TransitionActionEdit;ID=$TransitionActionID' )]")
             ->click();
+
         $Handles = $Selenium->get_window_handles();
         $Selenium->switch_to_window( $Handles->[1] );
 
@@ -172,9 +176,10 @@ $Selenium->RunTest(
 
         # check for edited test TransitionAction using filter on AdminProcessManagement screen
         my $TransitionActionRandomEdit = $TransitionActionRandom . "edit";
+        # wait to load element ( in some case with FireFox)
+        sleep 1;
         $Selenium->find_element( "Transition Actions", 'link_text' )->click();
-        $Selenium->WaitFor( JavaScript => 'return $("a.PopupType_TransitionAction:visible").length' );
-
+        $Selenium->WaitFor( JavaScript => 'return $("#TransitionActionFilter:visible").length' );
         $Selenium->find_element( "#TransitionActionFilter", 'css' )->send_keys($TransitionActionRandomEdit);
 
         $Self->True(
@@ -185,6 +190,7 @@ $Selenium->RunTest(
         # go to edit test TransitionAction screen again
         $Selenium->find_element("//a[contains(\@href, \'Subaction=TransitionActionEdit;ID=$TransitionActionID' )]")
             ->click();
+
         $Handles = $Selenium->get_window_handles();
         $Selenium->switch_to_window( $Handles->[1] );
 

--- a/scripts/test/Selenium/Agent/Admin/ProcessManagement/AdminProcessManagementTransitionAction.t
+++ b/scripts/test/Selenium/Agent/Admin/ProcessManagement/AdminProcessManagementTransitionAction.t
@@ -56,8 +56,7 @@ $Selenium->RunTest(
         $Selenium->find_element( "#Name",        'css' )->submit();
 
         # click on Transition Actions dropdown and "Create New Transition Action"
-        # wait to load element ( in some case with FireFox)
-        sleep 1;
+        $Selenium->WaitFor( JavaScript => 'return $("#ActivityFilter").length' );
         $Selenium->find_element( "Transition Actions", 'link_text' )->click();
 
         # wait to togle element
@@ -107,10 +106,8 @@ $Selenium->RunTest(
         $Selenium->switch_to_window( $Handles->[0] );
 
         # check for created test TransitionAction using filter on AdminProcessManagement screen
-        # wait to load element ( in some case with FireFox)
-        sleep 1;
+        $Selenium->WaitFor( JavaScript => 'return $("#TransitionActionFilter").length' );
         $Selenium->find_element( "Transition Actions", 'link_text' )->click();
-        $Selenium->WaitFor( JavaScript => 'return $("#TransitionActionFilter:visible").length' );
         $Selenium->find_element( "#TransitionActionFilter", 'css' )->send_keys($TransitionActionRandom);
 
         $Self->True(
@@ -177,11 +174,8 @@ $Selenium->RunTest(
 
         # check for edited test TransitionAction using filter on AdminProcessManagement screen
         my $TransitionActionRandomEdit = $TransitionActionRandom . "edit";
-
-        # wait to load element ( in some case with FireFox)
-        sleep 1;
+        $Selenium->WaitFor( JavaScript => "return \$('#TransitionActionFilter').length" );
         $Selenium->find_element( "Transition Actions", 'link_text' )->click();
-        $Selenium->WaitFor( JavaScript => 'return $("#TransitionActionFilter:visible").length' );
         $Selenium->find_element( "#TransitionActionFilter", 'css' )->send_keys($TransitionActionRandomEdit);
 
         $Self->True(

--- a/scripts/test/Selenium/Agent/Admin/ProcessManagement/AdminProcessManagementTransitionAction.t
+++ b/scripts/test/Selenium/Agent/Admin/ProcessManagement/AdminProcessManagementTransitionAction.t
@@ -57,7 +57,8 @@ $Selenium->RunTest(
 
         # click on Transition Actions dropdown and "Create New Transition Action"
         $Selenium->find_element( "Transition Actions", 'link_text' )->click();
-        sleep 1;
+        $Selenium->WaitFor( JavaScript => 'return $("a.PopupType_TransitionAction:visible").length' );
+
         $Selenium->find_element("//a[contains(\@href, \'Subaction=TransitionActionNew' )]")->click();
 
         # switch to pop up window
@@ -65,13 +66,7 @@ $Selenium->RunTest(
         $Selenium->switch_to_window( $Handles->[1] );
 
         # Wait until form has loaded, if neccessary
-        ACTIVESLEEP:
-        for my $Second ( 1 .. 20 ) {
-            if ( $Selenium->execute_script("return \$('#Name').length") ) {
-                last ACTIVESLEEP;
-            }
-            sleep 1;
-        }
+        $Selenium->WaitFor( JavaScript => 'return $("#Name").length' );
 
         # check AdminProcessManagementTransitionAction screen
         for my $ID (
@@ -110,9 +105,9 @@ $Selenium->RunTest(
 
         # check for created test TransitionAction using filter on AdminProcessManagement screen
         $Selenium->find_element( "Transition Actions", 'link_text' )->click();
-        sleep 1;
+        $Selenium->WaitFor( JavaScript => 'return $("a.PopupType_TransitionAction:visible").length' );
+
         $Selenium->find_element( "#TransitionActionFilter", 'css' )->send_keys($TransitionActionRandom);
-        sleep 1;
 
         $Self->True(
             $Selenium->find_element("//*[text()=\"$TransitionActionRandom\"]")->is_displayed(),
@@ -138,13 +133,7 @@ $Selenium->RunTest(
         $Selenium->switch_to_window( $Handles->[1] );
 
         # Wait until form has loaded, if neccessary
-        ACTIVESLEEP:
-        for my $Second ( 1 .. 20 ) {
-            if ( $Selenium->execute_script("return \$('#Name').length") ) {
-                last ACTIVESLEEP;
-            }
-            sleep 1;
-        }
+        $Selenium->WaitFor( JavaScript => 'return $("#Name").length' );
 
         # check stored value
         $Self->Is(
@@ -184,9 +173,9 @@ $Selenium->RunTest(
         # check for edited test TransitionAction using filter on AdminProcessManagement screen
         my $TransitionActionRandomEdit = $TransitionActionRandom . "edit";
         $Selenium->find_element( "Transition Actions", 'link_text' )->click();
-        sleep 1;
+        $Selenium->WaitFor( JavaScript => 'return $("a.PopupType_TransitionAction:visible").length' );
+
         $Selenium->find_element( "#TransitionActionFilter", 'css' )->send_keys($TransitionActionRandomEdit);
-        sleep 1;
 
         $Self->True(
             $Selenium->find_element("//*[text()=\"$TransitionActionRandomEdit\"]")->is_displayed(),
@@ -200,13 +189,7 @@ $Selenium->RunTest(
         $Selenium->switch_to_window( $Handles->[1] );
 
         # Wait until form has loaded, if neccessary
-        ACTIVESLEEP:
-        for my $Second ( 1 .. 20 ) {
-            if ( $Selenium->execute_script("return \$('#Name').length") ) {
-                last ACTIVESLEEP;
-            }
-            sleep 1;
-        }
+        $Selenium->WaitFor( JavaScript => 'return $("#Name").length' );
 
         # check edited values
         $Self->Is(
@@ -256,7 +239,7 @@ $Selenium->RunTest(
             Type => 'ProcessManagement_TransitionAction',
         );
 
-    }
+        }
 );
 
 1;

--- a/scripts/test/Selenium/Agent/Admin/ProcessManagement/AdminProcessManagementTransitionAction.t
+++ b/scripts/test/Selenium/Agent/Admin/ProcessManagement/AdminProcessManagementTransitionAction.t
@@ -239,7 +239,7 @@ $Selenium->RunTest(
             Type => 'ProcessManagement_TransitionAction',
         );
 
-        }
+    }
 );
 
 1;

--- a/scripts/test/Selenium/Agent/AgentCustomerInformationCenter.t
+++ b/scripts/test/Selenium/Agent/AgentCustomerInformationCenter.t
@@ -83,7 +83,7 @@ $Selenium->RunTest(
             "Setting for toggle widgets found on page",
         );
 
-        }
+    }
 );
 
 1;

--- a/scripts/test/Selenium/Agent/AgentCustomerInformationCenter.t
+++ b/scripts/test/Selenium/Agent/AgentCustomerInformationCenter.t
@@ -49,12 +49,12 @@ $Selenium->RunTest(
 
         my $ScriptAlias = $Kernel::OM->Get('Kernel::Config')->Get('ScriptAlias');
         $Selenium->get("${ScriptAlias}index.pl?Action=AgentCustomerInformationCenter");
-        sleep 1;
 
         # input search parameters
         $Selenium->find_element( "#AgentCustomerInformationCenterSearchCustomerID", 'css' )
             ->send_keys($TestCustomerUserLogin);
-        sleep 1;
+
+        $Selenium->WaitFor( JavaScript => 'return $("li.ui-menu-item:visible").length' );
         $Selenium->find_element("//*[text()='$TestCustomerUserLogin']")->click();
 
         # check customer information center page

--- a/scripts/test/Selenium/Agent/AgentTicketAttachment.t
+++ b/scripts/test/Selenium/Agent/AgentTicketAttachment.t
@@ -101,30 +101,21 @@ $Selenium->RunTest(
         my $Location           = $Kernel::OM->Get('Kernel::Config')->Get('Home')
             . "/scripts/test/sample/StdAttachment/$AttachmentName";
         $Selenium->find_element( "#FromCustomer", 'css' )->send_keys($TestCustomer);
-        sleep 1;
+        $Selenium->WaitFor( JavaScript => 'return $("li.ui-menu-item:visible").length' );
 
         $Selenium->find_element("//*[text()='$AutoCompleteString']")->click();
-        sleep 1;
+        $Selenium->WaitFor( JavaScript => 'return $("p.Value").length' );
+
         $Selenium->find_element( "#Dest option[value='2||Raw']", 'css' )->click();
         $Selenium->find_element( "#Subject",                     'css' )->send_keys($TicketSubject);
         $Selenium->find_element( "#RichText",                    'css' )->send_keys($TicketBody);
         $Selenium->find_element( "#FileUpload",                  'css' )->send_keys($Location);
-        sleep 0.1;
-
-        # wait until attachment is upoading
-        ACTIVESLEEP:
-        for my $Second ( 1 .. 20 ) {
-            if ( index( $Selenium->get_page_source(), $AttachmentName ) > -1 ) {
-                last ACTIVESLEEP;
-            }
-            sleep 1;
-        }
+        $Selenium->WaitFor( JavaScript => 'return $("#Subject").length' );
 
         $Selenium->find_element( "#Subject", 'css' )->submit();
-        sleep 1;
 
         # search for new created ticket on AgentTicketZoom screen
-        my ($TicketID, $TicketNumber) = $Kernel::OM->Get('Kernel::System::Ticket')->TicketSearch(
+        my ( $TicketID, $TicketNumber ) = $Kernel::OM->Get('Kernel::System::Ticket')->TicketSearch(
             Result         => 'HASH',
             Limit          => 1,
             CustomerUserID => $TestCustomer,
@@ -132,13 +123,7 @@ $Selenium->RunTest(
         );
 
         # wait until ticket is created
-        ACTIVESLEEP:
-        for my $Second ( 1 .. 20 ) {
-            if ( index( $Selenium->get_page_source(), $TicketNumber ) > -1 ) {
-                last ACTIVESLEEP;
-            }
-            sleep 1;
-        }
+        $Selenium->WaitFor( JavaScript => "return \$('form').length" );
 
         $Self->True(
             index( $Selenium->get_page_source(), $TicketNumber ) > -1,
@@ -198,7 +183,7 @@ $Selenium->RunTest(
             $Kernel::OM->Get('Kernel::System::Cache')->CleanUp( Type => $Cache );
         }
 
-    }
+        }
 );
 
 1;

--- a/scripts/test/Selenium/Agent/AgentTicketAttachment.t
+++ b/scripts/test/Selenium/Agent/AgentTicketAttachment.t
@@ -183,7 +183,7 @@ $Selenium->RunTest(
             $Kernel::OM->Get('Kernel::System::Cache')->CleanUp( Type => $Cache );
         }
 
-        }
+    }
 );
 
 1;

--- a/scripts/test/Selenium/Agent/AgentTicketBounce.t
+++ b/scripts/test/Selenium/Agent/AgentTicketBounce.t
@@ -192,7 +192,7 @@ $Selenium->RunTest(
         $Kernel::OM->Get('Kernel::System::Cache')->CleanUp( Type => 'Ticket' );
         $Kernel::OM->Get('Kernel::System::Cache')->CleanUp( Type => 'CustomerUser' );
 
-        }
+    }
 );
 
 1;

--- a/scripts/test/Selenium/Agent/AgentTicketBounce.t
+++ b/scripts/test/Selenium/Agent/AgentTicketBounce.t
@@ -91,9 +91,11 @@ $Selenium->RunTest(
         my $TicketBody         = "Selenium body test";
         $Selenium->find_element( "#Dest option[value='2||Raw']", 'css' )->click();
         $Selenium->find_element( "#ToCustomer",                  'css' )->send_keys($TestCustomer);
-        sleep 1;
+        $Selenium->WaitFor( JavaScript => 'return $("li.ui-menu-item:visible").length' );
+
         $Selenium->find_element("//*[text()='$AutoCompleteString']")->click();
-        sleep 1;
+        $Selenium->WaitFor( JavaScript => 'return $("p.Value").length' );
+
         $Selenium->find_element( "#Subject",  'css' )->send_keys($TicketSubject);
         $Selenium->find_element( "#RichText", 'css' )->send_keys($TicketBody);
         $Selenium->find_element( "#Subject",  'css' )->submit();
@@ -190,7 +192,7 @@ $Selenium->RunTest(
         $Kernel::OM->Get('Kernel::System::Cache')->CleanUp( Type => 'Ticket' );
         $Kernel::OM->Get('Kernel::System::Cache')->CleanUp( Type => 'CustomerUser' );
 
-    }
+        }
 );
 
 1;

--- a/scripts/test/Selenium/Agent/AgentTicketCustomer.t
+++ b/scripts/test/Selenium/Agent/AgentTicketCustomer.t
@@ -98,7 +98,8 @@ $Selenium->RunTest(
         my $TicketSubject = "Selenium Ticket";
         my $TicketBody    = "Selenium body test";
         $Selenium->find_element( "#FromCustomer", 'css' )->send_keys( $TestCustomers[0] );
-        sleep 1;
+        $Selenium->WaitFor( JavaScript => 'return $("li.ui-menu-item:visible").length' );
+
         $Selenium->find_element("//*[text()='$AutoCompleteString']")->click();
         $Selenium->find_element( "#Dest option[value='2||Raw']", 'css' )->click();
         $Selenium->find_element( "#Subject",                     'css' )->send_keys($TicketSubject);
@@ -107,13 +108,7 @@ $Selenium->RunTest(
         $Selenium->find_element( "#Subject", 'css' )->submit();
 
         # Wait until form has loaded, if neccessary
-        ACTIVESLEEP:
-        for my $Second ( 1 .. 20 ) {
-            if ( $Selenium->execute_script("return \$('form').length") ) {
-                last ACTIVESLEEP;
-            }
-            sleep 1;
-        }
+        $Selenium->WaitFor( JavaScript => 'return $("form").length' );
 
         # search for new created ticket on AgentTicketZoom screen
         my %TicketIDs = $Kernel::OM->Get('Kernel::System::Ticket')->TicketSearch(
@@ -157,29 +152,23 @@ $Selenium->RunTest(
         $Selenium->find_element( "#CustomerAutoComplete", 'css' )->clear();
         $Selenium->find_element( "#CustomerID",           'css' )->clear();
         $Selenium->find_element( "#CustomerAutoComplete", 'css' )->send_keys( $TestCustomers[1] );
-        sleep 1;
+        $Selenium->WaitFor( JavaScript => 'return $("li.ui-menu-item:visible").length' );
+
         $Selenium->find_element("//*[text()='$AutoCompleteString']")->click();
+        $Selenium->WaitFor( JavaScript => 'return $("#CustomerAutoComplete").length' );
 
-        # wait until customer data is loading
-        ACTIVESLEEP:
-        for my $Second ( 1 .. 20 ) {
-            sleep 1;
-
-            # check if customer data is loaded
-            if ( $Selenium->execute_script("return \$('#CustomerAutoComplete').length") ) {
-                last ACTIVESLEEP;
-            }
-            print "Waiting to load customer user data  $Second  second(s)...\n\n";
-        }
         $Selenium->find_element( "#CustomerAutoComplete", 'css' )->submit();
 
         $Selenium->switch_to_window( $Handles->[0] );
+        $Selenium->WaitFor( JavaScript => 'return $("div.MainBox").length' );
 
         # click on history link and switch window
         $Selenium->find_element("//*[text()='History']")->click();
-        sleep(2);
+        $Handles = '';
         $Handles = $Selenium->get_window_handles();
         $Selenium->switch_to_window( $Handles->[1] );
+
+        $Selenium->WaitFor( JavaScript => "return \$('table.DataTable').length" );
 
         # verify that action worked as expected
         my $HistoryText = "Updated: CustomerID=$TestCustomers[1];CustomerUser=$TestCustomers[1];";
@@ -220,7 +209,7 @@ $Selenium->RunTest(
         $Kernel::OM->Get('Kernel::System::Cache')->CleanUp( Type => 'Ticket' );
         $Kernel::OM->Get('Kernel::System::Cache')->CleanUp( Type => 'CustomerUser' );
 
-    }
+        }
 );
 
 1;

--- a/scripts/test/Selenium/Agent/AgentTicketCustomer.t
+++ b/scripts/test/Selenium/Agent/AgentTicketCustomer.t
@@ -209,7 +209,7 @@ $Selenium->RunTest(
         $Kernel::OM->Get('Kernel::System::Cache')->CleanUp( Type => 'Ticket' );
         $Kernel::OM->Get('Kernel::System::Cache')->CleanUp( Type => 'CustomerUser' );
 
-        }
+    }
 );
 
 1;

--- a/scripts/test/Selenium/Agent/AgentTicketEmail.t
+++ b/scripts/test/Selenium/Agent/AgentTicketEmail.t
@@ -191,7 +191,7 @@ $Selenium->RunTest(
         $Kernel::OM->Get('Kernel::System::Cache')->CleanUp( Type => 'Ticket' );
         $Kernel::OM->Get('Kernel::System::Cache')->CleanUp( Type => 'CustomerUser' );
 
-        }
+    }
 );
 
 1;

--- a/scripts/test/Selenium/Agent/AgentTicketEmail.t
+++ b/scripts/test/Selenium/Agent/AgentTicketEmail.t
@@ -115,7 +115,8 @@ $Selenium->RunTest(
         my $TicketBody         = "Selenium body test";
         $Selenium->find_element( "#Dest option[value='2||Raw']", 'css' )->click();
         $Selenium->find_element( "#ToCustomer",                  'css' )->send_keys($TestCustomer);
-        sleep 1;
+        $Selenium->WaitFor( JavaScript => 'return $("li.ui-menu-item:visible").length' );
+
         $Selenium->find_element("//*[text()='$AutoCompleteString']")->click();
         $Selenium->find_element( "#Subject",  'css' )->send_keys($TicketSubject);
         $Selenium->find_element( "#RichText", 'css' )->send_keys($TicketBody);
@@ -190,7 +191,7 @@ $Selenium->RunTest(
         $Kernel::OM->Get('Kernel::System::Cache')->CleanUp( Type => 'Ticket' );
         $Kernel::OM->Get('Kernel::System::Cache')->CleanUp( Type => 'CustomerUser' );
 
-    }
+        }
 );
 
 1;

--- a/scripts/test/Selenium/Agent/AgentTicketForward.t
+++ b/scripts/test/Selenium/Agent/AgentTicketForward.t
@@ -91,7 +91,7 @@ $Selenium->RunTest(
         my $TicketBody         = "Selenium body test";
         $Selenium->find_element( "#FromCustomer", 'css' )->send_keys($TestCustomer);
 
-        $Selenium->WaitFor( JavaScript => 'return $("li.ui-menu-item:visible").length' );
+        $Selenium->WaitFor( JavaScript => 'return $("li.ui-menu-item:visible")' );
 
         $Selenium->find_element("//*[text()='$AutoCompleteString']")->click();
         $Selenium->find_element( "#Dest option[value='2||Raw']", 'css' )->click();
@@ -136,7 +136,7 @@ $Selenium->RunTest(
         # input fields and send forward
         $Selenium->find_element( "#ToCustomer", 'css' )->send_keys($TestCustomer);
 
-        $Selenium->WaitFor( JavaScript => 'return $("li.ui-menu-item:visible").length' );
+        $Selenium->WaitFor( JavaScript => 'return $("li.ui-menu-item:visible")' );
 
         $Selenium->find_element("//*[text()='$AutoCompleteString']")->click();
         $Selenium->find_element( "#ComposeStateID option[value='4']", 'css' )->click();

--- a/scripts/test/Selenium/Agent/AgentTicketPhone.t
+++ b/scripts/test/Selenium/Agent/AgentTicketPhone.t
@@ -117,8 +117,7 @@ $Selenium->RunTest(
         $Selenium->WaitFor( JavaScript => 'return $("li.ui-menu-item:visible").length' );
 
         $Selenium->find_element("//*[text()='$AutoCompleteString']")->click();
-        $Selenium->WaitFor( JavaScript => 'retun $("p.Value").length' );
-
+        sleep(1);
         $Selenium->find_element( "#Dest option[value='2||Raw']", 'css' )->click();
         $Selenium->find_element( "#Subject",                     'css' )->send_keys($TicketSubject);
         $Selenium->find_element( "#RichText",                    'css' )->send_keys($TicketBody);
@@ -189,7 +188,7 @@ $Selenium->RunTest(
         $Kernel::OM->Get('Kernel::System::Cache')->CleanUp( Type => 'Ticket' );
         $Kernel::OM->Get('Kernel::System::Cache')->CleanUp( Type => 'CustomerUser' );
 
-        }
+    }
 );
 
 1;

--- a/scripts/test/Selenium/Agent/AgentTicketPhone.t
+++ b/scripts/test/Selenium/Agent/AgentTicketPhone.t
@@ -114,22 +114,18 @@ $Selenium->RunTest(
         my $TicketSubject      = "Selenium Ticket";
         my $TicketBody         = "Selenium body test";
         $Selenium->find_element( "#FromCustomer", 'css' )->send_keys($TestCustomer);
-        sleep 1;
+        $Selenium->WaitFor( JavaScript => 'return $("li.ui-menu-item:visible").length' );
+
         $Selenium->find_element("//*[text()='$AutoCompleteString']")->click();
-        sleep 1;
+        $Selenium->WaitFor( JavaScript => 'retun $("p.Value").length' );
+
         $Selenium->find_element( "#Dest option[value='2||Raw']", 'css' )->click();
         $Selenium->find_element( "#Subject",                     'css' )->send_keys($TicketSubject);
         $Selenium->find_element( "#RichText",                    'css' )->send_keys($TicketBody);
         $Selenium->find_element( "#Subject",                     'css' )->submit();
 
         # Wait until form has loaded, if neccessary
-        ACTIVESLEEP:
-        for my $Second ( 1 .. 20 ) {
-            if ( $Selenium->execute_script("return \$('form').length") ) {
-                last ACTIVESLEEP;
-            }
-            sleep 1;
-        }
+        $Selenium->WaitFor( JavaScript => 'return $("form").length' );
 
         # search for new created ticket on AgentTicketZoom screen
         my %TicketIDs = $Kernel::OM->Get('Kernel::System::Ticket')->TicketSearch(
@@ -193,7 +189,7 @@ $Selenium->RunTest(
         $Kernel::OM->Get('Kernel::System::Cache')->CleanUp( Type => 'Ticket' );
         $Kernel::OM->Get('Kernel::System::Cache')->CleanUp( Type => 'CustomerUser' );
 
-    }
+        }
 );
 
 1;

--- a/scripts/test/Selenium/Agent/AgentTicketPhoneCommon.t
+++ b/scripts/test/Selenium/Agent/AgentTicketPhoneCommon.t
@@ -141,15 +141,14 @@ $Selenium->RunTest(
 
             # return back to AgentTicketZoom
             $Selenium->switch_to_window( $Handles->[0] );
-
-            sleep(2);
+            $Selenium->WaitFor( JavaScript => "return \$('div.MainBox').length" );
 
             # click on history link and switch window
             $Selenium->find_element("//*[text()='History']")->click();
             $Handles = $Selenium->get_window_handles();
             $Selenium->switch_to_window( $Handles->[1] );
 
-            sleep(2);
+            $Selenium->WaitFor( JavaScript => "return \$('table.DataTable').length" );
 
             # verify for expected action
             $Self->True(
@@ -189,7 +188,7 @@ $Selenium->RunTest(
         $Kernel::OM->Get('Kernel::System::Cache')->CleanUp( Type => 'Ticket' );
         $Kernel::OM->Get('Kernel::System::Cache')->CleanUp( Type => 'CustomerUser' );
 
-    }
+        }
 );
 
 1;

--- a/scripts/test/Selenium/Agent/AgentTicketPhoneCommon.t
+++ b/scripts/test/Selenium/Agent/AgentTicketPhoneCommon.t
@@ -188,7 +188,7 @@ $Selenium->RunTest(
         $Kernel::OM->Get('Kernel::System::Cache')->CleanUp( Type => 'Ticket' );
         $Kernel::OM->Get('Kernel::System::Cache')->CleanUp( Type => 'CustomerUser' );
 
-        }
+    }
 );
 
 1;

--- a/scripts/test/Selenium/Agent/AgentTicketPhoneCommon.t
+++ b/scripts/test/Selenium/Agent/AgentTicketPhoneCommon.t
@@ -134,7 +134,7 @@ $Selenium->RunTest(
             }
 
             # add body text and submit
-            my $ActionText = $Action . " Selenium Test";
+            my $ActionText = $Action->{Name} . " Selenium Test";
             $Selenium->find_element( "#RichText",                      'css' )->send_keys($ActionText);
             $Selenium->find_element( "#NextStateID option[value='4']", 'css' )->click();
             $Selenium->find_element( "#submitRichText",                'css' )->click();

--- a/scripts/test/Selenium/Agent/AgentTicketPlain.t
+++ b/scripts/test/Selenium/Agent/AgentTicketPlain.t
@@ -100,7 +100,7 @@ $Selenium->RunTest(
         $Selenium->find_element( "#Dest option[value='2||Raw']", 'css' )->click();
         $Selenium->find_element( "#ToCustomer",                  'css' )->send_keys($TestCustomer);
 
-        sleep(2);
+        $Selenium->WaitFor( JavaScript => 'return $("li.ui-menu-item:visible").length' );
 
         $Selenium->find_element("//*[text()='$AutoCompleteString']")->click();
         $Selenium->find_element( "#Subject",  'css' )->send_keys($TicketSubject);
@@ -108,13 +108,7 @@ $Selenium->RunTest(
         $Selenium->find_element( "#Subject",  'css' )->submit();
 
         # Wait until form has loaded, if neccessary
-        ACTIVESLEEP:
-        for my $Second ( 1 .. 20 ) {
-            if ( $Selenium->execute_script("return \$('form').length") ) {
-                last ACTIVESLEEP;
-            }
-            sleep 1;
-        }
+        $Selenium->WaitFor( JavaScript => "return \$('form').length" );
 
         # get ticket number and ID
         my %TicketIDs = $Kernel::OM->Get('Kernel::System::Ticket')->TicketSearch(
@@ -198,7 +192,7 @@ $Selenium->RunTest(
                 Type => $Cache,
             );
         }
-    }
+        }
 );
 
 1;

--- a/scripts/test/Selenium/Agent/AgentTicketSearch.t
+++ b/scripts/test/Selenium/Agent/AgentTicketSearch.t
@@ -89,13 +89,7 @@ $Selenium->RunTest(
         $Selenium->get("${ScriptAlias}index.pl?Action=AgentTicketSearch");
 
         # Wait until form has loaded, if neccessary
-        ACTIVESLEEP:
-        for my $Second ( 1 .. 20 ) {
-            if ( $Selenium->execute_script("return \$('#SearchProfile').length") ) {
-                last ACTIVESLEEP;
-            }
-            sleep 1;
-        }
+        $Selenium->WaitFor( JavaScript => "return \$('#SearchProfile').length" );
 
         # check ticket search page
         for my $ID (
@@ -113,13 +107,7 @@ $Selenium->RunTest(
         $Selenium->find_element( "TicketNumber", 'name' )->submit();
 
         # Wait until form has loaded, if neccessary
-        ACTIVESLEEP:
-        for my $Second ( 1 .. 20 ) {
-            if ( $Selenium->execute_script("return \$('div.MainBox').length") ) {
-                last ACTIVESLEEP;
-            }
-            sleep 1;
-        }
+        $Selenium->WaitFor( JavaScript => "return \$('div.MainBox').length" );
 
         # check for expected result
         $Self->True(
@@ -131,13 +119,7 @@ $Selenium->RunTest(
         $Selenium->get("${ScriptAlias}index.pl?Action=AgentTicketSearch");
 
         # Wait until form has loaded, if neccessary
-        ACTIVESLEEP:
-        for my $Second ( 1 .. 20 ) {
-            if ( $Selenium->execute_script("return \$('#SearchProfile').length") ) {
-                last ACTIVESLEEP;
-            }
-            sleep 1;
-        }
+        $Selenium->WaitFor( JavaScript => "return \$('#SearchProfile').length" );
 
         $Selenium->find_element( "Fulltext", 'name' )->send_keys("abcdfgh");
         $Selenium->find_element( "Fulltext", 'name' )->submit();
@@ -161,7 +143,7 @@ $Selenium->RunTest(
         # make sure the cache is correct.
         $Kernel::OM->Get('Kernel::System::Cache')->CleanUp( Type => 'Ticket' );
 
-    }
+        }
 );
 
 1;

--- a/scripts/test/Selenium/Agent/AgentTicketSearch.t
+++ b/scripts/test/Selenium/Agent/AgentTicketSearch.t
@@ -143,7 +143,7 @@ $Selenium->RunTest(
         # make sure the cache is correct.
         $Kernel::OM->Get('Kernel::System::Cache')->CleanUp( Type => 'Ticket' );
 
-        }
+    }
 );
 
 1;

--- a/scripts/test/Selenium/Agent/Language.t
+++ b/scripts/test/Selenium/Agent/Language.t
@@ -55,13 +55,7 @@ $Selenium->RunTest(
             $Element->click();
             $Element->submit();
 
-            ACTIVESLEEP:
-            for my $Second ( 1 .. 20 ) {
-                if ( $Selenium->execute_script("return \$('.MainBox h1').length") ) {
-                    last ACTIVESLEEP;
-                }
-                sleep 1;
-            }
+            $Selenium->WaitFor( JavaScript => "return \$('.MainBox h1').length" );
 
             # now check if the language was correctly applied in the interface
             my $LanguageObject = Kernel::Language->new(
@@ -83,7 +77,7 @@ $Selenium->RunTest(
                 "Success notification in $Language",
             );
         }
-    }
+        }
 );
 
 1;

--- a/scripts/test/Selenium/Agent/Language.t
+++ b/scripts/test/Selenium/Agent/Language.t
@@ -77,7 +77,7 @@ $Selenium->RunTest(
                 "Success notification in $Language",
             );
         }
-        }
+    }
 );
 
 1;

--- a/scripts/test/Selenium/Customer/CustomerTicketAttachment.t
+++ b/scripts/test/Selenium/Customer/CustomerTicketAttachment.t
@@ -83,7 +83,9 @@ $Selenium->RunTest(
         $Selenium->find_element( "#Subject",                     'css' )->send_keys($SubjectRandom);
         $Selenium->find_element( "#RichText",                    'css' )->send_keys($TextRandom);
         $Selenium->find_element( "#Attachment",                  'css' )->send_keys($Location);
-        sleep 1;
+
+        # wait for upload attachment and submit ticket
+        $Selenium->WaitFor( JavaScript => "return \$('#Subject').length" );
         $Selenium->find_element( "#submitRichText", 'css' )->click();
 
         # obtain ticket number
@@ -134,7 +136,7 @@ $Selenium->RunTest(
         # make sure the cache is correct.
         $Kernel::OM->Get('Kernel::System::Cache')->CleanUp( Type => 'Ticket' );
 
-    }
+        }
 );
 
 1;

--- a/scripts/test/Selenium/Customer/CustomerTicketAttachment.t
+++ b/scripts/test/Selenium/Customer/CustomerTicketAttachment.t
@@ -136,7 +136,7 @@ $Selenium->RunTest(
         # make sure the cache is correct.
         $Kernel::OM->Get('Kernel::System::Cache')->CleanUp( Type => 'Ticket' );
 
-        }
+    }
 );
 
 1;

--- a/scripts/test/Selenium/Customer/CustomerTicketOverview.t
+++ b/scripts/test/Selenium/Customer/CustomerTicketOverview.t
@@ -69,13 +69,7 @@ $Selenium->RunTest(
         $Selenium->find_element( "#Subject",                     'css' )->submit();
 
         # Wait until form has loaded, if neccessary
-        ACTIVESLEEP:
-        for my $Second ( 1 .. 20 ) {
-            if ( $Selenium->execute_script("return \$('table.Overview').length") ) {
-                last ACTIVESLEEP;
-            }
-            sleep 1;
-        }
+        $Selenium->WaitFor( JavaScript => "return \$('table.Overview').length" );
 
         # get needed data
         my @User = $Kernel::OM->Get('Kernel::System::CustomerUser')->CustomerIDs(
@@ -136,7 +130,7 @@ $Selenium->RunTest(
         # make sure the cache is correct.
         $Kernel::OM->Get('Kernel::System::Cache')->CleanUp( Type => 'Ticket' );
 
-    }
+        }
 );
 
 1;

--- a/scripts/test/Selenium/Customer/CustomerTicketOverview.t
+++ b/scripts/test/Selenium/Customer/CustomerTicketOverview.t
@@ -130,7 +130,7 @@ $Selenium->RunTest(
         # make sure the cache is correct.
         $Kernel::OM->Get('Kernel::System::Cache')->CleanUp( Type => 'Ticket' );
 
-        }
+    }
 );
 
 1;

--- a/scripts/test/Selenium/Customer/CustomerTicketProcess.t
+++ b/scripts/test/Selenium/Customer/CustomerTicketProcess.t
@@ -293,7 +293,7 @@ $Selenium->RunTest(
             $Kernel::OM->Get('Kernel::System::Cache')->CleanUp( Type => $Cache );
         }
 
-        }
+    }
 );
 
 1;

--- a/scripts/test/Selenium/Customer/CustomerTicketProcess.t
+++ b/scripts/test/Selenium/Customer/CustomerTicketProcess.t
@@ -103,7 +103,7 @@ $Selenium->RunTest(
 
         # create first scenarion for test customer ticket process
         $Selenium->find_element( "#ProcessEntityID option[value='$ListReverse{$ProcessName}']", 'css' )->click();
-        sleep 1;
+        $Selenium->WaitFor( JavaScript => "return \$('#Subject').length" );
 
         my $SubjectRandom = 'Subject' . $Helper->GetRandomID();
         my $ContentRandom = 'Content' . $Helper->GetRandomID();
@@ -136,7 +136,7 @@ $Selenium->RunTest(
         $Selenium->find_element( "#Subject",                      'css' )->submit();
         $Selenium->switch_to_window( $Handles->[0] );
         $Selenium->refresh();
-        sleep 1;
+        $Selenium->WaitFor( JavaScript => "return \$('.Content').length" );
 
         # check for inputed values as final step in first scenario
         $Self->True(
@@ -158,7 +158,7 @@ $Selenium->RunTest(
         # create second scenarion for test customer ticket process
         $Selenium->get("${ScriptAlias}customer.pl?Action=CustomerTicketProcess");
         $Selenium->find_element( "#ProcessEntityID option[value='$ListReverse{$ProcessName}']", 'css' )->click();
-        sleep 1;
+        $Selenium->WaitFor( JavaScript => "return \$('#Subject').length" );
 
         # in this scenarion we just set ticket queue to junk to finish test
         $Selenium->find_element( "#QueueID option[value='3']", 'css' )->click();
@@ -284,7 +284,16 @@ $Selenium->RunTest(
         $ScriptAlias = $ConfigObject->Get('ScriptAlias');
         $Selenium->get("${ScriptAlias}index.pl?Action=AdminProcessManagement");
         $Selenium->find_element("//a[contains(\@href, \'Subaction=ProcessSync' )]")->click();
-    }
+
+        # make sure cache is correct
+        for my $Cache (
+            qw(ProcessManagement_Activity ProcessManagement_ActivityDialog ProcessManagement_Process ProcessManagement_Transition ProcessManagement_TransitionAction )
+            )
+        {
+            $Kernel::OM->Get('Kernel::System::Cache')->CleanUp( Type => $Cache );
+        }
+
+        }
 );
 
 1;

--- a/scripts/test/Selenium/Customer/CustomerTicketZoom.t
+++ b/scripts/test/Selenium/Customer/CustomerTicketZoom.t
@@ -141,7 +141,7 @@ $Selenium->RunTest(
         # make sure the cache is correct.
         $Kernel::OM->Get('Kernel::System::Cache')->CleanUp( Type => 'Ticket' );
 
-        }
+    }
 );
 
 1;

--- a/scripts/test/Selenium/Customer/CustomerTicketZoom.t
+++ b/scripts/test/Selenium/Customer/CustomerTicketZoom.t
@@ -69,13 +69,7 @@ $Selenium->RunTest(
         $Selenium->find_element( "#Subject",                     'css' )->submit();
 
         # Wait until form has loaded, if neccessary
-        ACTIVESLEEP:
-        for my $Second ( 1 .. 20 ) {
-            if ( $Selenium->execute_script("return \$('table.Overview').length") ) {
-                last ACTIVESLEEP;
-            }
-            sleep 1;
-        }
+        $Selenium->WaitFor( JavaScript => "return \$('table.Overview').length" );
 
         # get needed data
         my @User = $Kernel::OM->Get('Kernel::System::CustomerUser')->CustomerIDs(
@@ -147,7 +141,7 @@ $Selenium->RunTest(
         # make sure the cache is correct.
         $Kernel::OM->Get('Kernel::System::Cache')->CleanUp( Type => 'Ticket' );
 
-    }
+        }
 );
 
 1;

--- a/scripts/test/Selenium/Output/ToolBar/CICSearchCustomerID.t
+++ b/scripts/test/Selenium/Output/ToolBar/CICSearchCustomerID.t
@@ -104,7 +104,8 @@ $Selenium->RunTest(
         # input test user in search CustomerID
         my $AutoCCSearch = "$TestCustomerID $TestCompanyName";
         $Selenium->find_element( "#ToolBarCICSearchCustomerID", 'css' )->send_keys($TestCustomerID);
-        sleep 1;
+        $Selenium->WaitFor( JavaScript => 'return $("li.ui-menu-item:visible").length' );
+
         $Selenium->find_element("//*[text()='$AutoCCSearch']")->click();
 
         # verify search
@@ -136,7 +137,7 @@ $Selenium->RunTest(
             "Deleted CustomerUser - $CustomerID",
         );
 
-    }
+        }
 );
 
 1;

--- a/scripts/test/Selenium/Output/ToolBar/CICSearchCustomerUser.t
+++ b/scripts/test/Selenium/Output/ToolBar/CICSearchCustomerUser.t
@@ -102,7 +102,8 @@ $Selenium->RunTest(
         # input test user in search Customer user
         my $AutoCCSearch = "\"$TestCustomerLogin $TestCustomerLogin\" <$TestCustomerEmail>";
         $Selenium->find_element( "#ToolBarCICSearchCustomerUser", 'css' )->send_keys($TestCustomerLogin);
-        sleep 1;
+        $Selenium->WaitFor( JavaScript => 'return $("li.ui-menu-item:visible").length' );
+
         $Selenium->find_element("//*[text()='$AutoCCSearch']")->click();
 
         # verify search
@@ -134,7 +135,7 @@ $Selenium->RunTest(
             "Deleted CustomerUser - $CustomerID",
         );
 
-    }
+        }
 );
 
 1;

--- a/scripts/test/Selenium/Output/ToolBar/TicketSearchProfile.t
+++ b/scripts/test/Selenium/Output/ToolBar/TicketSearchProfile.t
@@ -146,7 +146,7 @@ $Selenium->RunTest(
             $Success,
             "Delete ticket - $TicketID"
         );
-        }
+    }
 );
 
 1;

--- a/scripts/test/Selenium/Output/ToolBar/TicketSearchProfile.t
+++ b/scripts/test/Selenium/Output/ToolBar/TicketSearchProfile.t
@@ -92,17 +92,8 @@ $Selenium->RunTest(
         # click on search
         $Selenium->find_element( "#GlobalSearchNav", 'css' )->click();
 
-        # wait until search window is loading
-        ACTIVESLEEP:
-        for my $Second ( 1 .. 20 ) {
-            sleep 1;
-
-            # check if customer data is loaded
-            if ( $Selenium->execute_script("return \$('#SearchProfileNew').length") ) {
-                last ACTIVESLEEP;
-            }
-            print "Waiting to load search window  $Second  second(s)...\n\n";
-        }
+        # Wait until form has loaded, if neccessary
+        $Selenium->WaitFor( JavaScript => "return \$('#SearchProfileNew').length" );
 
         # create new template search
         my $SearchProfileName = "SeleniumTest";
@@ -155,7 +146,7 @@ $Selenium->RunTest(
             $Success,
             "Delete ticket - $TicketID"
         );
-    }
+        }
 );
 
 1;


### PR DESCRIPTION
Hi @mgruner 

here is fixed and changed sleep with WaitFor function. We tested all Selenium test again, and there were some unsuccessful test that is cussed with WaitFor, we also fix that.
For example
 $Selenium->WaitFor( JavaScript => 'return $("li.ui-menu-item:visible").length' );
is changed to
 $Selenium->WaitFor( JavaScript => 'return $("li.ui-menu-item:visible")' );

And then all works fine. Please followup this, and tell us what do you think about this.

Regards
Zoran