### PR TITLE
Remove inconsistent check in TicketGet

### DIFF
--- a/Kernel/System/Ticket.pm
+++ b/Kernel/System/Ticket.pm
@@ -1177,7 +1177,6 @@ sub TicketGet {
             next DYNAMICFIELD if !$DynamicFieldConfig;
             next DYNAMICFIELD if !IsHashRefWithData($DynamicFieldConfig);
             next DYNAMICFIELD if !$DynamicFieldConfig->{Name};
-            next DYNAMICFIELD if !IsHashRefWithData( $DynamicFieldConfig->{Config} );
 
             # get the current value for each dynamic field
             my $Value = $DynamicFieldBackendObject->ValueGet(


### PR DESCRIPTION
Previously, Kernel::System::Ticket->TicketGet with DynamicFields => 1
would ignore dynamic fields whose Config is an empty hash ref.

This is inconsistent with the creation (and the rest of the handling of)
dynamic fields, which generally allow Config to be an empty hash ref.

This case does not seem to occur when generating dynamic fields through
the admin frontend, but it happened to me when writing tests, causing
a long debugging session in search for the missing dynamic field.