### PR TITLE
Master Selenium - improved sleep 1

### DIFF
--- a/scripts/test/Selenium/Agent/Admin/AdminDynamicField.t
+++ b/scripts/test/Selenium/Agent/Admin/AdminDynamicField.t
@@ -108,38 +108,15 @@ $Selenium->RunTest(
                     "#ValidID stored value",
                 );
 
-                $Selenium->go_back();
+                $Selenium->get("${ScriptAlias}index.pl?Action=AdminDynamicField");
 
                 # delete DynamicFields, check button for deleting Dynamic Field
                 my $DynamicFieldID = $Kernel::OM->Get('Kernel::System::DynamicField')->DynamicFieldGet(
                     Name => $RandomID
                 )->{ID};
 
-                # depending on browser use dirrefernt delete approach
-                if ( $TestBrowser eq 'firefox' ) {
-
-                    $Selenium->find_element(
-                        "//a[contains(\@data-query-string, \'Subaction=DynamicFieldDelete;ID=$DynamicFieldID' )]"
-                    )->click();
-
-                    # check for opened confirm text
-                    my $LanguageObject = Kernel::Language->new(
-                        UserLanguage => $Language,
-                    );
-
-                    $Self->Is(
-                        $Selenium->get_alert_text(),
-                        $LanguageObject->Get(
-                            'Do you really want to delete this dynamic field? ALL associated data will be LOST!'
-                        ),
-                        'Check for opened confirm text',
-                    );
-
-                    $Selenium->accept_alert();
-                }
-                else {
-
-                    my $CheckConfirmJS = <<"JAVASCRIPT";
+                # click on delete icon
+                my $CheckConfirmJS = <<"JAVASCRIPT";
 (function () {
     var lastConfirm = undefined;
     window.confirm = function (message) {
@@ -153,29 +130,26 @@ $Selenium->RunTest(
     };
 }());
 JAVASCRIPT
-                    $Selenium->execute_script($CheckConfirmJS);
+                $Selenium->execute_script($CheckConfirmJS);
 
-                    $Selenium->find_element(
-                        "//a[contains(\@data-query-string, \'Subaction=DynamicFieldDelete;ID=$DynamicFieldID' )]"
-                    )->click();
+                $Selenium->find_element(
+                    "//a[contains(\@data-query-string, \'Subaction=DynamicFieldDelete;ID=$DynamicFieldID' )]"
+                )->click();
 
-                    my $LanguageObject = Kernel::Language->new(
-                        UserLanguage => $Language,
-                    );
+                my $LanguageObject = Kernel::Language->new(
+                    UserLanguage => $Language,
+                );
 
-                    $Self->Is(
-                        $Selenium->execute_script("return window.getLastConfirm()"),
-                        $LanguageObject->Get(
-                            'Do you really want to delete this dynamic field? ALL associated data will be LOST!'
-                        ),
-                        'Check for opened confirm text',
-                    );
-                }
+                $Self->Is(
+                    $Selenium->execute_script("return window.getLastConfirm()"),
+                    $LanguageObject->Get(
+                        'Do you really want to delete this dynamic field? ALL associated data will be LOST!'
+                    ),
+                    'Check for opened confirm text',
+                );
 
-                # allow some time for field deletion
-                $Selenium->WaitFor( JavaScript => "return !\$('#DynamicFieldID_$DynamicFieldID').length" );
+                $Selenium->get("${ScriptAlias}index.pl?Action=AdminDynamicField");
 
-                $Selenium->refresh();
                 my $Success;
                 eval {
                     $Success = $Selenium->find_element( $RandomID, 'link_text' )->is_displayed();

--- a/scripts/test/Selenium/Agent/Admin/AdminNotification.t
+++ b/scripts/test/Selenium/Agent/Admin/AdminNotification.t
@@ -48,6 +48,7 @@ $Selenium->RunTest(
 
         # test filter for Notification
         $Selenium->find_element( "#FilterNotification", 'css' )->send_keys("Agent::AddNote");
+        sleep 1;
 
         $Self->True(
             $Selenium->find_element( "Agent::AddNote", 'link_text' )->is_displayed(),
@@ -74,9 +75,9 @@ $Selenium->RunTest(
         {
 
             # wait for notification overview
-            $Selenium->WaitFor( JavaScript => "return \$('#Notifications').length" );
+            $Selenium->WaitFor( JavaScript => 'return $("#Notifications").length' );
             $Selenium->find_element( "Agent::$Notification", 'link_text' )->click();
-            $Selenium->WaitFor( JavaScript => "return \$('#Subject').length" );
+            $Selenium->WaitFor( JavaScript => 'return $("#Subject").length' );
 
             # edit notification
             my $CurrentNotificationSubject = $Selenium->find_element( "#Subject", 'css' )->get_value();

--- a/scripts/test/Selenium/Agent/Admin/AdminNotification.t
+++ b/scripts/test/Selenium/Agent/Admin/AdminNotification.t
@@ -12,15 +12,16 @@ use utf8;
 
 use vars (qw($Self));
 
-# get needed objects
-my $ConfigObject = $Kernel::OM->Get('Kernel::Config');
-my $Selenium     = $Kernel::OM->Get('Kernel::System::UnitTest::Selenium');
+# get selenium object
+my $Selenium = $Kernel::OM->Get('Kernel::System::UnitTest::Selenium');
 
 $Selenium->RunTest(
     sub {
 
+        # get helper object
         my $Helper = $Kernel::OM->Get('Kernel::System::UnitTest::Helper');
 
+        # create and login test user
         my $TestUserLogin = $Helper->TestUserCreate(
             Groups => ['admin'],
         ) || die "Did not get test user";
@@ -31,6 +32,10 @@ $Selenium->RunTest(
             Password => $TestUserLogin,
         );
 
+        # get config object
+        my $ConfigObject = $Kernel::OM->Get('Kernel::Config');
+
+        # navigate to AdminNotification screen
         my $ScriptAlias = $ConfigObject->Get('ScriptAlias');
         $Selenium->get("${ScriptAlias}index.pl?Action=AdminNotification");
 
@@ -43,7 +48,6 @@ $Selenium->RunTest(
 
         # test filter for Notification
         $Selenium->find_element( "#FilterNotification", 'css' )->send_keys("Agent::AddNote");
-        sleep 1;
 
         $Self->True(
             $Selenium->find_element( "Agent::AddNote", 'link_text' )->is_displayed(),
@@ -62,7 +66,6 @@ $Selenium->RunTest(
 
         # clear test filter for Notification
         $Selenium->find_element( "#FilterNotification", 'css' )->clear();
-        sleep 1;
 
         # check defoult notification
         for my $Notification (
@@ -70,7 +73,10 @@ $Selenium->RunTest(
             )
         {
 
+            # wait for notification overview
+            $Selenium->WaitFor( JavaScript => "return \$('#Notifications').length" );
             $Selenium->find_element( "Agent::$Notification", 'link_text' )->click();
+            $Selenium->WaitFor( JavaScript => "return \$('#Subject').length" );
 
             # edit notification
             my $CurrentNotificationSubject = $Selenium->find_element( "#Subject", 'css' )->get_value();
@@ -94,7 +100,7 @@ $Selenium->RunTest(
 
         }
 
-        }
+    }
 );
 
 1;

--- a/scripts/test/Selenium/Agent/Admin/AdminTemplate.t
+++ b/scripts/test/Selenium/Agent/Admin/AdminTemplate.t
@@ -12,16 +12,16 @@ use utf8;
 
 use vars (qw($Self));
 
-# get needed objects
-my $ConfigObject = $Kernel::OM->Get('Kernel::Config');
-my $DBObject     = $Kernel::OM->Get('Kernel::System::DB');
-my $Selenium     = $Kernel::OM->Get('Kernel::System::UnitTest::Selenium');
+# get selenium object
+my $Selenium = $Kernel::OM->Get('Kernel::System::UnitTest::Selenium');
 
 $Selenium->RunTest(
     sub {
 
+        # get helper object
         my $Helper = $Kernel::OM->Get('Kernel::System::UnitTest::Helper');
 
+        # create and log in test user
         my $TestUserLogin = $Helper->TestUserCreate(
             Groups => ['admin'],
         ) || die "Did not get test user";
@@ -32,8 +32,11 @@ $Selenium->RunTest(
             Password => $TestUserLogin,
         );
 
-        my $ScriptAlias = $ConfigObject->Get('ScriptAlias');
+        # get config object
+        my $ConfigObject = $Kernel::OM->Get('Kernel::Config');
 
+        # navigate to AdminTemplate screen
+        my $ScriptAlias = $ConfigObject->Get('ScriptAlias');
         $Selenium->get("${ScriptAlias}index.pl?Action=AdminTemplate");
 
         # chech overview screen
@@ -44,6 +47,7 @@ $Selenium->RunTest(
 
         # click 'Add template'
         $Selenium->find_element("//a[contains(\@href, \'Subaction=Add' )]")->click();
+        $Selenium->WaitFor( JavaScript => "return \$('#TemplateType').length" );
 
         for my $ID (
             qw(TemplateType Name IDs ValidID Comment)
@@ -81,7 +85,6 @@ $Selenium->RunTest(
 
         # test search filter
         $Selenium->find_element( "#Filter", 'css' )->send_keys($TemplateRandomID);
-        sleep 1;
 
         $Self->True(
             $Selenium->find_element( $TemplateRandomID, 'link_text' )->is_displayed(),
@@ -147,7 +150,7 @@ $Selenium->RunTest(
 
         $Selenium->find_element("//a[contains(\@href, \'Subaction=Delete;ID=$TemplateID' )]")->click();
 
-        }
+    }
 );
 
 1;


### PR DESCRIPTION
Hi @mgruner 

There is improvement for some Selenium test. As we said recently we will make a couple PR for sleep in the tests.
This is first one, we will make the others soon.

In this PR there is one interesting case with AdminDynamicField.t, I think that I have mentioned this before. It worked fine with firefox, but in case phantomjs is used it did not work. We add our proposal how it could be solved. We check which browser is used duo to $Selenium->accept_alert(); does not work in phantomjs and $Selenium->execute_script($CheckConfirmJS);   does not work in Firefox (see line 118).
I am not sure if you like this hard-coding, but it works now :)

Please let me know what do you mean about it.

Regards
Zoran
