### PR TITLE
[ Master - Bug 11315 ] - subservice not apparent in overview when many services are in the list 

### DIFF
--- a/Kernel/Modules/AgentTicketService.pm
+++ b/Kernel/Modules/AgentTicketService.pm
@@ -750,7 +750,7 @@ sub _MaskServiceView {
     for my $Level ( 1 .. 5 ) {
         next LEVEL if !$Param{ 'ServiceStrg' . $Level };
         $Param{ServiceStrg}
-            .= '<ul class="ServiceOverviewList">' . $Param{ 'ServiceStrg' . $Level } . '</ul>';
+            .= '<ul class="ServiceOverviewList Level_' . $Level . '">' . $Param{ 'ServiceStrg' . $Level } . '</ul>';
     }
 
     return (

--- a/var/httpd/htdocs/skins/Agent/default/css/Core.AgentTicketService.css
+++ b/var/httpd/htdocs/skins/Agent/default/css/Core.AgentTicketService.css
@@ -37,6 +37,26 @@
     float: none;
 }
 
+.ServiceOverviewList.Level_1 {
+    margin-left: 0px;
+}
+
+.ServiceOverviewList.Level_2 {
+    margin-left: 10px;
+}
+
+.ServiceOverviewList.Level_3 {
+    margin-left: 20px;
+}
+
+.ServiceOverviewList.Level_4 {
+    margin-left: 30px;
+}
+
+.ServiceOverviewList.Level_5 {
+    margin-left: 40px;
+}
+
 .ServiceOverviewList li {
     float: left;
     list-style: none;


### PR DESCRIPTION
Hi @mgruner 

Here is PR with our proposal for fixing. We used something similar to Ticket Queue View. As you can see an indentation is not used for RTL. If it is needed, we will be able to provide new PR and solve this for service and queue view as well.
I suppose you know that there is possible only 5 level of services in TicketServiceView. I didn't want to fix it here but again if you consider that it should be fixed, we will be ready to solve it.

Regards
Zoran  