### PR TITLE
Master - Menu NavBar and MainMenu fixed for CIC

### DIFF
--- a/Kernel/Config/Files/Framework.xml
+++ b/Kernel/Config/Files/Framework.xml
@@ -4404,7 +4404,7 @@ via the Preferences button after logging in.
             <FrontendModuleReg>
                 <Description>Customer Information Center</Description>
                 <Title></Title>
-                <NavBarName>Customer Information Center</NavBarName>
+                <NavBarName>Customers</NavBarName>
                 <NavBar>
                     <Description Translatable="1"></Description>
                     <Name Translatable="1">Customer Information Center</Name>

--- a/Kernel/Output/HTML/Templates/Standard/AgentDashboardCommon.tt
+++ b/Kernel/Output/HTML/Templates/Standard/AgentDashboardCommon.tt
@@ -123,7 +123,7 @@ Core.UI.RegisterToggleTwoContainer($('#Dashboard[% Data.Name | html %]_cancel'),
         <ul class="Actions">
 [% RenderBlockStart("MainMenuItem") %]
             <li>
-                <a href="[% Data.Link %]">
+                <a href="[% Data.Link | Interpolate %]">
                     [% Translate(Data.Name) | html %]
                 </a>
             </li>


### PR DESCRIPTION
Hi @mgruner 

I fixed CIC NavBar. I saw that there was a mistake in SysConfig module registration for CIC, and I solved that on this way. I hope it is better. 

As you can see I also fixed link for MainMenuItem ( AgentCustomerInformationCenter::MainMenu###010-EditCustomerID ) in CIC, doing on this I saw that link for this menu item is not good. There should be interpolated value, and now it works fine.

Regards
Zoran