### PR TITLE
Master - Reset select in AgentPreferences

### DIFF
--- a/Kernel/Config/Files/Framework.xml
+++ b/Kernel/Config/Files/Framework.xml
@@ -4493,6 +4493,9 @@ via the Preferences button after logging in.
                 <Description>Agent Preferences</Description>
                 <Title></Title>
                 <NavBarName>Preferences</NavBarName>
+                <Loader>
+                    <JavaScript>Core.Agent.Preferences.js</JavaScript>
+                </Loader>
             </FrontendModuleReg>
         </Setting>
     </ConfigItem>

--- a/Kernel/Output/HTML/Templates/Standard/AgentPreferences.tt
+++ b/Kernel/Output/HTML/Templates/Standard/AgentPreferences.tt
@@ -127,3 +127,12 @@
     </div>
 </div>
 [% RenderBlockEnd("Body") %]
+[% WRAPPER JSOnDocumentComplete %]
+<script type="text/javascript">//<![CDATA[
+Core.Agent.Preferences.Init({
+    Localization: {
+        RemoveSelection: [% Translate("Remove selection") | JSON %]
+    }
+});
+//]]></script>
+[% END %]

--- a/var/httpd/htdocs/js/Core.Agent.Preferences.js
+++ b/var/httpd/htdocs/js/Core.Agent.Preferences.js
@@ -1,0 +1,100 @@
+// --
+// Copyright (C) 2003-2013 OTRS AG, http://otrs.org/
+// --
+// This software comes with ABSOLUTELY NO WARRANTY. For details, see
+// the enclosed file COPYING for license information (AGPL). If you
+// did not receive this file, see http://www.gnu.org/licenses/agpl.txt.
+// --
+
+"use strict";
+
+var Core = Core || {};
+Core.Agent = Core.Agent || {};
+
+/**
+ * @namespace Core.Agent.Preferences
+ * @memberof Core.Agent
+ * @author OTRS AG
+ * @description
+ *      This namespace contains the special module functions for the GenericInterface job module.
+ */
+Core.Agent.Preferences = (function (TargetNS) {
+
+    /**
+     * @private
+     * @name AddSelectClearButton
+     * @memberof Core.Agent.Preferences
+     * @function
+     * @description
+     *      Adds a button next to every select field to clear the selection.
+     *      Only select fields with size > 1 are selected (no dropdowns).
+     */
+    function AddSelectClearButton() {
+        var $SelectFields = $('select');
+
+        // Loop over all select fields available on the page
+        $SelectFields.each(function () {
+            var Size = parseInt($(this).attr('size'), 10),
+                $SelectField = $(this),
+                SelectID = this.id,
+                ButtonHTML = '<a href="#" title="' + TargetNS.Localization.RemoveSelection + '" class="PreferencesClearSelect" data-select="' + SelectID + '"><span>' + TargetNS.Localization.RemoveSelection + '</span><i class="fa fa-undo"></i></a>';
+
+
+            // Only handle select fields with a size > 1, leave all single-dropdown fields untouched
+            if (isNaN(Size) || Size <= 1) {
+                return;
+            }
+
+            // If select field has a tree selection icon already,
+            // // we want to insert the new code after that element
+            if ($SelectField.next('a.ShowTreeSelection').length) {
+                $SelectField = $SelectField.next('a.ShowTreeSelection');
+            }
+
+            // insert button HTML
+            $SelectField.after(ButtonHTML);
+        });
+
+        // Bind click event on newly inserted button
+        // The name of the corresponding select field is saved in a data attribute
+        $('.PreferencesClearSelect').on('click.ClearSelect', function () {
+            var SelectID = $(this).data('select'),
+                $SelectField = $('#' + SelectID);
+
+            if (!$SelectField.length) {
+                return;
+            }
+
+            // Clear field value
+            $SelectField.val('');
+            $(this).blur();
+
+            return false;
+        });
+    }
+
+    /**
+     * @name Localization
+     * @memberof Core.Agent.Preferences
+     * @member {Array}
+     * @description
+     *     The localization array for translation strings.
+     */
+    TargetNS.Localization = undefined;
+
+    /**
+     * @name Init
+     * @memberof Core.Agent.Preferences
+     * @function
+     * @param {Object} Params - Initialization and internationalization parameters.
+     * @description
+     *      This function initialize correctly all other function according to the local language.
+     */
+    TargetNS.Init = function (Params) {
+
+        TargetNS.Localization = Params.Localization;
+        AddSelectClearButton();
+    };
+
+    return TargetNS;
+}(Core.Agent.Preferences || {}));

--- a/var/httpd/htdocs/skins/Agent/default/css/Core.Form.css
+++ b/var/httpd/htdocs/skins/Agent/default/css/Core.Form.css
@@ -209,17 +209,17 @@ button.Reset:active {
 
 
 /**
- * @subsection    GenericAgent ClearSelect
+ * @subsection    GenericAgent and Preferences ClearSelect
  */
 
-.GenericAgentClearSelect {
+.GenericAgentClearSelect, .PreferencesClearSelect {
     width: 16px;
     height: 16px;
     margin-left: 3px;
     color: #333;
 }
 
-.GenericAgentClearSelect span {
+.GenericAgentClearSelect span, .PreferencesClearSelect span {
     position: absolute;
     left: -9999px;
     top: -9999px;


### PR DESCRIPTION
Hi @mgruner and @ManuelHecht 

There is a task, which I mentioned in mails, that Vladimir and Aleksandar have done on training.
Actually, I gave them to add reset button to select boxes for a couple screen in OTRS. 
They had template how it should do in AdminGenericAgent screen, and on the same way they changed AgentPreferences.tt. You can see it.
Maybe if you think that it is interesting for OTRS, we can make PR for the other screens.

We did this on:

* AgentStats:
  * Subaction=View
  * Subaction=EditSpecification
  * Subaction=EditXaxis
  * Subaction=EditValueSeries
  * Subaction=EditRestrictions

* AdminSLA - Subaction=SLAEdit

Please let me know what do you mean about it.

P.S. We will make a few more PR  from our training tasks next days. Of course we will do on the task that Martin gave us for invalid entities in Admin screens.   

Regards
Zoran
