### PR TITLE
Consistent wording on Dashboard

### DIFF
--- a/Kernel/Output/HTML/Standard/AgentDashboardTicketQueueOverview.tt
+++ b/Kernel/Output/HTML/Standard/AgentDashboardTicketQueueOverview.tt
@@ -39,7 +39,7 @@
 [% RenderBlockStart("ContentLargeTicketQueueOverviewNone") %]
         <tr>
             <td colspan="[% Data.ColumnCount | html %]">
-                [% Translate("No data found.") | html %]
+                [% Translate("none") | html %]
             </td>
         </tr>
 [% RenderBlockEnd("ContentLargeTicketQueueOverviewNone") %]


### PR DESCRIPTION
All Dashboard modules show `none` when no matching tickets were found
except of `Ticket Queue Overview` which shows `No data found`.
This makes for an inconsistent appearance of the Dashboard modules and
confuses users which might interpret this as an error message instead.