### PR TITLE
[ Master - Bug 11234 ] - Attachments lost due to filename collision in ArticleStorageFS

### DIFF
--- a/Kernel/System/Console/Command/Admin/Article/StorageSwitch.pm
+++ b/Kernel/System/Console/Command/Admin/Article/StorageSwitch.pm
@@ -72,7 +72,7 @@ The <green>$Name</green> command migrates article data from one storage backend 
 
  <green>otrs.console.pl $Self->{Name} --target ArticleStorageFS</green>
 
-You can specifiy limits for the tickets migrated with <yellow>--tickets-closed-before-date</yellow> and <yellow>--tickets-closed-before-days</yellow>.
+You can specify limits for the tickets migrated with <yellow>--tickets-closed-before-date</yellow> and <yellow>--tickets-closed-before-days</yellow>.
 
 To reduce load on the database for a running system, you can use the <yellow>--micro-sleep</yellow> parameter. The command will pause for the specified amount of microseconds after each ticket.
 

--- a/Kernel/System/Ticket.pm
+++ b/Kernel/System/Ticket.pm
@@ -6888,7 +6888,7 @@ sub TicketArticleStorageSwitch {
                     %{$Attachment},
                     ArticleID => $ArticleID,
                     UserID    => $Param{UserID},
-                    Force     => 1,
+                    Force     => 0,
                 );
             }
 

--- a/scripts/test/Console/Command/Admin/Article/StorageSwitch.t
+++ b/scripts/test/Console/Command/Admin/Article/StorageSwitch.t
@@ -1,0 +1,125 @@
+# --
+# Copyright (C) 2001-2015 OTRS AG, http://otrs.com/
+# --
+# This software comes with ABSOLUTELY NO WARRANTY. For details, see
+# the enclosed file COPYING for license information (AGPL). If you
+# did not receive this file, see http://www.gnu.org/licenses/agpl.txt.
+# --
+
+use strict;
+use warnings;
+use utf8;
+
+use vars (qw($Self));
+
+# get needed objects
+my $CommandObject = $Kernel::OM->Get('Kernel::System::Console::Command::Admin::Article::StorageSwitch');
+my $TicketObject = $Kernel::OM->Get('Kernel::System::Ticket');
+
+$Kernel::OM->ObjectParamAdd(
+    'Kernel::System::UnitTest::Helper' => {
+        RestoreSystemConfiguration => 1,
+    },
+);
+my $HelperObject = $Kernel::OM->Get('Kernel::System::UnitTest::Helper');
+
+# make sure ticket is created in ArticleStorageDB
+$Kernel::OM->Get('Kernel::System::SysConfig')->ConfigItemUpdate(
+    Valid => 1,
+    Key   => 'Ticket::StorageModule',
+    Value => 'Kernel::System::Ticket::ArticleStorageDB',
+);
+
+# create isolated time environment during test
+$HelperObject->FixedTimeSet(
+    $Kernel::OM->Get('Kernel::System::Time')->TimeStamp2SystemTime( String => '2000-10-20 00:00:00' ),
+);
+
+# create test ticket with attachments
+my $TicketID = $TicketObject->TicketCreate(
+    Title        => 'Some Ticket_Title',
+    Queue        => 'Raw',
+    Lock         => 'unlock',
+    Priority     => '3 normal',
+    State        => 'closed successful',
+    CustomerNo   => '123465',
+    CustomerUser => 'customer@example.com',
+    OwnerID      => 1,
+    UserID       => 1,
+);
+$Self->True(
+    $TicketID,
+    'TicketCreate()',
+);
+
+my $ArticleID = $TicketObject->ArticleCreate(
+    TicketID       => $TicketID,
+    ArticleType    => 'note-internal',
+    SenderType     => 'agent',
+    From           => 'Some Agent <email@example.com>',
+    To             => 'Some Customer <customer-a@example.com>',
+    Subject        => 'some short description',
+    Body           => 'the message text',
+    ContentType    => 'text/plain; charset=ISO-8859-15',
+    HistoryType    => 'OwnerUpdate',
+    HistoryComment => 'Some free text!',
+    UserID         => 1,
+    Attachment => [
+            {
+                Content     => 'empty',
+                ContentType => 'text/csv',
+                Filename    => 'Test 1.txt',
+            },
+            {
+                Content     => 'empty',
+                ContentType => 'text/csv',
+                Filename    => 'Test_1.txt',
+            },
+            {
+                Content     => 'empty',
+                ContentType => 'text/csv',
+                Filename    => 'Test-1.txt',
+            },
+            {
+                Content     => 'empty',
+                ContentType => 'text/csv',
+                Filename    => 'Test_1-1.txt',
+            },
+        ],
+    NoAgentNotify  => 1,
+);
+$Self->True(
+    $ArticleID,
+    'ArticleCreate()',
+);
+
+for my $Backend (qw(FS DB)) {
+
+    # try to execute command without any options
+    my $ExitCode = $CommandObject->Execute();
+    $Self->Is(
+        $ExitCode,
+        1,
+        "$Backend No options",
+    );
+
+    # provide options
+    $ExitCode = $CommandObject->Execute( '--target', 'ArticleStorage' . $Backend, '--tickets-closed-before-date', '2000-10-21 00:00:00'  );
+    $Self->Is(
+        $ExitCode,
+        0,
+        "$Backend with option: --target ArticleStorage$Backend --tickets-closed-before-date 2000-10-21 00:00:00",
+    );
+}
+
+# delete test ticket
+$TicketObject->TicketDelete(
+    TicketID => $TicketID,
+    UserID   => 1,
+);
+$Self->True(
+    $TicketID,
+    'TicketDelete()',
+);
+
+1;


### PR DESCRIPTION
http://bugs.otrs.org/show_bug.cgi?id=11234

Hello @mgruner ,

Hereby is our bug fix proposal. As you suggested there was part that is responsible for detecting filename collision, but it was not working in console command since Force was set to 1. 
Added unit test for console command StorageSwitch. Used fixed time to create safe environment so it doesn't get in conflict with other possible tickets during testing.

If there are questions or issues regarding this PR, please let me know.

Regards,
Sanjin