### PR TITLE
Genericinterface pendingtime diff

### DIFF
--- a/Kernel/GenericInterface/Operation/Ticket/Common.pm
+++ b/Kernel/GenericInterface/Operation/Ticket/Common.pm
@@ -735,7 +735,7 @@ sub ValidatePendingTime {
 
     # if only the Diff attribute is present, check if it's a valid number and return.
     # Nothing else needs to be checked in that case.
-    if (keys %{ $Param{PendingTime} } == 1 && exists('Diff', $Param{PendingTime})) {
+    if ( keys %{ $Param{PendingTime} } == 1 && exists( $Param{PendingTime}->{Diff} ) ) {
         return if $Param{PendingTime}->{Diff} !~ /^[0-9]+$/;
         return 1;
     }

--- a/Kernel/GenericInterface/Operation/Ticket/Common.pm
+++ b/Kernel/GenericInterface/Operation/Ticket/Common.pm
@@ -715,6 +715,12 @@ checks if the given pending time is valid.
         },
     );
 
+    my $Success = $CommonObject->ValidatePendingTime(
+        PendingTime => {
+            Diff => 10080,
+        },
+    );
+
     returns
     $Success = 1            # or 0
 
@@ -726,6 +732,13 @@ sub ValidatePendingTime {
     # check needed stuff
     return if !$Param{PendingTime};
     return if !IsHashRefWithData( $Param{PendingTime} );
+
+    # if only the Diff attribute is present, check if it's a valid number and return.
+    # Nothing else needs to be checked in that case.
+    if (keys %{ $Param{PendingTime} } == 1 && exists('Diff', $Param{PendingTime})) {
+        return if $Param{PendingTime}->{Diff} !~ /^[0-9]+$/;
+        return 1;
+    }
 
     # check that no time attribute is empty or negative
     for my $TimeAttribute ( sort keys %{ $Param{PendingTime} } ) {

--- a/Kernel/GenericInterface/Operation/Ticket/Common.pm
+++ b/Kernel/GenericInterface/Operation/Ticket/Common.pm
@@ -735,7 +735,7 @@ sub ValidatePendingTime {
 
     # if only the Diff attribute is present, check if it's a valid number and return.
     # Nothing else needs to be checked in that case.
-    if ( keys %{ $Param{PendingTime} } == 1 && exists( $Param{PendingTime}->{Diff} ) ) {
+    if ( keys %{ $Param{PendingTime} } == 1 && exists $Param{PendingTime}->{Diff} ) {
         return if $Param{PendingTime}->{Diff} !~ m{\A \d+ \z}msx;
         return 1;
     }

--- a/Kernel/GenericInterface/Operation/Ticket/Common.pm
+++ b/Kernel/GenericInterface/Operation/Ticket/Common.pm
@@ -736,7 +736,7 @@ sub ValidatePendingTime {
     # if only the Diff attribute is present, check if it's a valid number and return.
     # Nothing else needs to be checked in that case.
     if ( keys %{ $Param{PendingTime} } == 1 && exists( $Param{PendingTime}->{Diff} ) ) {
-        return if $Param{PendingTime}->{Diff} !~ /^[0-9]+$/;
+        return if $Param{PendingTime}->{Diff} !~ m{\A \d+ \z}msx;
         return 1;
     }
 

--- a/Kernel/GenericInterface/Operation/Ticket/Common.pm
+++ b/Kernel/GenericInterface/Operation/Ticket/Common.pm
@@ -735,7 +735,7 @@ sub ValidatePendingTime {
 
     # if only the Diff attribute is present, check if it's a valid number and return.
     # Nothing else needs to be checked in that case.
-    if ( keys %{ $Param{PendingTime} } == 1 && exists $Param{PendingTime}->{Diff} ) {
+    if ( keys %{ $Param{PendingTime} } == 1 && defined $Param{PendingTime}->{Diff} ) {
         return if $Param{PendingTime}->{Diff} !~ m{\A \d+ \z}msx;
         return 1;
     }

--- a/Kernel/GenericInterface/Operation/Ticket/TicketCreate.pm
+++ b/Kernel/GenericInterface/Operation/Ticket/TicketCreate.pm
@@ -110,6 +110,10 @@ perform TicketCreate Operation. This will return the created ticket number.
                     Hour   => 23,
                     Minute => 05,
                 },
+                # Or
+                # PendingTime {
+                #     Diff => 10080, # Pending time in minutes
+                #},
             },
             Article => {
                 ArticleTypeID                   => 123,                        # optional

--- a/Kernel/GenericInterface/Operation/Ticket/TicketUpdate.pm
+++ b/Kernel/GenericInterface/Operation/Ticket/TicketUpdate.pm
@@ -109,6 +109,10 @@ perform TicketCreate Operation. This will return the created ticket number.
                     Hour   => 23,
                     Minute => 05,
                 },
+                # Or
+                # PendingTime {
+                #     Diff => 10080, # Pending time in minutes
+                #},
             },
             Article {                                                          # optional
                 ArticleTypeID                   => 123,                        # optional

--- a/development/webservices/GenericTicketConnectorSOAP.wsdl
+++ b/development/webservices/GenericTicketConnectorSOAP.wsdl
@@ -258,28 +258,34 @@ WARNING: This WSDL file is for Development and Test purposes ONLY!
     </xsd:complexType>
 
     <xsd:complexType name="OTRS_PendingTime">
-        <xsd:sequence>
+        <xsd:choice>
+            <xsd:sequence>
+                <xsd:element
+                    name="Year"
+                    type="xsd:positiveInteger">
+                </xsd:element>
+                <xsd:element
+                    name="Month"
+                    type="xsd:positiveInteger">
+                </xsd:element>
+                <xsd:element
+                    name="Day"
+                    type="xsd:positiveInteger">
+                </xsd:element>
+                <xsd:element
+                    name="Hour"
+                    type="xsd:positiveInteger">
+                </xsd:element>
+                <xsd:element
+                    name="Minute"
+                    type="xsd:positiveInteger">
+                </xsd:element>
+            </xsd:sequence>
             <xsd:element
-                name="Year"
+                name="Diff"
                 type="xsd:positiveInteger">
             </xsd:element>
-            <xsd:element
-                name="Month"
-                type="xsd:positiveInteger">
-            </xsd:element>
-            <xsd:element
-                name="Day"
-                type="xsd:positiveInteger">
-            </xsd:element>
-            <xsd:element
-                name="Hour"
-                type="xsd:positiveInteger">
-            </xsd:element>
-            <xsd:element
-                name="Minute"
-                type="xsd:positiveInteger">
-            </xsd:element>
-        </xsd:sequence>
+        </xsd:choice>
     </xsd:complexType>
 
     <xsd:complexType name="OTRS_Article">

--- a/scripts/test/Console/Command/Admin/WebService/GenericTicketConnectorSOAP.wsdl
+++ b/scripts/test/Console/Command/Admin/WebService/GenericTicketConnectorSOAP.wsdl
@@ -258,28 +258,34 @@ WARNING: This WSDL file is for Development and Test purposes ONLY!
     </xsd:complexType>
 
     <xsd:complexType name="OTRS_PendingTime">
-        <xsd:sequence>
+        <xsd:choice>
+            <xsd:sequence>
+                <xsd:element
+                    name="Year"
+                    type="xsd:positiveInteger">
+                </xsd:element>
+                <xsd:element
+                    name="Month"
+                    type="xsd:positiveInteger">
+                </xsd:element>
+                <xsd:element
+                    name="Day"
+                    type="xsd:positiveInteger">
+                </xsd:element>
+                <xsd:element
+                    name="Hour"
+                    type="xsd:positiveInteger">
+                </xsd:element>
+                <xsd:element
+                    name="Minute"
+                    type="xsd:positiveInteger">
+                </xsd:element>
+            </xsd:sequence>
             <xsd:element
-                name="Year"
+                name="Diff"
                 type="xsd:positiveInteger">
             </xsd:element>
-            <xsd:element
-                name="Month"
-                type="xsd:positiveInteger">
-            </xsd:element>
-            <xsd:element
-                name="Day"
-                type="xsd:positiveInteger">
-            </xsd:element>
-            <xsd:element
-                name="Hour"
-                type="xsd:positiveInteger">
-            </xsd:element>
-            <xsd:element
-                name="Minute"
-                type="xsd:positiveInteger">
-            </xsd:element>
-        </xsd:sequence>
+        </xsd:choice>
     </xsd:complexType>
 
     <xsd:complexType name="OTRS_Article">


### PR DESCRIPTION
With this change you can perform a request towards GenericInterface with the PendingTime->{Diff} attribute set to a numeric value.

This allows for easier pending time setting for pending states. Kernel/System/Ticket.pm already supports this. I'm just adding it for GenericInterface where it always required the <year><month><day><hour><minute> attributes before.