### PR TITLE
Master - AdminGenericAgent - Unset ticket attributes

### DIFF
--- a/Kernel/Modules/AdminGenericAgent.pm
+++ b/Kernel/Modules/AdminGenericAgent.pm
@@ -437,13 +437,14 @@ sub _MaskUpdate {
         Class       => 'Modernize',
     );
     $JobData{NewOwnerStrg} = $LayoutObject->BuildSelection(
-        Data        => \%ShownUsers,
-        Name        => 'NewOwnerID',
-        Size        => 5,
-        Multiple    => 0,
-        Translation => 0,
-        SelectedID  => $JobData{NewOwnerID},
-        Class       => 'Modernize',
+        Data         => \%ShownUsers,
+        Name         => 'NewOwnerID',
+        Size         => 5,
+        Multiple     => 0,
+        Translation  => 0,
+        SelectedID   => $JobData{NewOwnerID},
+        Class        => 'Modernize',
+        PossibleNone => 1,
     );
     my %Hours;
     for my $Number ( 0 .. 23 ) {
@@ -512,11 +513,12 @@ sub _MaskUpdate {
                 Action => $Self->{Action},
             ),
         },
-        Name       => 'NewStateID',
-        Size       => 5,
-        Multiple   => 0,
-        SelectedID => $JobData{NewStateID},
-        Class      => 'Modernize',
+        Name         => 'NewStateID',
+        Size         => 5,
+        Multiple     => 0,
+        SelectedID   => $JobData{NewStateID},
+        Class        => 'Modernize',
+        PossibleNone => 1,
     );
     $JobData{NewPendingTimeTypeStrg} = $LayoutObject->BuildSelection(
         Data => [
@@ -573,6 +575,7 @@ sub _MaskUpdate {
         TreeView       => $TreeView,
         OnChangeSubmit => 0,
         Class          => 'Modernize',
+        PossibleNone   => 1,
     );
 
     # get priority object
@@ -598,11 +601,12 @@ sub _MaskUpdate {
                 Action => $Self->{Action},
             ),
         },
-        Name       => 'NewPriorityID',
-        Size       => 5,
-        Multiple   => 0,
-        SelectedID => $JobData{NewPriorityID},
-        Class      => 'Modernize',
+        Name         => 'NewPriorityID',
+        Size         => 5,
+        Multiple     => 0,
+        SelectedID   => $JobData{NewPriorityID},
+        Class        => 'Modernize',
+        PossibleNone => 1,
     );
 
     # get time option
@@ -722,11 +726,12 @@ sub _MaskUpdate {
                 Action => $Self->{Action},
             ),
         },
-        Name       => 'NewLockID',
-        Size       => 3,
-        Multiple   => 0,
-        SelectedID => $JobData{NewLockID},
-        Class      => 'Modernize',
+        Name         => 'NewLockID',
+        Size         => 3,
+        Multiple     => 0,
+        SelectedID   => $JobData{NewLockID},
+        Class        => 'Modernize',
+        PossibleNone => 1,
     );
 
     # Show server errors if ticket selection contains stop words
@@ -809,14 +814,15 @@ sub _MaskUpdate {
             Data => \%JobData,
         );
         $JobData{NewTypesStrg} = $LayoutObject->BuildSelection(
-            Data        => \%Type,
-            Name        => 'NewTypeID',
-            SelectedID  => $JobData{NewTypeID},
-            Sort        => 'AlphanumericValue',
-            Size        => 3,
-            Multiple    => 0,
-            Translation => 0,
-            Class       => 'Modernize',
+            Data         => \%Type,
+            Name         => 'NewTypeID',
+            SelectedID   => $JobData{NewTypeID},
+            Sort         => 'AlphanumericValue',
+            Size         => 3,
+            Multiple     => 0,
+            Translation  => 0,
+            Class        => 'Modernize',
+            PossibleNone => 1,
         );
         $LayoutObject->Block(
             Name => 'NewTicketType',
@@ -846,15 +852,16 @@ sub _MaskUpdate {
             Class       => 'Modernize',
         );
         $JobData{NewServicesStrg} = $LayoutObject->BuildSelection(
-            Data        => \%NewService,
-            Name        => 'NewServiceID',
-            SelectedID  => $JobData{NewServiceID},
-            Size        => 5,
-            Multiple    => 0,
-            TreeView    => $TreeView,
-            Translation => 0,
-            Max         => 200,
-            Class       => 'Modernize',
+            Data         => \%NewService,
+            Name         => 'NewServiceID',
+            SelectedID   => $JobData{NewServiceID},
+            Size         => 5,
+            Multiple     => 0,
+            TreeView     => $TreeView,
+            Translation  => 0,
+            Max          => 200,
+            Class        => 'Modernize',
+            PossibleNone => 1,
         );
         my %SLA = $Kernel::OM->Get('Kernel::System::SLA')->SLAList(
             UserID => $Self->{UserID},
@@ -871,15 +878,16 @@ sub _MaskUpdate {
             Class       => 'Modernize',
         );
         $JobData{NewSLAsStrg} = $LayoutObject->BuildSelection(
-            Data        => \%SLA,
-            Name        => 'NewSLAID',
-            SelectedID  => $JobData{NewSLAID},
-            Sort        => 'AlphanumericValue',
-            Size        => 5,
-            Multiple    => 0,
-            Translation => 0,
-            Max         => 200,
-            Class       => 'Modernize',
+            Data         => \%SLA,
+            Name         => 'NewSLAID',
+            SelectedID   => $JobData{NewSLAID},
+            Sort         => 'AlphanumericValue',
+            Size         => 5,
+            Multiple     => 0,
+            Translation  => 0,
+            Max          => 200,
+            Class        => 'Modernize',
+            PossibleNone => 1,
         );
         $LayoutObject->Block(
             Name => 'TicketService',
@@ -903,13 +911,14 @@ sub _MaskUpdate {
             Class       => 'Modernize',
         );
         $JobData{NewResponsibleStrg} = $LayoutObject->BuildSelection(
-            Data        => \%ShownUsers,
-            Name        => 'NewResponsibleID',
-            Size        => 5,
-            Multiple    => 0,
-            Translation => 0,
-            SelectedID  => $JobData{NewResponsibleID},
-            Class       => 'Modernize',
+            Data         => \%ShownUsers,
+            Name         => 'NewResponsibleID',
+            Size         => 5,
+            Multiple     => 0,
+            Translation  => 0,
+            SelectedID   => $JobData{NewResponsibleID},
+            Class        => 'Modernize',
+            PossibleNone => 1,
         );
         $LayoutObject->Block(
             Name => 'TicketResponsible',

--- a/Kernel/Output/HTML/Layout/Ticket.pm
+++ b/Kernel/Output/HTML/Layout/Ticket.pm
@@ -289,6 +289,7 @@ sub AgentQueueListOption {
             SelectedID    => $Param{SelectedID} || $Param{SelectedIDRefArray} || '',
             SelectedValue => $Param{Selected},
             Translation   => 0,
+            PossibleNone  => $Param{PossibleNone},
         );
         return $Param{MoveQueuesStrg};
     }
@@ -301,6 +302,11 @@ sub AgentQueueListOption {
         . '" class="'
         . $Class
         . "\" $Size $Multiple $OnChangeSubmit>\n";
+
+    if ( $Param{PossibleNone} ) {
+        $Param{MoveQueuesStrg} .= '<option value="">-</option>' . "\n";
+    }
+
     my %UsedData;
     my %Data;
 

--- a/Kernel/Output/HTML/Templates/Standard/AdminGenericAgent.tt
+++ b/Kernel/Output/HTML/Templates/Standard/AdminGenericAgent.tt
@@ -664,7 +664,8 @@ Core.Agent.Admin.GenericAgent.Init({
 
                         <label for="NewPendingTime">[% Translate("Pending date") | html %]:</label>
                         <div class="Field">
-                            <input type="text" name="NewPendingTime" id="NewPendingTime" value="[% Data.NewPendingTime | html %]" class="W10pc"/>
+                            <input type="text" name="NewPendingTime" id="NewPendingTime" value="[% Data.NewPendingTime | html %]" class="W10pc Validate_TimeUnits"/>
+                            <div id="NewPendingTimeError" class="TooltipErrorMessage"><p>[% Translate("Invalid time!") | html %]</p></div>
                             [% Data.NewPendingTimeTypeStrg %]
                         </div>
                         <div class="Clear"></div>
@@ -763,7 +764,8 @@ Core.Agent.Admin.GenericAgent.Init({
 
                         <label for="NewNoteTimeUnits">[% Translate("Time units") | html %] [% Translate(Config("Ticket::Frontend::TimeUnits")) | html %]:</label>
                         <div class="Field">
-                            <input type="text" name="NewNoteTimeUnits" id="NewNoteTimeUnits" value="[% Data.NewNoteTimeUnits | html %]" class="W20pc"/>
+                            <input type="text" name="NewNoteTimeUnits" id="NewNoteTimeUnits" value="[% Data.NewNoteTimeUnits | html %]" class="W20pc Validate_TimeUnits"/>
+                            <div id="NewNoteTimeUnitsError" class="TooltipErrorMessage"><p>[% Translate("Invalid time!") | html %]</p></div>
                         </div>
                         <div class="Clear"></div>
                     </fieldset>


### PR DESCRIPTION
Hello,

During bug testing, noticed issue with AdminGenericAgent. When selecting "Update/Add Ticket Attributes" there was no option to deselect value. This raised a problem, since there was no other option then to create new generic agent job if ticket attribute is inputted by mistake.
Added 'PossibleNone' for fields that are selection based. Think this will provide much nicer user experience.

Additionally fields 'Pending date' and 'Time units' didn't have validation to be numbers only, which could result in input that's not suppose to be. Now only numeral values can be inputted as supposed.
 
Please, review these small life improvement changes and let me know if there are any issued or questions regarding this PR.

Regards,
Sanjin