### PR TITLE
Allow selecting children of matched nodes during tree search

### DIFF
--- a/var/httpd/htdocs/js/Core.UI.TreeSelection.js
+++ b/var/httpd/htdocs/js/Core.UI.TreeSelection.js
@@ -265,7 +265,8 @@ Core.UI.TreeSelection = (function (TargetNS) {
                 }
             },
             search: {
-                show_only_matches: true
+                show_only_matches: true,
+                show_only_matches_children: true
             },
             plugins: [ 'search' ]
         })


### PR DESCRIPTION
Same as previous behavior in OTRS4. Solved by just activating parameter in jsTree search plugin.