### PR TITLE
TransitionAction->TickeArticleCreate: When a new article is created, …

### DIFF
--- a/Kernel/System/ProcessManagement/TransitionAction/TicketArticleCreate.pm
+++ b/Kernel/System/ProcessManagement/TransitionAction/TicketArticleCreate.pm
@@ -19,6 +19,7 @@ use base qw(Kernel::System::ProcessManagement::TransitionAction::Base);
 our @ObjectDependencies = (
     'Kernel::System::Log',
     'Kernel::System::Ticket',
+    'Kernel::System::User',
 );
 
 =head1 NAME
@@ -157,6 +158,18 @@ sub Run {
 
     # get ticket object
     my $TicketObject = $Kernel::OM->Get('Kernel::System::Ticket');
+
+    # If "From" is not set
+    if ( !$Param{Config}->{From} ) {
+
+        # Get current user data
+        my %User = $Kernel::OM->Get('Kernel::System::User')->GetUserData(
+            UserID => $Param{UserID},
+        );
+
+        # Set "From" field according to user - UserFullname <UserEmail>
+        $Param{Config}->{From} = $User{UserFullname} . ' <' . $User{UserEmail} . '>';
+    }
 
     my $ArticleID = $TicketObject->ArticleCreate(
         %{ $Param{Config} },


### PR DESCRIPTION
TransitionAction - TicketArticleCreate
Right now there is no possibility to set the "From" field of the article to the user that made change. Process creator can set this field to fixed value.

This patch allows tracking who created this article without going to the ticket history. If "From" field is not assigned, it will use current user data.

