### PR TITLE
Master - Fixed test MailTimeStamp

### DIFF
--- a/scripts/test/Time/MailTimeStamp.t
+++ b/scripts/test/Time/MailTimeStamp.t
@@ -121,8 +121,10 @@ for my $Test (@Tests) {
     $Self->Is(
         $MailTimeStamp,
         $Test->{Result},
-        "$Test->{Name} ($Test->{ServerTZ}) Timestamp $Test->{TimeStamp}:",
+        "$Test->{Name} ($Test->{ServerTZ}) Timestamp $Test->{TimeStampUTC}:",
     );
+
+    $HelperObject->FixedTimeUnset();
 }
 
 1;


### PR DESCRIPTION
Hi @mgruner 

Working on a bug with daylight time zone, I saw that there is a mistake in test MailTimeStamp. There was used wrong data which is uninitialized value in concatenation. I suppose it was type error.

I added also FixedTimeUnset to restore the regular system time behaviour.

Regards
Zoran