### PR TITLE
Sync custom agent preferences from LDAP

### DIFF
--- a/Kernel/System/Auth/Sync/LDAP.pm
+++ b/Kernel/System/Auth/Sync/LDAP.pm
@@ -293,6 +293,20 @@ sub Sync {
                     Message  => "Initial data for '$Param{User}' ($UserDN) created in RDBMS.",
                 );
 
+                # copy attributes
+                NEWATTRIBUTE:
+                for my $Attribute ( sort keys %SyncUser ) {
+                    next NEWATTRIBUTE if $Attribute =~ /^(User)?((First|Last)name|Email)$/;
+
+                    # update custom prefs
+                    $UserObject->SetPreferences(
+                        UserID => $UserID,
+                        Key    => $Attribute,
+                        Value  => $SyncUser{$Attribute},
+                    );
+
+                }
+
                 # sync initial groups
                 my $UserSyncInitialGroups = $ConfigObject->Get(
                     'AuthSyncModule::LDAP::UserSyncInitialGroups' . $Self->{Count}
@@ -338,7 +352,19 @@ sub Sync {
             for my $Attribute ( sort keys %SyncUser ) {
                 next ATTRIBUTE if $SyncUser{$Attribute} eq $UserData{$Attribute};
                 $AttributeChange = 1;
-                last ATTRIBUTE;
+                next ATTRIBUTE if $Attribute =~ /^(User)?((First|Last)name|Email)$/;
+
+                $Kernel::OM->Get('Kernel::System::Log')->Log(
+                    Priority => 'notice',
+                    Message =>
+                        "Updating $Attribute to ".$SyncUser{$Attribute}." from ".$UserData{$Attribute},
+                );
+                # update custom prefs
+                $UserObject->SetPreferences(
+                    UserID => $UserID,
+                    Key    => $Attribute,
+                    Value  => $SyncUser{$Attribute},
+                );
             }
 
             if ($AttributeChange) {


### PR DESCRIPTION
This allows to add any custom agent preference into AuthSyncModule::LDAP::UserSyncMap. We use it for example to sync phone numbers and department from ActiveDirectory to display it in the agent signature.