### PR TITLE
Fixed bug#11191 - Dashboard ticket filter TYPE.

### DIFF
--- a/Kernel/System/Ticket/ColumnFilter.pm
+++ b/Kernel/System/Ticket/ColumnFilter.pm
@@ -301,7 +301,7 @@ sub TypeFilterValuesGet {
     return if !$DBObject->Prepare(
         SQL => "SELECT DISTINCT(t.type_id), tt.name"
             . " FROM ticket t, ticket_type tt"
-            . " WHERE AND t.type_id = tt.id"
+            . " WHERE t.type_id = tt.id"
             . $TicketIDString
             . " ORDER BY t.type_id DESC",
     );


### PR DESCRIPTION
"I use otrs version 4.0.6 with MySQL 5.5.41-0ubuntu0.14.04.1

In the dashboard or the queue view I have problem with filter TYPE. The filter don't show any data and in the system log is this entry:

You have an error in your SQL syntax; check the manual that corresponds to your MySQL server version for the right syntax to use near 'AND t.type_id = tt.id AND ( t.id IN (33) ) ORDER BY t.type_id DESC' at line 1, SQL: 'SELECT DISTINCT(t.type_id), tt.name FROM ticket t, ticket_type tt WHERE AND t.type_id = tt.id AND ( t.id IN (33) ) ORDER BY t.type_id DESC'

Any idea?"

http://bugs.otrs.org/show_bug.cgi?id=11191
