### PR TITLE
Master - Added some info to make link 'AddAction' more specific for the Selenium tests

### DIFF
--- a/scripts/test/Selenium/Agent/Admin/AdminAttachment.t
+++ b/scripts/test/Selenium/Agent/Admin/AdminAttachment.t
@@ -44,7 +44,7 @@ $Selenium->RunTest(
         for my $File (qw(xls txt doc png pdf)) {
 
             # click 'add new attachment' link
-            $Selenium->find_element("//a[contains(\@href, \'Subaction=Add' )]")->click();
+            $Selenium->find_element("//a[contains(\@href, \'Action=AdminAttachment;Subaction=Add' )]")->click();
 
             # file checks
             my $Location = $ConfigObject->Get('Home')

--- a/scripts/test/Selenium/Agent/Admin/AdminAutoResponse.t
+++ b/scripts/test/Selenium/Agent/Admin/AdminAutoResponse.t
@@ -54,7 +54,7 @@ $Selenium->RunTest(
         $Selenium->find_element( "table tbody tr td", 'css' );
 
         # click 'Add auto response'
-        $Selenium->find_element("//a[contains(\@href, \'Subaction=Add' )]")->click();
+        $Selenium->find_element("//a[contains(\@href, \'Action=AdminAutoResponse;Subaction=Add' )]")->click();
 
         # check page
         for my $ID (
@@ -124,7 +124,7 @@ $Selenium->RunTest(
             );
         }
 
-        }
+    }
 
 );
 

--- a/scripts/test/Selenium/Agent/Admin/AdminEmailAccount.t
+++ b/scripts/test/Selenium/Agent/Admin/AdminEmailAccount.t
@@ -42,7 +42,7 @@ $Selenium->RunTest(
         $Selenium->find_element( "table tbody tr td", 'css' );
 
         # check "Add mail account" link
-        $Selenium->find_element("//a[contains(\@href, \'Subaction=AddNew' )]")->click();
+        $Selenium->find_element("//a[contains(\@href, \'Action=AdminMailAccount;Subaction=AddNew' )]")->click();
 
         for my $ID (
             qw(TypeAdd LoginAdd PasswordAdd HostAdd IMAPFolder Trusted DispatchingBy ValidID Comment)
@@ -101,7 +101,7 @@ $Selenium->RunTest(
             $Selenium->find_element("//a[contains(\@href, \'Subaction=Delete;ID=$MailAccountID' )]")->click();
         }
 
-        }
+    }
 
 );
 

--- a/scripts/test/Selenium/Agent/Admin/AdminNotificationEvent.t
+++ b/scripts/test/Selenium/Agent/Admin/AdminNotificationEvent.t
@@ -55,7 +55,7 @@ $Selenium->RunTest(
         $Selenium->find_element( "table tbody tr td", 'css' );
 
         # click "Add notification"
-        $Selenium->find_element("//a[contains(\@href, \'Subaction=Add' )]")->click();
+        $Selenium->find_element("//a[contains(\@href, \'Action=AdminNotificationEvent;Subaction=Add' )]")->click();
 
         # check add NotificationEvent screen
         for my $ID (
@@ -179,7 +179,7 @@ $Selenium->RunTest(
         # delete test SLA with delete button
         $Selenium->find_element("//a[contains(\@href, \'Subaction=Delete;ID=$NotifEventID{ID}' )]")->click();
 
-        }
+    }
 
 );
 

--- a/scripts/test/Selenium/Agent/Admin/AdminPostMasterFilter.t
+++ b/scripts/test/Selenium/Agent/Admin/AdminPostMasterFilter.t
@@ -41,7 +41,7 @@ $Selenium->RunTest(
         $Selenium->find_element( "table tbody tr td", 'css' );
 
         # click 'Add filter'
-        $Selenium->find_element("//a[contains(\@href, \'Subaction=AddAction' )]")->click();
+        $Selenium->find_element("//a[contains(\@href, \'Action=AdminPostMasterFilter;Subaction=AddAction' )]")->click();
 
         # check client side validation
         $Selenium->find_element( "#EditName", 'css' )->clear();
@@ -165,7 +165,7 @@ $Selenium->RunTest(
         # delete test PostMasterFilter with delete button
         $Selenium->find_element("//a[contains(\@href, \'Subaction=Delete;Name=$PostMasterRandomID' )]")->click();
 
-        }
+    }
 
 );
 

--- a/scripts/test/Selenium/Agent/Admin/AdminPriority.t
+++ b/scripts/test/Selenium/Agent/Admin/AdminPriority.t
@@ -45,7 +45,7 @@ $Selenium->RunTest(
         $Selenium->find_element( "table tbody tr td", 'css' );
 
         # click 'add new priority' link
-        $Selenium->find_element("//a[contains(\@href, \'Subaction=Add' )]")->click();
+        $Selenium->find_element("//a[contains(\@href, \'Action=AdminPriority;Subaction=Add' )]")->click();
 
         # check add page
         my $Element = $Selenium->find_element( "#Name", 'css' );
@@ -142,7 +142,7 @@ $Selenium->RunTest(
             Type => 'Priority',
         );
 
-        }
+    }
 );
 
 1;

--- a/scripts/test/Selenium/Agent/Admin/AdminRole.t
+++ b/scripts/test/Selenium/Agent/Admin/AdminRole.t
@@ -63,7 +63,7 @@ $Selenium->RunTest(
         }
 
         # click 'add new role' linK
-        $Selenium->find_element("//a[contains(\@href, \'Subaction=Add' )]")->click();
+        $Selenium->find_element("//a[contains(\@href, \'Action=AdminRole;Subaction=Add' )]")->click();
 
         # check add page
         my $Element = $Selenium->find_element( "#Name", 'css' );

--- a/scripts/test/Selenium/Agent/Admin/AdminSystemAddress.t
+++ b/scripts/test/Selenium/Agent/Admin/AdminSystemAddress.t
@@ -63,7 +63,7 @@ $Selenium->RunTest(
         $Selenium->find_element( "table tbody tr td", 'css' );
 
         # click 'add system address'
-        $Selenium->find_element("//a[contains(\@href, \'Subaction=Add')]")->click();
+        $Selenium->find_element("//a[contains(\@href, \'Action=AdminSystemAddress;Subaction=Add')]")->click();
 
         # check add new SystemAddress screen
         for my $ID (

--- a/scripts/test/Selenium/Agent/Admin/AdminTemplate.t
+++ b/scripts/test/Selenium/Agent/Admin/AdminTemplate.t
@@ -46,7 +46,7 @@ $Selenium->RunTest(
         $Selenium->find_element( "#Filter",           'css' );
 
         # click 'Add template'
-        $Selenium->find_element("//a[contains(\@href, \'Subaction=Add' )]")->click();
+        $Selenium->find_element("//a[contains(\@href, \'Action=AdminTemplate;Subaction=Add' )]")->click();
         $Selenium->WaitFor( JavaScript => "return \$('#TemplateType').length" );
 
         for my $ID (

--- a/scripts/test/Selenium/Agent/Admin/AdminType.t
+++ b/scripts/test/Selenium/Agent/Admin/AdminType.t
@@ -39,7 +39,7 @@ $Selenium->RunTest(
         $Selenium->find_element( "table tbody tr td", 'css' );
 
         # click 'add new type' link
-        $Selenium->find_element("//a[contains(\@href, \'Subaction=Add' )]")->click();
+        $Selenium->find_element("//a[contains(\@href, \'Action=AdminType;Subaction=Add' )]")->click();
 
         # check add page
         my $Element = $Selenium->find_element( "#Name", 'css' );
@@ -136,7 +136,7 @@ $Selenium->RunTest(
             Type => 'Type',
         );
 
-        }
+    }
 );
 
 1;

--- a/scripts/test/Selenium/Agent/Admin/AdminUser.t
+++ b/scripts/test/Selenium/Agent/Admin/AdminUser.t
@@ -57,7 +57,7 @@ $Selenium->RunTest(
         );
 
         # check add agent page
-        $Selenium->find_element("//a[contains(\@href, \'Subaction=Add' )]")->click();
+        $Selenium->find_element("//a[contains(\@href, \'Action=AdminUser;Subaction=Add' )]")->click();
 
         for my $ID (
             qw(UserFirstname UserLastname UserLogin UserEmail)


### PR DESCRIPTION
Hi @mgruner 

We fixed the links for AddAction here. We mentioned this in conversation with Carlos, I believe it is better now, because if Agent had admin permissions there would be Stats/Add action, and the these tests would be failed.

If you like it you can marge it. I know that we make some PRs with updated some of them tests ( e.g. https://github.com/OTRS/otrs/pull/619, and others for "invalid" display ), and you could have conflicts during the merging. In that case I will be able to solve this depending witch PR is merged first.

If you have any suggestions, please let me know.

Regards
Zoran