### PR TITLE
Master - Improved selenium tests (AdminRole/Group display invalid entities)

### DIFF
--- a/scripts/test/Selenium/Agent/Admin/AdminGroup.t
+++ b/scripts/test/Selenium/Agent/Admin/AdminGroup.t
@@ -105,8 +105,10 @@ $Selenium->RunTest(
         $Selenium->find_element("//input[\@value='$UserID'][\@name='ro']")->click();
         $Selenium->find_element("//input[\@value='$UserID'][\@name='note']")->click();
         $Selenium->find_element("//input[\@value='$UserID'][\@name='owner']")->click();
-
         $Selenium->find_element("//button[\@value='Submit'][\@type='submit']")->click();
+
+        # wait until overview screen has loaded, if neccessary
+        $Selenium->WaitFor( JavaScript => 'return $("#Groups").length' );
 
         # check edited test group permissions
         $Selenium->find_element( $RandomID, 'link_text' )->click();
@@ -153,9 +155,10 @@ $Selenium->RunTest(
         $Selenium->find_element( "#GroupName",                 'css' )->submit();
 
         # chack class of invalid Group in the overview table
-        $Selenium->get("${ScriptAlias}index.pl?Action=AdminGroup");
         $Self->True(
-            $Selenium->find_element( "tr.Invalid", 'css' ),
+            $Selenium->execute_script(
+                "return \$('tr.Invalid td a:contains($RandomID)').length"
+            ),
             "There is a class 'Invalid' for test Group",
         );
 

--- a/scripts/test/Selenium/Agent/Admin/AdminRole.t
+++ b/scripts/test/Selenium/Agent/Admin/AdminRole.t
@@ -131,7 +131,9 @@ $Selenium->RunTest(
 
         # chack class of invalid Role in the overview table
         $Self->True(
-            $Selenium->find_element( "tr.Invalid", 'css' ),
+            $Selenium->execute_script(
+                "return \$('tr.Invalid td a:contains($RandomID)').length"
+            ),
             "There is a class 'Invalid' for test Role",
         );
 


### PR DESCRIPTION
Hi @mgruner 

There is improved Selenium test for checking Invalid class
Doing on task for displaying invalid entities we saw that it could be better if we found more specific Invalid class. If there is filter it is OK, because it is checked for Invalid class after filtering. However if filter did not used, there could be found any other entity with Invalid class.

Regards
Zoran