### PR TITLE
Micro-optimize FilenameCleanup in Kernel::System::Main

### DIFF
--- a/Kernel/System/Main.pm
+++ b/Kernel/System/Main.pm
@@ -226,13 +226,15 @@ sub FilenameCleanUp {
         return;
     }
 
-    if ( $Param{Type} && $Param{Type} =~ /^md5/i ) {
+    my $Type = lc($Param{Type} || 'local');
+
+    if ( $Type eq 'md5' ) {
         $Kernel::OM->Get('Kernel::System::Encode')->EncodeOutput( \$Param{Filename} );
         $Param{Filename} = md5_hex( $Param{Filename} );
     }
 
     # replace invalid token for attachment file names
-    elsif ( $Param{Type} && $Param{Type} =~ /^attachment/i ) {
+    elsif ( $Type eq 'attachment' ) {
 
         # replace invalid token like < > ? " : ; | \ / or *
         $Param{Filename} =~ s/[ <>\?":\\\*\|\/;\[\]]/_/g;


### PR DESCRIPTION
The file system backend of Kernel::System::Cache uses it,
so it is a pretty hot path. In a profiling of a ticket
listing, this patch reduces the total run time of
FilenameCleanup from 34ms to 2.4ms, and the overall run
time of the request by 3%