### PR TITLE
Master - Fixed typo in comments of constructors

### DIFF
--- a/Kernel/System/CustomerAuth.pm
+++ b/Kernel/System/CustomerAuth.pm
@@ -40,7 +40,7 @@ create an object. Do not use it directly, instead use:
 
     use Kernel::System::ObjectManager;
     local $Kernel::OM = Kernel::System::ObjectManager->new();
-    my $CustomerUserObject = $Kernel::OM->Get('Kernel::System::CustomerUser');
+    my $CustomerAuthObject = $Kernel::OM->Get('Kernel::System::CustomerAuth');
 
 =cut
 

--- a/Kernel/System/Priority.pm
+++ b/Kernel/System/Priority.pm
@@ -40,7 +40,7 @@ create an object
 
     use Kernel::System::ObjectManager;
     local $Kernel::OM = Kernel::System::ObjectManager->new();
-    my $LockObject = $Kernel::OM->Get('Kernel::System::Priority');
+    my $PriorityObject = $Kernel::OM->Get('Kernel::System::Priority');
 
 
 =cut

--- a/Kernel/System/Queue.pm
+++ b/Kernel/System/Queue.pm
@@ -46,7 +46,7 @@ create an object. Do not use it directly, instead use:
 
     use Kernel::System::ObjectManager;
     local $Kernel::OM = Kernel::System::ObjectManager->new();
-    my $QueueObject = $Kernel::OM->Get('Kernel::System::Auth');
+    my $QueueObject = $Kernel::OM->Get('Kernel::System::Queue');
 
 =cut
 

--- a/Kernel/System/Scheduler.pm
+++ b/Kernel/System/Scheduler.pm
@@ -56,7 +56,7 @@ create a time object. Do not use it directly, instead use:
 
     use Kernel::System::ObjectManager;
     local $Kernel::OM = Kernel::System::ObjectManager->new();
-    my $TimeObject = $Kernel::OM->Get('Kernel::System::Scheduler');
+    my $SchedulerObject = $Kernel::OM->Get('Kernel::System::Scheduler');
 
 
 =cut

--- a/Kernel/System/SystemData.pm
+++ b/Kernel/System/SystemData.pm
@@ -37,7 +37,7 @@ create an object. Do not use it directly, instead use:
 
     use Kernel::System::ObjectManager;
     local $Kernel::OM = Kernel::System::ObjectManager->new();
-    my $ValidObject = $Kernel::OM->Get('Kernel::System::SystemData');
+    my $SystemDataObject = $Kernel::OM->Get('Kernel::System::SystemData');
 
 =cut
 


### PR DESCRIPTION
Hi @mgruner 

We saw that there are some typo in comments, how to create backend objects. We felt free to fix it in this PR.
If you want you can marge it.

Regards
Zoran