### PR TITLE
Fixed #11295: 'No such user' notification while otrs automatically responses…

### DIFF
--- a/Kernel/System/TemplateGenerator.pm
+++ b/Kernel/System/TemplateGenerator.pm
@@ -581,7 +581,7 @@ sub AutoResponse {
     }
 
     # get recipient
-    my %User = $Kernel::OM->Get('Kernel::System::CustomerUser')->GetPreferences(
+    my %User = $Kernel::OM->Get('Kernel::System::CustomerUser')->CustomerUserDataGet(
         UserID => $Ticket{CustomerUserID},
     );
 


### PR DESCRIPTION
This should fix [#11295](http://bugs.otrs.org/show_bug.cgi?id=11295) which was introduced in 203084b771be5d98ef8ea4aa87427e12a04edb58 (release 4.0.8)