### PR TITLE
Fix action highlight behavior in certain situations

### DIFF
--- a/var/httpd/htdocs/skins/Agent/default/css/Core.Agent.TicketMenuModuleCluster.css
+++ b/var/httpd/htdocs/skins/Agent/default/css/Core.Agent.TicketMenuModuleCluster.css
@@ -77,7 +77,7 @@
 }
 
 .Cluster ul ul li a:hover {
-    border: 0px;
+    border-color: transparent;
     background: #ddd;
 }
 

--- a/var/httpd/htdocs/skins/Agent/default/css/Core.WidgetMenu.css
+++ b/var/httpd/htdocs/skins/Agent/default/css/Core.WidgetMenu.css
@@ -260,16 +260,16 @@ ul.ContextFunctions li:last-child:hover > a {
 
 .Actions li a,
 .Actions li span {
-    padding: 5px 2px;
+    padding: 5px 2px 0;
     color: #000;
     display: inline-block;
+    border-bottom: 2px solid transparent;
 }
 
 .Actions li a:hover,
 .Actions li span:hover,
 .OverviewZoom a:hover {
-    border-bottom: 2px solid #FF9922;
-    padding-bottom: 0px;
+    border-color: #FF9922;
 }
 
 .Actions li.NoHover:hover a {


### PR DESCRIPTION
Currently, if user hovers the cursor right on the edge of a ticket action (where orange highlight is supposed to show), browser will enter a perpetual state of activating and deactivating hover mode, like in the animation below:

![Weird](https://cloud.githubusercontent.com/assets/6049445/8823789/0e3aa846-3070-11e5-93fc-b6a685955e4c.gif "Weird")

Behavior has been confirmed in all major browsers (Firefox/Chrome/IE), and will continue as long as user does not move the mouse from position that activated the highlight.

This is because border is applied only to hover state, and does not exist in normal state (padding is applied/removed instead). It's much better practice to define transparent border in normal state, and just color it on hover (exactly what this fix does).
