### PR TITLE
Master port to OM - Output/LinkObject

### DIFF
--- a/Kernel/Output/HTML/Layout.pm
+++ b/Kernel/Output/HTML/Layout.pm
@@ -402,27 +402,10 @@ EOF
     $Self->{CustomTemplateDir}         = $ConfigObject->Get('CustomTemplateDir') . '/HTML/' . $Theme;
     $Self->{CustomStandardTemplateDir} = $ConfigObject->Get('CustomTemplateDir') . '/HTML/' . 'Standard';
 
-    # load sub layout files
+    # get main object
     my $MainObject = $Kernel::OM->Get('Kernel::System::Main');
 
-    my $Dir = $ConfigObject->Get('TemplateDir') . '/HTML';
-    if ( -e $Dir ) {
-        my @Files = $MainObject->DirectoryRead(
-            Directory => $Dir,
-            Filter    => 'Layout*.pm',
-        );
-        for my $File (@Files) {
-            if ( $File !~ /Layout.pm$/ ) {
-                $File =~ s{\A.*\/(.+?).pm\z}{$1}xms;
-                my $ClassName = "Kernel::Output::HTML::$File";
-                if ( !$MainObject->RequireBaseClass($ClassName) ) {
-                    $Self->FatalError();
-                }
-            }
-        }
-    }
-
-    # load sub layout files from new directory
+    # load sub layout files
     my $NewDir = $ConfigObject->Get('TemplateDir') . '/HTML/Layout';
     if ( -e $NewDir ) {
         my @NewFiles = $MainObject->DirectoryRead(

--- a/Kernel/Output/HTML/Layout/LinkObject.pm
+++ b/Kernel/Output/HTML/Layout/LinkObject.pm
@@ -6,16 +6,18 @@
 # did not receive this file, see http://www.gnu.org/licenses/agpl.txt.
 # --
 
-package Kernel::Output::HTML::LayoutLinkObject;
+package Kernel::Output::HTML::Layout::LinkObject;
 
 use strict;
 use warnings;
 
 use Kernel::System::LinkObject;
 
+our $ObjectManagerDisabled = 1;
+
 =head1 NAME
 
-Kernel::Output::HTML::LayoutLinkObject - all LinkObject-related HTML functions
+Kernel::Output::HTML::Layout::LinkObject - all LinkObject-related HTML functions
 
 =head1 SYNOPSIS
 
@@ -42,7 +44,7 @@ sub LinkObjectTableCreate {
     # check needed stuff
     for my $Argument (qw(LinkListWithData ViewMode)) {
         if ( !$Param{$Argument} ) {
-            $Self->{LogObject}->Log(
+            $Kernel::OM->Get('Kernel::System::Log')->Log(
                 Priority => 'error',
                 Message  => "Need $Argument!",
             );
@@ -80,10 +82,13 @@ create a complex output table
 sub LinkObjectTableCreateComplex {
     my ( $Self, %Param ) = @_;
 
+    # get log object
+    my $LogObject = $Kernel::OM->Get('Kernel::System::Log');
+
     # check needed stuff
     for my $Argument (qw(LinkListWithData ViewMode)) {
         if ( !$Param{$Argument} ) {
-            $Self->{LogObject}->Log(
+            $LogObject->Log(
                 Priority => 'error',
                 Message  => "Need $Argument!",
             );
@@ -93,7 +98,7 @@ sub LinkObjectTableCreateComplex {
 
     # check link list
     if ( ref $Param{LinkListWithData} ne 'HASH' ) {
-        $Self->{LogObject}->Log(
+        $LogObject->Log(
             Priority => 'error',
             Message  => 'LinkListWithData must be a hash referance!',
         );
@@ -399,20 +404,15 @@ sub LinkObjectTableCreateSimple {
 
     # check needed stuff
     if ( !$Param{LinkListWithData} || ref $Param{LinkListWithData} ne 'HASH' ) {
-        $Self->{LogObject}->Log(
+        $Kernel::OM->Get('Kernel::System::Link')->Log(
             Priority => 'error',
             Message  => 'Need LinkListWithData!'
         );
         return;
     }
 
-    # load link core module
-    if ( !$Self->{LinkObject} ) {
-        $Self->{LinkObject} = Kernel::System::LinkObject->new( %{$Self} );
-    }
-
     # get type list
-    my %TypeList = $Self->{LinkObject}->TypeList(
+    my %TypeList = $Kernel::OM->Get('Kernel::System::LinkObject')->TypeList(
         UserID => $Self->{UserID},
     );
 
@@ -526,20 +526,15 @@ sub LinkObjectSelectableObjectList {
 
     # check needed stuff
     if ( !$Param{Object} ) {
-        $Self->{LogObject}->Log(
+        $Kernel::OM->Get('Kernel::System::Log')->Log(
             Priority => 'error',
             Message  => 'Need Object!'
         );
         return;
     }
 
-    # load link core module
-    if ( !$Self->{LinkObject} ) {
-        $Self->{LinkObject} = Kernel::System::LinkObject->new( %{$Self} );
-    }
-
     # get possible objects list
-    my %PossibleObjectsList = $Self->{LinkObject}->PossibleObjectsList(
+    my %PossibleObjectsList = $Kernel::OM->Get('Kernel::System::LinkObject')->PossibleObjectsList(
         Object => $Param{Object},
         UserID => $Self->{UserID},
     );
@@ -607,7 +602,7 @@ sub LinkObjectSelectableObjectList {
     }
 
     # create new instance of the layout object
-    my $LayoutObject = Kernel::Output::HTML::Layout->new( %{$Self} );
+    my $LayoutObject = $Kernel::OM->Get('Kernel::Output::HTML::Layout');
 
     # create target object string
     my $TargetObjectStrg = $LayoutObject->BuildSelection(
@@ -635,7 +630,7 @@ sub LinkObjectSearchOptionList {
 
     # check needed stuff
     if ( !$Param{Object} ) {
-        $Self->{LogObject}->Log(
+        $Kernel::OM->Get('Kernel::System::Log')->Log(
             Priority => 'error',
             Message  => 'Need Object!'
         );
@@ -677,7 +672,7 @@ sub _LinkObjectContentStringCreate {
     # check needed stuff
     for my $Argument (qw(Object ContentData LayoutObject)) {
         if ( !$Param{$Argument} ) {
-            $Self->{LogObject}->Log(
+            $Kernel::OM->Get('Kernel::System::Log')->Log(
                 Priority => 'error',
                 Message  => "Need $Argument!",
             );
@@ -686,9 +681,8 @@ sub _LinkObjectContentStringCreate {
     }
 
     # load link core module
-    if ( !$Self->{LinkObject} ) {
-        $Self->{LinkObject} = Kernel::System::LinkObject->new( %{$Self} );
-    }
+    my $LinkObject = $Kernel::OM->Get('Kernel::System::LinkObject');
+
 
     # load backend
     my $BackendObject = $Self->_LoadLinkObjectLayoutBackend(
@@ -700,7 +694,7 @@ sub _LinkObjectContentStringCreate {
 
         my $ContentString = $BackendObject->ContentStringCreate(
             %Param,
-            LinkObject   => $Self->{LinkObject},
+            LinkObject   => $LinkObject,
             LayoutObject => $Param{LayoutObject},
         );
 
@@ -722,7 +716,7 @@ sub _LinkObjectContentStringCreate {
         $Blockname = 'Plain';
 
         # get type list
-        my %TypeList = $Self->{LinkObject}->TypeList(
+        my %TypeList = $LinkObject->TypeList(
             UserID => $Self->{UserID},
         );
 
@@ -765,7 +759,7 @@ sub _LinkObjectContentStringCreate {
         $Blockname = 'Plain';
 
         # get type list
-        my %TypeList = $Self->{LinkObject}->TypeList(
+        my %TypeList = $LinkObject->TypeList(
             UserID => $Self->{UserID},
         );
 
@@ -843,9 +837,12 @@ load a linkobject layout backend module
 sub _LoadLinkObjectLayoutBackend {
     my ( $Self, %Param ) = @_;
 
+    # get log object
+    my $LogObject = $Kernel::OM->Get('Kernel::System::Log');
+
     # check needed stuff
     if ( !$Param{Object} ) {
-        $Self->{LogObject}->Log(
+        $LogObject->Log(
             Priority => 'error',
             Message  => 'Need Object!',
         );
@@ -859,8 +856,8 @@ sub _LoadLinkObjectLayoutBackend {
     my $GenericModule = "Kernel::Output::HTML::LinkObject$Param{Object}";
 
     # load the backend module
-    if ( !$Self->{MainObject}->Require($GenericModule) ) {
-        $Self->{LogObject}->Log(
+    if ( !$Kernel::OM->Get('Kernel::System::Main')->Require($GenericModule) ) {
+        $LogObject->Log(
             Priority => 'error',
             Message  => "Can't load backend module $Param{Object}!"
         );
@@ -874,7 +871,7 @@ sub _LoadLinkObjectLayoutBackend {
     );
 
     if ( !$BackendObject ) {
-        $Self->{LogObject}->Log(
+        $LogObject->Log(
             Priority => 'error',
             Message  => "Can't create a new instance of backend module $Param{Object}!",
         );

--- a/Kernel/Output/HTML/Layout/LinkObject.pm
+++ b/Kernel/Output/HTML/Layout/LinkObject.pm
@@ -853,7 +853,7 @@ sub _LoadLinkObjectLayoutBackend {
     return $Self->{Cache}->{LoadLinkObjectLayoutBackend}->{ $Param{Object} }
         if $Self->{Cache}->{LoadLinkObjectLayoutBackend}->{ $Param{Object} };
 
-    my $GenericModule = "Kernel::Output::HTML::LinkObject$Param{Object}";
+    my $GenericModule = "Kernel::Output::HTML::LinkObject::$Param{Object}";
 
     # load the backend module
     if ( !$Kernel::OM->Get('Kernel::System::Main')->Require($GenericModule) ) {

--- a/Kernel/Output/HTML/Layout/LinkObject.pm
+++ b/Kernel/Output/HTML/Layout/LinkObject.pm
@@ -404,7 +404,7 @@ sub LinkObjectTableCreateSimple {
 
     # check needed stuff
     if ( !$Param{LinkListWithData} || ref $Param{LinkListWithData} ne 'HASH' ) {
-        $Kernel::OM->Get('Kernel::System::Link')->Log(
+        $Kernel::OM->Get('Kernel::System::Log')->Log(
             Priority => 'error',
             Message  => 'Need LinkListWithData!'
         );
@@ -682,7 +682,6 @@ sub _LinkObjectContentStringCreate {
 
     # load link core module
     my $LinkObject = $Kernel::OM->Get('Kernel::System::LinkObject');
-
 
     # load backend
     my $BackendObject = $Self->_LoadLinkObjectLayoutBackend(

--- a/Kernel/Output/HTML/LinkObject/Ticket.pm
+++ b/Kernel/Output/HTML/LinkObject/Ticket.pm
@@ -6,7 +6,7 @@
 # did not receive this file, see http://www.gnu.org/licenses/agpl.txt.
 # --
 
-package Kernel::Output::HTML::LinkObjectTicket;
+package Kernel::Output::HTML::LinkObject::Ticket;
 
 use strict;
 use warnings;
@@ -32,7 +32,7 @@ our @ObjectDependencies = (
 
 =head1 NAME
 
-Kernel::Output::HTML::LinkObjectTicket - layout backend module
+Kernel::Output::HTML::LinkObject::Ticket - layout backend module
 
 =head1 SYNOPSIS
 
@@ -46,7 +46,7 @@ All layout functions of link object (ticket).
 
 create an object
 
-    $BackendObject = Kernel::Output::HTML::LinkObjectTicket->new(
+    $BackendObject = Kernel::Output::HTML::LinkObject::Ticket->new(
         UserLanguage => 'en',
         UserID       => 1,
     );

--- a/scripts/test/Selenium/Agent/AgentLinkObject.t
+++ b/scripts/test/Selenium/Agent/AgentLinkObject.t
@@ -23,7 +23,7 @@ $Selenium->RunTest(
 
         # create and login test customer
         my $TestUserLogin = $Helper->TestUserCreate(
-            Groups => ['admin', 'users'],
+            Groups => [ 'admin', 'users' ],
         ) || die "Did not get test user";
 
         $Selenium->Login(
@@ -73,7 +73,7 @@ $Selenium->RunTest(
         $Selenium->switch_to_window( $Handles->[1] );
 
         # search for second created test ticket
-        $Selenium->find_element(".//*[\@id='SEARCH::TicketNumber']")->send_keys($TicketNumbers[1]);
+        $Selenium->find_element(".//*[\@id='SEARCH::TicketNumber']")->send_keys( $TicketNumbers[1] );
         $Selenium->find_element(".//*[\@id='SEARCH::TicketNumber']")->submit();
 
         # link created test tickets

--- a/scripts/test/Selenium/Agent/AgentLinkObject.t
+++ b/scripts/test/Selenium/Agent/AgentLinkObject.t
@@ -1,0 +1,128 @@
+# --
+# Copyright (C) 2001-2015 OTRS AG, http://otrs.com/
+# --
+# This software comes with ABSOLUTELY NO WARRANTY. For details, see
+# the enclosed file COPYING for license information (AGPL). If you
+# did not receive this file, see http://www.gnu.org/licenses/agpl.txt.
+# --
+
+use strict;
+use warnings;
+use utf8;
+
+use vars (qw($Self));
+
+# get selenium object
+my $Selenium = $Kernel::OM->Get('Kernel::System::UnitTest::Selenium');
+
+$Selenium->RunTest(
+    sub {
+
+        # get helper object
+        my $Helper = $Kernel::OM->Get('Kernel::System::UnitTest::Helper');
+
+        # create and login test customer
+        my $TestUserLogin = $Helper->TestUserCreate(
+            Groups => ['admin', 'users'],
+        ) || die "Did not get test user";
+
+        $Selenium->Login(
+            Type     => 'Agent',
+            User     => $TestUserLogin,
+            Password => $TestUserLogin,
+        );
+
+        # get test user ID
+        my $TestUserID = $Kernel::OM->Get('Kernel::System::User')->UserLookup(
+            UserLogin => $TestUserLogin,
+        );
+
+        # get ticket object
+        my $TicketObject = $Kernel::OM->Get('Kernel::System::Ticket');
+
+        # create test tickets
+        my @TicketIDs;
+        my @TicketNumbers;
+        for my $Ticket ( 1 .. 2 ) {
+            my $TicketNumber = $TicketObject->TicketCreateNumber();
+            my $TicketID     = $TicketObject->TicketCreate(
+                TN           => $TicketNumber,
+                Title        => 'Some Ticket Title',
+                Queue        => 'Raw',
+                Lock         => 'unlock',
+                Priority     => '3 normal',
+                State        => 'new',
+                CustomerID   => '123465',
+                CustomerUser => 'customer@example.com',
+                OwnerID      => $TestUserID,
+                UserID       => $TestUserID,
+            );
+            push @TicketIDs,     $TicketID;
+            push @TicketNumbers, $TicketNumber;
+        }
+
+        # navigate to zoom view of created test ticket
+        my $ScriptAlias = $Kernel::OM->Get('Kernel::Config')->Get('ScriptAlias');
+        $Selenium->get("${ScriptAlias}index.pl?Action=AgentTicketZoom;TicketID=$TicketIDs[0]");
+
+        # click on 'Link'
+        $Selenium->find_element("//a[contains(\@href, \'Action=AgentLinkObject;SourceObject=Ticket;' )]")->click();
+
+        # switch to link object window
+        my $Handles = $Selenium->get_window_handles();
+        $Selenium->switch_to_window( $Handles->[1] );
+
+        # search for second created test ticket
+        $Selenium->find_element(".//*[\@id='SEARCH::TicketNumber']")->send_keys($TicketNumbers[1]);
+        $Selenium->find_element(".//*[\@id='SEARCH::TicketNumber']")->submit();
+
+        # link created test tickets
+        $Selenium->find_element("//input[\@value='$TicketIDs[1]'][\@type='checkbox']")->click();
+        $Selenium->find_element( "#TypeIdentifier option[value='ParentChild::Target']", 'css' )->click();
+        $Selenium->find_element("//button[\@type='submit'][\@name='AddLinks']")->click();
+
+        # close link object window and switch back to agent ticket zoom
+        $Selenium->close();
+        $Selenium->switch_to_window( $Handles->[0] );
+
+        # refresh agent ticket zoom
+        $Selenium->refresh();
+
+        # verify that parent test tickets is linked with child test ticket
+        $Self->True(
+            index( $Selenium->get_page_source(), 'Child' ) > -1,
+            "Child - found",
+        );
+        $Self->True(
+            index( $Selenium->get_page_source(), "T:" . $TicketNumbers[1] ) > -1,
+            "TicketNumber $TicketNumbers[1] - found",
+        );
+
+        # click on child ticket
+        $Selenium->find_element("//a[contains(\@href, \'Action=AgentTicketZoom;TicketID=$TicketIDs[1]' )]")->click();
+
+        # verify that child test ticket is linked with parent test ticket
+        $Self->True(
+            index( $Selenium->get_page_source(), 'Parent' ) > -1,
+            "Parent - found",
+        );
+        $Self->True(
+            index( $Selenium->get_page_source(), "T:" . $TicketNumbers[0] ) > -1,
+            "TicketNumber $TicketNumbers[0] - found",
+        );
+
+        # delete created test tickets
+        for my $TicketID (@TicketIDs) {
+            my $Success = $TicketObject->TicketDelete(
+                TicketID => $TicketID,
+                UserID   => $TestUserID,
+            );
+            $Self->True(
+                $Success,
+                "Delete ticket - $TicketID"
+            );
+        }
+    }
+);
+
+1;


### PR DESCRIPTION
Hello,

Hereby is PR for last ported modules from Output directory, covering Layout/LinkObject.pm and  LinkObject/Ticket.pm with AgentLinkObject.t selenium test.

In Layout/LinkObject.pm, line 263-264 and 448-449, we left creation of the new layout object instance way it was before. We tried porting it, using ObjectParamAdd(), but only this way worked. If you could just confirm this is right approach or should we use different way. 

In LinkObject/Ticket.pm, since objects are called in constructor for the creation of new LayoutObject instance, we didn't port them. Should we call them again in every function where they are needed or to leave calling from the constructor. Need confirmation here as well.

Since these are last modules from Output, we updated Layout.pm so it doesn't load old sub modules.

Regards,
Sanjin
S7

