### PR TITLE
Provide SolutionInMin also without Solution Dest.

### DIFF
--- a/Kernel/System/Ticket.pm
+++ b/Kernel/System/Ticket.pm
@@ -1506,29 +1506,28 @@ sub _TicketGetClosed {
         Ticket => $Param{Ticket},
         UserID => $Param{UserID} || 1,
     );
+    
+    # get time object
+    my $TimeObject = $Kernel::OM->Get('Kernel::System::Time');
+
+    # get unix time stamps
+    my $CreateTime = $TimeObject->TimeStamp2SystemTime(
+        String => $Param{Ticket}->{Created},
+    );
+    my $SolutionTime = $TimeObject->TimeStamp2SystemTime(
+        String => $Data{Closed},
+    );
+
+    # get time between creation and solution
+    my $WorkingTime = $TimeObject->WorkingTime(
+        StartTime => $CreateTime,
+        StopTime  => $SolutionTime,
+        Calendar  => $Escalation{Calendar},
+    );
+
+    $Data{SolutionInMin} = int( $WorkingTime / 60 );    
 
     if ( $Escalation{SolutionTime} ) {
-
-        # get time object
-        my $TimeObject = $Kernel::OM->Get('Kernel::System::Time');
-
-        # get unix time stamps
-        my $CreateTime = $TimeObject->TimeStamp2SystemTime(
-            String => $Param{Ticket}->{Created},
-        );
-        my $SolutionTime = $TimeObject->TimeStamp2SystemTime(
-            String => $Data{Closed},
-        );
-
-        # get time between creation and solution
-        my $WorkingTime = $TimeObject->WorkingTime(
-            StartTime => $CreateTime,
-            StopTime  => $SolutionTime,
-            Calendar  => $Escalation{Calendar},
-        );
-
-        $Data{SolutionInMin} = int( $WorkingTime / 60 );
-
         my $EscalationSolutionTime = $Escalation{SolutionTime} * 60;
         $Data{SolutionDiffInMin} = int( ( $EscalationSolutionTime - $WorkingTime ) / 60 );
     }


### PR DESCRIPTION
The ticket has a solution time and thus also a solution time in min, even if there's no solution-destination-time. There's no reason to make the calculation of SolutionInMin depending from Escalation(SolutionTime).

see also PR#718, PR#719