### PR TITLE
[ Master bug11373 ] - CustomerID in AgentTicketPhone accepts any value

### DIFF
--- a/Kernel/Config/Files/ProcessManagement.xml
+++ b/Kernel/Config/Files/ProcessManagement.xml
@@ -360,6 +360,17 @@
             </Array>
         </Setting>
     </ConfigItem>
+    <ConfigItem Name="Ticket::Frontend::AgentTicketProcess::CustomerIDReadOnly" Required="1" Valid="1">
+        <Description Translatable="1">Controls if CutomerID is editable in the agent interface.</Description>
+        <Group>ProcessManagement</Group>
+        <SubGroup>Frontend::Agent::Ticket::ViewProcess</SubGroup>
+        <Setting>
+            <Option SelectedID="0">
+                <Item Key="0" Translatable="1">No</Item>
+                <Item Key="1" Translatable="1">Yes</Item>
+            </Option>
+        </Setting>
+    </ConfigItem>
     <ConfigItem Name="ProcessManagement::Transition::Debug::Enabled" Required="1" Valid="1">
         <Description Translatable="1">If enabled debugging information for transitions is logged.</Description>
         <Group>ProcessManagement</Group>

--- a/Kernel/Config/Files/ProcessManagement.xml
+++ b/Kernel/Config/Files/ProcessManagement.xml
@@ -365,7 +365,7 @@
         <Group>ProcessManagement</Group>
         <SubGroup>Frontend::Agent::Ticket::ViewProcess</SubGroup>
         <Setting>
-            <Option SelectedID="0">
+            <Option SelectedID="1">
                 <Item Key="0" Translatable="1">No</Item>
                 <Item Key="1" Translatable="1">Yes</Item>
             </Option>

--- a/Kernel/Config/Files/Ticket.xml
+++ b/Kernel/Config/Files/Ticket.xml
@@ -3242,7 +3242,7 @@
         <Group>Ticket</Group>
         <SubGroup>Frontend::Agent::Ticket::ViewPhoneNew</SubGroup>
         <Setting>
-            <Option SelectedID="0">
+            <Option SelectedID="1">
                 <Item Key="0" Translatable="1">No</Item>
                 <Item Key="1" Translatable="1">Yes</Item>
             </Option>
@@ -3379,7 +3379,7 @@
         <Group>Ticket</Group>
         <SubGroup>Frontend::Agent::Ticket::ViewEmailNew</SubGroup>
         <Setting>
-            <Option SelectedID="0">
+            <Option SelectedID="1">
                 <Item Key="0" Translatable="1">No</Item>
                 <Item Key="1" Translatable="1">Yes</Item>
             </Option>
@@ -5602,7 +5602,7 @@
         <Group>Ticket</Group>
         <SubGroup>Frontend::Agent::Ticket::ViewCustomer</SubGroup>
         <Setting>
-            <Option SelectedID="0">
+            <Option SelectedID="1">
                 <Item Key="0" Translatable="1">No</Item>
                 <Item Key="1" Translatable="1">Yes</Item>
             </Option>

--- a/Kernel/Config/Files/Ticket.xml
+++ b/Kernel/Config/Files/Ticket.xml
@@ -3237,6 +3237,17 @@
             <String Regex="">customer</String>
         </Setting>
     </ConfigItem>
+    <ConfigItem Name="Ticket::Frontend::AgentTicketPhone::CustomerIDReadOnly" Required="1" Valid="1">
+        <Description Translatable="1">Controls if CutomerID is editable in the agent interface.</Description>
+        <Group>Ticket</Group>
+        <SubGroup>Frontend::Agent::Ticket::ViewPhoneNew</SubGroup>
+        <Setting>
+            <Option SelectedID="0">
+                <Item Key="0" Translatable="1">No</Item>
+                <Item Key="1" Translatable="1">Yes</Item>
+            </Option>
+        </Setting>
+    </ConfigItem>
     <ConfigItem Name="Ticket::Frontend::AgentTicketPhone::AllowMultipleFrom" Required="1" Valid="1">
         <Description Translatable="1">Controls if more than one from entry can be set in the new phone ticket in the agent interface.</Description>
         <Group>Ticket</Group>
@@ -3361,6 +3372,17 @@
         <SubGroup>Frontend::Agent::Ticket::ViewEmailNew</SubGroup>
         <Setting>
             <String Regex="">agent</String>
+        </Setting>
+    </ConfigItem>
+    <ConfigItem Name="Ticket::Frontend::AgentTicketEmail::CustomerIDReadOnly" Required="1" Valid="1">
+        <Description Translatable="1">Controls if CutomerID is editable in the agent interface.</Description>
+        <Group>Ticket</Group>
+        <SubGroup>Frontend::Agent::Ticket::ViewEmailNew</SubGroup>
+        <Setting>
+            <Option SelectedID="0">
+                <Item Key="0" Translatable="1">No</Item>
+                <Item Key="1" Translatable="1">Yes</Item>
+            </Option>
         </Setting>
     </ConfigItem>
     <ConfigItem Name="Ticket::Frontend::AgentTicketEmail###Subject" Required="1" Valid="1">

--- a/Kernel/Config/Files/Ticket.xml
+++ b/Kernel/Config/Files/Ticket.xml
@@ -5597,6 +5597,17 @@
             </Option>
         </Setting>
     </ConfigItem>
+    <ConfigItem Name="Ticket::Frontend::AgentTicketCustomer::CustomerIDReadOnly" Required="1" Valid="1">
+        <Description Translatable="1">Controls if CutomerID is editable in the agent interface.</Description>
+        <Group>Ticket</Group>
+        <SubGroup>Frontend::Agent::Ticket::ViewCustomer</SubGroup>
+        <Setting>
+            <Option SelectedID="0">
+                <Item Key="0" Translatable="1">No</Item>
+                <Item Key="1" Translatable="1">Yes</Item>
+            </Option>
+        </Setting>
+    </ConfigItem>
     <ConfigItem Name="Ticket::Frontend::MergeText" Required="1" Valid="1">
         <Description Translatable="1">When tickets are merged, the customer can be informed per email by setting the check box "Inform Sender". In this text area, you can define a pre-formatted text which can later be modified by the agents.</Description>
         <Group>Ticket</Group>

--- a/Kernel/Output/HTML/Templates/Standard/AgentTicketCustomer.tt
+++ b/Kernel/Output/HTML/Templates/Standard/AgentTicketCustomer.tt
@@ -49,7 +49,7 @@
 
                             <label for="CustomerID" class="Mandatory"><span class="Marker">*</span> [% Translate("CustomerID") | html %]:</label>
                             <div class="Field">
-                                <input type="text" id="CustomerID" name="CustomerID" value="[% Data.CustomerID | html %]" class="W75pc Validate_Required [% Data.CustomerIDInvalid | html %]"/>
+                                <input type="text" id="CustomerID" name="CustomerID" value="[% Data.CustomerID | html %]" [% IF Config("Ticket::Frontend::AgentTicketCustomer::CustomerIDReadOnly") %] readonly [% END %] class="W75pc Validate_Required [% Data.CustomerIDInvalid | html %]"/>
                                 <div id="CustomerIDError" class="TooltipErrorMessage"><p>[% Translate("This field is required.") | html %]</p></div>
                                 <div id="CustomerIDServerError" class="TooltipErrorMessage"><p>[% Translate("This field is required.") | html %]</p></div>
                             </div>

--- a/Kernel/Output/HTML/Templates/Standard/AgentTicketEmail.tt
+++ b/Kernel/Output/HTML/Templates/Standard/AgentTicketEmail.tt
@@ -321,8 +321,9 @@ $('#Dest').bind('change', function (Event) {
 
                     <label for="CustomerID">[% Translate("CustomerID") | html %]:</label>
                     <div class="Field">
-                        <input type="text" name="CustomerID" id="CustomerID" value="[% Data.CustomerID | html %]" class="W75pc"/>
+                        <input type="text" name="CustomerID" id="CustomerID" value="[% Data.CustomerID | html %]" [% IF Config("Ticket::Frontend::AgentTicketEmail::CustomerIDReadOnly") %] readonly [% END %] class="W75pc"/>
                     </div>
+
                     <div class="Clear"></div>
 
 [% RenderBlockStart("TicketService") %]

--- a/Kernel/Output/HTML/Templates/Standard/AgentTicketPhone.tt
+++ b/Kernel/Output/HTML/Templates/Standard/AgentTicketPhone.tt
@@ -169,7 +169,7 @@
 
                     <label for="CustomerID">[% Translate("CustomerID") | html %]:</label>
                     <div class="Field">
-                        <input type="text" name="CustomerID" id="CustomerID" value="[% Data.CustomerID | html %]" [% IF Config("Ticket::Frontend::AgentTicketEmail::CustomerIDReadOnly") %] readonly [% END %] class="W75pc"/>
+                        <input type="text" name="CustomerID" id="CustomerID" value="[% Data.CustomerID | html %]" [% IF Config("Ticket::Frontend::AgentTicketPhone::CustomerIDReadOnly") %] readonly [% END %] class="W75pc"/>
                     </div>
                     <div class="Clear"></div>
 

--- a/Kernel/Output/HTML/Templates/Standard/AgentTicketPhone.tt
+++ b/Kernel/Output/HTML/Templates/Standard/AgentTicketPhone.tt
@@ -169,7 +169,7 @@
 
                     <label for="CustomerID">[% Translate("CustomerID") | html %]:</label>
                     <div class="Field">
-                        <input type="text" name="CustomerID" id="CustomerID" value="[% Data.CustomerID | html %]" class="W75pc"/>
+                        <input type="text" name="CustomerID" id="CustomerID" value="[% Data.CustomerID | html %]" [% IF Config("Ticket::Frontend::AgentTicketEmail::CustomerIDReadOnly") %] readonly [% END %] class="W75pc"/>
                     </div>
                     <div class="Clear"></div>
 

--- a/Kernel/Output/HTML/Templates/Standard/ProcessManagement/Customer.tt
+++ b/Kernel/Output/HTML/Templates/Standard/ProcessManagement/Customer.tt
@@ -33,7 +33,7 @@
     [% Data.LabelCustomerID | html %]:
 </label>
 <div class="Field">
-    <input type="text" id="CustomerID" name="CustomerID" value="[% Data.CustomerID | html %]" class="W50pc [% Data.CustomerIDServerError | html %]"/>
+    <input type="text" id="CustomerID" name="CustomerID" value="[% Data.CustomerID | html %]" [% IF Config( "Ticket::Frontend::AgentTicketProcess::CustomerIDReadOnly") %] readonly [% END %] class="W50pc [% Data.CustomerIDServerError | html %]"/>
     <div id="CustomerIDError" class="TooltipErrorMessage"><p>[% Translate("This field is required.") | html %]</p></div>
     <div id="CustomerIDServerError" class="TooltipErrorMessage"><p>[% Translate("This field is required.") | html %]</p></div>
 [% RenderBlockStart("rw:Customer:DescriptionShort") %]


### PR DESCRIPTION
http://bugs.otrs.org/show_bug.cgi?id=11373

Hi @mgruner ,

This is my proposal for fixing. As you can see, I added new SysConfig items which them is possible to configure if CustomerID can be edited in AgentTicketPhone and AgentTicketEmail screens. To be honest I don't like adding new config items. My intention was that allow users to have options which they prefer. 
In next release we can choose one of them.

Please let me know what do you think about that.

Regards
Zoran