### PR TITLE
Removed EntityIDs from process management canvas tool tips to optimise readability

### DIFF
--- a/var/httpd/htdocs/js/Core.Agent.Admin.ProcessManagement.Canvas.js
+++ b/var/httpd/htdocs/js/Core.Agent.Admin.ProcessManagement.Canvas.js
@@ -326,7 +326,7 @@ Core.Agent.Admin.ProcessManagement.Canvas = (function (TargetNS) {
         text += "<ul>";
         if (AssignedTransitionActions.length) {
             $.each(AssignedTransitionActions, function (Key, Value) {
-                text += "<li>" + Core.App.EscapeHTML(Core.Agent.Admin.ProcessManagement.ProcessData.TransitionAction[Value].Name) + " (" + Core.App.EscapeHTML(Value) + ") </li>";
+                text += "<li>" + Core.App.EscapeHTML(Core.Agent.Admin.ProcessManagement.ProcessData.TransitionAction[Value].Name) + "</li>";
             });
         }
         else {
@@ -423,7 +423,7 @@ Core.Agent.Admin.ProcessManagement.Canvas = (function (TargetNS) {
                     }
                     SelectedInterface += InterfaceValue.substr(0, 1);
                 });
-                text += "<li><span class=\"AvailableIn\">" + SelectedInterface + "</span> " + Core.App.EscapeHTML(Core.Agent.Admin.ProcessManagement.ProcessData.ActivityDialog[Value].Name) + " (" + Core.App.EscapeHTML(Value) + ") </li>";
+                text += "<li><span class=\"AvailableIn\">" + SelectedInterface + "</span> " + Core.App.EscapeHTML(Core.Agent.Admin.ProcessManagement.ProcessData.ActivityDialog[Value].Name) + " </li>";
             });
         }
         else {


### PR DESCRIPTION
The tool tips are great, but since the entity ids are longer, the tooltip content is most often difficult or impossible to read. Thus the information intended to be served by tooltips is none.

This small fix simply removed the entity ids and displays the names only.

-- Cheers, Nils
