### PR TITLE
Master - Changed output of invalid attachments on overview screen

### DIFF
--- a/Kernel/Modules/AdminAttachment.pm
+++ b/Kernel/Modules/AdminAttachment.pm
@@ -357,13 +357,6 @@ sub _Overview {
                 ID => $ID,
             );
 
-            if ( $ValidList{ $Data{ValidID} } eq 'valid' ) {
-                $Data{Invalid} = '';
-            }
-            else {
-                $Data{Invalid} = 'Invalid';
-            }
-
             $LayoutObject->Block(
                 Name => 'OverviewResultRow',
                 Data => {

--- a/Kernel/Output/HTML/Templates/Standard/AdminAttachment.tt
+++ b/Kernel/Output/HTML/Templates/Standard/AdminAttachment.tt
@@ -75,15 +75,7 @@
                                 </a>
                             </td>
                             <td title="[% Data.Comment | html %]">[% Data.Comment | truncate(20) | html %]</td>
-                            <td>
-                                <div class="Flag Valid" title="[% Translate(Data.Valid) | html %]">
-                                    <span class="[% IF Data.ValidID == 1 %]ValidID[% END %]
-                                                 [% IF Data.ValidID == 2 %]InvalidID[% END %]
-                                                 [% IF Data.ValidID == 3 %]InvalidTmpID[% END %]">
-                                    </span>
-                                </div>
-                                <div> [% Translate(Data.Valid) | html %] </div>
-                            </td>
+                            <td>[% Translate(Data.Valid) | html %]</td>
                             <td>[% Data.ChangeTime | Localize("TimeShort") %]</td>
                             <td>[% Data.CreateTime | Localize("TimeShort") %]</td>
                             <td class="Center">

--- a/Kernel/Output/HTML/Templates/Standard/AdminAttachment.tt
+++ b/Kernel/Output/HTML/Templates/Standard/AdminAttachment.tt
@@ -67,7 +67,7 @@
                         </tr>
 [% RenderBlockEnd("NoDataFoundMsg") %]
 [% RenderBlockStart("OverviewResultRow") %]
-                        <tr class="[% Data.Invalid | html %]">
+                        <tr class="  [% IF Data.ValidID != 1 %]Invalid[% END %]">
                             <td><a class="AsBlock" href="[% Env("Baselink") %]Action=[% Env("Action") %];Subaction=Change;ID=[% Data.ID | uri %]">[% Data.Name | html %]</a></td>
                             <td title="[% Translate("Download file") | html %]: [% Data.Filename | html %]">
                                 <a href="[% Env("Baselink") %]Action=[% Env("Action") %];Subaction=Download;ID=[% Data.ID | uri %];[% Env("ChallengeTokenParam") | html %]">
@@ -75,7 +75,15 @@
                                 </a>
                             </td>
                             <td title="[% Data.Comment | html %]">[% Data.Comment | truncate(20) | html %]</td>
-                            <td>[% Translate(Data.Valid) | html %]</td>
+                            <td>
+                                <div class="Flag Valid" title="[% Translate(Data.Valid) | html %]">
+                                    <span class="[% IF Data.ValidID == 1 %]ValidID[% END %]
+                                                 [% IF Data.ValidID == 2 %]InvalidID[% END %]
+                                                 [% IF Data.ValidID == 3 %]InvalidTmpID[% END %]">
+                                    </span>
+                                </div>
+                                <div> [% Translate(Data.Valid) | html %] </div>
+                            </td>
                             <td>[% Data.ChangeTime | Localize("TimeShort") %]</td>
                             <td>[% Data.CreateTime | Localize("TimeShort") %]</td>
                             <td class="Center">

--- a/var/httpd/htdocs/skins/Agent/default/css/Core.Default.css
+++ b/var/httpd/htdocs/skins/Agent/default/css/Core.Default.css
@@ -559,14 +559,6 @@ dd {
     margin: 0px auto;
 }
 
-.Flag.Valid {
-    width: 17px;
-    height: 8px;
-    float: left;
-    cursor: unset;
-    margin: 5px 10px;
-}
-
 .Flag span {
     display: block;
     height: 100%;
@@ -575,11 +567,6 @@ dd {
     /* set a default color for priorities */
     background-color: #cdcdcd;
 }
-
-.Flag.Valid span {
-    cursor: unset;
-}
-
 
 .Flag span.Escalated {
     background-color:#ff505e;
@@ -611,18 +598,6 @@ dd {
 
 .Flag span.PriorityID-5 {
     background-color:#ff505e;
-}
-
-.Flag span.ValidID {
-    background-color: #8bef4d;
-}
-
-.Flag span.InvalidID {
-    background-color:#ff505e;
-}
-
-.Flag span.InvalidTmpID {
-    background-color:#ffaaaa;
 }
 
 /**

--- a/var/httpd/htdocs/skins/Agent/default/css/Core.Default.css
+++ b/var/httpd/htdocs/skins/Agent/default/css/Core.Default.css
@@ -559,6 +559,14 @@ dd {
     margin: 0px auto;
 }
 
+.Flag.Valid {
+    width: 17px;
+    height: 8px;
+    float: left;
+    cursor: unset;
+    margin: 5px 10px;
+}
+
 .Flag span {
     display: block;
     height: 100%;
@@ -567,6 +575,11 @@ dd {
     /* set a default color for priorities */
     background-color: #cdcdcd;
 }
+
+.Flag.Valid span {
+    cursor: unset;
+}
+
 
 .Flag span.Escalated {
     background-color:#ff505e;
@@ -598,6 +611,18 @@ dd {
 
 .Flag span.PriorityID-5 {
     background-color:#ff505e;
+}
+
+.Flag span.ValidID {
+    background-color: #8bef4d;
+}
+
+.Flag span.InvalidID {
+    background-color:#ff505e;
+}
+
+.Flag span.InvalidTmpID {
+    background-color:#ffaaaa;
 }
 
 /**
@@ -929,20 +954,20 @@ iframe.TextOption.Customer {
     font-weight: normal !important;
 }
 
-.ui-state-default, 
-.ui-widget-content .ui-state-default, 
+.ui-state-default,
+.ui-widget-content .ui-state-default,
 .ui-widget-header .ui-state-default {
     background: #f2f2f2 !important;
 }
 
-.ui-state-hover, 
-.ui-widget-content .ui-state-hover, 
-.ui-widget-header .ui-state-hover, 
-.ui-state-focus, 
-.ui-widget-content .ui-state-focus, 
+.ui-state-hover,
+.ui-widget-content .ui-state-hover,
+.ui-widget-header .ui-state-hover,
+.ui-state-focus,
+.ui-widget-content .ui-state-focus,
 .ui-widget-header .ui-state-focus {
     background: #ddd !important;
-} 
+}
 
 /**
  * @subsection global CKEditor fixes/improvements
@@ -952,13 +977,13 @@ iframe.TextOption.Customer {
     width: 40px !important;
 }
 
-#cke_RichText, 
-.cke_toolbar > .cke_toolgroup, 
-.cke_toolbar .cke_combo_button, 
+#cke_RichText,
+.cke_toolbar > .cke_toolgroup,
+.cke_toolbar .cke_combo_button,
 .cke_inner .cke_contents,
 .cke_dialog_body,
-input.cke_dialog_ui_input_password, 
-input.cke_dialog_ui_input_text, 
+input.cke_dialog_ui_input_password,
+input.cke_dialog_ui_input_text,
 textarea.cke_dialog_ui_input_textarea {
     border-radius: 0px !important;
 }
@@ -967,8 +992,8 @@ textarea.cke_dialog_ui_input_textarea {
     background-color: #ccc;
 }
 
-input.cke_dialog_ui_input_password:focus, 
-input.cke_dialog_ui_input_text:focus, 
+input.cke_dialog_ui_input_password:focus,
+input.cke_dialog_ui_input_text:focus,
 textarea.cke_dialog_ui_input_textarea:focus {
     box-shadow: none !important;
     border-color: #f92 !important;


### PR DESCRIPTION
Hi @mgruner 

We changed a little admin attachment overview. It is our proposal in this moment.
To be honest we played with it :) 
However maybe it could be interesting and we can change the other Admin overview screen on the same way. 
As I said it is only proposal, but we did this also in purpose of training, because I would like to see how our new colleagues understand some features which have already  been in OTRS, but they should use a couple of  them for implementing something new or alike.

It look like this:
![valid_flags_1](https://cloud.githubusercontent.com/assets/6348760/8158096/3aa371e8-135a-11e5-8378-ea7c24cfdb78.png)

Another proposal is something like this (flag at the beginning of table):
![valid_flags](https://cloud.githubusercontent.com/assets/6348760/8158063/f66f45d8-1359-11e5-977d-2a748e707651.png)

What do you think about that, in any case we will be able to provide one PR for some Admin screen 
( e.g. AdminSalutation and AdminSignature  ) with implemented this features for greying out invalid entity at the end of day. And if  you agree with our proposal we can add the flags as well.
Please give me the feedback about it.

Regards
Zoran
