### PR TITLE
Bugfix in Bulk actions: preserve Unlock option

### DIFF
--- a/Kernel/Modules/AgentTicketBulk.pm
+++ b/Kernel/Modules/AgentTicketBulk.pm
@@ -1090,7 +1090,7 @@ sub _Mask {
     $Param{UnlockYesNoOption} = $LayoutObject->BuildSelection(
         Data       => $ConfigObject->Get('YesNoOptions'),
         Name       => 'Unlock',
-        SelectedID => $Param{Unlock} || 1,
+        SelectedID => $Param{Unlock} // 1,
     );
 
     # show spell check


### PR DESCRIPTION
`$Param{Unlock}` can be 1 or 0, so `$Param{Unlock} || 1` is always 1.

This leads to the "Unlock Tickets" choice always being set to "Yes".