### PR TITLE
Master - PDF object issue

### DIFF
--- a/Kernel/Modules/AgentStats.pm
+++ b/Kernel/Modules/AgentStats.pm
@@ -2387,11 +2387,7 @@ sub Run {
             $MainObject->Require('Kernel::System::PDF');
 
             # get PDF object
-            my $PDFObject;
-
-            if ( $ConfigObject->Get('PDF') ) {
-                $PDFObject = $Kernel::OM->Get('Kernel::System::PDF');
-            }
+            my $PDFObject = ( $ConfigObject->Get('PDF') ) ? $Kernel::OM->Get('Kernel::System::PDF') : undef;
 
             # PDF Output
             if ($PDFObject) {

--- a/Kernel/Modules/AgentTicketPrint.pm
+++ b/Kernel/Modules/AgentTicketPrint.pm
@@ -184,7 +184,8 @@ sub Run {
     }
 
     # get PDF object
-    my $PDFObject = $Kernel::OM->Get('Kernel::System::PDF');
+    my $PDFObject
+        = ( $Kernel::OM->Get('Kernel::Config')->Get('PDF') ) ? $Kernel::OM->Get('Kernel::System::PDF') : undef;
 
     # generate pdf output
     if ($PDFObject) {

--- a/Kernel/Modules/AgentTicketSearch.pm
+++ b/Kernel/Modules/AgentTicketSearch.pm
@@ -783,7 +783,8 @@ sub Run {
         elsif ( $GetParam{ResultForm} eq 'Print' ) {
 
             # get PDF object
-            my $PDFObject = $Kernel::OM->Get('Kernel::System::PDF');
+            my $PDFObject
+                = ( $Kernel::OM->Get('Kernel::Config')->Get('PDF') ) ? $Kernel::OM->Get('Kernel::System::PDF') : undef;
 
             my @PDFData;
             for my $TicketID (@ViewableTicketIDs) {

--- a/Kernel/Modules/CustomerTicketPrint.pm
+++ b/Kernel/Modules/CustomerTicketPrint.pm
@@ -101,7 +101,8 @@ sub Run {
         $Ticket{PendingUntil} = '-';
     }
 
-    my $PDFObject = $Kernel::OM->Get('Kernel::System::PDF');
+    my $PDFObject
+        = ( $Kernel::OM->Get('Kernel::Config')->Get('PDF') ) ? $Kernel::OM->Get('Kernel::System::PDF') : undef;
 
     # generate pdf output
     if ($PDFObject) {

--- a/Kernel/System/Console/Command/Maint/Stats/Generate.pm
+++ b/Kernel/System/Console/Command/Maint/Stats/Generate.pm
@@ -260,7 +260,11 @@ sub Run {
     }
     my %Attachment;
 
-    if ( $Self->{Format} eq 'PDF' && $Kernel::OM->Get('Kernel::System::PDF') ) {
+    # get PDF object
+    my $PDFObject
+        = ( $Kernel::OM->Get('Kernel::Config')->Get('PDF') ) ? $Kernel::OM->Get('Kernel::System::PDF') : undef;
+
+    if ( $Self->{Format} eq 'PDF' && $PDFObject ) {
 
         $Self->Print("<yellow>Chosen format: PDF.</yellow>\n");
 
@@ -342,7 +346,7 @@ sub Run {
         }
 
         # create new pdf document
-        $Kernel::OM->Get('Kernel::System::PDF')->DocumentNew(
+        $PDFObject->DocumentNew(
             Title  => $Kernel::OM->Get('Kernel::Config')->Get('Product') . ': ' . $Title,
             Encode => 'utf-8',
         );
@@ -354,21 +358,21 @@ sub Run {
 
             # if first page
             if ( $Counter == 1 ) {
-                $Kernel::OM->Get('Kernel::System::PDF')->PageNew(
+                $PDFObject->PageNew(
                     %PageParam,
                     FooterRight => $Page . ' ' . $Counter,
                 );
             }
 
             # output table (or a fragment of it)
-            %TableParam = $Kernel::OM->Get('Kernel::System::PDF')->Table( %TableParam, );
+            %TableParam = $PDFObject->Table( %TableParam, );
 
             # stop output or another page
             if ( $TableParam{State} ) {
                 $Loop = 0;
             }
             else {
-                $Kernel::OM->Get('Kernel::System::PDF')->PageNew(
+                $PDFObject->PageNew(
                     %PageParam,
                     FooterRight => $Page . ' ' . ( $Counter + 1 ),
                 );
@@ -382,7 +386,7 @@ sub Run {
         }
 
         # return the document
-        my $PDFString = $Kernel::OM->Get('Kernel::System::PDF')->DocumentOutput();
+        my $PDFString = $PDFObject->DocumentOutput();
 
         # save the pdf with the title and timestamp as filename, or read it from param
         my $Filename;

--- a/scripts/test/PDF.t
+++ b/scripts/test/PDF.t
@@ -15,7 +15,7 @@ use vars (qw($Self));
 # get needed objects
 my $ConfigObject = $Kernel::OM->Get('Kernel::Config');
 my $MainObject   = $Kernel::OM->Get('Kernel::System::Main');
-my $PDFObject    = $Kernel::OM->Get('Kernel::System::PDF');
+my $PDFObject    = ( $Kernel::OM->Get('Kernel::Config')->Get('PDF') ) ? $Kernel::OM->Get('Kernel::System::PDF') : undef;
 
 die 'PDF support is disabled in sysconfig or CPAN module PDF::API2 is missing!'
     if !$PDFObject;

--- a/scripts/test/Selenium/Agent/AgentTicketPrint.t
+++ b/scripts/test/Selenium/Agent/AgentTicketPrint.t
@@ -1,0 +1,137 @@
+# --
+# Copyright (C) 2001-2015 OTRS AG, http://otrs.com/
+# --
+# This software comes with ABSOLUTELY NO WARRANTY. For details, see
+# the enclosed file COPYING for license information (AGPL). If you
+# did not receive this file, see http://www.gnu.org/licenses/agpl.txt.
+# --
+
+use strict;
+use warnings;
+use utf8;
+
+use vars (qw($Self));
+
+# get selenium object
+my $Selenium = $Kernel::OM->Get('Kernel::System::UnitTest::Selenium');
+
+$Selenium->RunTest(
+    sub {
+
+        # get helper object
+        $Kernel::OM->ObjectParamAdd(
+            'Kernel::System::UnitTest::Helper' => {
+                RestoreSystemConfiguration => 1,
+                }
+        );
+        my $Helper = $Kernel::OM->Get('Kernel::System::UnitTest::Helper');
+
+        # get sysconfig object
+        my $SysConfigObject = $Kernel::OM->Get('Kernel::System::SysConfig');
+
+        # disable PDF output
+        $SysConfigObject->ConfigItemUpdate(
+            Valid => 1,
+            Key   => 'PDF',
+            Value => 1
+        );
+
+        # create and log in test user
+        my $TestUserLogin = $Helper->TestUserCreate(
+            Groups => [ 'admin', 'users' ],
+        ) || die "Did not get test user";
+
+        $Selenium->Login(
+            Type     => 'Agent',
+            User     => $TestUserLogin,
+            Password => $TestUserLogin,
+        );
+
+        # get Ticket object
+        my $TicketObject = $Kernel::OM->Get('Kernel::System::Ticket');
+
+        # create test customer
+        my $TestCustomer = 'Customer' . $Helper->GetRandomID();
+        my $TicketID     = $TicketObject->TicketCreate(
+            Title        => 'Selenium Test Ticket',
+            Queue        => 'Raw',
+            Priority     => '3 normal',
+            Lock         => 'unlock',
+            State        => 'open',
+            CustomerID   => $TestCustomer,
+            CustomerUser => "$TestCustomer\@localhost.com",
+            OwnerID      => 1,
+            UserID       => 1,
+        );
+
+        my $ScriptAlias = $Kernel::OM->Get('Kernel::Config')->Get('ScriptAlias');
+
+        # navigate to AgentTicketZoom screen
+        $Selenium->get("${ScriptAlias}index.pl?Action=AgentTicketZoom;TicketID=$TicketID");
+
+        # click on print menu item
+        $Selenium->find_element("//a[contains(\@href, \'Action=AgentTicketPrint;TicketID=$TicketID\' )]")->click();
+
+        # switch to another window
+        my $Handles = $Selenium->get_window_handles();
+        $Selenium->switch_to_window( $Handles->[1] );
+
+        # wait until print screen is loaded
+        # ACTIVESLEEP:
+        # for my $Second ( 1 .. 20 ) {
+        #     if ( index( $Selenium->get_page_source(), "$TitleRandom" ) > -1, )  {
+        #         last ACTIVESLEEP;
+        #     }
+        #     sleep 1;
+        # }
+        sleep 3;
+
+        # check for printed values of test ticket
+        $Self->True(
+            index( $Selenium->get_page_source(), "printed by $TestUserLogin $TestUserLogin" ) > -1,
+            "Header data is found on print screen - printed by $TestUserLogin $TestUserLogin",
+        );
+
+        $Self->True(
+            index( $Selenium->get_page_source(), "State" ) > -1
+                && index( $Selenium->get_page_source(), "open" ) > -1,
+            "State: open - found on print screen",
+        );
+
+        $Self->True(
+            index( $Selenium->get_page_source(), "Queue" ) > -1
+                && index( $Selenium->get_page_source(), "3 normal" ) > -1,
+            "Queue: Raw - found on print screen",
+        );
+
+        $Self->True(
+            index( $Selenium->get_page_source(), "CustomerID" ) > -1
+                && index( $Selenium->get_page_source(), "$TestCustomer" ) > -1,
+            "CustomerID: $TestCustomer - found on print screen",
+        );
+
+        $Self->True(
+            index( $Selenium->get_page_source(), "Priority" ) > -1
+                && index( $Selenium->get_page_source(), "3 normal" ) > -1,
+            "Priority: 3 normal - found on print screen",
+        );
+
+        # delete test ticket
+        my $Success = $TicketObject->TicketDelete(
+            TicketID => $TicketID,
+            UserID   => 1,
+        );
+        $Self->True(
+            $Success,
+            "Ticket is deleted - $TicketID"
+        );
+
+        # make sure the cache is correct.
+        $Kernel::OM->Get('Kernel::System::Cache')->CleanUp(
+            Type => 'Ticket',
+        );
+
+    }
+);
+
+1;

--- a/scripts/test/Selenium/Agent/AgentTicketSearchPrint.t
+++ b/scripts/test/Selenium/Agent/AgentTicketSearchPrint.t
@@ -1,0 +1,146 @@
+# --
+# Copyright (C) 2001-2015 OTRS AG, http://otrs.com/
+# --
+# This software comes with ABSOLUTELY NO WARRANTY. For details, see
+# the enclosed file COPYING for license information (AGPL). If you
+# did not receive this file, see http://www.gnu.org/licenses/agpl.txt.
+# --
+
+use strict;
+use warnings;
+use utf8;
+
+use vars (qw($Self));
+
+# get selenium object
+my $Selenium = $Kernel::OM->Get('Kernel::System::UnitTest::Selenium');
+
+$Selenium->RunTest(
+    sub {
+
+        # get helper object
+        $Kernel::OM->ObjectParamAdd(
+            'Kernel::System::UnitTest::Helper' => {
+                RestoreSystemConfiguration => 1,
+                }
+        );
+        my $Helper = $Kernel::OM->Get('Kernel::System::UnitTest::Helper');
+
+        # get sysconfig object
+        my $SysConfigObject = $Kernel::OM->Get('Kernel::System::SysConfig');
+
+        # disable PDF output
+        $SysConfigObject->ConfigItemUpdate(
+            Valid => 1,
+            Key   => 'PDF',
+            Value => 1
+        );
+
+        # create and login test user
+        my $TestUserLogin = $Helper->TestUserCreate(
+            Groups => [ 'admin', 'users' ],
+        ) || die "Did not get test user";
+
+        $Selenium->Login(
+            Type     => 'Agent',
+            User     => $TestUserLogin,
+            Password => $TestUserLogin,
+        );
+
+        # get test user ID
+        my $TestUserID = $Kernel::OM->Get('Kernel::System::User')->UserLookup(
+            UserLogin => $TestUserLogin,
+        );
+
+        # create test customer
+        my $TestCustomerUser = $Helper->TestCustomerUserCreate(
+            Groups => ['admin'],
+        ) || die "Did not get test user";
+
+        # get test customer user ID
+        my %TestCustomerUserID = $Kernel::OM->Get('Kernel::System::CustomerUser')->CustomerUserDataGet(
+            User => $TestCustomerUser,
+        );
+
+        # get ticket object
+        my $TicketObject = $Kernel::OM->Get('Kernel::System::Ticket');
+
+        # create test ticket
+        my $TitleRandom    = "Title" . $Helper->GetRandomID();
+        my $CustomerRandom = "Customer" . $Helper->GetRandomID();
+        my $TicketID       = $TicketObject->TicketCreate(
+            Title      => $TitleRandom,
+            Queue      => 'Raw',
+            Lock       => 'unlock',
+            Priority   => '3 normal',
+            State      => 'open',
+            CustomerID => $TestCustomerUserID{UserCustomerID},
+            OwnerID    => $TestUserID,
+            UserID     => $TestUserID,
+        );
+        $Self->True(
+            $TicketID,
+            "Created $TitleRandom ticket",
+        );
+
+        # get test ticket number
+        my %Ticket = $TicketObject->TicketGet(
+            TicketID => $TicketID,
+        );
+
+        # navigate to AgentTicketSearch
+        my $ScriptAlias = $Kernel::OM->Get('Kernel::Config')->Get('ScriptAlias');
+        $Selenium->get("${ScriptAlias}index.pl?Action=AgentTicketSearch");
+
+        # Wait until form has loaded, if neccessary
+        $Selenium->WaitFor( JavaScript => "return \$('#SearchProfile').length" );
+
+        # check ticket search page
+        for my $ID (
+            qw(SearchProfile SearchProfileNew Attribute ResultForm SearchFormSubmit)
+            )
+        {
+            my $Element = $Selenium->find_element( "#$ID", 'css' );
+            $Element->is_enabled();
+            $Element->is_displayed();
+        }
+
+        # add search filter by ticket number and run it
+        $Selenium->find_element( ".AddButton",                        'css' )->click();
+        $Selenium->find_element( "TicketNumber",                      'name' )->send_keys( $Ticket{TicketNumber} );
+        $Selenium->find_element( "#ResultForm option[value='Print']", 'css' )->click();
+        $Selenium->find_element( "TicketNumber",                      'name' )->submit();
+
+        # wait until print screen is loaded
+        # ACTIVESLEEP:
+        # for my $Second ( 1 .. 20 ) {
+        #     if ( index( $Selenium->get_page_source(), "$TitleRandom" ) > -1, )  {
+        #         last ACTIVESLEEP;
+        #     }
+        #     sleep 1;
+        # }
+        sleep 3;
+
+        # check for expected result
+        $Self->True(
+            index( $Selenium->get_page_source(), $TitleRandom ) > -1,
+            "Ticket $TitleRandom found on page",
+        );
+
+        # clean up test data from the DB
+        my $Success = $TicketObject->TicketDelete(
+            TicketID => $TicketID,
+            UserID   => $TestUserID,
+        );
+        $Self->True(
+            $Success,
+            "Ticket with ticket number $Ticket{TicketNumber} is deleted"
+        );
+
+        # make sure the cache is correct.
+        $Kernel::OM->Get('Kernel::System::Cache')->CleanUp( Type => 'Ticket' );
+
+    }
+);
+
+1;

--- a/scripts/test/Selenium/Customer/CustomerTicketPrint.t
+++ b/scripts/test/Selenium/Customer/CustomerTicketPrint.t
@@ -1,0 +1,144 @@
+# --
+# Copyright (C) 2001-2015 OTRS AG, http://otrs.com/
+# --
+# This software comes with ABSOLUTELY NO WARRANTY. For details, see
+# the enclosed file COPYING for license information (AGPL). If you
+# did not receive this file, see http://www.gnu.org/licenses/agpl.txt.
+# --
+
+use strict;
+use warnings;
+use utf8;
+
+use vars (qw($Self));
+
+# get selenium object
+my $Selenium = $Kernel::OM->Get('Kernel::System::UnitTest::Selenium');
+
+$Selenium->RunTest(
+    sub {
+
+        # get helper object
+        $Kernel::OM->ObjectParamAdd(
+            'Kernel::System::UnitTest::Helper' => {
+                RestoreSystemConfiguration => 1,
+                }
+        );
+        my $Helper = $Kernel::OM->Get('Kernel::System::UnitTest::Helper');
+
+        # get sysconfig object
+        my $SysConfigObject = $Kernel::OM->Get('Kernel::System::SysConfig');
+
+        # enable PDF output
+        $SysConfigObject->ConfigItemUpdate(
+            Valid => 1,
+            Key   => 'PDF',
+            Value => 1
+        );
+
+        # create test customer user and login
+        my $TestCustomerUserLogin = $Helper->TestCustomerUserCreate(
+            Groups => ['users'],
+        ) || die "Did not get test user";
+
+        $Selenium->Login(
+            Type     => 'Customer',
+            User     => $TestCustomerUserLogin,
+            Password => $TestCustomerUserLogin,
+        );
+
+        # get needed data
+        my @User = $Kernel::OM->Get('Kernel::System::CustomerUser')->CustomerIDs(
+            User => $TestCustomerUserLogin,
+        );
+        my $TestCustomerID = $User[0];
+
+        # get Ticket object
+        my $TicketObject = $Kernel::OM->Get('Kernel::System::Ticket');
+
+        # create test customer
+        my $TicketNumber = $TicketObject->TicketCreateNumber();
+        my $TicketID     = $TicketObject->TicketCreate(
+            TN           => $TicketNumber,
+            Title        => 'Selenium Test Ticket',
+            Queue        => 'Raw',
+            Priority     => '3 normal',
+            Lock         => 'unlock',
+            State        => 'open',
+            CustomerID   => $TestCustomerID,
+            CustomerUser => "$TestCustomerUserLogin\@localhost.com",
+            OwnerID      => 1,
+            UserID       => 1,
+        );
+
+        my $ScriptAlias = $Kernel::OM->Get('Kernel::Config')->Get('ScriptAlias');
+
+        # navigate to CustomerTicketZoom screen
+        $Selenium->get("${ScriptAlias}customer.pl?Action=CustomerTicketZoom;TicketNumber=$TicketNumber");
+
+        # click on print menu item
+        $Selenium->find_element("//a[contains(\@href, \'Action=CustomerTicketPrint;TicketID=$TicketID\' )]")->click();
+
+        # switch to another window
+        my $Handles = $Selenium->get_window_handles();
+        $Selenium->switch_to_window( $Handles->[1] );
+
+        # wait until print screen is loaded
+        # ACTIVESLEEP:
+        # for my $Second ( 1 .. 20 ) {
+        #     if ( index( $Selenium->get_page_source(), "$TitleRandom" ) > -1, )  {
+        #         last ACTIVESLEEP;
+        #     }
+        #     sleep 1;
+        # }
+        sleep 3;
+
+        # check for printed values of test ticket
+        $Self->True(
+            index( $Selenium->get_page_source(), "printed by $TestCustomerUserLogin" ) > -1,
+            "Header data is found on print screen - printed by $TestCustomerUserLogin",
+        );
+
+        $Self->True(
+            index( $Selenium->get_page_source(), "State:" ) > -1
+                && index( $Selenium->get_page_source(), "open" ) > -1,
+            "State: open - found on print screen",
+        );
+
+        $Self->True(
+            index( $Selenium->get_page_source(), "Queue:" ) > -1
+                && index( $Selenium->get_page_source(), "3 normal" ) > -1,
+            "Queue: Raw - found on print screen",
+        );
+
+        $Self->True(
+            index( $Selenium->get_page_source(), "CustomerID:" ) > -1
+                && index( $Selenium->get_page_source(), "$TestCustomerUserLogin" ) > -1,
+            "CustomerID: $TestCustomerUserLogin - found on print screen",
+        );
+
+        $Self->True(
+            index( $Selenium->get_page_source(), "Priority:" ) > -1
+                && index( $Selenium->get_page_source(), "3 normal" ) > -1,
+            "Priority: 3 normal - found on print screen",
+        );
+
+        # delete test ticket
+        my $Success = $TicketObject->TicketDelete(
+            TicketID => $TicketID,
+            UserID   => 1,
+        );
+        $Self->True(
+            $Success,
+            "Ticket is deleted - $TicketID"
+        );
+
+        # make sure the cache is correct
+        $Kernel::OM->Get('Kernel::System::Cache')->CleanUp(
+            Type => 'Ticket',
+        );
+
+    }
+);
+
+1;


### PR DESCRIPTION
Hi @mgruner 

While we were porting some modules for ITSM packages, we saw that there is bug with Print output.
I felt free to open a bug. There is link to the bug.
http://bugs.otrs.org/show_bug.cgi?id=11332

I solved it. I also added test for the modules that I fixed. I believe that it is good, but I know that it could be solved on another way. And I had some ideas. 

The problem is because PDF object return nothing if PDF SysConfig is not enabled.

~~~perl
sub new {
    my ( $Type, %Param ) = @_;

    # allocate new hash for object
    my $Self = {};
    bless( $Self, $Type );

    # load PDF::API2
    return if !$Kernel::OM->Get('Kernel::Config')->Get('PDF');
...
~~~

Maybe it could be better if we change it on the following way ( return 0 instead return ):

~~~perl
sub new {
    my ( $Type, %Param ) = @_;

    # allocate new hash for object
    my $Self = {};
    bless( $Self, $Type );

    # load PDF::API2
    return 0 if !$Kernel::OM->Get('Kernel::Config')->Get('PDF');
... 
# the same could be solved with the other 'returns'

~~~


Similar to this there was situation with PGP and SMIME objects.
I have not changed PDF.pm yet. It is only my proposal. With my fix I solved the issue, but with this my proposal in the comment, i belive we could solve it on the better way.

What do you think about all of that, please let me know.

Regards
Zoran
