### PR TITLE
Fix left offset handling in Agent and Customer interface; Turn off Dialog overflow hiding

### DIFF
--- a/var/httpd/htdocs/js/Core.UI.InputFields.js
+++ b/var/httpd/htdocs/js/Core.UI.InputFields.js
@@ -817,8 +817,12 @@ Core.UI.InputFields = (function (TargetNS) {
                     // Create main container
                     $ContainerObj = $('<div />').insertAfter($InputContainerObj);
                     $ContainerObj.addClass('InputField_Container')
-                        .attr('tabindex', '-1')
-                        .css('left', $SearchObj.offset().left + 'px');
+                        .attr('tabindex', '-1');
+
+                    // Set left offset if in Customer interface
+                    if (Core.Debug.CheckDependency('Core.UI.InputFields', 'Core.Customer', 'Core.Customer', true)) {
+                        $ContainerObj.css('left', $SearchObj.offset().left + 'px');
+                    }
 
                     // Create container for jsTree code
                     $TreeContainerObj = $('<div />').appendTo($ContainerObj);

--- a/var/httpd/htdocs/js/Core.UI.InputFields.js
+++ b/var/httpd/htdocs/js/Core.UI.InputFields.js
@@ -820,7 +820,7 @@ Core.UI.InputFields = (function (TargetNS) {
                         .attr('tabindex', '-1');
 
                     // Set left offset if in Customer interface
-                    if (Core.Debug.CheckDependency('Core.UI.InputFields', 'Core.Customer', 'Core.Customer', true)) {
+                    if (Core.Customer) {
                         $ContainerObj.css('left', $SearchObj.offset().left + 'px');
                     }
 

--- a/var/httpd/htdocs/skins/Agent/default/css/Core.Dialog.css
+++ b/var/httpd/htdocs/skins/Agent/default/css/Core.Dialog.css
@@ -73,7 +73,6 @@
 }
 
 .Dialog > .Content {
-    overflow: hidden;
     position: relative;
 }
 

--- a/var/httpd/htdocs/skins/Agent/default/css/Core.InputFields.css
+++ b/var/httpd/htdocs/skins/Agent/default/css/Core.InputFields.css
@@ -207,13 +207,13 @@ div.InputField_ToolbarContainer ul li a:hover {
  * @subsection  jsTree theme
  */
 .jstree-InputField {
-    font-size: 11px !important;
-    overflow-x: hidden !important;
-    border: none !important;
-    box-shadow: none !important;
-    height: 100% !important;
-    margin: 0 !important;
-    padding: 0 !important;
+    font-size: 11px;
+    overflow-x: hidden;
+    border: none;
+    box-shadow: none;
+    height: 100%;
+    margin: 0;
+    padding: 0;
 }
 .jstree-InputField .jstree-node,
 .jstree-InputField .jstree-children,

--- a/var/httpd/htdocs/skins/Agent/default/css/Core.Responsive.css
+++ b/var/httpd/htdocs/skins/Agent/default/css/Core.Responsive.css
@@ -1059,6 +1059,70 @@
         padding-bottom: 0px !important;
     }
 
+    /* Input Fields */
+    
+    div.InputField_InputContainer {
+        width: 90%;
+        margin-right: 10px;
+    }
+    
+    div.InputField_InputContainer input.InputField_Search {
+        padding: 3px;
+        font-size: 0.9em;
+        width: 100% !important;
+    }
+    
+    div.InputField_Container {
+        margin-top: -1px;
+    }
+    
+    div.InputField_Selection {
+        height: 1.4em;
+        line-height: 0.8em;
+    }
+    
+    div.InputField_Selection div,
+    div.InputField_FiltersList,
+    div.InputField_ToolbarContainer ul li a {
+        font-size: 0.8em;
+    }
+    
+    div.InputField_Selection div.Text,
+    div.InputField_Selection div.Remove a {
+        padding: 3px 4px;
+    }
+    
+    div.InputField_More {
+        top: 8px;
+    }
+    
+    div.InputField_FiltersList span {
+        vertical-align: 10%;
+    }
+    
+    .jstree-InputField {
+        font-size: 0.9em;
+    }
+   
+    div.InputField_TreeContainer {
+        max-height: 103px;
+        line-height: 1.4em;
+    }
+    
+    .jstree-InputField-Tree .jstree-node,
+    .jstree-InputField-Tree .jstree-anchor,
+    .jstree-InputField-NoTree .jstree-node,
+    .jstree-InputField-NoTree .jstree-anchor,
+    .jstree-InputField-Tree .jstree-icon:empty {
+        line-height: 1.4em;
+    }
+    
+    .jstree-InputField-Tree .jstree-wholerow,
+    .jstree-InputField-NoTree .jstree-wholerow {
+        line-height: 1.4em;
+        height: 1.5em;
+    }
+
 }
 
 /*  ~ Tablet landscape */


### PR DESCRIPTION
Left offset for the drop downs should be fixed now. I also had to turn off *overflow: hidden;* directive in Dialog CSS, since it hides our drop downs if dialog is too narrow. Apparently, this rule didn't have any impact on the look of the dialogs across the pages, but I could be wrong.

@mgruner Do you have a list of all places where you implemented Input Fields? I would really like to check every use case personally, since there might be some hidden problems in border line cases. Thanks!