### PR TITLE
[ Master - Bug 11496 ] - Search field shown even if type and service disabled

### DIFF
--- a/Kernel/Modules/CustomerTicketSearch.pm
+++ b/Kernel/Modules/CustomerTicketSearch.pm
@@ -1850,8 +1850,11 @@ sub MaskForm {
 sub _StopWordsServerErrorsGet {
     my ( $Self, %Param ) = @_;
 
+    # get layout object
+    my $LayoutObject = $Kernel::OM->Get('Kernel::Output::HTML::Layout');
+
     if ( !%Param ) {
-        $Kernel::OM->Get('Kernel::Output::HTML::Layout')->FatalError( Message => "Got no values to check." );
+        $LayoutObject->FatalError( Message => "Got no values to check." );
     }
 
     my %StopWordsServerErrors;
@@ -1882,7 +1885,7 @@ sub _StopWordsServerErrorsGet {
             next FIELD if !@{ $StopWords->{$Field} };
 
             $StopWordsServerErrors{ $Field . 'Invalid' }        = 'ServerError';
-            $StopWordsServerErrors{ $Field . 'InvalidTooltip' } = $Self->{LayoutObject}->{LanguageObject}
+            $StopWordsServerErrors{ $Field . 'InvalidTooltip' } = $LayoutObject->{LanguageObject}
                 ->Translate('Please remove the following words because they cannot be used for the search:')
                 . ' '
                 . join( ',', sort @{ $StopWords->{$Field} } );

--- a/Kernel/Output/HTML/Templates/Standard/CustomerTicketSearch.tt
+++ b/Kernel/Output/HTML/Templates/Standard/CustomerTicketSearch.tt
@@ -98,21 +98,28 @@
             </fieldset>
 [% RenderBlockEnd("Attachment") %]
 
+[% IF Config('Ticket::Service') || Config('Ticket::Type') %]
             <fieldset class="Columns">
+[% IF Config('Ticket::Service') %]
                 <div class="Column">
                     <h2><label for="ServiceIDs">[% Translate("Services") | html %]:</label></h2>
                     <div>
                         [% Data.ServicesStrg %]
                     </div>
                 </div>
+[% END %]
+[% IF Config('Ticket::Type') %]
                 <div class="Column">
                     <h2><label for="TypeIDs">[% Translate("Types") | html %]:</label></h2>
                     <div>
                         [% Data.TypesStrg %]
                     </div>
                 </div>
+[% END %]
                 <div class="Clear"></div>
             </fieldset>
+[% END %]
+
             <fieldset class="Columns">
                 <div class="Column">
                     <h2><label for="PriorityIDs">[% Translate("Priority") | html %]:</label></h2>


### PR DESCRIPTION
http://bugs.otrs.org/show_bug.cgi?id=11496

Hello @mgruner ,

Hereby is our proposal for fixing this bug. Set condition in CustomerTicketSearch.tt to check which part should be shown depending on config. There was other option to solve this with blocks, if you don't prefer this way i will revisit this bug and solve it differently

Additionally while working on it, found out that there was left $Self->{LayoutObject} in CustomerTicketSearch.pm. So corrected that as well

If you have any questions regarding this PR, please let me know.

Regards,
Sanjin