### PR TITLE
[Master - Bug 11067]  Uncheck of Roles when using a filter.

### DIFF
--- a/scripts/test/Selenium/Agent/Admin/AdminQueueTemplates.t
+++ b/scripts/test/Selenium/Agent/Admin/AdminQueueTemplates.t
@@ -37,10 +37,12 @@ $Selenium->RunTest(
             UserLogin => $TestUserLogin,
         );
 
-        # create test queue
-        my $QueueRandomID = "queue" . $Helper->GetRandomID();
-        my $QueueID       = $Kernel::OM->Get('Kernel::System::Queue')->QueueAdd(
-            Name            => $QueueRandomID,
+        my $ScriptAlias = $Kernel::OM->Get('Kernel::Config')->Get('ScriptAlias');
+
+        # add test queue
+        my $QueueName = "queue" . $Helper->GetRandomID();
+        my $QueueID = $Kernel::OM->Get('Kernel::System::Queue')->QueueAdd(
+            Name            => $QueueName,
             ValidID         => 1,
             GroupID         => 1,
             SystemAddressID => 1,
@@ -51,31 +53,38 @@ $Selenium->RunTest(
         );
         $Self->True(
             $QueueID,
-            "Created Queue - $QueueRandomID",
+            "Created Queue - $QueueName",
         );
 
         # get standard template object
         my $StandardTemplateObject = $Kernel::OM->Get('Kernel::System::StandardTemplate');
+        my @Templates;
 
         # create test template
-        my $TemplateRandomID = "template" . $Helper->GetRandomID();
-        my $TemplateID       = $StandardTemplateObject->StandardTemplateAdd(
-            Name         => $TemplateRandomID,
-            Template     => 'Thank you for your email.',
-            ContentType  => 'text/plain; charset=utf-8',
-            TemplateType => 'Answer',
-            ValidID      => 1,
-            UserID       => $UserID,
-        );
-        $Self->True(
-            $QueueID,
-            "Created StandardTemplate - $TemplateRandomID",
-        );
+        for ( 1 .. 2 ) {
+            my $StandardTemplateName = "standard template" . $Helper->GetRandomID();
+            my $TemplateID       = $StandardTemplateObject->StandardTemplateAdd(
+                Name         => $StandardTemplateName,
+                Template     => 'Thank you for your email.',
+                ContentType  => 'text/plain; charset=utf-8',
+                TemplateType => 'Answer',
+                ValidID      => 1,
+                UserID       => $UserID,
+            );
 
-        # get script alias
-        my $ScriptAlias = $Kernel::OM->Get('Kernel::Config')->Get('ScriptAlias');
+            $Self->True(
+                $TemplateID,
+                "Test StandardTemplate is created - $TemplateID"
+            );
 
-        # navigate to AdminQueueTemplates screen
+            my %Template = (
+                TemplateID => $TemplateID,
+                Name       => $StandardTemplateName,
+            );
+            push @Templates, \%Template;
+        }
+
+        # check overview AdminQueueTemplates screen
         $Selenium->VerifiedGet("${ScriptAlias}index.pl?Action=AdminQueueTemplates");
 
         # check overview AdminQueueTemplates
@@ -90,41 +99,74 @@ $Selenium->RunTest(
 
         # check for test template and test queue on screen
         $Self->True(
-            index( $Selenium->get_page_source(), $TemplateRandomID ) > -1,
-            "$TemplateRandomID found on screen"
+            index( $Selenium->get_page_source(), $Templates[0]->{Name} ) > -1,
+            "$Templates[0]->{Name} found on screen"
         );
         $Self->True(
-            index( $Selenium->get_page_source(), $QueueRandomID ) > -1,
-            "$QueueRandomID found on screen"
+            index( $Selenium->get_page_source(), $QueueName ) > -1,
+            "$QueueName found on screen"
         );
 
         # test search filters
-        $Selenium->find_element( "#FilterTemplates", 'css' )->send_keys($TemplateRandomID);
-        $Selenium->find_element( "#FilterQueues",    'css' )->send_keys($QueueRandomID);
+        $Selenium->find_element( "#FilterTemplates", 'css' )->send_keys( $Templates[0]->{Name} );
+        $Selenium->find_element( "#FilterQueues",    'css' )->send_keys($QueueName);
         sleep 1;
 
         $Self->True(
-            $Selenium->find_element("//a[contains(\@href, \'Subaction=Template;ID=$TemplateID' )]")->is_displayed(),
-            "$TemplateRandomID found on screen with filter on",
+            $Selenium->find_element("//a[contains(\@href, \'Subaction=Template;ID=$Templates[0]->{TemplateID}' )]")
+                ->is_displayed(),
+            "$Templates[0]->{Name} found on screen with filter on",
         );
 
         $Self->True(
             $Selenium->find_element("//a[contains(\@href, \'Subaction=Queue;ID=$QueueID' )]")->is_displayed(),
-            "$QueueRandomID found on screen with filter on",
+            "$QueueName found on screen with filter on",
         );
 
-        # change test Queue relation for test Queue
-        $Selenium->find_element("//a[contains(\@href, \'Subaction=Template;ID=$TemplateID' )]")->VerifiedClick();
-
+        # change test Queue relation for the first Template
+        $Selenium->find_element("//a[contains(\@href, \'Subaction=Template;ID=$Templates[0]->{TemplateID}' )]")
+            ->click();
         $Selenium->find_element("//input[\@value='$QueueID'][\@type='checkbox']")->click();
         $Selenium->find_element("//button[\@value='Save'][\@type='submit']")->VerifiedClick();
 
-        # check test Template relation for test Queue
-        $Selenium->find_element("//a[contains(\@href, \'Subaction=Queue;ID=$QueueID' )]")->VerifiedClick();
 
+        # change test Template relation for test Queue
+        $Selenium->find_element("//a[contains(\@href, \'Subaction=Queue;ID=$QueueID' )]")->VerifiedClick();
+        $Selenium->find_element("//input[\@value='$Templates[1]->{TemplateID}'][\@type='checkbox']")->click();
+
+        # test checked and unchecked values while filter is used for Template
+        # test filter with "WrongFilterTemplate" to uncheck all values
+        $Selenium->find_element( "#Filter", 'css' )->clear();
+        $Selenium->find_element( "#Filter", 'css' )->send_keys("WrongFilterTemplate");
+
+        # test is no data matches
         $Self->True(
-            $Selenium->find_element("//input[\@value='$TemplateID'][\@type='checkbox']")->is_selected(),
-            "$QueueRandomID is in a relation with $TemplateRandomID",
+            $Selenium->find_element( ".FilterMessage.Hidden>td", 'css' )->is_displayed(),
+            "'No data matches' is displayed'"
+        );
+
+        # check template filter with existing Template
+        $Selenium->find_element( "#Filter", 'css' )->clear();
+        $Selenium->find_element( "#Filter", 'css' )->send_keys( $Templates[1]->{Name} );
+        sleep 1;
+
+        # uncheck the second test standard template
+        $Selenium->find_element("//input[\@value='$Templates[1]->{TemplateID}'][\@type='checkbox']")->click();
+
+        # test checked and unchecked values after using filter
+        $Selenium->find_element( "#Filter", 'css' )->clear();
+        $Selenium->find_element( "#Filter", 'css' )->send_keys("StandardTemplate");
+        sleep 1;
+
+        $Self->Is(
+            $Selenium->find_element("//input[\@value='$Templates[0]->{TemplateID}'][\@type='checkbox']")->is_selected(),
+            1,
+            "$QueueName is in a relation with $Templates[0]->{Name}",
+        );
+        $Self->Is(
+            $Selenium->find_element("//input[\@value='$Templates[1]->{TemplateID}'][\@type='checkbox']")->is_selected(),
+            0,
+            "$QueueName is not in a relation with $Templates[1]->{Name}",
         );
 
         # since there are no tickets that rely on our test QueueTemplate,
@@ -145,13 +187,18 @@ $Selenium->RunTest(
             );
             $Self->True(
                 $Success,
-                "Deleted - $QueueRandomID",
+                "Deleted queue- $QueueName",
             );
         }
 
-        if ($TemplateID) {
+        for my $Template (@Templates) {
             $Success = $StandardTemplateObject->StandardTemplateDelete(
-                ID => $TemplateID,
+                ID => $Template->{TemplateID},
+            );
+
+            $Self->True(
+                $Success,
+                "Deleted StandardTemplate - $Template->{TemplateID}",
             );
         }
 

--- a/scripts/test/Selenium/Agent/Admin/AdminQueueTemplates.t
+++ b/scripts/test/Selenium/Agent/Admin/AdminQueueTemplates.t
@@ -137,6 +137,7 @@ $Selenium->RunTest(
         # test filter with "WrongFilterTemplate" to uncheck all values
         $Selenium->find_element( "#Filter", 'css' )->clear();
         $Selenium->find_element( "#Filter", 'css' )->send_keys("WrongFilterTemplate");
+        sleep 1;
 
         # test is no data matches
         $Self->True(

--- a/scripts/test/Selenium/Agent/Admin/AdminQueueTemplates.t
+++ b/scripts/test/Selenium/Agent/Admin/AdminQueueTemplates.t
@@ -41,7 +41,7 @@ $Selenium->RunTest(
 
         # add test queue
         my $QueueName = "queue" . $Helper->GetRandomID();
-        my $QueueID = $Kernel::OM->Get('Kernel::System::Queue')->QueueAdd(
+        my $QueueID   = $Kernel::OM->Get('Kernel::System::Queue')->QueueAdd(
             Name            => $QueueName,
             ValidID         => 1,
             GroupID         => 1,
@@ -63,7 +63,7 @@ $Selenium->RunTest(
         # create test template
         for ( 1 .. 2 ) {
             my $StandardTemplateName = "standard template" . $Helper->GetRandomID();
-            my $TemplateID       = $StandardTemplateObject->StandardTemplateAdd(
+            my $TemplateID           = $StandardTemplateObject->StandardTemplateAdd(
                 Name         => $StandardTemplateName,
                 Template     => 'Thank you for your email.',
                 ContentType  => 'text/plain; charset=utf-8',
@@ -128,7 +128,6 @@ $Selenium->RunTest(
             ->click();
         $Selenium->find_element("//input[\@value='$QueueID'][\@type='checkbox']")->click();
         $Selenium->find_element("//button[\@value='Save'][\@type='submit']")->VerifiedClick();
-
 
         # change test Template relation for test Queue
         $Selenium->find_element("//a[contains(\@href, \'Subaction=Queue;ID=$QueueID' )]")->VerifiedClick();

--- a/scripts/test/Selenium/Agent/Admin/AdminRoleGroup.t
+++ b/scripts/test/Selenium/Agent/Admin/AdminRoleGroup.t
@@ -33,27 +33,27 @@ $Selenium->RunTest(
         );
 
         #add test role
-        my $RoleRandomID = $Helper->GetRandomID();
+        my $RoleName = $Helper->GetRandomID();
         my $RoleID       = $Kernel::OM->Get('Kernel::System::Group')->RoleAdd(
-            Name    => $RoleRandomID,
+            Name    => $RoleName,
             ValidID => 1,
             UserID  => 1,
         );
         $Self->True(
             $RoleID,
-            "Created Role - $RoleRandomID",
+            "Created Role - $RoleName",
         );
 
         # add test group
-        my $GroupRandomID = $Helper->GetRandomID();
+        my $GroupName = $Helper->GetRandomID();
         my $GroupID       = $Kernel::OM->Get('Kernel::System::Group')->GroupAdd(
-            Name    => $GroupRandomID,
+            Name    => $GroupName,
             ValidID => 1,
             UserID  => 1,
         );
         $Self->True(
             $GroupID,
-            "Created Group - $RoleRandomID",
+            "Created Group - $RoleName",
         );
 
         # get script alias
@@ -67,29 +67,29 @@ $Selenium->RunTest(
         $Selenium->find_element( "#Groups", 'css' );
 
         $Self->True(
-            index( $Selenium->get_page_source(), $RoleRandomID ) > -1,
-            "$RoleRandomID role found on page",
+            index( $Selenium->get_page_source(), $RoleName ) > -1,
+            "$RoleName role found on page",
         );
 
         $Self->True(
-            index( $Selenium->get_page_source(), $GroupRandomID ) > -1,
-            "$GroupRandomID group found on page",
+            index( $Selenium->get_page_source(), $GroupName ) > -1,
+            "$GroupName group found on page",
         );
 
         # test filter for Roles
-        $Selenium->find_element( "#FilterRoles", 'css' )->send_keys($RoleRandomID);
+        $Selenium->find_element( "#FilterRoles", 'css' )->send_keys($RoleName);
         sleep 1;
         $Self->True(
-            $Selenium->find_element( "$RoleRandomID", 'link_text' )->is_displayed(),
-            "$RoleRandomID role found on page",
+            $Selenium->find_element( "$RoleName", 'link_text' )->is_displayed(),
+            "$RoleName role found on page",
         );
 
         # test filter for Groups
-        $Selenium->find_element( "#FilterGroups", 'css' )->send_keys($GroupRandomID);
+        $Selenium->find_element( "#FilterGroups", 'css' )->send_keys($GroupName);
         sleep 1;
         $Self->True(
-            $Selenium->find_element( "$GroupRandomID", 'link_text' )->is_displayed(),
-            "$GroupRandomID group found on page",
+            $Selenium->find_element( "$GroupName", 'link_text' )->is_displayed(),
+            "$GroupName group found on page",
         );
 
         # clear test filter for Roles and Groups
@@ -98,85 +98,120 @@ $Selenium->RunTest(
         sleep 1;
 
         # edit group relations for test role
-        $Selenium->find_element( $RoleRandomID, 'link_text' )->VerifiedClick();
-        $Selenium->find_element("//input[\@value='$GroupID'][\@name='ro']")->click();
-        $Selenium->find_element("//input[\@value='$GroupID'][\@name='note']")->click();
-        $Selenium->find_element("//input[\@value='$GroupID'][\@name='owner']")->click();
+        $Selenium->find_element( $RoleName, 'link_text' )->VerifiedClick();
+
+        # set permissions
+        for my $Permission ( qw(ro note owner) ) {
+            $Selenium->find_element("//input[\@value='$GroupID'][\@name='$Permission']")->click();
+        }
+
         $Selenium->find_element("//button[\@value='Save'][\@type='submit']")->VerifiedClick();
 
-        # check edited test group permissions
-        $Selenium->find_element( $RoleRandomID, 'link_text' )->VerifiedClick();
-        $Self->Is(
-            $Selenium->find_element("//input[\@value='$GroupID'][\@name='ro']")->is_selected(),
-            1,
-            "ro permission for group $GroupRandomID is enabled",
-        );
-        $Self->Is(
-            $Selenium->find_element("//input[\@value='$GroupID'][\@name='note']")->is_selected(),
-            1,
-            "note permission for group $GroupRandomID is enabled",
-        );
-        $Self->Is(
-            $Selenium->find_element("//input[\@value='$GroupID'][\@name='owner']")->is_selected(),
-            1,
-            "owner permission for group $GroupRandomID is enabled",
+        my @Test = (
+            {
+                'ro'        => 1,
+                'move_into' => 0,
+                'create'    => 0,
+                'note'      => 1,
+                'owner'     => 1,
+                'priority'  => 0,
+                'rw'        => 0,
+            },
+            {
+                'ro'        => 1,
+                'move_into' => 1,
+                'create'    => 1,
+                'note'      => 0,
+                'owner'     => 1,
+                'priority'  => 1,
+                'rw'        => 0,
+            },
         );
 
-        $Self->Is(
-            $Selenium->find_element("//input[\@value='$GroupID'][\@name='move_into']")->is_selected(),
-            0,
-            "move_into permission for group $GroupRandomID is disabled",
+        # check edited test group permissions
+        $Selenium->find_element( $RoleName, 'link_text' )->VerifiedClick();
+
+        # check permissions
+        for my $Permission ( keys $Test[0] ) {
+            my $Enabled = $Test[0]{$Permission} ? 'enabled':'disabled';
+            $Self->Is(
+                $Selenium->find_element("//input[\@value='$GroupID'][\@name='$Permission']")->is_selected(),
+                $Test[0]{$Permission},
+                "$Permission permission for group $GroupName and role $RoleName is $Enabled",
+            );
+        }
+
+        # test checked and unchecked values while filter by group is used
+        # test filter with "WrongFilterGroup" to uncheck all values
+        $Selenium->find_element( "#Filter", 'css' )->clear();
+        $Selenium->find_element( "#Filter", 'css' )->send_keys("WrongFilterGroup");
+        sleep 1;
+
+        # test if no data is matches
+        $Self->True(
+            $Selenium->find_element( ".FilterMessage.Hidden>td", 'css' )->is_displayed(),
+            "'No data matches' is displayed'"
         );
-        $Self->Is(
-            $Selenium->find_element("//input[\@value='$GroupID'][\@name='priority']")->is_selected(),
-            0,
-            "priority permission for group $GroupRandomID is disabled",
-        );
+        $Selenium->find_element( "#Filter", 'css' )->clear();
+
+        # check permissions
+        for my $Permission ( keys $Test[0] ) {
+            my $Enabled = $Test[0]{$Permission} ? 'enabled':'disabled';
+            $Self->Is(
+                $Selenium->find_element("//input[\@value='$GroupID'][\@name='$Permission']")->is_selected(),
+                $Test[0]{$Permission},
+                "$Permission permission for group $GroupName and role $RoleName is $Enabled",
+            );
+        }
 
         # navigate to AdminRoleGroup screen again
         $Selenium->VerifiedGet("${ScriptAlias}index.pl?Action=AdminRoleGroup");
 
         # edit role relations for test group
-        $Selenium->find_element( $GroupRandomID, 'link_text' )->VerifiedClick();
-        $Selenium->find_element("//input[\@value='$RoleID'][\@name='move_into']")->click();
-        $Selenium->find_element("//input[\@value='$RoleID'][\@name='priority']")->click();
-        $Selenium->find_element("//input[\@value='$RoleID'][\@name='create']")->click();
+        $Selenium->find_element( $GroupName, 'link_text' )->VerifiedClick();
+
+        # set permissions
+        for my $Permission ( qw(note move_into priority create) ) {
+            $Selenium->find_element("//input[\@value='$RoleID'][\@name='$Permission']")->click();
+        }
         $Selenium->find_element("//button[\@value='Save'][\@type='submit']")->VerifiedClick();
 
         # check edited test group permissions
-        $Selenium->find_element( $GroupRandomID, 'link_text' )->VerifiedClick();
-        $Self->Is(
-            $Selenium->find_element("//input[\@value='$RoleID'][\@name='ro']")->is_selected(),
-            1,
-            "ro permission for role $RoleRandomID is enabled",
-        );
+        $Selenium->find_element( $GroupName, 'link_text' )->VerifiedClick();
 
-        $Self->Is(
-            $Selenium->find_element("//input[\@value='$RoleID'][\@name='note']")->is_selected(),
-            1,
-            "note permission for role $RoleRandomID is enabled",
-        );
-        $Self->Is(
-            $Selenium->find_element("//input[\@value='$RoleID'][\@name='owner']")->is_selected(),
-            1,
-            "owner permission for role $RoleRandomID is enabled",
-        );
+        # check permissions
+        for my $Permission ( keys $Test[1] ) {
+            my $Enabled = $Test[1]{$Permission} ? 'enabled':'disabled';
+            $Self->Is(
+                $Selenium->find_element("//input[\@value='$RoleID'][\@name='$Permission']")->is_selected(),
+                $Test[1]{$Permission},
+                "$Permission permission for group $GroupName and role $RoleName is $Enabled",
+            );
+        }
 
-        $Self->Is(
-            $Selenium->find_element("//input[\@value='$RoleID'][\@name='move_into']")->is_selected(),
-            1,
-            "move_into permission for role $RoleRandomID is enabled",
+        # test checked and unchecked values while filter is used for Role
+        # test filter with "WrongFilterRole" to uncheck all values
+        $Selenium->find_element( "#Filter", 'css' )->clear();
+        $Selenium->find_element( "#Filter", 'css' )->send_keys("WrongFilterRole");
+        sleep 1;
+
+        # test is no data matches
+        $Self->True(
+            $Selenium->find_element( ".FilterMessage.Hidden>td", 'css' )->is_displayed(),
+            "'No data matches' is displayed'"
         );
-        $Self->Is(
-            $Selenium->find_element("//input[\@value='$RoleID'][\@name='priority']")->is_selected(),
-            1,
-            "priority permission for role $RoleRandomID is enabled",
-        );
-        $Self->Is(
-            $Selenium->find_element("//input[\@value='$RoleID'][\@name='create']")->is_selected(),
-            1,
-            "create permission for role $RoleRandomID is enabled",
-        );
+        $Selenium->find_element( "#Filter", 'css' )->clear();
+
+        # check role relations for group after using filter by role
+                # check permissions
+        for my $Permission ( keys $Test[1] ) {
+            my $Enabled = $Test[1]{$Permission} ? 'enabled':'disabled';
+            $Self->Is(
+                $Selenium->find_element("//input[\@value='$RoleID'][\@name='$Permission']")->is_selected(),
+                $Test[1]{$Permission},
+                "$Permission permission for group $GroupName and role $RoleName is $Enabled",
+            );
+        }
 
         # since there are no tickets that rely on our test group and role, we can remove them again
         # from the DB
@@ -186,12 +221,10 @@ $Selenium->RunTest(
                 SQL => "DELETE FROM group_role WHERE group_id = $GroupID",
             );
 
-            if ($Success) {
-                $Self->True(
-                    $Success,
-                    "GroupRoleDelete - for $GroupRandomID",
-                );
-            }
+            $Self->True(
+                $Success,
+                "GroupRoleDelete - for $GroupName",
+            );
 
             $Success = $DBObject->Do(
                 SQL => "DELETE FROM groups WHERE id = $GroupID",
@@ -199,7 +232,7 @@ $Selenium->RunTest(
 
             $Self->True(
                 $Success,
-                "GroupDelete - $GroupRandomID",
+                "GroupDelete - $GroupName",
             );
         }
 
@@ -211,14 +244,19 @@ $Selenium->RunTest(
 
             $Self->True(
                 $Success,
-                "RoleDelete - $RoleRandomID",
+                "RoleDelete - $RoleName",
             );
         }
 
-        # make sure the cache is correct
-        $Kernel::OM->Get('Kernel::System::Cache')->CleanUp( Type => 'Group' );
-        $Kernel::OM->Get('Kernel::System::Cache')->CleanUp( Type => 'Role' );
-
+        # make sure the cache is correct.
+        for my $Cache (
+            qw (Group Role)
+            )
+        {
+            $Kernel::OM->Get('Kernel::System::Cache')->CleanUp(
+                Type => $Cache,
+            );
+        }
     }
 );
 

--- a/scripts/test/Selenium/Agent/Admin/AdminRoleGroup.t
+++ b/scripts/test/Selenium/Agent/Admin/AdminRoleGroup.t
@@ -107,36 +107,35 @@ $Selenium->RunTest(
 
         $Selenium->find_element("//button[\@value='Save'][\@type='submit']")->VerifiedClick();
 
-        my @Test = (
-            {
-                'ro'        => 1,
-                'move_into' => 0,
-                'create'    => 0,
-                'note'      => 1,
-                'owner'     => 1,
-                'priority'  => 0,
-                'rw'        => 0,
-            },
-            {
-                'ro'        => 1,
-                'move_into' => 1,
-                'create'    => 1,
-                'note'      => 0,
-                'owner'     => 1,
-                'priority'  => 1,
-                'rw'        => 0,
-            },
+        my %TestFirst = (
+            'ro'        => 1,
+            'move_into' => 0,
+            'create'    => 0,
+            'note'      => 1,
+            'owner'     => 1,
+            'priority'  => 0,
+            'rw'        => 0,
+        );
+
+        my %TestSecond = (
+            'ro'        => 1,
+            'move_into' => 1,
+            'create'    => 1,
+            'note'      => 0,
+            'owner'     => 1,
+            'priority'  => 1,
+            'rw'        => 0,
         );
 
         # check edited test group permissions
         $Selenium->find_element( $RoleName, 'link_text' )->VerifiedClick();
 
         # check permissions
-        for my $Permission ( sort keys $Test[0] ) {
-            my $Enabled = $Test[0]{$Permission} ? 'enabled' : 'disabled';
+        for my $Permission ( sort keys %TestFirst ) {
+            my $Enabled = $TestFirst{$Permission} ? 'enabled' : 'disabled';
             $Self->Is(
                 $Selenium->find_element("//input[\@value='$GroupID'][\@name='$Permission']")->is_selected(),
-                $Test[0]{$Permission},
+                $TestFirst{$Permission},
                 "$Permission permission for group $GroupName and role $RoleName is $Enabled",
             );
         }
@@ -155,11 +154,11 @@ $Selenium->RunTest(
         $Selenium->find_element( "#Filter", 'css' )->clear();
 
         # check permissions
-        for my $Permission ( sort keys $Test[0] ) {
-            my $Enabled = $Test[0]{$Permission} ? 'enabled' : 'disabled';
+        for my $Permission ( sort keys %TestFirst ) {
+            my $Enabled = $TestFirst{$Permission} ? 'enabled' : 'disabled';
             $Self->Is(
                 $Selenium->find_element("//input[\@value='$GroupID'][\@name='$Permission']")->is_selected(),
-                $Test[0]{$Permission},
+                $TestFirst{$Permission},
                 "$Permission permission for group $GroupName and role $RoleName is $Enabled",
             );
         }
@@ -180,11 +179,11 @@ $Selenium->RunTest(
         $Selenium->find_element( $GroupName, 'link_text' )->VerifiedClick();
 
         # check permissions
-        for my $Permission ( sort keys $Test[1] ) {
-            my $Enabled = $Test[1]{$Permission} ? 'enabled' : 'disabled';
+        for my $Permission ( sort keys %TestSecond ) {
+            my $Enabled = $TestSecond{$Permission} ? 'enabled' : 'disabled';
             $Self->Is(
                 $Selenium->find_element("//input[\@value='$RoleID'][\@name='$Permission']")->is_selected(),
-                $Test[1]{$Permission},
+                $TestSecond{$Permission},
                 "$Permission permission for group $GroupName and role $RoleName is $Enabled",
             );
         }
@@ -204,11 +203,11 @@ $Selenium->RunTest(
 
         # check role relations for group after using filter by role
         # check permissions
-        for my $Permission ( sort keys $Test[1] ) {
-            my $Enabled = $Test[1]{$Permission} ? 'enabled' : 'disabled';
+        for my $Permission ( sort keys %TestSecond ) {
+            my $Enabled = $TestSecond{$Permission} ? 'enabled' : 'disabled';
             $Self->Is(
                 $Selenium->find_element("//input[\@value='$RoleID'][\@name='$Permission']")->is_selected(),
-                $Test[1]{$Permission},
+                $TestSecond{$Permission},
                 "$Permission permission for group $GroupName and role $RoleName is $Enabled",
             );
         }

--- a/scripts/test/Selenium/Agent/Admin/AdminRoleGroup.t
+++ b/scripts/test/Selenium/Agent/Admin/AdminRoleGroup.t
@@ -34,7 +34,7 @@ $Selenium->RunTest(
 
         #add test role
         my $RoleName = $Helper->GetRandomID();
-        my $RoleID       = $Kernel::OM->Get('Kernel::System::Group')->RoleAdd(
+        my $RoleID   = $Kernel::OM->Get('Kernel::System::Group')->RoleAdd(
             Name    => $RoleName,
             ValidID => 1,
             UserID  => 1,
@@ -46,7 +46,7 @@ $Selenium->RunTest(
 
         # add test group
         my $GroupName = $Helper->GetRandomID();
-        my $GroupID       = $Kernel::OM->Get('Kernel::System::Group')->GroupAdd(
+        my $GroupID   = $Kernel::OM->Get('Kernel::System::Group')->GroupAdd(
             Name    => $GroupName,
             ValidID => 1,
             UserID  => 1,
@@ -101,7 +101,7 @@ $Selenium->RunTest(
         $Selenium->find_element( $RoleName, 'link_text' )->VerifiedClick();
 
         # set permissions
-        for my $Permission ( qw(ro note owner) ) {
+        for my $Permission (qw(ro note owner)) {
             $Selenium->find_element("//input[\@value='$GroupID'][\@name='$Permission']")->click();
         }
 
@@ -132,8 +132,8 @@ $Selenium->RunTest(
         $Selenium->find_element( $RoleName, 'link_text' )->VerifiedClick();
 
         # check permissions
-        for my $Permission ( keys $Test[0] ) {
-            my $Enabled = $Test[0]{$Permission} ? 'enabled':'disabled';
+        for my $Permission ( sort keys $Test[0] ) {
+            my $Enabled = $Test[0]{$Permission} ? 'enabled' : 'disabled';
             $Self->Is(
                 $Selenium->find_element("//input[\@value='$GroupID'][\@name='$Permission']")->is_selected(),
                 $Test[0]{$Permission},
@@ -155,8 +155,8 @@ $Selenium->RunTest(
         $Selenium->find_element( "#Filter", 'css' )->clear();
 
         # check permissions
-        for my $Permission ( keys $Test[0] ) {
-            my $Enabled = $Test[0]{$Permission} ? 'enabled':'disabled';
+        for my $Permission ( sort keys $Test[0] ) {
+            my $Enabled = $Test[0]{$Permission} ? 'enabled' : 'disabled';
             $Self->Is(
                 $Selenium->find_element("//input[\@value='$GroupID'][\@name='$Permission']")->is_selected(),
                 $Test[0]{$Permission},
@@ -171,7 +171,7 @@ $Selenium->RunTest(
         $Selenium->find_element( $GroupName, 'link_text' )->VerifiedClick();
 
         # set permissions
-        for my $Permission ( qw(note move_into priority create) ) {
+        for my $Permission (qw(note move_into priority create)) {
             $Selenium->find_element("//input[\@value='$RoleID'][\@name='$Permission']")->click();
         }
         $Selenium->find_element("//button[\@value='Save'][\@type='submit']")->VerifiedClick();
@@ -180,8 +180,8 @@ $Selenium->RunTest(
         $Selenium->find_element( $GroupName, 'link_text' )->VerifiedClick();
 
         # check permissions
-        for my $Permission ( keys $Test[1] ) {
-            my $Enabled = $Test[1]{$Permission} ? 'enabled':'disabled';
+        for my $Permission ( sort keys $Test[1] ) {
+            my $Enabled = $Test[1]{$Permission} ? 'enabled' : 'disabled';
             $Self->Is(
                 $Selenium->find_element("//input[\@value='$RoleID'][\@name='$Permission']")->is_selected(),
                 $Test[1]{$Permission},
@@ -203,9 +203,9 @@ $Selenium->RunTest(
         $Selenium->find_element( "#Filter", 'css' )->clear();
 
         # check role relations for group after using filter by role
-                # check permissions
-        for my $Permission ( keys $Test[1] ) {
-            my $Enabled = $Test[1]{$Permission} ? 'enabled':'disabled';
+        # check permissions
+        for my $Permission ( sort keys $Test[1] ) {
+            my $Enabled = $Test[1]{$Permission} ? 'enabled' : 'disabled';
             $Self->Is(
                 $Selenium->find_element("//input[\@value='$RoleID'][\@name='$Permission']")->is_selected(),
                 $Test[1]{$Permission},

--- a/scripts/test/Selenium/Agent/Admin/AdminRoleUser.t
+++ b/scripts/test/Selenium/Agent/Admin/AdminRoleUser.t
@@ -134,7 +134,6 @@ $Selenium->RunTest(
         # check if relation is clear
         $Selenium->find_element( $RoleName, 'link_text' )->VerifiedClick();
 
-
         $Self->Is(
             $Selenium->find_element("//input[\@value='$RoleID']")->is_selected(),
             0,

--- a/scripts/test/Selenium/Agent/Admin/AdminRoleUser.t
+++ b/scripts/test/Selenium/Agent/Admin/AdminRoleUser.t
@@ -38,16 +38,16 @@ $Selenium->RunTest(
         );
 
         #add test role
-        my $RoleRandomID = "role" . $Helper->GetRandomID();
+        my $RoleName = "role" . $Helper->GetRandomID();
 
         my $RoleID = $Kernel::OM->Get('Kernel::System::Group')->RoleAdd(
-            Name    => $RoleRandomID,
+            Name    => $RoleName,
             ValidID => 1,
             UserID  => $UserID,
         );
         $Self->True(
             $RoleID,
-            "Created Role - $RoleRandomID",
+            "Created Role - $RoleName",
         );
 
         # get script alias
@@ -68,8 +68,8 @@ $Selenium->RunTest(
             "$TestUserLogin user found on page",
         );
         $Self->True(
-            index( $Selenium->get_page_source(), $RoleRandomID ) > -1,
-            "$RoleRandomID role found on page",
+            index( $Selenium->get_page_source(), $RoleName ) > -1,
+            "$RoleName role found on page",
         );
 
         # test filter for Users
@@ -82,12 +82,12 @@ $Selenium->RunTest(
         );
 
         # test filter for Roles
-        $Selenium->find_element( "#FilterRoles", 'css' )->send_keys($RoleRandomID);
+        $Selenium->find_element( "#FilterRoles", 'css' )->send_keys($RoleName);
         sleep 1;
 
         $Self->True(
-            $Selenium->find_element( "$RoleRandomID", 'link_text' )->is_displayed(),
-            "$RoleRandomID role found on page",
+            $Selenium->find_element( "$RoleName", 'link_text' )->is_displayed(),
+            "$RoleName role found on page",
         );
 
         # change test role relation for test user
@@ -97,12 +97,34 @@ $Selenium->RunTest(
         $Selenium->find_element("//button[\@value='Save'][\@type='submit']")->VerifiedClick();
 
         #check and edit test user relation for test role
-        $Selenium->find_element( $RoleRandomID, 'link_text' )->VerifiedClick();
+        $Selenium->find_element( $RoleName, 'link_text' )->VerifiedClick();
 
         $Self->Is(
             $Selenium->find_element("//input[\@value='$UserID']")->is_selected(),
             1,
-            "Role $RoleRandomID relation for user $TestUserLogin is enabled",
+            "Role $RoleName relation for user $TestUserLogin is enabled",
+        );
+
+        # test checked and unchecked values while filter by role is used
+        # test filter with "WrongFilterRole" to uncheck a value
+        $Selenium->find_element( "#Filter", 'css' )->clear();
+        $Selenium->find_element( "#Filter", 'css' )->send_keys("WrongFilterRole");
+        sleep 1;
+
+        # test if no data is matches
+        $Self->True(
+            $Selenium->find_element( ".FilterMessage.Hidden>td", 'css' )->is_displayed(),
+            "'No data matches' is displayed'"
+        );
+        $Selenium->find_element( "#Filter", 'css' )->clear();
+        $Selenium->find_element( "#Filter", 'css' )->send_keys($TestUserLogin);
+        sleep 1;
+
+        # check role relation for agent after using filter by agent
+        $Self->Is(
+            $Selenium->find_element("//input[\@value='$UserID']")->is_selected(),
+            1,
+            "Role $RoleName relation for user $TestUserLogin is enabled",
         );
 
         # remove test relation
@@ -110,12 +132,35 @@ $Selenium->RunTest(
         $Selenium->find_element("//button[\@value='Save'][\@type='submit']")->VerifiedClick();
 
         # check if relation is clear
-        $Selenium->find_element( $RoleRandomID, 'link_text' )->VerifiedClick();
+        $Selenium->find_element( $RoleName, 'link_text' )->VerifiedClick();
+
 
         $Self->Is(
-            $Selenium->find_element("//input[\@value='$UserID']")->is_selected(),
+            $Selenium->find_element("//input[\@value='$RoleID']")->is_selected(),
             0,
-            "User $TestUserLogin is not in relation with role $RoleRandomID",
+            "User $TestUserLogin is not in relation with role $RoleName",
+        );
+
+        # test checked and unchecked values while filter by user is used
+        # test filter with "WrongFilterRole" to uncheck a value
+        $Selenium->find_element( "#Filter", 'css' )->clear();
+        $Selenium->find_element( "#Filter", 'css' )->send_keys("WrongFilterRole");
+        sleep 1;
+
+        # test if no data is matches
+        $Self->True(
+            $Selenium->find_element( ".FilterMessage.Hidden>td", 'css' )->is_displayed(),
+            "'No data matches' is displayed'"
+        );
+        $Selenium->find_element( "#Filter", 'css' )->clear();
+        $Selenium->find_element( "#Filter", 'css' )->send_keys($RoleName);
+        sleep 1;
+
+        # check role relation for agent after using filter by role
+        $Self->Is(
+            $Selenium->find_element("//input[\@value='$RoleID']")->is_selected(),
+            0,
+            "User $TestUserLogin is not in relation with role $RoleName",
         );
 
         # since there are no tickets that rely on our test role we can remove it from DB
@@ -125,7 +170,7 @@ $Selenium->RunTest(
             );
             $Self->True(
                 $Success,
-                "RoleDelete - $RoleRandomID",
+                "RoleDelete - $RoleName",
             );
         }
 

--- a/scripts/test/Selenium/Agent/Admin/AdminUserGroup.t
+++ b/scripts/test/Selenium/Agent/Admin/AdminUserGroup.t
@@ -95,38 +95,38 @@ $Selenium->RunTest(
         # edit test group permission for test agent
         $Selenium->find_element( $GroupName, 'link_text' )->VerifiedClick();
 
-        my @Test = (
-            {
-                'ro'        => 1,
-                'move_into' => 1,
-                'create'    => 1,
-                'note'      => 1,
-                'owner'     => 1,
-                'priority'  => 1,
-                'rw'        => 1,
-            },
-            {
-                'ro'        => 0,
-                'move_into' => 1,
-                'create'    => 1,
-                'note'      => 0,
-                'owner'     => 0,
-                'priority'  => 1,
-                'rw'        => 0,
-            },
-            {
-                'ro'        => 1,
-                'move_into' => 1,
-                'create'    => 1,
-                'note'      => 1,
-                'owner'     => 0,
-                'priority'  => 0,
-                'rw'        => 0,
-            },
+        my %TestFirst = (
+            'ro'        => 1,
+            'move_into' => 1,
+            'create'    => 1,
+            'note'      => 1,
+            'owner'     => 1,
+            'priority'  => 1,
+            'rw'        => 1,
+        );
+
+        my %TestSecond = (
+            'ro'        => 0,
+            'move_into' => 1,
+            'create'    => 1,
+            'note'      => 0,
+            'owner'     => 0,
+            'priority'  => 1,
+            'rw'        => 0,
+        );
+
+        my %TestThird = (
+            'ro'        => 1,
+            'move_into' => 1,
+            'create'    => 1,
+            'note'      => 1,
+            'owner'     => 0,
+            'priority'  => 0,
+            'rw'        => 0,
         );
 
         # check permissions
-        for my $Permission ( sort keys $Test[0] ) {
+        for my $Permission ( sort keys %TestFirst ) {
             $Self->True(
                 $Selenium->find_element("//input[\@value='$UserID'][\@name='$Permission']"),
                 "$Permission permission for user $TestUserLogin in group $GroupName is enabled",
@@ -144,11 +144,11 @@ $Selenium->RunTest(
         $Selenium->find_element( $GroupName, 'link_text' )->VerifiedClick();
 
         # check permissions
-        for my $Permission ( sort keys $Test[1] ) {
-            my $Enabled = $Test[1]{$Permission} ? 'enabled' : 'disabled';
+        for my $Permission ( sort keys %TestSecond ) {
+            my $Enabled = $TestSecond{$Permission} ? 'enabled' : 'disabled';
             $Self->Is(
                 $Selenium->find_element("//input[\@value='$UserID'][\@name='$Permission']")->is_selected(),
-                $Test[1]{$Permission},
+                $TestSecond{$Permission},
                 "$Permission permission for user $TestUserLogin in group $GroupName is $Enabled",
             );
         }
@@ -168,11 +168,11 @@ $Selenium->RunTest(
 
         # check group relations for user after using filter by group
         # check permissions
-        for my $Permission ( sort keys $Test[1] ) {
-            my $Enabled = $Test[1]{$Permission} ? 'enabled' : 'disabled';
+        for my $Permission ( sort keys %TestSecond ) {
+            my $Enabled = $TestSecond{$Permission} ? 'enabled' : 'disabled';
             $Self->Is(
                 $Selenium->find_element("//input[\@value='$UserID'][\@name='$Permission']")->is_selected(),
-                $Test[1]{$Permission},
+                $TestSecond{$Permission},
                 "$Permission permission for user $TestUserLogin in group $GroupName is $Enabled",
             );
         }
@@ -193,11 +193,11 @@ $Selenium->RunTest(
         # check edited test agent permissions
         $Selenium->find_element( $FullTestUserLogin, 'link_text' )->VerifiedClick();
 
-        for my $Permission ( sort keys $Test[2] ) {
-            my $Enabled = $Test[2]{$Permission} ? 'enabled' : 'disabled';
+        for my $Permission ( sort keys %TestThird ) {
+            my $Enabled = $TestThird{$Permission} ? 'enabled' : 'disabled';
             $Self->Is(
                 $Selenium->find_element("//input[\@value='$GroupID'][\@name='$Permission']")->is_selected(),
-                $Test[2]{$Permission},
+                $TestThird{$Permission},
                 "$Permission permission for user $TestUserLogin in group $GroupName is $Enabled",
             );
         }

--- a/scripts/test/Selenium/Agent/Admin/AdminUserGroup.t
+++ b/scripts/test/Selenium/Agent/Admin/AdminUserGroup.t
@@ -44,16 +44,16 @@ $Selenium->RunTest(
         $Kernel::OM->Get('Kernel::System::Cache')->CleanUp( Type => 'Group' );
 
         # create test group
-        my $GroupRandomID = 'group' . $Helper->GetRandomID();
+        my $GroupName = 'group' . $Helper->GetRandomID();
         my $GroupID       = $Kernel::OM->Get('Kernel::System::Group')->GroupAdd(
-            Name    => $GroupRandomID,
+            Name    => $GroupName,
             Comment => 'Selenium test group',
             ValidID => 1,
             UserID  => 1,
         );
         $Self->True(
             $GroupID,
-            "Created Group - $GroupRandomID",
+            "Created Group - $GroupName",
         );
 
         # navigate to AdminUserGroup screen
@@ -64,7 +64,7 @@ $Selenium->RunTest(
         $Selenium->find_element( "#Groups", 'css' );
 
         # click on created test group
-        $Selenium->find_element( $GroupRandomID, 'link_text' )->VerifiedClick();
+        $Selenium->find_element( $GroupName, 'link_text' )->VerifiedClick();
 
         # give full read and write access to the tickets in test group for test user
         $Selenium->find_element("//input[\@value='$UserID'][\@name='rw']")->click();
@@ -80,11 +80,11 @@ $Selenium->RunTest(
         );
 
         # test filter for groups
-        $Selenium->find_element( "#FilterGroups", 'css' )->send_keys($GroupRandomID);
+        $Selenium->find_element( "#FilterGroups", 'css' )->send_keys($GroupName);
         sleep 1;
         $Self->True(
-            $Selenium->find_element( "$GroupRandomID", 'link_text' )->is_displayed(),
-            "$GroupRandomID group found on page",
+            $Selenium->find_element( "$GroupName", 'link_text' )->is_displayed(),
+            "$GroupName group found on page",
         );
 
         # clear test filter for Users and Groups
@@ -93,66 +93,118 @@ $Selenium->RunTest(
         sleep 1;
 
         # edit test group permission for test agent
-        $Selenium->find_element( $GroupRandomID, 'link_text' )->VerifiedClick();
+        $Selenium->find_element( $GroupName, 'link_text' )->VerifiedClick();
 
-        $Selenium->find_element("//input[\@value='$UserID'][\@name='rw']")->click();
-        $Selenium->find_element("//input[\@value='$UserID'][\@name='ro']")->click();
-        $Selenium->find_element("//input[\@value='$UserID'][\@name='note']")->click();
-        $Selenium->find_element("//input[\@value='$UserID'][\@name='owner']")->click();
+        my @Test = (
+            {
+                'ro'        => 1,
+                'move_into' => 1,
+                'create'    => 1,
+                'note'      => 1,
+                'owner'     => 1,
+                'priority'  => 1,
+                'rw'        => 1,
+            },
+            {
+                'ro'        => 0,
+                'move_into' => 1,
+                'create'    => 1,
+                'note'      => 0,
+                'owner'     => 0,
+                'priority'  => 1,
+                'rw'        => 0,
+            },
+            {
+                'ro'        => 1,
+                'move_into' => 1,
+                'create'    => 1,
+                'note'      => 1,
+                'owner'     => 0,
+                'priority'  => 0,
+                'rw'        => 0,
+            },
+        );
+
+        # check permissions
+        for my $Permission ( sort keys $Test[0] ) {
+            $Self->True(
+                $Selenium->find_element("//input[\@value='$UserID'][\@name='$Permission']"),
+                "$Permission permission for user $TestUserLogin in group $GroupName is enabled",
+            );
+        }
+
+        # set permissions
+        for my $Permission ( qw(rw ro note owner) ) {
+            $Selenium->find_element("//input[\@value='$UserID'][\@name='$Permission']")->click();
+        }
 
         $Selenium->find_element("//button[\@value='Save'][\@type='submit']")->VerifiedClick();
 
         # check edited test group permissions
-        $Selenium->find_element( $GroupRandomID, 'link_text' )->VerifiedClick();
+        $Selenium->find_element( $GroupName, 'link_text' )->VerifiedClick();
 
-        $Self->Is(
-            $Selenium->find_element("//input[\@value='$UserID'][\@name='move_into']")->is_selected(),
-            1,
-            "move_into permission for group $GroupRandomID is enabled",
+        # check permissions
+        for my $Permission ( keys $Test[1] ) {
+            my $Enabled = $Test[1]{$Permission} ? 'enabled':'disabled';
+            $Self->Is(
+                $Selenium->find_element("//input[\@value='$UserID'][\@name='$Permission']")->is_selected(),
+                $Test[1]{$Permission},
+                "$Permission permission for user $TestUserLogin in group $GroupName is $Enabled",
+            );
+        }
+
+        # test checked and unchecked values while filter by user is used
+        # test filter with "WrongFilterGroup" to uncheck all values
+        $Selenium->find_element( "#Filter", 'css' )->clear();
+        $Selenium->find_element( "#Filter", 'css' )->send_keys("WrongFilterGroup");
+        sleep 1;
+
+        # test if no data is matches
+        $Self->True(
+            $Selenium->find_element( ".FilterMessage.Hidden>td", 'css' )->is_displayed(),
+            "'No data matches' is displayed'"
         );
-        $Self->Is(
-            $Selenium->find_element("//input[\@value='$UserID'][\@name='create']")->is_selected(),
-            1,
-            "create permission for group $GroupRandomID is enabled",
-        );
-        $Self->Is(
-            $Selenium->find_element("//input[\@value='$UserID'][\@name='rw']")->is_selected(),
-            0,
-            "rw permission for group $GroupRandomID is disabled",
-        );
+        $Selenium->find_element( "#Filter", 'css' )->clear();
+
+        # check group relations for user after using filter by group
+        # check permissions
+        for my $Permission ( keys $Test[1] ) {
+            my $Enabled = $Test[1]{$Permission} ? 'enabled':'disabled';
+            $Self->Is(
+                $Selenium->find_element("//input[\@value='$UserID'][\@name='$Permission']")->is_selected(),
+                $Test[1]{$Permission},
+                "$Permission permission for user $TestUserLogin in group $GroupName is $Enabled",
+            );
+        }
 
         # go back to AdminUserGroup screen
         $Selenium->VerifiedGet("${ScriptAlias}index.pl?Action=AdminUserGroup");
 
         # edit test group permission for test agent
         $Selenium->find_element( $FullTestUserLogin, 'link_text' )->VerifiedClick();
-        $Selenium->find_element("//input[\@value='$GroupID'][\@name='ro']")->click();
-        $Selenium->find_element("//input[\@value='$GroupID'][\@name='note']")->click();
+
+        # set permissions
+        for my $Permission ( qw(ro note priority) ) {
+            $Selenium->find_element("//input[\@value='$GroupID'][\@name='$Permission']")->click();
+        }
 
         $Selenium->find_element("//button[\@value='Save'][\@type='submit']")->VerifiedClick();
 
         # check edited test agent permissions
         $Selenium->find_element( $FullTestUserLogin, 'link_text' )->VerifiedClick();
 
-        $Self->Is(
-            $Selenium->find_element("//input[\@value='$GroupID'][\@name='ro']")->is_selected(),
-            1,
-            "ro permission for group $GroupID is enabled",
-        );
-        $Self->Is(
-            $Selenium->find_element("//input[\@value='$GroupID'][\@name='note']")->is_selected(),
-            1,
-            "note permission for group $GroupID is enabled",
-        );
-        $Self->Is(
-            $Selenium->find_element("//input[\@value='$GroupID'][\@name='rw']")->is_selected(),
-            0,
-            "rw permission for group $GroupID is disabled",
-        );
+        for my $Permission ( keys $Test[2] ) {
+            my $Enabled = $Test[2]{$Permission} ? 'enabled':'disabled';
+            $Self->Is(
+                $Selenium->find_element("//input[\@value='$GroupID'][\@name='$Permission']")->is_selected(),
+                $Test[2]{$Permission},
+                "$Permission permission for user $TestUserLogin in group $GroupName is $Enabled",
+            );
+        }
 
         # since there are no tickets that rely on our test group, we can remove them again
         # from the DB
-        if ($GroupRandomID) {
+        if ($GroupName) {
             my $DBObject = $Kernel::OM->Get('Kernel::System::DB');
             my $Success  = $DBObject->Do(
                 SQL => "DELETE FROM group_user WHERE group_id = $GroupID",
@@ -160,18 +212,18 @@ $Selenium->RunTest(
             if ($Success) {
                 $Self->True(
                     $Success,
-                    "GroupUserDelete - $GroupRandomID",
+                    "GroupUserDelete - $GroupName",
                 );
             }
 
-            $GroupRandomID = $DBObject->Quote($GroupRandomID);
+            $GroupName = $DBObject->Quote($GroupName);
             $Success       = $DBObject->Do(
                 SQL  => "DELETE FROM groups WHERE name = ?",
-                Bind => [ \$GroupRandomID ],
+                Bind => [ \$GroupName ],
             );
             $Self->True(
                 $Success,
-                "GroupDelete - $GroupRandomID",
+                "GroupDelete - $GroupName",
             );
         }
 

--- a/scripts/test/Selenium/Agent/Admin/AdminUserGroup.t
+++ b/scripts/test/Selenium/Agent/Admin/AdminUserGroup.t
@@ -45,7 +45,7 @@ $Selenium->RunTest(
 
         # create test group
         my $GroupName = 'group' . $Helper->GetRandomID();
-        my $GroupID       = $Kernel::OM->Get('Kernel::System::Group')->GroupAdd(
+        my $GroupID   = $Kernel::OM->Get('Kernel::System::Group')->GroupAdd(
             Name    => $GroupName,
             Comment => 'Selenium test group',
             ValidID => 1,
@@ -134,7 +134,7 @@ $Selenium->RunTest(
         }
 
         # set permissions
-        for my $Permission ( qw(rw ro note owner) ) {
+        for my $Permission (qw(rw ro note owner)) {
             $Selenium->find_element("//input[\@value='$UserID'][\@name='$Permission']")->click();
         }
 
@@ -144,8 +144,8 @@ $Selenium->RunTest(
         $Selenium->find_element( $GroupName, 'link_text' )->VerifiedClick();
 
         # check permissions
-        for my $Permission ( keys $Test[1] ) {
-            my $Enabled = $Test[1]{$Permission} ? 'enabled':'disabled';
+        for my $Permission ( sort keys $Test[1] ) {
+            my $Enabled = $Test[1]{$Permission} ? 'enabled' : 'disabled';
             $Self->Is(
                 $Selenium->find_element("//input[\@value='$UserID'][\@name='$Permission']")->is_selected(),
                 $Test[1]{$Permission},
@@ -168,8 +168,8 @@ $Selenium->RunTest(
 
         # check group relations for user after using filter by group
         # check permissions
-        for my $Permission ( keys $Test[1] ) {
-            my $Enabled = $Test[1]{$Permission} ? 'enabled':'disabled';
+        for my $Permission ( sort keys $Test[1] ) {
+            my $Enabled = $Test[1]{$Permission} ? 'enabled' : 'disabled';
             $Self->Is(
                 $Selenium->find_element("//input[\@value='$UserID'][\@name='$Permission']")->is_selected(),
                 $Test[1]{$Permission},
@@ -184,7 +184,7 @@ $Selenium->RunTest(
         $Selenium->find_element( $FullTestUserLogin, 'link_text' )->VerifiedClick();
 
         # set permissions
-        for my $Permission ( qw(ro note priority) ) {
+        for my $Permission (qw(ro note priority)) {
             $Selenium->find_element("//input[\@value='$GroupID'][\@name='$Permission']")->click();
         }
 
@@ -193,8 +193,8 @@ $Selenium->RunTest(
         # check edited test agent permissions
         $Selenium->find_element( $FullTestUserLogin, 'link_text' )->VerifiedClick();
 
-        for my $Permission ( keys $Test[2] ) {
-            my $Enabled = $Test[2]{$Permission} ? 'enabled':'disabled';
+        for my $Permission ( sort keys $Test[2] ) {
+            my $Enabled = $Test[2]{$Permission} ? 'enabled' : 'disabled';
             $Self->Is(
                 $Selenium->find_element("//input[\@value='$GroupID'][\@name='$Permission']")->is_selected(),
                 $Test[2]{$Permission},
@@ -217,7 +217,7 @@ $Selenium->RunTest(
             }
 
             $GroupName = $DBObject->Quote($GroupName);
-            $Success       = $DBObject->Do(
+            $Success   = $DBObject->Do(
                 SQL  => "DELETE FROM groups WHERE name = ?",
                 Bind => [ \$GroupName ],
             );

--- a/var/httpd/htdocs/js/Core.Form.js
+++ b/var/httpd/htdocs/js/Core.Form.js
@@ -1,5 +1,5 @@
 // --
-// Copyright (C) 2001-2015 OTRS AG, http://otrs.com/
+// Copyright (C) 2001-2016 OTRS AG, http://otrs.com/
 // --
 // This software comes with ABSOLUTELY NO WARRANTY. For details, see
 // the enclosed file COPYING for license information (AGPL). If you
@@ -168,14 +168,15 @@ Core.Form = (function (TargetNS) {
 
             // Adjust  checkbox selection, if filter is used/changed
             Core.App.Subscribe('Event.UI.Table.InitTableFilter.Change', function ($FilterInput, $Container) {
+
+                var CountCheckboxesVisible = $Checkboxes.filter('[id!=' + $SelectAllCheckbox.attr('id') + ']:visible');
+
                 // Only continue, if the filter event is associated with the container we are working in
                 if (!$.contains($Container[0], $SelectAllCheckbox[0])) {
                     return;
                 }
 
-                var CountCheckboxesVisible = $Checkboxes.filter('[id!=' + $SelectAllCheckbox.attr('id') + ']:visible');
-
-                if ( CountCheckboxesVisible.length && (CountCheckboxesVisible.filter(':checked').length === CountCheckboxesVisible.length)) {
+                if (CountCheckboxesVisible.length && (CountCheckboxesVisible.filter(':checked').length === CountCheckboxesVisible.length)) {
                     $SelectAllCheckbox.prop('checked', true);
                 }
                 else {

--- a/var/httpd/htdocs/js/Core.Form.js
+++ b/var/httpd/htdocs/js/Core.Form.js
@@ -1,5 +1,5 @@
 // --
-// Copyright (C) 2001-2016 OTRS AG, http://otrs.com/
+// Copyright (C) 2001-2015 OTRS AG, http://otrs.com/
 // --
 // This software comes with ABSOLUTELY NO WARRANTY. For details, see
 // the enclosed file COPYING for license information (AGPL). If you
@@ -162,19 +162,25 @@ Core.Form = (function (TargetNS) {
     TargetNS.InitSelectAllCheckboxes = function ($Checkboxes, $SelectAllCheckbox) {
         if (isJQueryObject($Checkboxes, $SelectAllCheckbox)) {
             // Mark SelectAll checkbox if all depending checkboxes are already marked on initialization
-            if ($Checkboxes.filter('[id!=' + $SelectAllCheckbox.attr('id') + ']').length === $Checkboxes.filter(':checked').length) {
+            if ($Checkboxes.filter(':checked').length && ($Checkboxes.filter('[id!=' + $SelectAllCheckbox.attr('id') + ']').length === $Checkboxes.filter(':checked').length)) {
                 $SelectAllCheckbox.prop('checked', true);
             }
 
-            // Remove checkbox selection, if filter is used/changed
+            // Adjust  checkbox selection, if filter is used/changed
             Core.App.Subscribe('Event.UI.Table.InitTableFilter.Change', function ($FilterInput, $Container) {
                 // Only continue, if the filter event is associated with the container we are working in
                 if (!$.contains($Container[0], $SelectAllCheckbox[0])) {
                     return;
                 }
 
-                $Checkboxes.prop('checked', false);
-                $SelectAllCheckbox.prop('checked', false);
+                var CountCheckboxesVisible = $Checkboxes.filter('[id!=' + $SelectAllCheckbox.attr('id') + ']:visible');
+
+                if ( CountCheckboxesVisible.length && (CountCheckboxesVisible.filter(':checked').length === CountCheckboxesVisible.length)) {
+                    $SelectAllCheckbox.prop('checked', true);
+                }
+                else {
+                    $SelectAllCheckbox.prop('checked', false);
+                }
             });
         }
     };


### PR DESCRIPTION
http://bugs.otrs.org/show_bug.cgi?id=11067

Hi @mgruner 

Here is fixed the filter in admin screens, actually this PR is updated old one which there was for rel-4_0. 
We also added some test for this feature. We tested it only in AdminRoleGroup, AdminRoleUser, AdminUserGroup. If you want we will be able to add tests for other screen as well ( e.g. AdminCustomerUserGroup, AdminCustomerUserService, AdminQueueTemplates ...)

Regards
Zoran