### PR TITLE
Add UnitTest::Helper methods for starting and rolling back transactions

### DIFF
--- a/scripts/test/Ticket.t
+++ b/scripts/test/Ticket.t
@@ -12,6 +12,12 @@ use utf8;
 
 use vars (qw($Self));
 
+$Kernel::OM->ObjectParamAdd(
+    'Kernel::System::UnitTest::Helper' => {
+        RestoreDatabase => 1,
+    }
+);
+
 # get needed objects
 my $HelperObject  = $Kernel::OM->Get('Kernel::System::UnitTest::Helper');
 my $QueueObject   = $Kernel::OM->Get('Kernel::System::Queue');

--- a/scripts/test/Ticket/ArchiveSystem.t
+++ b/scripts/test/Ticket/ArchiveSystem.t
@@ -12,7 +12,14 @@ use utf8;
 
 use vars (qw($Self));
 
-# get config object
+$Kernel::OM->ObjectParamAdd(
+    'Kernel::System::UnitTest::Helper' => {
+        RestoreDatabase => 1,
+    }
+);
+
+# get needed objects
+my $HelperObject = $Kernel::OM->Get('Kernel::System::UnitTest::Helper');
 my $ConfigObject = $Kernel::OM->Get('Kernel::Config');
 
 $ConfigObject->Set(

--- a/scripts/test/Ticket/ArticleStorage.t
+++ b/scripts/test/Ticket/ArticleStorage.t
@@ -14,7 +14,14 @@ use vars (qw($Self));
 
 use Unicode::Normalize;
 
+$Kernel::OM->ObjectParamAdd(
+    'Kernel::System::UnitTest::Helper' => {
+        RestoreDatabase => 1,
+    }
+);
+
 # get needed objects
+my $HelperObject = $Kernel::OM->Get('Kernel::System::UnitTest::Helper');
 my $ConfigObject = $Kernel::OM->Get('Kernel::Config');
 my $MainObject   = $Kernel::OM->Get('Kernel::System::Main');
 my $TicketObject = $Kernel::OM->Get('Kernel::System::Ticket');

--- a/scripts/test/UnitTest/Helper.t
+++ b/scripts/test/UnitTest/Helper.t
@@ -41,4 +41,30 @@ $Self->False(
     $DuplicateFound,
     "GetRandomID() returned no duplicates",
 );
+
+
+# Test transactions
+
+$HelperObject->BeginWork();
+
+my $TestUserLogin = $HelperObject->TestUserCreate();
+
+$Self->True(
+    $TestUserLogin,
+    'Can create test user',
+);
+
+$HelperObject->Rollback();
+$Kernel::OM->Get('Kernel::System::Cache')->CleanUp();
+
+my %User = $Kernel::OM->Get('Kernel::System::User')->GetUserData(
+    User => $TestUserLogin,
+);
+
+$Self->False(
+    $User{UserID},
+    'Rollback worked',
+);
+
+
 1;


### PR DESCRIPTION
this way, tests that do not need to interact with the outside can
easily discard their own test objects, and avoid polluting the DB.