### PR TITLE
[Master - bug11330]  LogModule::LogFile::Date creates log files ending in single digit

### DIFF
--- a/Kernel/System/Log/File.pm
+++ b/Kernel/System/Log/File.pm
@@ -35,7 +35,7 @@ sub new {
     if ( $ConfigObject->Get('LogModule::LogFile::Date') ) {
         my ( $s, $m, $h, $D, $M, $Y, $WD, $YD, $DST ) = localtime( time() );    ## no critic
         $Y = $Y + 1900;
-        $M++;
+        $M = sprintf '%02d', ++$M;
         $Self->{LogFile} .= ".$Y-$M";
     }
 


### PR DESCRIPTION
http://bugs.otrs.org/show_bug.cgi?id=11330

Hi Martin,

Here is my proposal for fixing this bug. Please let me know if you have any suggestion about that.

Regards
Zoran