### PR TITLE
Master - fixed title for input type password for Sendmail SysConfig 

### DIFF
--- a/Kernel/Output/HTML/Templates/Standard/AdminSysConfigEdit.tt
+++ b/Kernel/Output/HTML/Templates/Standard/AdminSysConfigEdit.tt
@@ -95,7 +95,8 @@
 
 [% RenderBlockStart("ConfigElementString") %]
                             <div class="String">
-                                <input type="[% Data.InputType | html %]" name="[% Data.ElementKey | html %]" value="[% Data.Content | html %]" title="[% Data.Content | html %]" [% Data.ReadOnlyAttribute %]/>
+                                <input type="[% Data.InputType | html %]" name="[% Data.ElementKey | html %]" value="[% Data.Content | html %]"
+                                    [% IF Data.InputType != 'password' %]title="[% Data.Content | html %]"[% END %] [% Data.ReadOnlyAttribute %]/>
                                 <p class="DefaultValue">
                                     [% Translate("Default value") | html %]: [% Data.Default | html %]
                                 </p>


### PR DESCRIPTION

Hi,

We saw that password SysConfig item display title on hover with value. I fixed it in this PR.
If you mean that it is good, you can merge it to master.

Regards
Zoran