### PR TITLE
[ Master - 11346 ] - Naming different when adding columns to CIC vs Dashboard

### DIFF
--- a/Kernel/Output/HTML/Templates/Standard/AgentCustomerInformationCenter.tt
+++ b/Kernel/Output/HTML/Templates/Standard/AgentCustomerInformationCenter.tt
@@ -10,6 +10,8 @@
 <div class="MainBox ARIARoleMain LayoutFixedSidebar SidebarLast">
     <h1>[% Translate("Customer Information Center") | html %] &mdash; <a href="#" id="CustomerInformationCenterHeading">[% Data.CustomerIDTitle | html %]</a></h1>
 
+[% InsertTemplate("AgentDashboardCommon.tt") %]
+
 [% WRAPPER JSOnDocumentComplete %]
 <script type="text/javascript">//<![CDATA[
     Core.Agent.Dashboard.Init();
@@ -19,8 +21,6 @@
     });
 //]]></script>
 [% END %]
-
-[% InsertTemplate("AgentDashboardCommon.tt") %]
 
 </div>
 [% RenderBlockEnd("Content") %]


### PR DESCRIPTION
http://bugs.otrs.org/show_bug.cgi?id=11346

Hi Martin,

Here I my fix for this issue. There was a problem in place where the template  is included.
I tested it for all screens where there is ticket overview. I think it is solved now, and there is the same behavior everywhere. 

Regards
Zoran