### PR TITLE
[Rel-4_0 Bug 11334] - If you don't have permission in a queue, you get an eMail Notification

### DIFF
--- a/Kernel/System/Ticket/Article.pm
+++ b/Kernel/System/Ticket/Article.pm
@@ -2743,6 +2743,17 @@ sub SendAgentNotification {
         DynamicFields => 0,
     );
 
+    # get create permission groups
+    my %UserGroups = $Kernel::OM->Get('Kernel::System::Group')->GroupMemberList(
+        UserID => $Param{RecipientID},
+        Type   => 'ro',
+        Result => 'HASH',
+    );
+    my $GroupID = $Kernel::OM->Get('Kernel::System::Queue')->GetQueueGroupID( QueueID => $Ticket{QueueID} );
+
+    # check if the user have the permissions to read a ticket on a determined queue
+    return 1 if !$UserGroups{$GroupID};
+
     if (
         $Ticket{StateType} eq 'closed' &&
         $Param{Type} eq 'NewTicket'


### PR DESCRIPTION
http://bugs.otrs.org/show_bug.cgi?id=11334

Hi @carlosgarciac,

We fixed this bug, this is our proposal. We solve this in the SendAgentNotification function of Article.pm.
At first I tried to solve it in ArticleCreate but I believe that it is better to fix here. In this case all possible notification is covered.
We used your advice and we checked a permission  using “GetQueueGroupID” and GroupMemberList(), thanks for that it was useful.
Please let me know if you have any suggestion.

Regards
Zoran