### PR TITLE
TicketUpdate web service: error message, docs

### DIFF
--- a/Kernel/GenericInterface/Operation/Ticket/TicketUpdate.pm
+++ b/Kernel/GenericInterface/Operation/Ticket/TicketUpdate.pm
@@ -22,7 +22,7 @@ our $ObjectManagerDisabled = 1;
 
 =head1 NAME
 
-Kernel::GenericInterface::Operation::Ticket::TicketCreate - GenericInterface Ticket TicketCreate Operation backend
+Kernel::GenericInterface::Operation::Ticket::TicketUpdate - GenericInterface Ticket TicketUpdate Operation backend
 
 =head1 SYNOPSIS
 
@@ -64,7 +64,8 @@ sub new {
 
 =item Run()
 
-perform TicketCreate Operation. This will return the created ticket number.
+perform TicketUpdate Operation. This will return the updated TicketID and
+if applicable the created ArticleID.
 
     my $Result = $OperationObject->Run(
         Data => {
@@ -172,10 +173,9 @@ perform TicketCreate Operation. This will return the created ticket number.
         ErrorMessage    => '',                      # in case of error
         Data            => {                        # result data payload after Operation
             TicketID    => 123,                     # Ticket  ID number in OTRS (help desk system)
-            TicketNumber => 2324454323322           # Ticket Number in OTRS (Help desk system)
             ArticleID   => 43,                      # Article ID number in OTRS (help desk system)
             Error => {                              # should not return errors
-                    ErrorCode    => 'Ticket.Create.ErrorCode'
+                    ErrorCode    => 'TicketUpdate.ErrorCode'
                     ErrorMessage => 'Error Description'
             },
         },
@@ -505,9 +505,9 @@ sub Run {
         for my $AttachmentItem (@AttachmentList) {
             if ( !IsHashRefWithData($AttachmentItem) ) {
                 return {
-                    ErrorCode => 'TicketCreate.InvalidParameter',
+                    ErrorCode => 'TicketUpdate.InvalidParameter',
                     ErrorMessage =>
-                        "TicketCreate: Ticket->Attachment parameter is invalid!",
+                        "TicketUpdate: Ticket->Attachment parameter is invalid!",
                 };
             }
 


### PR DESCRIPTION
I found some references in the TicketUpdate web service to
TicketCreate which are there because of copy and paste, I guess.
This commit change these to TicketUpdate.

Also I corrected the documentation on the returned data structure.

As a side note: I wanted to add a test to catch the error message about the attachments which I changed, but this was not so easy to trigger. the closest I could get was by passing `Attachment => [[]],` but this returned locally 'Error in SOAPOutputRecursion'  and I did not want to test against an error message brought up by SOAP::Lite. If you'd be interested you can find this here: https://github.com/mbeijen/otrs-1/commit/8b8cccebe664103cc7d0a105090d6053382fe0a7?diff=unified