### PR TITLE
'MaxRequestsPerChild' → 'MaxConnectionsPerChild'

### DIFF
--- a/scripts/apache2-httpd.include.conf
+++ b/scripts/apache2-httpd.include.conf
@@ -135,4 +135,14 @@ Alias /otrs-web/ "/opt/otrs/var/httpd/htdocs/"
 </IfModule>
 
 # Limit the number of requests per child to avoid excessive memory usage
-MaxRequestsPerChild 4000
+<IfModule mod_version.c>
+    <IfVersion < 2.4>
+        MaxRequestsPerChild 4000
+    </IfVersion>
+    <IfVersion >= 2.4>
+        MaxConnectionsPerChild 4000
+    </IfVersion>
+</IfModule>
+<IfModule !mod_version.c>
+    MaxRequestsPerChild 4000
+</IfModule>


### PR DESCRIPTION
Since Apache httpd 2.3.9, the `MaxRequestsPerChild` directive is named `MaxConnectionsPerChild`.
Defaulting to the old name for now in case `mod_version` isn't available is fine for now, as the old name will be still available for backwards compatibility.

See also: http://httpd.apache.org/docs/2.4/en/mod/mpm_common.html#maxconnectionsperchild