### PR TITLE
Changed behavior when creating phone ticket out of a chat

### DIFF
--- a/Kernel/Modules/AgentTicketPhone.pm
+++ b/Kernel/Modules/AgentTicketPhone.pm
@@ -1427,11 +1427,6 @@ sub Run {
                     $Success = $ChatObject->ChatDelete(
                         ChatID => $GetParam{FromChatID},
                     );
-
-                    # remove possible chat invitations from this chat
-                    $Success = $ChatObject->ChatInviteRemove(
-                        InvitationChatID => $GetParam{FromChatID},
-                    );
                 }
 
                 # otherwise set chat status to closed and inform other agents

--- a/Kernel/Modules/AgentTicketPhone.pm
+++ b/Kernel/Modules/AgentTicketPhone.pm
@@ -1411,9 +1411,92 @@ sub Run {
                 );
             }
             if ($ChatArticleID) {
-                $ChatObject->ChatDelete(
+
+                # check is customer actively present
+                # it means customer has accepted this chat and not left it!
+                my $CustomerPresent = $ChatObject->CustomerPresent(
                     ChatID => $GetParam{FromChatID},
+                    Active => 1,
                 );
+
+                my $Success;
+
+                # if there is no customer present in the chat
+                # just remove the chat
+                if ( !$CustomerPresent ) {
+                    $Success = $ChatObject->ChatDelete(
+                        ChatID => $GetParam{FromChatID},
+                    );
+
+                    # remove possible chat invitations from this chat
+                    $Success = $ChatObject->ChatInviteRemove(
+                        InvitationChatID => $GetParam{FromChatID},
+                    );
+                }
+
+                # otherwise set chat status to closed and inform other agents
+                else {
+                    $Success = $ChatObject->ChatUpdate(
+                        ChatID     => $GetParam{FromChatID},
+                        Status     => 'closed',
+                        Deprecated => 1,
+                    );
+
+                    # get user data
+                    my %User = $Kernel::OM->Get('Kernel::System::User')->GetUserData(
+                        UserID => $Self->{UserID},
+                    );
+
+                    my $RequesterName = $User{UserFullname};
+                    $RequesterName ||= $Self->{UserID};
+
+                    my $LeaveMessage = $Kernel::OM->Get('Kernel::Language')->Translate(
+                        "%s has left the chat.",
+                        $RequesterName,
+                    );
+
+                    $Success = $ChatObject->ChatMessageAdd(
+                        ChatID          => $GetParam{FromChatID},
+                        ChatterID       => $Self->{UserID},
+                        ChatterType     => 'User',
+                        MessageText     => $LeaveMessage,
+                        SystemGenerated => 1,
+                    );
+
+                    # time after chat will be removed
+                    my $ChatTTL = $Kernel::OM->Get('Kernel::Config')->Get('ChatEngine::ChatTTL');
+
+                    my $ChatClosedMessage = $Kernel::OM->Get('Kernel::Language')->Translate(
+                        "This chat has been closed and will be removed in %s hours.",
+                        $ChatTTL,
+                    );
+
+                    $Success = $ChatObject->ChatMessageAdd(
+                        ChatID          => $GetParam{FromChatID},
+                        ChatterID       => $Self->{UserID},
+                        ChatterType     => 'User',
+                        MessageText     => $ChatClosedMessage,
+                        SystemGenerated => 1,
+                    );
+
+                    # remove all AGENT participants from chat
+                    my @ParticipantsList = $ChatObject->ChatParticipantList(
+                        ChatID => $GetParam{FromChatID},
+                    );
+                    CHATPARTICIPANT:
+                    for my $ChatParticipant (@ParticipantsList) {
+
+                        # skip it this participant is not agent
+                        next CHATPARTICIPANT if $ChatParticipant->{ChatterType} ne 'User';
+
+                        # remove this participants from the chat
+                        $Success = $ChatObject->ChatParticipantRemove(
+                            ChatID      => $GetParam{FromChatID},
+                            ChatterID   => $ChatParticipant->{ChatterID},
+                            ChatterType => 'User',
+                        );
+                    }
+                }
             }
         }
 


### PR DESCRIPTION
Changed behavior when creating a new phone ticket from a chat:
If Customer is in a chat, chat won't be deleted immediately (as it's on all other forms).

Best Regards,
Igor