### PR TITLE
[ Rel-5_0 - Bug 8220 ] - OutOfOffice does not check if end date is before start date

### DIFF
--- a/Kernel/Modules/AdminUser.pm
+++ b/Kernel/Modules/AdminUser.pm
@@ -244,7 +244,10 @@ sub Run {
                             )
                             )
                         {
-                            $Note .= $LayoutObject->Notify( Info => $Object->Error() );
+                            $Note .= $LayoutObject->Notify(
+                                Info     => $Object->Error(),
+                                Priority => 'Error'
+                            );
                         }
                     }
                 }

--- a/Kernel/Output/HTML/Preferences/OutOfOffice.pm
+++ b/Kernel/Output/HTML/Preferences/OutOfOffice.pm
@@ -11,6 +11,8 @@ package Kernel::Output::HTML::Preferences::OutOfOffice;
 use strict;
 use warnings;
 
+use Kernel::Language qw(Translatable);
+
 our @ObjectDependencies = (
     'Kernel::Output::HTML::Layout',
     'Kernel::System::Web::Request',
@@ -146,10 +148,10 @@ sub Run {
             );
         }
 
-        $Self->{Message} = 'Preferences updated successfully!';
+        $Self->{Message} = Translatable('Preferences updated successfully!');
     }
     else {
-        $Self->{Error} = "Start date shouldn't be defined after End date!";
+        $Self->{Error} = Translatable('Please specify an end date that is after the start date.');
         return;
     }
 

--- a/Kernel/Output/HTML/Preferences/OutOfOffice.pm
+++ b/Kernel/Output/HTML/Preferences/OutOfOffice.pm
@@ -17,6 +17,7 @@ our @ObjectDependencies = (
     'Kernel::Config',
     'Kernel::System::User',
     'Kernel::System::AuthSession',
+    'Kernel::System::Time',
 );
 
 sub new {
@@ -90,48 +91,68 @@ sub Run {
     #  get needed objects
     my $UserObject    = $Kernel::OM->Get('Kernel::System::User');
     my $SessionObject = $Kernel::OM->Get('Kernel::System::AuthSession');
+    my $ParamObject   = $Kernel::OM->Get('Kernel::System::Web::Request');
+    my $TimeObject    = $Kernel::OM->Get('Kernel::System::Time');
 
     for my $Key (
         qw(OutOfOffice OutOfOfficeStartYear OutOfOfficeStartMonth OutOfOfficeStartDay OutOfOfficeEndYear OutOfOfficeEndMonth OutOfOfficeEndDay)
         )
     {
+        $Param{$Key} = $ParamObject->GetParam( Param => $Key );
+    }
 
-        $Param{$Key} = $Kernel::OM->Get('Kernel::System::Web::Request')->GetParam( Param => $Key );
+    my $OutOfOfficeStartTime = $TimeObject->TimeStamp2SystemTime(
+        String => "$Param{OutOfOfficeStartYear}-$Param{OutOfOfficeStartMonth}-$Param{OutOfOfficeStartDay} 00:00:00",
+    );
+    my $OutOfOfficeEndTime = $TimeObject->TimeStamp2SystemTime(
+        String => "$Param{OutOfOfficeEndYear}-$Param{OutOfOfficeEndMonth}-$Param{OutOfOfficeEndDay} 00:00:00",
+    );
 
-        if ( defined $Param{$Key} ) {
+    if ( $OutOfOfficeStartTime <= $OutOfOfficeEndTime ) {
+        for my $Key (
+            qw(OutOfOffice OutOfOfficeStartYear OutOfOfficeStartMonth OutOfOfficeStartDay OutOfOfficeEndYear OutOfOfficeEndMonth OutOfOfficeEndDay)
+            )
+        {
+            if ( defined $Param{$Key} ) {
 
-            # pref update db
-            if ( !$Kernel::OM->Get('Kernel::Config')->Get('DemoSystem') ) {
-                $UserObject->SetPreferences(
-                    UserID => $Param{UserData}->{UserID},
-                    Key    => $Key,
-                    Value  => $Param{$Key},
-                );
-            }
+                # pref update db
+                if ( !$Kernel::OM->Get('Kernel::Config')->Get('DemoSystem') ) {
+                    $UserObject->SetPreferences(
+                        UserID => $Param{UserData}->{UserID},
+                        Key    => $Key,
+                        Value  => $Param{$Key},
+                    );
+                }
 
-            # update SessionID
-            if ( $Param{UserData}->{UserID} eq $Self->{UserID} ) {
-                $SessionObject->UpdateSessionID(
-                    SessionID => $Self->{SessionID},
-                    Key       => $Key,
-                    Value     => $Param{$Key},
-                );
+                # update SessionID
+                if ( $Param{UserData}->{UserID} eq $Self->{UserID} ) {
+                    $SessionObject->UpdateSessionID(
+                        SessionID => $Self->{SessionID},
+                        Key       => $Key,
+                        Value     => $Param{$Key},
+                    );
+                }
             }
         }
+
+        # also update the lastname to remove out of office message
+        if ( $Param{UserData}->{UserID} eq $Self->{UserID} ) {
+            my %User = $UserObject->GetUserData( UserID => $Self->{UserID} );
+
+            $SessionObject->UpdateSessionID(
+                SessionID => $Self->{SessionID},
+                Key       => 'UserLastname',
+                Value     => $User{UserLastname},
+            );
+        }
+
+        $Self->{Message} = 'Preferences updated successfully!';
+    }
+    else {
+        $Self->{Error} = "Start date shouldn't be defined after End date!";
+        return;
     }
 
-    # also update the lastname to remove out of office message
-    if ( $Param{UserData}->{UserID} eq $Self->{UserID} ) {
-        my %User = $UserObject->GetUserData( UserID => $Self->{UserID} );
-
-        $SessionObject->UpdateSessionID(
-            SessionID => $Self->{SessionID},
-            Key       => 'UserLastname',
-            Value     => $User{UserLastname},
-        );
-    }
-
-    $Self->{Message} = 'Preferences updated successfully!';
     return 1;
 }
 

--- a/scripts/test/Selenium/Output/Preferences/Agent/OutOfOffice.t
+++ b/scripts/test/Selenium/Output/Preferences/Agent/OutOfOffice.t
@@ -18,8 +18,10 @@ my $Selenium = $Kernel::OM->Get('Kernel::System::UnitTest::Selenium');
 $Selenium->RunTest(
     sub {
 
+        # get helper object
         my $Helper = $Kernel::OM->Get('Kernel::System::UnitTest::Helper');
 
+        # create and login test user
         my $TestUserLogin = $Helper->TestUserCreate(
             Groups => ['admin'],
         ) || die "Did not get test user";
@@ -30,6 +32,7 @@ $Selenium->RunTest(
             Password => $TestUserLogin,
         );
 
+        # get script alias
         my $ScriptAlias = $Kernel::OM->Get('Kernel::Config')->Get('ScriptAlias');
 
         # go to agent preferences
@@ -38,10 +41,15 @@ $Selenium->RunTest(
         # wait until form has loaded, if neccessary
         $Selenium->WaitFor( JavaScript => 'return typeof($) === "function" && $("body").length' );
 
+        # get current time stamp
+        my $TimeStamp = $Kernel::OM->Get('Kernel::System::Time')->CurrentTimestamp();
+        my $CurrentYear = substr( $TimeStamp, 0, 4 );
+
         # change test user out of office preference
+        my $EndYear = $CurrentYear + 1;
         $Selenium->find_element( "#OutOfOfficeOn", 'css' )->click();
         $Selenium->execute_script(
-            "\$('#OutOfOfficeEndYear').val('2016').trigger('redraw.InputField').trigger('change');"
+            "\$('#OutOfOfficeEndYear').val('$EndYear').trigger('redraw.InputField').trigger('change');"
         );
         $Selenium->find_element( "#Update", 'css' )->click();
 
@@ -53,6 +61,23 @@ $Selenium->RunTest(
         $Self->True(
             index( $Selenium->get_page_source(), $UpdateMessage ) > -1,
             'Agent preference out of office time - updated'
+        );
+
+        # set start time after end time, see bug #8220
+        my $StartYear = $CurrentYear + 2;
+        $Selenium->execute_script(
+            "\$('#OutOfOfficeStartYear').val('$StartYear').trigger('redraw.InputField').trigger('change');"
+        );
+        $Selenium->find_element( "#Update", 'css' )->click();
+
+        # wait until form has loaded, if neccessary
+        $Selenium->WaitFor( JavaScript => 'return typeof($) === "function" && $("body").length' );
+
+        # check for error message on screen
+        my $ErrorMessage = "Start date shouldn't be defined after End date!";
+        $Self->True(
+            index( $Selenium->get_page_source(), $ErrorMessage ) > -1,
+            'Agent preference out of office time - not updated'
         );
     }
 );

--- a/scripts/test/Selenium/Output/Preferences/Agent/OutOfOffice.t
+++ b/scripts/test/Selenium/Output/Preferences/Agent/OutOfOffice.t
@@ -74,7 +74,7 @@ $Selenium->RunTest(
         $Selenium->WaitFor( JavaScript => 'return typeof($) === "function" && $("body").length' );
 
         # check for error message on screen
-        my $ErrorMessage = "Start date shouldn't be defined after End date!";
+        my $ErrorMessage = "Please specify an end date that is after the start date.";
         $Self->True(
             index( $Selenium->get_page_source(), $ErrorMessage ) > -1,
             'Agent preference out of office time - not updated'


### PR DESCRIPTION
http://bugs.otrs.org/show_bug.cgi?id=8220

Hello,

Hereby is fix proposal for this bug. Added error message and prevented preference update if user try to set out of office start time after end time. This check is for AdminUser and AgentPreference. Modified selenium test to check for this fix.

If there are any question regarding this PR, please let me know.

Regards,
Sanjin