### PR TITLE
Modularize Postmaster CheckFollowUp

### DIFF
--- a/Kernel/Config/Files/Ticket.xml
+++ b/Kernel/Config/Files/Ticket.xml
@@ -10100,6 +10100,26 @@ Thanks for your help!
             </Hash>
         </Setting>
     </ConfigItem>
+    <ConfigItem Name="PostMaster::CheckFollowUpModule###0100-InSubject" Required="1" Valid="1">
+        <Description Translatable="1">Checks if an E-Mail is a followup to an existing ticket by searching the subject for a valid ticket number.</Description>
+        <Group>Ticket</Group>
+        <SubGroup>Core::PostMaster</SubGroup>
+        <Setting>
+            <Hash>
+                <Item Key="Module">Kernel::System::PostMaster::Filter::CheckFollowUpInSubject</Item>
+            </Hash>
+        </Setting>
+    </ConfigItem>
+    <ConfigItem Name="PostMaster::CheckFollowUpModule###0200-InReferences" Required="1" Valid="1">
+        <Description Translatable="1">Executes follow up checks on In-Reply-To or References headers for mails that don't have a ticket number in the subject.</Description>
+        <Group>Ticket</Group>
+        <SubGroup>Core::PostMaster</SubGroup>
+        <Setting>
+            <Hash>
+                <Item Key="Module">Kernel::System::PostMaster::Filter::CheckFollowUpInReferences</Item>
+            </Hash>
+        </Setting>
+    </ConfigItem>
     <ConfigItem Name="SendNoAutoResponseRegExp" Required="1" Valid="1">
         <Description Translatable="1">If this regex matches, no message will be send by the autoresponder.</Description>
         <Group>Ticket</Group>

--- a/Kernel/System/PostMaster/Filter/CheckFollowUpInReferences.pm
+++ b/Kernel/System/PostMaster/Filter/CheckFollowUpInReferences.pm
@@ -1,0 +1,59 @@
+# --
+# Copyright (C) 2001-2015 OTRS AG, http://otrs.com/
+# --
+# This software comes with ABSOLUTELY NO WARRANTY. For details, see
+# the enclosed file COPYING for license information (AGPL). If you
+# did not receive this file, see http://www.gnu.org/licenses/agpl.txt.
+# --
+
+package Kernel::System::PostMaster::Filter::CheckFollowUpInReferences;
+
+use strict;
+use warnings;
+
+our @ObjectDependencies = (
+    'Kernel::Config',
+    'Kernel::System::Ticket',
+);
+
+sub new {
+    my ( $Type, %Param ) = @_;
+
+    # allocate new hash for object
+    my $Self = {};
+    bless( $Self, $Type );
+
+    $Self->{ParserObject} = $Param{ParserObject} || die "Got no ParserObject";
+
+    return $Self;
+}
+
+sub Run {
+    my ( $Self, %Param ) = @_;
+
+    if (! $Kernel::OM->Get('Kernel::Config')->Get('PostmasterFollowUpSearchInReferences') ) {
+        return;
+    }
+
+    my @References = $Self->{ParserObject}->GetReferences();
+
+    return if ! @References;
+
+    my $TicketObject = $Kernel::OM->Get('Kernel::System::Ticket');
+
+    for my $Reference (@References) {
+
+        # get ticket id of message id
+        my $TicketID = $TicketObject->ArticleGetTicketIDOfMessageID(
+            MessageID => "<$Reference>",
+        );
+
+        if ( $TicketID ) {
+            return $TicketID;
+        }
+    }
+
+    return;
+}
+
+1;

--- a/Kernel/System/PostMaster/Filter/CheckFollowUpInSubject.pm
+++ b/Kernel/System/PostMaster/Filter/CheckFollowUpInSubject.pm
@@ -1,0 +1,41 @@
+# --
+# Copyright (C) 2001-2015 OTRS AG, http://otrs.com/
+# --
+# This software comes with ABSOLUTELY NO WARRANTY. For details, see
+# the enclosed file COPYING for license information (AGPL). If you
+# did not receive this file, see http://www.gnu.org/licenses/agpl.txt.
+# --
+
+package Kernel::System::PostMaster::Filter::CheckFollowUpInSubject;
+
+use strict;
+use warnings;
+
+our @ObjectDependencies = (
+    'Kernel::Config',
+    'Kernel::System::Ticket',
+);
+
+sub new {
+    my ( $Type, %Param ) = @_;
+
+    # allocate new hash for object
+    my $Self = {};
+    return bless( $Self, $Type );
+}
+
+sub Run {
+    my ( $Self, %Param ) = @_;
+
+    my $TicketObject = $Kernel::OM->Get('Kernel::System::Ticket');
+
+    my $Subject = $Param{Subject} || '';
+
+    my $Tn = $TicketObject->GetTNByString($Subject);
+    return if ! $Tn;
+
+    my $TicketID = $TicketObject->TicketCheckNumber( Tn => $Tn );
+    return $TicketID;
+}
+
+1;


### PR DESCRIPTION
Pluggable architecture for deciding whether an email belongs to an existing ticket.

This ports two existing checks (Ticket number in subject, and `In-Reply-To`/`References` header) to the new API.