### PR TITLE
Fixed bug#4661 - SearchProfiles updated on UserLogin

### DIFF
--- a/Kernel/Config/Files/Framework.xml
+++ b/Kernel/Config/Files/Framework.xml
@@ -6577,6 +6577,18 @@ via the Preferences button after logging in.
             </Hash>
         </Setting>
     </ConfigItem>
+    <ConfigItem Name="CustomerUser::EventModulePost###100-UpdateSearchProfiles" Required="0" Valid="1">
+        <Description Translatable="1">Event module that updates customer user search profiles if login changes.</Description>
+        <Group>Framework</Group>
+        <SubGroup>Core::CustomerUser</SubGroup>
+        <Setting>
+            <Hash>
+                <Item Key="Module">Kernel::System::CustomerUser::Event::SearchProfileUpdate</Item>
+                <Item Key="Event">CustomerUserUpdate</Item>
+                <Item Key="Transaction">0</Item>
+            </Hash>
+        </Setting>
+    </ConfigItem>
     <ConfigItem Name="CustomerUser::EventModulePost###100-UpdateServiceMembership" Required="0" Valid="1">
         <Description Translatable="1">Event module that updates customer user service membership if login changes.</Description>
         <Group>Framework</Group>

--- a/Kernel/System/CustomerUser/Event/SearchProfileUpdate.pm
+++ b/Kernel/System/CustomerUser/Event/SearchProfileUpdate.pm
@@ -1,0 +1,66 @@
+# --
+# Copyright (C) 2001-2015 OTRS AG, http://otrs.com/
+# --
+# This software comes with ABSOLUTELY NO WARRANTY. For details, see
+# the enclosed file COPYING for license information (AGPL). If you
+# did not receive this file, see http://www.gnu.org/licenses/agpl.txt.
+# --
+
+package Kernel::System::CustomerUser::Event::SearchProfileUpdate;
+
+use strict;
+use warnings;
+
+our @ObjectDependencies = (
+    'Kernel::System::Log',
+    'Kernel::System::SearchProfile',
+);
+
+sub new {
+    my ( $Type, %Param ) = @_;
+
+    # allocate new hash for object
+    my $Self = {};
+    bless( $Self, $Type );
+
+    return $Self;
+}
+
+sub Run {
+    my ( $Self, %Param ) = @_;
+
+    # check needed stuff
+    for (qw( Data Event Config UserID )) {
+        if ( !$Param{$_} ) {
+            $Kernel::OM->Get('Kernel::System::Log')->Log(
+                Priority => 'error',
+                Message  => "Need $_!"
+            );
+            return;
+        }
+    }
+    for (qw( UserLogin NewData OldData )) {
+        if ( !$Param{Data}->{$_} ) {
+            $Kernel::OM->Get('Kernel::System::Log')->Log(
+                Priority => 'error',
+                Message  => "Need $_ in Data!"
+            );
+            return;
+        }
+    }
+
+    # only update CustomerUser search profiles if fields have really changed
+    if ( lc $Param{Data}->{OldData}->{UserLogin} ne lc $Param{Data}->{NewData}->{UserLogin} ) {
+
+        # update searchprofiles
+        $Kernel::OM->Get('Kernel::System::SearchProfile')->SearchProfileUpdateUserLogin(
+            Base => 'CustomerTicketSearch',
+            UserLogin    => $Param{Data}->{OldData}->{UserLogin},
+            NewUserLogin => $Param{Data}->{NewData}->{UserLogin},
+        );
+    }
+
+    return 1;
+}
+
+1;


### PR DESCRIPTION
This is a bug fix for bug#4661.
ref: http://bugs.otrs.org/show_bug.cgi?id=4661

Previously, when the login name of an agent or customer user changed,
their search profiles were lost.

I introduced a function in Kernel::System::SearchProfile to update
the search profiles for a given login, plus I modified UserUpdate
and wrote an event module for CustomerUsers.
I also wrote unit tests to cover these scenarios.