### PR TITLE
[ Master - Bug 11325]  Dashboard TicketList: Queuefilter in an empty list shows inactive queues, too

### DIFF
--- a/Kernel/System/Ticket/ColumnFilter.pm
+++ b/Kernel/System/Ticket/ColumnFilter.pm
@@ -971,9 +971,9 @@ sub _GeneralDataGet {
         return;
     }
 
-    # get data list
+    # get data list just for valid
     my %DataList = $BackendObject->$FuctionName(
-        Valid  => 0,
+        Valid  => 1,
         UserID => $Param{UserID},
     );
 

--- a/Kernel/System/Ticket/ColumnFilter.pm
+++ b/Kernel/System/Ticket/ColumnFilter.pm
@@ -149,7 +149,6 @@ sub QueueFilterValuesGet {
         return $Self->_GeneralDataGet(
             ModuleName   => 'Kernel::System::Queue',
             FunctionName => 'QueueList',
-            Valid        => 1,
             UserID       => $Param{UserID},
         );
     }
@@ -934,7 +933,6 @@ get data list
     my $Values = $ColumnFilterObject->_GeneralDataGet(
             ModuleName   => 'Kernel::System::Object',
             FunctionName => 'FunctionNameList',
-            Valid        => 0,     # optional, defaults to 0
             UserID       => $Param{UserID},
     );
 
@@ -995,11 +993,9 @@ sub _GeneralDataGet {
         return;
     }
 
-    my $Valid = $Param{Valid} // 0;
-
     # get data list
     my %DataList = $BackendObject->$FuctionName(
-        Valid  => $Valid,
+        Valid  => 1,
         UserID => $Param{UserID},
     );
 

--- a/Kernel/System/Ticket/ColumnFilter.pm
+++ b/Kernel/System/Ticket/ColumnFilter.pm
@@ -149,6 +149,7 @@ sub QueueFilterValuesGet {
         return $Self->_GeneralDataGet(
             ModuleName   => 'Kernel::System::Queue',
             FunctionName => 'QueueList',
+            Valid        => 1,
             UserID       => $Param{UserID},
         );
     }
@@ -924,6 +925,29 @@ sub DynamicFieldFilterValuesGet {
     return \%Data;
 }
 
+=begin Internal:
+
+=item _GeneralDataGet()
+
+get data list
+
+    my $Values = $ColumnFilterObject->_GeneralDataGet(
+            ModuleName   => 'Kernel::System::Object',
+            FunctionName => 'FunctionNameList',
+            Valid        => 0,     # optional, defaults to 0
+            UserID       => $Param{UserID},
+    );
+
+    returns
+
+    $Values = {
+        1 => 'ValueA',
+        2 => 'ValueB',
+        3 => 'ValueC'
+    };
+
+=cut
+
 sub _GeneralDataGet {
     my ( $Self, %Param ) = @_;
 
@@ -971,9 +995,11 @@ sub _GeneralDataGet {
         return;
     }
 
-    # get data list just for valid
+    my $Valid = $Param{Valid} // 0;
+
+    # get data list
     my %DataList = $BackendObject->$FuctionName(
-        Valid  => 1,
+        Valid  => $Valid,
         UserID => $Param{UserID},
     );
 
@@ -1031,6 +1057,10 @@ sub _TicketIDStringGet {
     return $TicketIDString;
 }
 
+1;
+
+=end Internal:
+
 =back
 
 =head1 TERMS AND CONDITIONS
@@ -1042,5 +1072,3 @@ the enclosed file COPYING for license information (AGPL). If you
 did not receive this file, see L<http://www.gnu.org/licenses/agpl.txt>.
 
 =cut
-
-1;


### PR DESCRIPTION
http://bugs.otrs.org/show_bug.cgi?id=11325

Hi @carlosgarciac 

There is our proposal for fixing. I mentioned you in email another possible solution.
Maybe this one actually is the best one. We saw looking into code that there are two case for filling out filter data. The first one is "$ColumnName.FilterValuesGet()" in case there are TicketIDs and the second one is _GeneralDataGet in TicketIDs is not provided ( for empty table)

We saw that there is not unit test for ColumnFilter.pm, we will be able to do that if you want.

Regards
Zoran & Aleksandar
