### PR TITLE
Postmaster: Followup-check by dynamic field header

### DIFF
--- a/Kernel/Config/Files/Ticket.xml
+++ b/Kernel/Config/Files/Ticket.xml
@@ -10121,7 +10121,7 @@ Thanks for your help!
         </Setting>
     </ConfigItem>
     <ConfigItem Name="PostMaster::CheckFollowUpModule###0800-DynamicField" Required="1" Valid="1">
-        <Description Translatable="1">Executes follow up checks on a dynamic field  header. If a ticket with the same content of the dynamic field (and in configurable states) is found, it is considered a follow-up to that ticket. The dynamic field must be configured as a text field.</Description>
+        <Description Translatable="1">Executes follow up checks on a dynamic field  header. If a ticket with the same content of the dynamic field (and in one of the state types configred in &quot;StateType&quot; below) is found, it is considered a follow-up to that ticket. The dynamic field must be configured as a text field.</Description>
         <Group>Ticket</Group>
         <SubGroup>Core::PostMaster</SubGroup>
         <Setting>

--- a/Kernel/Config/Files/Ticket.xml
+++ b/Kernel/Config/Files/Ticket.xml
@@ -10121,7 +10121,7 @@ Thanks for your help!
         </Setting>
     </ConfigItem>
     <ConfigItem Name="PostMaster::CheckFollowUpModule###0800-DynamicField" Required="1" Valid="1">
-        <Description Translatable="1">Executes follow up checks on a dynamic field  header. If a ticket with the same content of the dyanmic field (and in configurable states) is found, it is considered a follow-up to that ticket. The dynamic field must be configured as a text field.</Description>
+        <Description Translatable="1">Executes follow up checks on a dynamic field  header. If a ticket with the same content of the dynamic field (and in configurable states) is found, it is considered a follow-up to that ticket. The dynamic field must be configured as a text field.</Description>
         <Group>Ticket</Group>
         <SubGroup>Core::PostMaster</SubGroup>
         <Setting>

--- a/Kernel/Config/Files/Ticket.xml
+++ b/Kernel/Config/Files/Ticket.xml
@@ -10120,7 +10120,7 @@ Thanks for your help!
             </Hash>
         </Setting>
     </ConfigItem>
-    <ConfigItem Name="PostMaster::CheckFollowUpModule###0800-DynamicField" Required="1" Valid="1">
+    <ConfigItem Name="PostMaster::CheckFollowUpModule###0800-DynamicField" Required="0" Valid="0">
         <Description Translatable="1">Executes follow up checks on a dynamic field  header. If a ticket with the same content of the dynamic field (and in one of the state types configred in &quot;StateType&quot; below) is found, it is considered a follow-up to that ticket. The dynamic field must be configured as a text field.</Description>
         <Group>Ticket</Group>
         <SubGroup>Core::PostMaster</SubGroup>

--- a/Kernel/Config/Files/Ticket.xml
+++ b/Kernel/Config/Files/Ticket.xml
@@ -10120,6 +10120,26 @@ Thanks for your help!
             </Hash>
         </Setting>
     </ConfigItem>
+    <ConfigItem Name="PostMaster::CheckFollowUpModule###0800-DynamicField" Required="1" Valid="1">
+        <Description Translatable="1">Executes follow up checks on a dynamic field  header. If a ticket with the same content of the dyanmic field (and in configurable states) is found, it is considered a follow-up to that ticket. The dynamic field must be configured as a text field.</Description>
+        <Group>Ticket</Group>
+        <SubGroup>Core::PostMaster</SubGroup>
+        <Setting>
+            <Hash>
+                <Item Key="Module">Kernel::System::PostMaster::Filter::CheckFollowUpDynamicField</Item>
+                <Item Key="Header">X-OTRS-DynamicField-FollowUpDetection</Item>
+                <Item Key="DynamicField">FollowUpDetection</Item>
+                <Item Key="StateTypes">
+                    <Array>
+                        <Item>new</Item>
+                        <Item>open</Item>
+                        <Item>pending auto</Item>
+                        <Item>pending reminder</Item>
+                    </Array>
+                </Item>
+            </Hash>
+        </Setting>
+    </ConfigItem>
     <ConfigItem Name="SendNoAutoResponseRegExp" Required="1" Valid="1">
         <Description Translatable="1">If this regex matches, no message will be send by the autoresponder.</Description>
         <Group>Ticket</Group>

--- a/Kernel/Output/HTML/Ticket/OverviewSmall.pm
+++ b/Kernel/Output/HTML/Ticket/OverviewSmall.pm
@@ -65,7 +65,7 @@ sub new {
         $Self->{StoredFilters} = $StoredFilters;
     }
 
-    # get the configured dyanmic fields from the Small Overview setting as a basis
+    # get the configured dynamic fields from the Small Overview setting as a basis
     my %DefaultDynamicFields = %{ $ConfigObject->Get("Ticket::Frontend::OverviewSmall")->{DynamicField} || {} };
 
     my %DefaultColumns = map { 'DynamicField_' . $_ => $DefaultDynamicFields{$_} } sort keys %DefaultDynamicFields;

--- a/Kernel/System/EmailParser.pm
+++ b/Kernel/System/EmailParser.pm
@@ -975,6 +975,9 @@ sub _MailAddressParse {
     my ( $Self, %Param ) = @_;
 
     my $Email = $Param{Email};
+    if ( !defined $Email ) {
+        return;
+    }
     my $Cache = $Self->{EmailCache};
 
     if ( $Self->{EmailCache}->{$Email} ) {

--- a/Kernel/System/PostMaster.pm
+++ b/Kernel/System/PostMaster.pm
@@ -155,7 +155,7 @@ sub Run {
     my $GetParam = $Self->GetEmailParams();
 
     # check if follow up
-    my ( $Tn, $TicketID ) = $Self->CheckFollowUp( %{$GetParam} );
+    my ( $Tn, $TicketID ) = $Self->CheckFollowUp( GetParam => $GetParam );
 
     # get config objects
     my $ConfigObject = $Kernel::OM->Get('Kernel::Config');
@@ -217,7 +217,7 @@ sub Run {
     # ----------------------
 
     # check if follow up (again, with new GetParam)
-    ( $Tn, $TicketID ) = $Self->CheckFollowUp( %{$GetParam} );
+    ( $Tn, $TicketID ) = $Self->CheckFollowUp( GetParam => $GetParam );
 
     # check if it's a follow up ...
     if ( $Tn && $TicketID ) {
@@ -431,7 +431,9 @@ sub Run {
 to detect the ticket number in processing email
 
     my ($TicketNumber, $TicketID) = $PostMasterObject->CheckFollowUp(
-        Subject => 'Re: [Ticket:#123456] Some Subject',
+        GetParam => {
+            Subject => 'Re: [Ticket:#123456] Some Subject',
+        },
     );
 
 =cut

--- a/Kernel/System/PostMaster.pm
+++ b/Kernel/System/PostMaster.pm
@@ -458,6 +458,7 @@ sub CheckFollowUp {
 
             my $CheckObject = $Jobs->{$Job}->{Module}->new(
                 %{$Self},
+                Config => $Jobs->{$Job},
             );
 
             if ( !$CheckObject ) {

--- a/Kernel/System/PostMaster/Filter/CheckFollowUpDynamicField.pm
+++ b/Kernel/System/PostMaster/Filter/CheckFollowUpDynamicField.pm
@@ -49,7 +49,7 @@ sub Run {
         return;
     }
 
-    my $HeaderValue = $Param{ $Self->{Header} };
+    my $HeaderValue = $Param{GetParam}{ $Self->{Header} };
     if ( !IsStringWithData($HeaderValue) ) {
         return;
     }
@@ -67,6 +67,11 @@ sub Run {
     if ( $TicketID ) {
         return $TicketID;
     }
+    else {
+        # make sure the new ticket has the dynamic field set
+        $Param{GetParam}{"X-OTRS-DynamicField-$Self->{DynamicField}"} = $HeaderValue;
+    }
+    return;
 }
 
 1;

--- a/Kernel/System/PostMaster/Filter/CheckFollowUpDynamicField.pm
+++ b/Kernel/System/PostMaster/Filter/CheckFollowUpDynamicField.pm
@@ -1,0 +1,72 @@
+# --
+# Copyright (C) 2001-2015 OTRS AG, http://otrs.com/
+# --
+# This software comes with ABSOLUTELY NO WARRANTY. For details, see
+# the enclosed file COPYING for license information (AGPL). If you
+# did not receive this file, see http://www.gnu.org/licenses/agpl.txt.
+# --
+
+package Kernel::System::PostMaster::Filter::CheckFollowUpDynamicField;
+
+use strict;
+use warnings;
+
+our @ObjectDependencies = (
+    'Kernel::Config',
+    'Kernel::System::Ticket',
+    'Kernel::System::DynamicField',
+    'Kernel::System::DynamicField::Backend',
+);
+
+use Kernel::System::VariableCheck qw(IsHashRefWithData IsStringWithData);
+
+sub new {
+    my ( $Type, %Param ) = @_;
+
+    # allocate new hash for object
+    my $Self = {};
+    bless( $Self, $Type );
+
+    $Self->{ParserObject} = $Param{ParserObject} || die "Got no ParserObject";
+    $Self->{DynamicField} = $Param{Config}{DynamicField};
+    $Self->{Header}       = $Param{Config}{Header};
+    $Self->{StateTypes}   = $Param{Config}{StateTypes};
+
+    return $Self;
+}
+
+sub Run {
+    my ( $Self, %Param ) = @_;
+
+    if ( !$Self->{DynamicField} ) {
+        return;
+    }
+
+    my $DynamicFieldConfig = $Kernel::OM->Get('Kernel::System::DynamicField')->DynamicFieldGet(
+        Name => $Self->{DynamicField},
+    );
+    if ( !IsHashRefWithData($DynamicFieldConfig) ) {
+        return;
+    }
+
+    my $HeaderValue = $Param{ $Self->{Header} };
+    if ( !IsStringWithData($HeaderValue) ) {
+        return;
+    }
+
+    my ($TicketID) = $Kernel::OM->Get('Kernel::System::Ticket')->TicketSearch(
+        Result                               => 'ARRAY',
+        Limit                                => 1,
+        UserID                               => 1,
+        StateType                            => $Self->{StateTypes},
+        "DynamicField_$Self->{DynamicField}" => {
+            Equals => $HeaderValue,
+        },
+    );
+
+    if ( $TicketID ) {
+        return $TicketID;
+    }
+}
+
+1;

--- a/Kernel/System/PostMaster/Filter/CheckFollowUpDynamicField.pm
+++ b/Kernel/System/PostMaster/Filter/CheckFollowUpDynamicField.pm
@@ -28,9 +28,9 @@ sub new {
     bless( $Self, $Type );
 
     $Self->{ParserObject} = $Param{ParserObject} || die "Got no ParserObject";
-    $Self->{DynamicField} = $Param{Config}{DynamicField};
-    $Self->{Header}       = $Param{Config}{Header};
-    $Self->{StateTypes}   = $Param{Config}{StateTypes};
+    $Self->{DynamicField} = $Param{Config}->{DynamicField};
+    $Self->{Header}       = $Param{Config}->{Header};
+    $Self->{StateTypes}   = $Param{Config}->{StateTypes};
 
     return $Self;
 }
@@ -49,7 +49,7 @@ sub Run {
         return;
     }
 
-    my $HeaderValue = $Param{GetParam}{ $Self->{Header} };
+    my $HeaderValue = $Param{GetParam}->{ $Self->{Header} };
     if ( !IsStringWithData($HeaderValue) ) {
         return;
     }
@@ -69,7 +69,7 @@ sub Run {
     }
     else {
         # make sure the new ticket has the dynamic field set
-        $Param{GetParam}{"X-OTRS-DynamicField-$Self->{DynamicField}"} = $HeaderValue;
+        $Param{GetParam}->{"X-OTRS-DynamicField-$Self->{DynamicField}"} = $HeaderValue;
     }
     return;
 }

--- a/Kernel/System/PostMaster/Filter/CheckFollowUpInSubject.pm
+++ b/Kernel/System/PostMaster/Filter/CheckFollowUpInSubject.pm
@@ -29,7 +29,7 @@ sub Run {
 
     my $TicketObject = $Kernel::OM->Get('Kernel::System::Ticket');
 
-    my $Subject = $Param{GetParam}{Subject} || '';
+    my $Subject = $Param{GetParam}->{Subject} || '';
 
     my $Tn = $TicketObject->GetTNByString($Subject);
     return if !$Tn;

--- a/Kernel/System/PostMaster/Filter/CheckFollowUpInSubject.pm
+++ b/Kernel/System/PostMaster/Filter/CheckFollowUpInSubject.pm
@@ -29,7 +29,7 @@ sub Run {
 
     my $TicketObject = $Kernel::OM->Get('Kernel::System::Ticket');
 
-    my $Subject = $Param{Subject} || '';
+    my $Subject = $Param{GetParam}{Subject} || '';
 
     my $Tn = $TicketObject->GetTNByString($Subject);
     return if !$Tn;

--- a/scripts/test/PostMaster/CheckFollowUpDynamicField.t
+++ b/scripts/test/PostMaster/CheckFollowUpDynamicField.t
@@ -1,0 +1,140 @@
+# --
+# Copyright (C) 2001-2015 OTRS AG, http://otrs.com/
+# --
+# This software comes with ABSOLUTELY NO WARRANTY. For details, see
+# the enclosed file COPYING for license information (AGPL). If you
+# did not receive this file, see http://www.gnu.org/licenses/agpl.txt.
+# --
+
+use strict;
+use warnings;
+use utf8;
+
+use vars (qw($Self));
+
+use Kernel::System::PostMaster;
+use Kernel::System::VariableCheck qw(IsHashRefWithData);
+
+# get needed objects
+my $ConfigObject        = $Kernel::OM->Get('Kernel::Config');
+my $MainObject          = $Kernel::OM->Get('Kernel::System::Main');
+my $DynamicFieldObject  = $Kernel::OM->Get('Kernel::System::DynamicField');
+my $TicketObject        = $Kernel::OM->Get('Kernel::System::Ticket');
+
+my $FieldName = 'FollowUpDetection';
+my $Header    = "X-OTRS-DynamicField-$FieldName";
+my $Config = $ConfigObject->Get('PostMaster::CheckFollowUpModule')->{'0800-DynamicField'};
+$Config->{DynamicField} = $FieldName;
+$Config->{Header}       = "X-OTRS-DynamicField-$FieldName";
+$Config->{StateTypes}   = [ 'new', 'open' ];
+
+$ConfigObject->Set(
+    Key         => 'PostmasterX-Header',
+    Value       => [$Header],
+);
+
+$ConfigObject->Set(
+    Key   => 'PostmasterDefaultState',
+    Value => 'new'
+);
+
+
+my $DynamicField = $DynamicFieldObject->DynamicFieldGet(
+    Name => $FieldName,
+);
+
+if ( !IsHashRefWithData( $DynamicField ) ) {
+    $DynamicFieldObject->DynamicFieldAdd(
+        Name    => $FieldName,
+        Label   => $FieldName . '_test',
+        FieldOrder      => 9992,
+        FieldType       => 'Text',
+        ObjectType      => 'Ticket',
+        ValidID         => 1,
+        UserID          => 1,
+        Config          => { dummy => 1},
+    );
+    $DynamicField = $DynamicFieldObject->DynamicFieldGet(
+        Name => $FieldName,
+    );
+}
+
+
+my %TicketsToDelete;
+sub ProcessMailFile {
+    my ( $Number ) = @_;
+    my $Path = $ConfigObject->Get('Home') .
+        "/scripts/test/sample/PostMaster/PostMaster-CheckFollowUp$Number.box";
+    my $Lines = $MainObject->FileRead(
+        Location => $Path,
+        Mode     => 'binmode',
+        Result   => 'ARRAY',
+    );
+    my $PostMasterObject = Kernel::System::PostMaster->new(
+        Email   => $Lines,
+        Trusted => 1,
+    );
+    my ( $Code, $TicketID ) =  $PostMasterObject->Run();
+    if ( $TicketID ) {
+        $TicketsToDelete{ $TicketID } = 1;
+    }
+    return ( $Code, $TicketID );
+}
+
+my ( $Code, $FirstTicketID ) = ProcessMailFile( 1 );
+
+$Self->Is( $Code, 1, 'New ticket from email' );
+
+my %Ticket = $TicketObject->TicketGet(
+    TicketID    => $FirstTicketID,
+    UserID      => 1,
+    DynamicFields       => 1,
+);
+
+$Self->Is(
+    $Ticket{"DynamicField_$FieldName"},
+    "OTRS Rocks",
+    'Dynamic field set correctly',
+);
+
+( $Code, my $FollowUpTicketID ) = ProcessMailFile( 2 );
+
+$Self->Is( $Code, 2, 'Detected a follow-up through a dynamic field'  );
+$Self->Is( $FirstTicketID, $FollowUpTicketID, 'Follow-up to the correct ticket' );
+
+( $Code, my $UnrelatedTicketID ) = ProcessMailFile( 3 );
+
+$Self->Is( $Code, 1, 'Different FollowUpDetection-header led to new ticket'  );
+
+my $Success = $TicketObject->StateSet(
+    TicketID    => $FirstTicketID,
+    State       => 'merged',
+    UserID      => 1,
+);
+
+$Self->True($Success, 'Could close ticket');
+
+( $Code, my $RetryTicketID ) = ProcessMailFile( 1 );
+
+$Self->Is( $Code, 1, 'No follow-up if previous ticket is neither open nor new');
+
+
+for my $TicketID (sort keys %TicketsToDelete) {
+    my $Deleted = $TicketObject->TicketDelete(
+        TicketID => $TicketID,
+        UserID   => 1,
+    );
+    $Self->True( $Deleted, "Ticket (ID $TicketID) deleted" );
+}
+
+my $Deleted = $DynamicFieldObject->DynamicFieldDelete(
+    ID     => $DynamicField->{ID},
+    UserID => 1,
+);
+
+$Self->True(
+    $Deleted,
+    'Dynamic Field deleted',
+);
+
+1;

--- a/scripts/test/PostMaster/CheckFollowUpDynamicField.t
+++ b/scripts/test/PostMaster/CheckFollowUpDynamicField.t
@@ -61,7 +61,7 @@ if ( !IsHashRefWithData( $DynamicField ) ) {
 
 
 my %TicketsToDelete;
-sub ProcessMailFile {
+my $ProcessMailFile = sub {
     my ( $Number ) = @_;
     my $Path = $ConfigObject->Get('Home') .
         "/scripts/test/sample/PostMaster/PostMaster-CheckFollowUp$Number.box";
@@ -79,9 +79,9 @@ sub ProcessMailFile {
         $TicketsToDelete{ $TicketID } = 1;
     }
     return ( $Code, $TicketID );
-}
+};
 
-my ( $Code, $FirstTicketID ) = ProcessMailFile( 1 );
+my ( $Code, $FirstTicketID ) = $ProcessMailFile->( 1 );
 
 $Self->Is( $Code, 1, 'New ticket from email' );
 
@@ -97,12 +97,12 @@ $Self->Is(
     'Dynamic field set correctly',
 );
 
-( $Code, my $FollowUpTicketID ) = ProcessMailFile( 2 );
+( $Code, my $FollowUpTicketID ) = $ProcessMailFile->( 2 );
 
 $Self->Is( $Code, 2, 'Detected a follow-up through a dynamic field'  );
 $Self->Is( $FirstTicketID, $FollowUpTicketID, 'Follow-up to the correct ticket' );
 
-( $Code, my $UnrelatedTicketID ) = ProcessMailFile( 3 );
+( $Code, my $UnrelatedTicketID ) = $ProcessMailFile->( 3 );
 
 $Self->Is( $Code, 1, 'Different FollowUpDetection-header led to new ticket'  );
 
@@ -114,7 +114,7 @@ my $Success = $TicketObject->StateSet(
 
 $Self->True($Success, 'Could close ticket');
 
-( $Code, my $RetryTicketID ) = ProcessMailFile( 1 );
+( $Code, my $RetryTicketID ) = $ProcessMailFile->( 1 );
 
 $Self->Is( $Code, 1, 'No follow-up if previous ticket is neither open nor new');
 

--- a/scripts/test/sample/PostMaster/PostMaster-CheckFollowUp1.box
+++ b/scripts/test/sample/PostMaster/PostMaster-CheckFollowUp1.box
@@ -1,0 +1,7 @@
+To: support@example.com
+Subject: A Ticket with CheckFollowUp-Header (original)
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+X-OTRS-DynamicField-FollowUpDetection: OTRS Rocks
+
+Some unnecessary text here.

--- a/scripts/test/sample/PostMaster/PostMaster-CheckFollowUp2.box
+++ b/scripts/test/sample/PostMaster/PostMaster-CheckFollowUp2.box
@@ -1,0 +1,7 @@
+To: support@example.com
+Subject: A Ticket with CheckFollowUp-Header (follow-up)
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+X-OTRS-DynamicField-FollowUpDetection: OTRS Rocks
+
+This body intentionally left bla... oh, wait!

--- a/scripts/test/sample/PostMaster/PostMaster-CheckFollowUp3.box
+++ b/scripts/test/sample/PostMaster/PostMaster-CheckFollowUp3.box
@@ -1,0 +1,7 @@
+To: support@example.com
+Subject: A Ticket with CheckFollowUp-Header (unrelated)
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+X-OTRS-DynamicField-FollowUpDetection: OTRS rules
+
+This has a different CheckFollowUp-header than the other two mails.


### PR DESCRIPTION
This new module lets you define a header that is connected to a dyanmic field. If an existing ticket (in configurable states) has this dynamic field set to the same value as the header in an incoming mail, the mail is considered a follow-up to this ticket.

Use cases include for example cron jobs that only send mails on errors; with this feature, you can make sure that all mails form a certain cron job end up in the same ticket, until somebody resolves the problem and the ticket.