### PR TITLE
Master - Fixed Customers navbar

### DIFF
--- a/Kernel/Modules/AdminCustomerCompany.pm
+++ b/Kernel/Modules/AdminCustomerCompany.pm
@@ -30,7 +30,7 @@ sub Run {
     my $ConfigObject = $Kernel::OM->Get('Kernel::Config');
 
     my $Nav = $ParamObject->GetParam( Param => 'Nav' ) || 0;
-    my $NavigationBarType = $Nav eq 'Agent' ? 'Companies' : 'Admin';
+    my $NavigationBarType = $Nav eq 'Agent' ? 'Customers' : 'Admin';
     my $Search = $ParamObject->GetParam( Param => 'Search' );
     $Search
         ||= $ConfigObject->Get('AdminCustomerCompany::RunInitialWildcardSearch') ? '*' : '';


### PR DESCRIPTION
Hi @mgruner 

I saw that navbar 'indicator' for AdminCustomerCompany  is not valid in case "Customer Administration" is selected from Customers menu. I feel free to fix it.

Regards
Zoran