### PR TITLE
 [Master - Bug11152] - Ending of daylight saving time caused system collapse

### DIFF
--- a/Kernel/System/Time.pm
+++ b/Kernel/System/Time.pm
@@ -570,7 +570,13 @@ sub WorkingTime {
             }
         }
 
-        # reduce time => go to next day 00:00:00
+        # reduce time => go to next day 12:00:00
+        # go to next day 12:00:00 instead of 00:00:00
+        # because of switching to/from daylight saving time,
+        # $CTime00 will be set to 00:00:00 in next loop
+        # see bug http://bugs.otrs.org/show_bug.cgi?id=11152
+        # There is the issue only in time zone
+        # which have ending time from 00:00:00 to 23:00:00
         $Param{StartTime} = $Self->Date2SystemTime(
             Year   => $Year,
             Month  => $Month,
@@ -578,7 +584,8 @@ sub WorkingTime {
             Hour   => 23,
             Minute => 59,
             Second => 59,
-        ) + 1;
+        ) + 12 * 60 * 60 + 1;
+
     }
     return $Counted;
 }

--- a/scripts/test/Time/WorkingTime.t
+++ b/scripts/test/Time/WorkingTime.t
@@ -22,6 +22,7 @@ my @Tests = (
         TimeStampUTCStop  => '2015-05-19 12:00:00',
         ServerTZ          => 'UTC',
         Result            => '7776000',               # 90 days
+        ResultTime        => '90 days',
     },
     {
         Name              => 'Europe/Berlin ( Daylight Saving Time UTC+1 => UTC+2 )',
@@ -29,6 +30,7 @@ my @Tests = (
         TimeStampUTCStop  => '2015-05-19 12:00:00',
         ServerTZ          => 'Europe/Berlin',
         Result            => '7779600',                                                 # 90 days and 1h
+        ResultTime        => '90 days and 1h',
     },
     {
         Name              => 'UTC',
@@ -36,6 +38,7 @@ my @Tests = (
         TimeStampUTCStop  => '2015-02-22 04:00:00',
         ServerTZ          => 'UTC',
         Result            => '21600',                                                   # 6h
+        ResultTime        => '6h',
     },
     {
         Name              => 'America/Sao_Paulo - end DST from 00 to 23  ( UTC-2 => UTC-3 )',
@@ -43,34 +46,23 @@ my @Tests = (
         TimeStampUTCStop  => '2015-02-22 04:00:00',
         ServerTZ          => 'America/Sao_Paulo',
         Result            => '18000',                                                           # 5h
-    },
-    {
-        Name              => 'Europe/Berlin',
-        TimeStampUTCStart => '2015-02-21 22:00:00',
-        TimeStampUTCStop  => '2015-02-22 04:00:00',
-        ServerTZ          => 'Europe/Berlin',
-        Result            => '21600',                                                           # 6h
+        ResultTime        => '5h',
     },
     {
         Name              => 'UTC with min and sec',
         TimeStampUTCStart => '2015-02-20 22:10:05',
         TimeStampUTCStop  => '2015-02-25 04:30:20',
         ServerTZ          => 'UTC',
-        Result            => '368415',                                                          # 4 days 06:20:15.
+        Result            => '368415',                                                          # 4 days 06:20:15
+        ResultTime        => '4 days 06:20:15',
     },
     {
         Name              => 'America/Sao_Paulo - end DST from 00 to 23 - with min and sec',
         TimeStampUTCStart => '2015-02-20 22:10:05',
         TimeStampUTCStop  => '2015-02-25 04:30:20',
         ServerTZ          => 'America/Sao_Paulo',
-        Result            => '364815',                                                          # 4 days 05:20:15.
-    },
-    {
-        Name              => 'Europe/Berlin with min and sec',
-        TimeStampUTCStart => '2015-02-20 22:10:05',
-        TimeStampUTCStop  => '2015-02-25 04:30:20',
-        ServerTZ          => 'Europe/Berlin',
-        Result            => '368415',                                                          # 4 days 06:20:15.
+        Result            => '364815',                                                          # 4 days 05:20:15
+        ResultTime        => '4 days 05:20:15',
     },
     {
         Name              => 'UTC',
@@ -78,6 +70,7 @@ my @Tests = (
         TimeStampUTCStop  => '2015-10-18 04:00:00',
         ServerTZ          => 'UTC',
         Result            => '21600',                                                           # 6h
+        ResultTime        => '6h',
     },
     {
         Name              => 'America/Sao_Paulo - start DST from 00 to 01 ( UTC-3 => UTC-2 )',
@@ -85,13 +78,7 @@ my @Tests = (
         TimeStampUTCStop  => '2015-10-18 04:00:00',
         ServerTZ          => 'America/Sao_Paulo',
         Result            => '25200',                                                            # 7h
-    },
-    {
-        Name              => 'Europe/Berlin',
-        TimeStampUTCStart => '2015-10-17 22:00:00',
-        TimeStampUTCStop  => '2015-10-18 04:00:00',
-        ServerTZ          => 'Europe/Berlin',
-        Result            => '21600',                                                            # 6h
+        ResultTime        => '7h',
     },
     {
         Name              => 'UTC',
@@ -99,13 +86,15 @@ my @Tests = (
         TimeStampUTCStop  => '2015-03-22 12:00:00',
         ServerTZ          => 'UTC',
         Result            => '86400',                                                            # 24h
+        ResultTime        => '24h',
     },
     {
         Name              => 'America/Asuncion -Paraguay - end DST from 00 to 23  ( UTC-3 => UTC-4 )',
         TimeStampUTCStart => '2015-03-21 12:00:00',
         TimeStampUTCStop  => '2015-03-22 12:00:00',
         ServerTZ          => 'America/Asuncion',
-        Result            => '82800',                                                                    # 24h
+        Result            => '82800',                                                                    # 23h
+        ResultTime        => '23h',
     },
     {
         Name              => 'UTC',
@@ -113,6 +102,7 @@ my @Tests = (
         TimeStampUTCStop  => '2015-09-22 04:00:00',
         ServerTZ          => 'UTC',
         Result            => '57600',                                                                    # 16h
+        ResultTime        => '16h',
     },
     {
         Name              => 'Asia/Tehran - end DST from 00 to 23  ( UTC+3:30 => UTC+4:30 )',
@@ -120,6 +110,7 @@ my @Tests = (
         TimeStampUTCStop  => '2015-09-22 04:00:00',
         ServerTZ          => 'Asia/Tehran',
         Result            => '54000',                                                                    # 15h
+        ResultTime        => '15h',
     },
     {
         Name              => 'UTC',
@@ -127,6 +118,7 @@ my @Tests = (
         TimeStampUTCStop  => '2015-03-22 04:00:00',
         ServerTZ          => 'UTC',
         Result            => '57600',                                                                    # 16h
+        ResultTime        => '16h',
     },
     {
         Name              => 'Asia/Tehran - end DST from 00 to 01  ( UTC+4:30 => UTC+3:30 )',
@@ -134,6 +126,7 @@ my @Tests = (
         TimeStampUTCStop  => '2015-03-22 04:00:00',
         ServerTZ          => 'Asia/Tehran',
         Result            => '61200',                                                                    # 17h
+        ResultTime        => '17h',
     },
     {
         Name              => 'UTC',
@@ -141,6 +134,7 @@ my @Tests = (
         TimeStampUTCStop  => '2015-04-22 04:00:00',
         ServerTZ          => 'UTC',
         Result            => '7833600',               # 90 days and 16h
+        ResultTime        => '90 days and 16h',
     },
     {
         Name              => 'Australia/Sydney - end DST from 00 to 01  ( UTC+11 => UTC+10 )',
@@ -148,6 +142,7 @@ my @Tests = (
         TimeStampUTCStop  => '2015-04-22 04:00:00',
         ServerTZ          => 'Asia/Tehran',
         Result            => '7837200',                                                          # 90 days and 17h
+        ResultTime        => '90 days and 17h',
     },
 );
 
@@ -225,7 +220,7 @@ for my $Test (@Tests) {
     $Self->Is(
         $WorkingTime,
         $Test->{Result},
-        "$Test->{Name} ($Test->{ServerTZ}) working time from $Start to $Stop: $WorkingTime",
+        "$Test->{Name} ($Test->{ServerTZ}) working time from $Start to $Stop: $WorkingTime ($Test->{ResultTime})",
     );
 
     $HelperObject->FixedTimeUnset();

--- a/scripts/test/Time/WorkingTime.t
+++ b/scripts/test/Time/WorkingTime.t
@@ -17,123 +17,137 @@ use vars (qw($Self));
 
 my @Tests = (
     {
-        Name         => 'UTC',
+        Name              => 'UTC',
         TimeStampUTCStart => '2015-02-17 12:00:00',
         TimeStampUTCStop  => '2015-05-19 12:00:00',
-        ServerTZ     => 'UTC',
-        Result       => '57600',    # 90 days
+        ServerTZ          => 'UTC',
+        Result            => '7776000',               # 90 days
     },
     {
-        Name         => 'Europe/Berlin ( Daylight Saving Time UTC+1 => UTC+2 )',
+        Name              => 'Europe/Berlin ( Daylight Saving Time UTC+1 => UTC+2 )',
         TimeStampUTCStart => '2015-02-17 12:00:00',
         TimeStampUTCStop  => '2015-05-19 12:00:00',
-        ServerTZ     => 'Europe/Berlin',
-        Result       => '21600',    # 90 days and 1h
+        ServerTZ          => 'Europe/Berlin',
+        Result            => '7779600',                                                 # 90 days and 1h
     },
     {
-        Name         => 'UTC',
+        Name              => 'UTC',
         TimeStampUTCStart => '2015-02-21 22:00:00',
         TimeStampUTCStop  => '2015-02-22 04:00:00',
-        ServerTZ     => 'UTC',
-        Result       => '21600',    # 6h
+        ServerTZ          => 'UTC',
+        Result            => '21600',                                                   # 6h
     },
     {
-        Name         => 'America/Sao_Paulo - end DST from 00 to 23  ( UTC-2 => UTC-3 )',
+        Name              => 'America/Sao_Paulo - end DST from 00 to 23  ( UTC-2 => UTC-3 )',
         TimeStampUTCStart => '2015-02-21 22:00:00',
         TimeStampUTCStop  => '2015-02-22 04:00:00',
-        ServerTZ     => 'America/Sao_Paulo',
-        Result       => '18000',    # 5h
+        ServerTZ          => 'America/Sao_Paulo',
+        Result            => '18000',                                                           # 5h
     },
     {
-        Name         => 'Europe/Berlin',
+        Name              => 'Europe/Berlin',
         TimeStampUTCStart => '2015-02-21 22:00:00',
         TimeStampUTCStop  => '2015-02-22 04:00:00',
-        ServerTZ     => 'Europe/Berlin',
-        Result       => '21600',    # 6h
+        ServerTZ          => 'Europe/Berlin',
+        Result            => '21600',                                                           # 6h
     },
     {
-        Name         => 'UTC with min and sec',
+        Name              => 'UTC with min and sec',
         TimeStampUTCStart => '2015-02-20 22:10:05',
         TimeStampUTCStop  => '2015-02-25 04:30:20',
-        ServerTZ     => 'UTC',
-        Result       => '368415',    # 4 days 06:20:15.
+        ServerTZ          => 'UTC',
+        Result            => '368415',                                                          # 4 days 06:20:15.
     },
     {
-        Name         => 'America/Sao_Paulo - end DST from 00 to 23 - with min and sec',
+        Name              => 'America/Sao_Paulo - end DST from 00 to 23 - with min and sec',
         TimeStampUTCStart => '2015-02-20 22:10:05',
         TimeStampUTCStop  => '2015-02-25 04:30:20',
-        ServerTZ     => 'America/Sao_Paulo',
-        Result       => '364815',    # 4 days 05:20:15.
+        ServerTZ          => 'America/Sao_Paulo',
+        Result            => '364815',                                                          # 4 days 05:20:15.
     },
     {
-        Name         => 'Europe/Berlin with min and sec',
+        Name              => 'Europe/Berlin with min and sec',
         TimeStampUTCStart => '2015-02-20 22:10:05',
         TimeStampUTCStop  => '2015-02-25 04:30:20',
-        ServerTZ     => 'Europe/Berlin',
-        Result       => '368415',    # 4 days 06:20:15.
+        ServerTZ          => 'Europe/Berlin',
+        Result            => '368415',                                                          # 4 days 06:20:15.
     },
     {
-        Name         => 'UTC',
+        Name              => 'UTC',
         TimeStampUTCStart => '2015-10-17 22:00:00',
         TimeStampUTCStop  => '2015-10-18 04:00:00',
-        ServerTZ     => 'UTC',
-        Result       => '21600',    # 6h
+        ServerTZ          => 'UTC',
+        Result            => '21600',                                                           # 6h
     },
     {
-        Name         => 'America/Sao_Paulo - start DST from 00 to 01 ( UTC-3 => UTC-2 )',
+        Name              => 'America/Sao_Paulo - start DST from 00 to 01 ( UTC-3 => UTC-2 )',
         TimeStampUTCStart => '2015-10-17 22:00:00',
         TimeStampUTCStop  => '2015-10-18 04:00:00',
-        ServerTZ     => 'America/Sao_Paulo',
-        Result       => '25200',    # 7h
+        ServerTZ          => 'America/Sao_Paulo',
+        Result            => '25200',                                                            # 7h
     },
     {
-        Name         => 'Europe/Berlin',
+        Name              => 'Europe/Berlin',
         TimeStampUTCStart => '2015-10-17 22:00:00',
         TimeStampUTCStop  => '2015-10-18 04:00:00',
-        ServerTZ     => 'Europe/Berlin',
-        Result       => '21600',    # 6h
+        ServerTZ          => 'Europe/Berlin',
+        Result            => '21600',                                                            # 6h
     },
     {
-        Name         => 'UTC',
+        Name              => 'UTC',
         TimeStampUTCStart => '2015-03-21 12:00:00',
         TimeStampUTCStop  => '2015-03-22 12:00:00',
-        ServerTZ     => 'UTC',
-        Result       => '86400',    # 24h
+        ServerTZ          => 'UTC',
+        Result            => '86400',                                                            # 24h
     },
     {
-        Name         => 'America/Asuncion -Paraguay - end DST from 00 to 23  ( UTC-3 => UTC-4 )' ,
+        Name              => 'America/Asuncion -Paraguay - end DST from 00 to 23  ( UTC-3 => UTC-4 )',
         TimeStampUTCStart => '2015-03-21 12:00:00',
         TimeStampUTCStop  => '2015-03-22 12:00:00',
-        ServerTZ     => 'America/Asuncion',
-        Result       => '82800',    # 24h
+        ServerTZ          => 'America/Asuncion',
+        Result            => '82800',                                                                    # 24h
     },
     {
-        Name         => 'UTC',
+        Name              => 'UTC',
         TimeStampUTCStart => '2015-09-21 12:00:00',
         TimeStampUTCStop  => '2015-09-22 04:00:00',
-        ServerTZ     => 'UTC',
-        Result       => '57600',    # 16h
+        ServerTZ          => 'UTC',
+        Result            => '57600',                                                                    # 16h
     },
     {
-        Name         => 'Asia/Tehran - end DST from 00 to 23  ( UTC+3:30 => UTC+4:30 )' ,
+        Name              => 'Asia/Tehran - end DST from 00 to 23  ( UTC+3:30 => UTC+4:30 )',
         TimeStampUTCStart => '2015-09-21 12:00:00',
         TimeStampUTCStop  => '2015-09-22 04:00:00',
-        ServerTZ     => 'Asia/Tehran',
-        Result       => '54000',    # 15h
+        ServerTZ          => 'Asia/Tehran',
+        Result            => '54000',                                                                    # 15h
     },
     {
-        Name         => 'UTC',
+        Name              => 'UTC',
         TimeStampUTCStart => '2015-03-21 12:00:00',
         TimeStampUTCStop  => '2015-03-22 04:00:00',
-        ServerTZ     => 'UTC',
-        Result       => '57600',    # 16h
+        ServerTZ          => 'UTC',
+        Result            => '57600',                                                                    # 16h
     },
     {
-        Name         => 'Asia/Tehran - end DST from 00 to 01  ( UTC+4:30 => UTC+3:30 )' ,
+        Name              => 'Asia/Tehran - end DST from 00 to 01  ( UTC+4:30 => UTC+3:30 )',
         TimeStampUTCStart => '2015-03-21 12:00:00',
         TimeStampUTCStop  => '2015-03-22 04:00:00',
-        ServerTZ     => 'Asia/Tehran',
-        Result       => '61200',    # 17h
+        ServerTZ          => 'Asia/Tehran',
+        Result            => '61200',                                                                    # 17h
+    },
+    {
+        Name              => 'UTC',
+        TimeStampUTCStart => '2015-01-21 12:00:00',
+        TimeStampUTCStop  => '2015-04-22 04:00:00',
+        ServerTZ          => 'UTC',
+        Result            => '7833600',               # 90 days and 16h
+    },
+    {
+        Name              => 'Australia/Sydney - end DST from 00 to 01  ( UTC+11 => UTC+10 )',
+        TimeStampUTCStart => '2015-01-21 12:00:00',
+        TimeStampUTCStop  => '2015-04-22 04:00:00',
+        ServerTZ          => 'Asia/Tehran',
+        Result            => '7837200',                                                          # 90 days and 17h
     },
 );
 
@@ -214,7 +228,7 @@ for my $Test (@Tests) {
         "$Test->{Name} ($Test->{ServerTZ}) working time from $Start to $Stop: $WorkingTime",
     );
 
-     $HelperObject->FixedTimeUnset();
+    $HelperObject->FixedTimeUnset();
 }
 
 1;

--- a/scripts/test/Time/WorkingTime.t
+++ b/scripts/test/Time/WorkingTime.t
@@ -1,0 +1,220 @@
+# --
+# Copyright (C) 2001-2015 OTRS AG, http://otrs.com/
+# --
+# This software comes with ABSOLUTELY NO WARRANTY. For details, see
+# the enclosed file COPYING for license information (AGPL). If you
+# did not receive this file, see http://www.gnu.org/licenses/agpl.txt.
+# --
+
+## no critic (Modules::RequireExplicitPackage)
+use strict;
+use warnings;
+use utf8;
+
+use Time::Local;
+
+use vars (qw($Self));
+
+my @Tests = (
+    {
+        Name         => 'UTC',
+        TimeStampUTCStart => '2015-02-17 12:00:00',
+        TimeStampUTCStop  => '2015-05-19 12:00:00',
+        ServerTZ     => 'UTC',
+        Result       => '57600',    # 90 days
+    },
+    {
+        Name         => 'Europe/Berlin ( Daylight Saving Time UTC+1 => UTC+2 )',
+        TimeStampUTCStart => '2015-02-17 12:00:00',
+        TimeStampUTCStop  => '2015-05-19 12:00:00',
+        ServerTZ     => 'Europe/Berlin',
+        Result       => '21600',    # 90 days and 1h
+    },
+    {
+        Name         => 'UTC',
+        TimeStampUTCStart => '2015-02-21 22:00:00',
+        TimeStampUTCStop  => '2015-02-22 04:00:00',
+        ServerTZ     => 'UTC',
+        Result       => '21600',    # 6h
+    },
+    {
+        Name         => 'America/Sao_Paulo - end DST from 00 to 23  ( UTC-2 => UTC-3 )',
+        TimeStampUTCStart => '2015-02-21 22:00:00',
+        TimeStampUTCStop  => '2015-02-22 04:00:00',
+        ServerTZ     => 'America/Sao_Paulo',
+        Result       => '18000',    # 5h
+    },
+    {
+        Name         => 'Europe/Berlin',
+        TimeStampUTCStart => '2015-02-21 22:00:00',
+        TimeStampUTCStop  => '2015-02-22 04:00:00',
+        ServerTZ     => 'Europe/Berlin',
+        Result       => '21600',    # 6h
+    },
+    {
+        Name         => 'UTC with min and sec',
+        TimeStampUTCStart => '2015-02-20 22:10:05',
+        TimeStampUTCStop  => '2015-02-25 04:30:20',
+        ServerTZ     => 'UTC',
+        Result       => '368415',    # 4 days 06:20:15.
+    },
+    {
+        Name         => 'America/Sao_Paulo - end DST from 00 to 23 - with min and sec',
+        TimeStampUTCStart => '2015-02-20 22:10:05',
+        TimeStampUTCStop  => '2015-02-25 04:30:20',
+        ServerTZ     => 'America/Sao_Paulo',
+        Result       => '364815',    # 4 days 05:20:15.
+    },
+    {
+        Name         => 'Europe/Berlin with min and sec',
+        TimeStampUTCStart => '2015-02-20 22:10:05',
+        TimeStampUTCStop  => '2015-02-25 04:30:20',
+        ServerTZ     => 'Europe/Berlin',
+        Result       => '368415',    # 4 days 06:20:15.
+    },
+    {
+        Name         => 'UTC',
+        TimeStampUTCStart => '2015-10-17 22:00:00',
+        TimeStampUTCStop  => '2015-10-18 04:00:00',
+        ServerTZ     => 'UTC',
+        Result       => '21600',    # 6h
+    },
+    {
+        Name         => 'America/Sao_Paulo - start DST from 00 to 01 ( UTC-3 => UTC-2 )',
+        TimeStampUTCStart => '2015-10-17 22:00:00',
+        TimeStampUTCStop  => '2015-10-18 04:00:00',
+        ServerTZ     => 'America/Sao_Paulo',
+        Result       => '25200',    # 7h
+    },
+    {
+        Name         => 'Europe/Berlin',
+        TimeStampUTCStart => '2015-10-17 22:00:00',
+        TimeStampUTCStop  => '2015-10-18 04:00:00',
+        ServerTZ     => 'Europe/Berlin',
+        Result       => '21600',    # 6h
+    },
+    {
+        Name         => 'UTC',
+        TimeStampUTCStart => '2015-03-21 12:00:00',
+        TimeStampUTCStop  => '2015-03-22 12:00:00',
+        ServerTZ     => 'UTC',
+        Result       => '86400',    # 24h
+    },
+    {
+        Name         => 'America/Asuncion -Paraguay - end DST from 00 to 23  ( UTC-3 => UTC-4 )' ,
+        TimeStampUTCStart => '2015-03-21 12:00:00',
+        TimeStampUTCStop  => '2015-03-22 12:00:00',
+        ServerTZ     => 'America/Asuncion',
+        Result       => '82800',    # 24h
+    },
+    {
+        Name         => 'UTC',
+        TimeStampUTCStart => '2015-09-21 12:00:00',
+        TimeStampUTCStop  => '2015-09-22 04:00:00',
+        ServerTZ     => 'UTC',
+        Result       => '57600',    # 16h
+    },
+    {
+        Name         => 'Asia/Tehran - end DST from 00 to 23  ( UTC+3:30 => UTC+4:30 )' ,
+        TimeStampUTCStart => '2015-09-21 12:00:00',
+        TimeStampUTCStop  => '2015-09-22 04:00:00',
+        ServerTZ     => 'Asia/Tehran',
+        Result       => '54000',    # 15h
+    },
+    {
+        Name         => 'UTC',
+        TimeStampUTCStart => '2015-03-21 12:00:00',
+        TimeStampUTCStop  => '2015-03-22 04:00:00',
+        ServerTZ     => 'UTC',
+        Result       => '57600',    # 16h
+    },
+    {
+        Name         => 'Asia/Tehran - end DST from 00 to 01  ( UTC+4:30 => UTC+3:30 )' ,
+        TimeStampUTCStart => '2015-03-21 12:00:00',
+        TimeStampUTCStop  => '2015-03-22 04:00:00',
+        ServerTZ     => 'Asia/Tehran',
+        Result       => '61200',    # 17h
+    },
+);
+
+# get needed objects
+my $ConfigObject = $Kernel::OM->Get('Kernel::Config');
+my $HelperObject = $Kernel::OM->Get('Kernel::System::UnitTest::Helper');
+
+# Use a calendar with the same business hours for every day so that the UT runs correctly
+#   on every day of the week and outside usual business hours.
+my %Week;
+my @Days = qw(Sun Mon Tue Wed Thu Fri Sat);
+for my $Day (@Days) {
+    $Week{$Day} = [ 0 .. 23 ];
+}
+$Kernel::OM->Get('Kernel::Config')->Set(
+    Key   => 'TimeWorkingHours',
+    Value => \%Week,
+);
+$Kernel::OM->Get('Kernel::System::SysConfig')->ConfigItemUpdate(
+    Valid => 1,
+    Key   => 'TimeWorkingHours',
+    Value => \%Week,
+);
+
+for my $Test (@Tests) {
+
+    # set the server time zone
+    local $ENV{TZ} = $Test->{ServerTZ};
+
+    # Convert UTC timestamp to system time and set it.
+    $Test->{TimeStampUTCStart} =~ m/(\d{4})-(\d{1,2})-(\d{1,2})\s(\d{1,2}):(\d{1,2}):(\d{1,2})/;
+
+    my $FixedTimeStart = Time::Local::timegm(
+        $6, $5, $4, $3, ( $2 - 1 ), $1
+    );
+
+    # Convert UTC timestamp to system time and set it.
+    $Test->{TimeStampUTCStop} =~ m/(\d{4})-(\d{1,2})-(\d{1,2})\s(\d{1,2}):(\d{1,2}):(\d{1,2})/;
+
+    my $FixedTimeStop = Time::Local::timegm(
+        $6, $5, $4, $3, ( $2 - 1 ), $1
+    );
+
+    $HelperObject->FixedTimeSet(
+        $FixedTimeStart,
+    );
+
+    # Set OTRS time zone to arbitrary value to make sure it is ignored.
+    $ConfigObject->Set(
+        Key   => 'TimeZone',
+        Value => int rand 20 - 10,
+    );
+
+    $Kernel::OM->ObjectsDiscard(
+        Objects => ['Kernel::System::Time'],
+    );
+
+    my $TimeObject = $Kernel::OM->Get('Kernel::System::Time');
+
+    my $StopTime = $TimeObject->SystemTime();
+    my ( $Sec, $Min, $Hour, $Day, $Month, $Year, $WDay ) = localtime $FixedTimeStop;
+    $Year  += 1900;
+    $Month += 1;
+    my $Stop = "$Day-$Month-$Year $Hour:$Min:$Sec";
+    ( $Sec, $Min, $Hour, $Day, $Month, $Year, $WDay ) = localtime $FixedTimeStart;
+    $Year  += 1900;
+    $Month += 1;
+    my $Start = "$Day-$Month-$Year $Hour:$Min:$Sec";
+
+    my $WorkingTime = $TimeObject->WorkingTime(
+        StartTime => $FixedTimeStart,
+        StopTime  => $FixedTimeStop,
+    );
+
+    $Self->Is(
+        $WorkingTime,
+        $Test->{Result},
+        "$Test->{Name} ($Test->{ServerTZ}) working time from $Start to $Stop: $WorkingTime",
+    );
+
+     $HelperObject->FixedTimeUnset();
+}
+
+1;


### PR DESCRIPTION
http://bugs.otrs.org/show_bug.cgi?id=11152

Hi @mgruner ,

This is my proposal for fixing. I tested it a lot, and this is one solution which could be acceptable. 
Maybe it should be tested a little bit more (e.g. different time zone...  )
You can see in the comments that there is the issue  only in the time zone which have ending time from 00:00:00 to 23:00:00.
I tried to fix with another solution where I compare new StartTime and  $CTime00 + 24 * 60 * 60. This is something similar to solution in DestinationTime() function.

<pre>
        # Compensate for switching to/from daylight saving time
        # (day is shorter or longer than 24h)
        if ( $NewCTime != $CTime00 + 24 * 60 * 60 ) {
            my $Diff = $NewCTime - $CTime00 - 24 * 60 * 60;
            $DestinationTime += $Diff;
        }
</pre>

Please let me know what do you think about that.

Regards
Zoran