### PR TITLE
Master - Fixed build selections for Select and MultiSelect widget elements in Statistics

### DIFF
--- a/Kernel/Output/HTML/Statistics/View.pm
+++ b/Kernel/Output/HTML/Statistics/View.pm
@@ -758,6 +758,7 @@ sub XAxisWidget {
             }
         }
 
+        my $Multiple = ( $ObjectAttribute->{Block} eq 'MultiSelectField' ) ? 1 : 0;
         if ( $ObjectAttribute->{Block} eq 'SelectField' ) {
             $ObjectAttribute->{Block} = 'MultiSelectField';
         }
@@ -768,7 +769,7 @@ sub XAxisWidget {
             $BlockData{SelectField} = $LayoutObject->BuildSelection(
                 Data           => $ObjectAttribute->{Values},
                 Name           => 'XAxis' . $ObjectAttribute->{Element},
-                Multiple       => 1,
+                Multiple       => $Multiple,
                 Size           => 5,
                 Class          => "Modernize $DFTreeClass",
                 SelectedID     => $ObjectAttribute->{SelectedValues},
@@ -848,6 +849,7 @@ sub YAxisWidget {
             }
         }
 
+        my $Multiple = ( $ObjectAttribute->{Block} eq 'MultiSelectField' ) ? 1 : 0;
         if ( $ObjectAttribute->{Block} eq 'SelectField' ) {
             $ObjectAttribute->{Block} = 'MultiSelectField';
         }
@@ -858,7 +860,7 @@ sub YAxisWidget {
             $BlockData{SelectField} = $LayoutObject->BuildSelection(
                 Data           => $ObjectAttribute->{Values},
                 Name           => 'YAxis' . $ObjectAttribute->{Element},
-                Multiple       => 1,
+                Multiple       => $Multiple,
                 Size           => 5,
                 Class          => "Modernize $DFTreeClass",
                 SelectedID     => $ObjectAttribute->{SelectedValues},
@@ -977,6 +979,7 @@ sub RestrictionsWidget {
             $ObjectAttribute->{SelectedValues} = undef;
         }
 
+        my $Multiple = ( $ObjectAttribute->{Block} eq 'MultiSelectField' ) ? 1 : 0;
         if (
             $ObjectAttribute->{Block} eq 'MultiSelectField'
             || $ObjectAttribute->{Block} eq 'SelectField'
@@ -988,7 +991,7 @@ sub RestrictionsWidget {
             $BlockData{SelectField} = $LayoutObject->BuildSelection(
                 Data           => $ObjectAttribute->{Values},
                 Name           => 'Restrictions' . $ObjectAttribute->{Element},
-                Multiple       => 1,
+                Multiple       => $Multiple,
                 Size           => 5,
                 Class          => "Modernize $DFTreeClass",
                 SelectedID     => $ObjectAttribute->{SelectedValues},

--- a/Kernel/Output/HTML/Statistics/View.pm
+++ b/Kernel/Output/HTML/Statistics/View.pm
@@ -2000,6 +2000,7 @@ sub _ColumnAndRowTranslation {
                     $Element->{Translation}
                     && $Element->{Block} ne 'Time'
                     && !$Element->{SortIndividual}
+                    && $Element->{Element} ne 'SortSequence'
                     )
                 {
                     $Sort{$Use} = 1;


### PR DESCRIPTION
Hi @carlosfrodriguez 

Working on TimeAccounting I saw that there are some issues. I felt free to fix them here.

* There was problem because all attributes were multiselect. It is not good for example for 'OrderBy', 'SortSequence' or 'Limit'. 
* The second problem was with sorting. There was sorting always by Value _ColumnAndRowTranslation() no mater which  type is selected in SortSequence  ('ascending' or 'descending',) 

There maybe should clean up some code. For example I think that it is not needed text "Please select only one element or turn off the button 'Fixed'." in /Statistics/RestrictionsWidget.tt, and some other. We can discus about it.

Please let me know what do you think about it.

Regards
Zoran