### PR TITLE
Fix BUG#11475

### DIFF
--- a/Kernel/System/MailAccount/IMAP.pm
+++ b/Kernel/System/MailAccount/IMAP.pm
@@ -229,11 +229,11 @@ sub _Fetch {
                                 . "$File, report it on http://bugs.otrs.org/)!",
                         );
                     }
+                    # mark email to delete once it was processed
+                    $IMAPObject->delete($Messageno);
                     undef $PostMasterObject;
-                }
 
-                # mark email to delete if it got processed
-                $IMAPObject->delete($Messageno);
+                }
 
                 # check limit
                 $Self->{Limit}++;

--- a/Kernel/System/MailAccount/IMAPTLS.pm
+++ b/Kernel/System/MailAccount/IMAPTLS.pm
@@ -233,11 +233,10 @@ sub _Fetch {
                                 . "$File, report it on http://bugs.otrs.org/)!",
                         );
                     }
+                    # mark email to delete once it was processed
+                    $IMAPObject->delete_message($Messageno);
                     undef $PostMasterObject;
                 }
-
-                # mark email for deletion if it got processed
-                $IMAPObject->delete_message($Messageno);
 
                 # check limit
                 $Self->{Limit}++;


### PR DESCRIPTION
Don't delete mails, just because the IMAP server didn't return any
payload at the time of asking for it.
Delete mails only from the server, once payload was provided and the
mail was successfully processed by PostMaster.