### PR TITLE
Master - Changed output for invalid entities (Signature&Salutaion)

### DIFF
--- a/Kernel/Output/HTML/Templates/Standard/AdminSalutation.tt
+++ b/Kernel/Output/HTML/Templates/Standard/AdminSalutation.tt
@@ -66,7 +66,7 @@
                         </tr>
 [% RenderBlockEnd("NoDataFoundMsg") %]
 [% RenderBlockStart("OverviewResultRow") %]
-                        <tr>
+                        <tr [% IF Data.ValidID != 1 %]class="Invalid"[% END %]>
                             <td>
                                 <a class="AsBlock" href="[% Env("Baselink") %]Action=[% Env("Action") %];Subaction=Change;ID=[% Data.ID | uri %]">[% Data.Name | html %]</a>
                             </td>

--- a/Kernel/Output/HTML/Templates/Standard/AdminSignature.tt
+++ b/Kernel/Output/HTML/Templates/Standard/AdminSignature.tt
@@ -64,7 +64,7 @@
                         </tr>
 [% RenderBlockEnd("NoDataFoundMsg") %]
 [% RenderBlockStart("OverviewResultRow") %]
-                        <tr>
+                        <tr [% IF Data.ValidID != 1 %]class="Invalid"[% END %]>
                             <td>
                                 <a class="AsBlock" href="[% Env("Baselink") %]Action=[% Env("Action") %];Subaction=Change;ID=[% Data.ID | uri %]">[% Data.Name | html %]</a>
                             </td>


### PR DESCRIPTION
Hi @mgruner 

As I  mentioned  today, there is PR with a changed output for invalid Signature and Salutation.
We changed a little it, I believe that it is better now. A class is added only if it is needed instead empty class as there is in AdminAttachment. I will reopen PR for AdminAttachment and change like there is in this one. 
Please let me know what do you think about it, we will be able to do as there is in AdminAttachment if you mean that it is necessary.

Regards
Zoran & Vladimir