### PR TITLE
memory optimized 'split(...)' using look behind and only create Email…

### DIFF
--- a/Kernel/Output/HTML/ArticleCheckSMIME.pm
+++ b/Kernel/Output/HTML/ArticleCheckSMIME.pm
@@ -101,17 +101,6 @@ sub Check {
             UserID    => $Self->{UserID},
         );
 
-        my @Email = ();
-        my @Lines = split( /\n/, $Message );
-        for my $Line (@Lines) {
-            push( @Email, $Line . "\n" );
-        }
-
-        my $ParserObject = Kernel::System::EmailParser->new(
-            %{$Self},
-            Email => \@Email,
-        );
-
         use MIME::Parser;
         my $Parser = MIME::Parser->new();
         $Parser->decode_headers(0);
@@ -154,6 +143,12 @@ sub Check {
                     }
                 );
             }
+
+            my @Email = split( /(?<=\n)/, $Message );
+            my $ParserObject = Kernel::System::EmailParser->new(
+                %{$Self},
+                Email => \@Email,
+            );
 
             # get all email addresses on article
             my %EmailsToSearch;


### PR DESCRIPTION
If SMIME is enabled every message (SMIME or not) is split in lines and every line copied in memory.
This takes a long time and consumes a lot of memory for huge messages with attachments.
Also EmailParser is created for every message. Even if not necessary.
This patch improves the performance by using look behind regexp and creating the parser just when needed
