### PR TITLE
Master - port to OM output ticket menu process

### DIFF
--- a/scripts/test/Selenium/Output/Ticket/MenuProcess.t
+++ b/scripts/test/Selenium/Output/Ticket/MenuProcess.t
@@ -1,0 +1,218 @@
+# --
+# Copyright (C) 2001-2015 OTRS AG, http://otrs.com/
+# --
+# This software comes with ABSOLUTELY NO WARRANTY. For details, see
+# the enclosed file COPYING for license information (AGPL). If you
+# did not receive this file, see http://www.gnu.org/licenses/agpl.txt.
+# --
+
+use strict;
+use warnings;
+use utf8;
+
+use vars (qw($Self));
+
+# get process needed objects
+my $ProcessObject           = $Kernel::OM->Get('Kernel::System::ProcessManagement::DB::Process');
+my $TransitionObject        = $Kernel::OM->Get('Kernel::System::ProcessManagement::DB::Transition');
+my $ActivityObject          = $Kernel::OM->Get('Kernel::System::ProcessManagement::DB::Activity');
+my $TransitionActionsObject = $Kernel::OM->Get('Kernel::System::ProcessManagement::DB::TransitionAction');
+my $ActivityDialogObject    = $Kernel::OM->Get('Kernel::System::ProcessManagement::DB::ActivityDialog');
+
+# get selenium object
+my $Selenium = $Kernel::OM->Get('Kernel::System::UnitTest::Selenium');
+
+$Selenium->RunTest(
+    sub {
+
+        # get helper object
+        my $Helper = $Kernel::OM->Get('Kernel::System::UnitTest::Helper');
+
+        my $TestUserLogin = $Helper->TestUserCreate(
+            Groups => [ 'admin', 'users' ],
+        ) || die "Did not get test user";
+
+        $Selenium->Login(
+            Type     => 'Agent',
+            User     => $TestUserLogin,
+            Password => $TestUserLogin,
+        );
+
+        # get test user ID
+        my $TestUserID = $Kernel::OM->Get('Kernel::System::User')->UserLookup(
+            UserLogin => $TestUserLogin,
+        );
+
+        # get config object
+        my $ConfigObject = $Kernel::OM->Get('Kernel::Config');
+
+        my $ScriptAlias = $ConfigObject->Get('ScriptAlias');
+
+        # import test selenium process
+        $Selenium->get("${ScriptAlias}index.pl?Action=AdminProcessManagement");
+        my $Location = $ConfigObject->Get('Home')
+            . "/development/samples/process/TestProcess.yml";
+        $Selenium->find_element( "#FileUpload",                'css' )->send_keys($Location);
+        $Selenium->find_element( "#OverwriteExistingEntities", 'css' )->click();
+        $Selenium->find_element("//button[\@value='Upload process configuration'][\@type='submit']")->click();
+        $Selenium->find_element("//a[contains(\@href, \'Subaction=ProcessSync' )]")->click();
+
+        # get process list
+        my $List = $ProcessObject->ProcessList(
+            UseEntities => 1,
+            UserID      => $TestUserID,
+        );
+
+        # get process entity
+        my %ListReverse = reverse %{$List};
+        my $ProcessName = "TestProcess";
+
+        my $Process = $ProcessObject->ProcessGet(
+            EntityID => $ListReverse{$ProcessName},
+            UserID   => $TestUserID,
+        );
+
+        # get ticket object
+        my $TicketObject = $Kernel::OM->Get('Kernel::System::Ticket');
+
+        # create test ticket
+        my $TicketID = $TicketObject->TicketCreate(
+            Title        => 'Some Ticket Title',
+            Queue        => 'Raw',
+            Lock         => 'unlock',
+            Priority     => '3 normal',
+            State        => 'new',
+            CustomerID   => '123465',
+            CustomerUser => 'customer@example.com',
+            OwnerID      => $TestUserID,
+            UserID       => $TestUserID,
+        );
+
+        # go to test created ticket zoom
+        $Selenium->get("${ScriptAlias}index.pl?Action=AgentTicketZoom;TicketID=$TicketID");
+
+        # check if process enroll is available for test ticket
+        $Self->True(
+            $Selenium->find_element(
+                "//a[contains(\@href, \'Action=AgentTicketProcess;IsProcessEnroll=1;TicketID=$TicketID' )]"),
+            "Ticket menu Process Enroll - found"
+        );
+
+        # delete created test tickets
+        my $Success = $TicketObject->TicketDelete(
+            TicketID => $TicketID,
+            UserID   => $TestUserID,
+        );
+        $Self->True(
+            $Success,
+            "Delete ticket - $TicketID"
+        );
+
+        # clean up activities
+        for my $Item ( @{ $Process->{Activities} } ) {
+            my $Activity = $ActivityObject->ActivityGet(
+                EntityID            => $Item,
+                UserID              => $TestUserID,
+                ActivityDialogNames => 0,
+            );
+
+            # clean up activity dialogs
+            for my $ActivityDialogItem ( @{ $Activity->{ActivityDialogs} } ) {
+                my $ActivityDialog = $ActivityDialogObject->ActivityDialogGet(
+                    EntityID => $ActivityDialogItem,
+                    UserID   => $TestUserID,
+                );
+
+                # delete test activity dialog
+                $Success = $ActivityDialogObject->ActivityDialogDelete(
+                    ID     => $ActivityDialog->{ID},
+                    UserID => $TestUserID,
+                );
+                $Self->True(
+                    $Success,
+                    "ActivityDialog deleted - $ActivityDialog->{Name},",
+                );
+            }
+
+            # delete test activity
+            $Success = $ActivityObject->ActivityDelete(
+                ID     => $Activity->{ID},
+                UserID => $TestUserID,
+            );
+
+            $Self->True(
+                $Success,
+                "Activity deleted - $Activity->{Name},",
+            );
+        }
+
+        # clean up transition actions
+        for my $Item ( @{ $Process->{TransitionActions} } ) {
+            my $TransitionAction = $TransitionActionsObject->TransitionActionGet(
+                EntityID => $Item,
+                UserID   => $TestUserID,
+            );
+
+            # delete test transition action
+            $Success = $TransitionActionsObject->TransitionActionDelete(
+                ID     => $TransitionAction->{ID},
+                UserID => $TestUserID,
+            );
+
+            $Self->True(
+                $Success,
+                "TransitionAction deleted - $TransitionAction->{Name},",
+            );
+        }
+
+        # clean up transition
+        for my $Item ( @{ $Process->{Transitions} } ) {
+            my $Transition = $TransitionObject->TransitionGet(
+                EntityID => $Item,
+                UserID   => $TestUserID,
+            );
+
+            # delete test transition
+            $Success = $TransitionObject->TransitionDelete(
+                ID     => $Transition->{ID},
+                UserID => $TestUserID,
+            );
+
+            $Self->True(
+                $Success,
+                "Transition deleted - $Transition->{Name},",
+            );
+        }
+
+        # delete test process
+        $Success = $ProcessObject->ProcessDelete(
+            ID     => $Process->{ID},
+            UserID => $TestUserID,
+        );
+
+        $Self->True(
+            $Success,
+            "Process deleted - $Process->{Name},",
+        );
+
+        $Selenium->get("${ScriptAlias}index.pl?Action=AdminProcessManagement");
+        $Selenium->find_element("//a[contains(\@href, \'Subaction=ProcessSync' )]")->click();
+
+        # make sure the cache is correct.
+        $Kernel::OM->Get('Kernel::System::Cache')->CleanUp(
+            Type => 'Ticket',
+        );
+
+        # make sure the cache is correct.
+        for my $Cache (
+            qw (ProcessManagement_Activity ProcessManagement_ActivityDialog ProcessManagement_Transition ProcessManagement_TransitionAction Ticket)
+            )
+        {
+            $Kernel::OM->Get('Kernel::System::Cache')->CleanUp(
+                Type => $Cache,
+            );
+        }
+    }
+);
+
+1;


### PR DESCRIPTION
Hi @mgruner 

There are ported Ticket/MenuProcess.pm to OM and test for it.

Please check this in constructor:

<pre>
   for (qw( LayoutObject UserID )) {
         $Self->{$_} = $Param{$_} || die "Got no $_!";
     }

    $Kernel::OM->ObjectParamAdd(
        'Kernel::Output::HTML::NavBarAgentTicketProcess' => {
            %{$Self},
        },
    );
    $Self->{NavBarModule} = $Kernel::OM->Get('Kernel::Output::HTML::NavBarAgentTicketProcess');
</pre>

As you can see we add $Self param for NavBarAgentTicketProcess.pm, we will port to OM also NavBarAgentTicketProcess.pm next days, and maybe then it will not be needed.

Regards
Zoran
