### PR TITLE
[ Master - Bug 11132 ] - Loss of attached files with long Cyrillic names

### DIFF
--- a/Kernel/System/Main.pm
+++ b/Kernel/System/Main.pm
@@ -263,6 +263,15 @@ sub FilenameCleanUp {
 
         # replace invalid token like [ ] * : ? " < > ; | \ /
         $Param{Filename} =~ s/[<>\?":\\\*\|\/;\[\]]/_/g;
+
+        # cut the string if too long
+        if ( length( $Param{Filename} ) > 100 ) {
+            my $Ext = '';
+            if ( $Param{Filename} =~ /^.*(\.(..|...|....))$/ ) {
+                $Ext = $1;
+            }
+            $Param{Filename} = substr( $Param{Filename}, 0, 80 ) . $Ext;
+        }
     }
 
     return $Param{Filename};

--- a/Kernel/System/Main.pm
+++ b/Kernel/System/Main.pm
@@ -270,7 +270,7 @@ sub FilenameCleanUp {
             if ( $Param{Filename} =~ /^.*(\.(..|...|....))$/ ) {
                 $Ext = $1;
             }
-            $Param{Filename} = substr( $Param{Filename}, 0, 80 ) . $Ext;
+            $Param{Filename} = substr( $Param{Filename}, 0, 70 ) . $Ext;
         }
     }
 

--- a/scripts/test/Ticket/ArticleStorageNameLenght.t
+++ b/scripts/test/Ticket/ArticleStorageNameLenght.t
@@ -64,10 +64,10 @@ my @Tests = (
         FileName    => 'abcdefghjkabcdefghjk',
     },
 
-    # attachment with 60 character long Latin FileName
+    # attachment with 75 character long Latin FileName
     {
-        Description => 'Latin 60 characters',
-        FileName    => 'abcdefghjkabcdefghjkabcdefghjkabcdefghjkabcdefghjkabcdefghjk',
+        Description => 'Latin 75 characters',
+        FileName    => 'abcdefghjkabcdefghjkabcdefghjkabcdefghjkabcdefghjkabcdefghjkabcdefghjkabcde',
     },
 
     # attachment with 120 character long Latin FileName
@@ -91,14 +91,14 @@ my @Tests = (
         FileName    => 'шђпчћжђшпчшђпчћжђшпч',
     },
 
-    # attachment with 60 character long Cyrillic FileName
+    # attachment with 75 character long Cyrillic FileName
     {
-        Description => 'Cyrillic 60 characters',
+        Description => 'Cyrillic 75 characters',
         FileName =>
-            'шђпчћжђшпчшђпчћжђшпчшђпчћжђшпчшђпчћжђшпчшђпчћжђшпчшђпчћжђшпч',
+            'шђпчћжђшпчшђпчћжђшпчшђпчћжђшпчшђпчћжђшпчшђпчћжђшпчшђпчћжђшпчшђпчћжђшпчшђпчћ',
     },
 
-# attachment with 120 character long Cyrillic FileName, approximately limit for Linux file name reaching 255 bytes after encoding Cyrillic letters
+    # attachment with 120 character long Cyrillic FileName, approximately limit for Linux file name reaching 255 bytes after encoding Cyrillic letters
     {
         Description => 'Cyrillic 120 characters',
         FileName =>
@@ -119,7 +119,7 @@ my @Tests = (
         FileName    => '人だけの会員制転職サ人だけの会員制転職サ',
     },
 
-# attachment with 75 character long Japanese FileName, approximately limit for Linux file name reaching 255 bytes after encoding Japanese letters
+    # attachment with 75 character long Japanese FileName, approximately limit for Linux file name reaching 255 bytes after encoding Japanese letters
     {
         Description => 'Japanese 75 characters',
         FileName =>

--- a/scripts/test/Ticket/ArticleStorageNameLenght.t
+++ b/scripts/test/Ticket/ArticleStorageNameLenght.t
@@ -1,0 +1,268 @@
+# --
+# Copyright (C) 2001-2015 OTRS AG, http://otrs.com/
+# --
+# This software comes with ABSOLUTELY NO WARRANTY. For details, see
+# the enclosed file COPYING for license information (AGPL). If you
+# did not receive this file, see http://www.gnu.org/licenses/agpl.txt.
+# --
+
+use strict;
+use warnings;
+use utf8;
+
+use vars (qw($Self));
+
+use Unicode::Normalize;
+
+# get needed objects
+my $ConfigObject = $Kernel::OM->Get('Kernel::Config');
+my $MainObject   = $Kernel::OM->Get('Kernel::System::Main');
+my $TicketObject = $Kernel::OM->Get('Kernel::System::Ticket');
+
+my $TicketID = $TicketObject->TicketCreate(
+    Title        => 'Some Ticket_Title',
+    Queue        => 'Raw',
+    Lock         => 'unlock',
+    Priority     => '3 normal',
+    State        => 'closed successful',
+    CustomerNo   => '123465',
+    CustomerUser => 'customer@example.com',
+    OwnerID      => 1,
+    UserID       => 1,
+);
+$Self->True(
+    $TicketID,
+    'TicketCreate()',
+);
+
+my $ArticleID = $TicketObject->ArticleCreate(
+    TicketID       => $TicketID,
+    ArticleType    => 'note-internal',
+    SenderType     => 'agent',
+    From           => 'Some Agent <email@example.com>',
+    To             => 'Some Customer <customer-a@example.com>',
+    Subject        => 'some short description',
+    Body           => 'the message text',
+    ContentType    => 'text/plain; charset=ISO-8859-15',
+    HistoryType    => 'OwnerUpdate',
+    HistoryComment => 'Some free text!',
+    UserID         => 1,
+    NoAgentNotify  => 1,                                          # if you don't want to send agent notifications
+);
+
+$Self->True(
+    $ArticleID,
+    'ArticleCreate()',
+);
+
+my @Tests = (
+
+    # Latin characters, 1 byte per character when encoding
+    # attachment with 20 character long Latin name,
+    {
+        Description => 'Latin 20 characters',
+        FileName    => 'abcdefghjkabcdefghjk',
+    },
+
+    # attachment with 60 character long Latin FileName
+    {
+        Description => 'Latin 60 characters',
+        FileName    => 'abcdefghjkabcdefghjkabcdefghjkabcdefghjkabcdefghjkabcdefghjk',
+    },
+
+    # attachment with 120 character long Latin FileName
+    {
+        Description => 'Latin 120 characters',
+        FileName =>
+            'abcdefghjkabcdefghjkabcdefghjkabcdefghjkabcdefghjkabcdefghjkabcdefghjkabcdefghjkabcdefghjkabcdefghjkabcdefghjkabcdefghjk',
+    },
+
+    # attachment with 140 character long Latin FileName
+    {
+        Description => 'Latin 140 characters',
+        FileName =>
+            'abcdefghjkabcdefghjkabcdefghjkabcdefghjkabcdefghjkabcdefghjkabcdefghjkabcdefghjkabcdefghjkabcdefghjkabcdefghjkabcdefghjkabcdefghjkabcdefghjk',
+    },
+
+    # Cyrillic character, 2 byte per character when encoding
+    # attachment with 20 character long Cyrillic name,
+    {
+        Description => 'Cyrillic 20 characters',
+        FileName    => 'шђпчћжђшпчшђпчћжђшпч',
+    },
+
+    # attachment with 60 character long Cyrillic FileName
+    {
+        Description => 'Cyrillic 60 characters',
+        FileName =>
+            'шђпчћжђшпчшђпчћжђшпчшђпчћжђшпчшђпчћжђшпчшђпчћжђшпчшђпчћжђшпч',
+    },
+
+# attachment with 120 character long Cyrillic FileName, approximately limit for Linux file name reaching 255 bytes after encoding Cyrillic letters
+    {
+        Description => 'Cyrillic 120 characters',
+        FileName =>
+            'шђпчћжђшпчшђпчћжђшпчшђпчћжђшпчшђпчћжђшпчшђпчћжђшпчшђпчћжђшпчшђпчћжђшпчшђпчћжђшпчшђпчћжђшпчшђпчћжђшпчшђпчћжђшпчшђпчћжђшпч',
+    },
+
+    # attachment with 140 character long Cyrillic FileName, have to cut name to create attachment file in FS backend
+    {
+        Description => 'Cyrillic 140 characters',
+        FileName =>
+            'шђпчћжђшпчшђпчћжђшпчшђпчћжђшпчшђпчћжђшпчшђпчћжђшпчшђпчћжђшпчшђпчћжђшпчшђпчћжђшпчшђпчћжђшпчшђпчћжђшпчшђпчћжђшпчшђпчћжђшпчшђпчћжђшпчшђпчћжђшпч',
+    },
+
+    # Japanese charcters, 3 byte per character when encoding
+    # attachment with 20 character long Japanese name,
+    {
+        Description => 'Japanese 20 characters',
+        FileName    => '人だけの会員制転職サ人だけの会員制転職サ',
+    },
+
+# attachment with 75 character long Japanese FileName, approximately limit for Linux file name reaching 255 bytes after encoding Japanese letters
+    {
+        Description => 'Japanese 75 characters',
+        FileName =>
+            '人だけの会員制転職サ人だけの会員制転職サ人だけの会員制転職サ人だけの会員制転職サ人だけの会員制転職サ人だけの会員制転職サ人だけの会員制転職サ人だけの会',
+    },
+
+    # attachment with 120 character long Japanese FileName, have to cut name to create attachment file in FS backend
+    {
+        Description => 'Japanese 120 characters',
+        FileName =>
+            '人だけの会員制転職サ人だけの会員制転職サ人だけの会員制転職サ人だけの会員制転職サ人だけの会員制転職サ人だけの会員制転職サ人だけの会員制転職サ人だけの会員制転職サ人だけの会員制転職サ人だけの会員制転職サ人だけの会員制転職サ人だけの会員制転職サ',
+    },
+
+    # attachment with 140 character long Japanese FileName, have to cut name to create attachment file in FS backend
+    {
+        Description => 'Japanese 140 characters',
+        FileName =>
+            '人だけの会員制転職サ人だけの会員制転職サ人だけの会員制転職サ人だけの会員制転職サ人だけの会員制転職サ人だけの会員制転職サ人だけの会員制転職サ人だけの会員制転職サ人だけの会員制転職サ人だけの会員制転職サ',
+    },
+);
+
+for my $Test (@Tests) {
+
+    # article attachment checks
+    for my $Backend (qw(DB FS)) {
+
+        # make sure that the TicketObject gets recreated for each loop.
+        $Kernel::OM->ObjectsDiscard( Objects => ['Kernel::System::Ticket'] );
+
+        $ConfigObject->Set(
+            Key   => 'Ticket::StorageModule',
+            Value => 'Kernel::System::Ticket::ArticleStorage' . $Backend,
+        );
+
+        my $TicketObject = $Kernel::OM->Get('Kernel::System::Ticket');
+
+        $Self->True(
+            $TicketObject->isa( 'Kernel::System::Ticket::ArticleStorage' . $Backend ),
+            "TicketObject loaded the correct backend",
+        );
+
+        my $Ext                    = '.txt';
+        my $FileName               = $Test->{FileName} . $Ext;
+        my $Content                = '123';
+        my $MD5Orig                = $MainObject->MD5sum( String => $Content );
+        my $ArticleWriteAttachment = $TicketObject->ArticleWriteAttachment(
+            Content     => $Content,
+            Filename    => $FileName,
+            ContentType => 'text/html',
+            ArticleID   => $ArticleID,
+            UserID      => 1,
+        );
+        $Self->True(
+            $ArticleWriteAttachment,
+            "$Backend ArticleWriteAttachment() - $Test->{Description} - Original name $FileName",
+        );
+
+        my %AttachmentIndex = $TicketObject->ArticleAttachmentIndex(
+            ArticleID => $ArticleID,
+            UserID    => 1,
+        );
+
+        # get target file name
+        my $TargetFileName;
+        if ( $Backend eq 'DB' ) {
+            $TargetFileName = $FileName,
+        }
+        else {
+            $TargetFileName = $MainObject->FilenameCleanUp(
+                Filename => $FileName,
+                Type     => 'Local',
+            );
+        }
+
+        # Mac OS (HFS+) will store all filenames as NFD internally.
+        if ( $^O eq 'darwin' && $Backend eq 'FS' ) {
+            $TargetFileName = Unicode::Normalize::NFD($TargetFileName);
+        }
+
+        $Self->Is(
+            $AttachmentIndex{1}->{Filename},
+            $TargetFileName,
+            "$Backend ArticleAttachmentIndex() Attachment name $Test->{Description}"
+        );
+
+        my %Data = $TicketObject->ArticleAttachment(
+            ArticleID => $ArticleID,
+            FileID    => 1,
+            UserID    => 1,
+        );
+        $Self->True(
+            $Data{Content},
+            "$Backend ArticleAttachment() Content - Attachment name $Test->{Description}",
+        );
+        $Self->True(
+            $Data{ContentType},
+            "$Backend ArticleAttachment() ContentType - Attachment name $Test->{Description}",
+        );
+        $Self->True(
+            $Data{Content} eq $Content,
+            "$Backend ArticleWriteAttachment() / ArticleAttachment() Content - Attachment name $Test->{Description}",
+        );
+        $Self->True(
+            $Data{ContentType} eq 'text/html',
+            "$Backend ArticleWriteAttachment() / ArticleAttachment() ContentType - Attachment name $Test->{Description}",
+        );
+        my $MD5New = $MainObject->MD5sum( String => $Data{Content} );
+        $Self->Is(
+            $MD5Orig || '1',
+            $MD5New  || '2',
+            "$Backend MD5 - Attachment name $Test->{Description}",
+        );
+        my $Delete = $TicketObject->ArticleDeleteAttachment(
+            ArticleID => $ArticleID,
+            UserID    => 1,
+        );
+        $Self->True(
+            $Delete,
+            "$Backend ArticleDeleteAttachment() - Attachment name $Test->{Description}",
+        );
+
+        %AttachmentIndex = $TicketObject->ArticleAttachmentIndex(
+            ArticleID => $ArticleID,
+            UserID    => 1,
+        );
+
+        $Self->IsDeeply(
+            \%AttachmentIndex,
+            {},
+            "$Backend ArticleAttachmentIndex() after delete - Attachment name $Test->{Description}"
+        );
+    }
+}
+
+# the ticket is no longer needed
+$TicketObject->TicketDelete(
+    TicketID => $TicketID,
+    UserID   => 1,
+);
+
+$Self->True(
+    $TicketObject,
+    'TicketDelete()',
+);
+
+1;

--- a/scripts/test/Ticket/ArticleStorageNameLenght.t
+++ b/scripts/test/Ticket/ArticleStorageNameLenght.t
@@ -1,5 +1,5 @@
 # --
-# Copyright (C) 2001-2015 OTRS AG, http://otrs.com/
+# Copyright (C) 2001-2016 OTRS AG, http://otrs.com/
 # --
 # This software comes with ABSOLUTELY NO WARRANTY. For details, see
 # the enclosed file COPYING for license information (AGPL). If you
@@ -47,7 +47,7 @@ my $ArticleID = $TicketObject->ArticleCreate(
     HistoryType    => 'OwnerUpdate',
     HistoryComment => 'Some free text!',
     UserID         => 1,
-    NoAgentNotify  => 1,                                          # if you don't want to send agent notifications
+    NoAgentNotify  => 1,
 );
 
 $Self->True(
@@ -98,7 +98,7 @@ my @Tests = (
             'шђпчћжђшпчшђпчћжђшпчшђпчћжђшпчшђпчћжђшпчшђпчћжђшпчшђпчћжђшпчшђпчћжђшпчшђпчћ',
     },
 
-    # attachment with 120 character long Cyrillic FileName, approximately limit for Linux file name reaching 255 bytes after encoding Cyrillic letters
+# attachment with 120 character long Cyrillic FileName, approximately limit for Linux file name reaching 255 bytes after encoding Cyrillic letters
     {
         Description => 'Cyrillic 120 characters',
         FileName =>
@@ -113,17 +113,20 @@ my @Tests = (
     },
 
     # Japanese charcters, 3 byte per character when encoding
+    # there are issues with some distributions when encoding 3 byte characters, conduct OS check for these tests
     # attachment with 20 character long Japanese name,
     {
         Description => 'Japanese 20 characters',
         FileName    => '人だけの会員制転職サ人だけの会員制転職サ',
+        OSCheck     => 1,
     },
 
-    # attachment with 75 character long Japanese FileName, approximately limit for Linux file name reaching 255 bytes after encoding Japanese letters
+# attachment with 75 character long Japanese FileName, approximately limit for Linux file name reaching 255 bytes after encoding Japanese letters
     {
         Description => 'Japanese 75 characters',
         FileName =>
             '人だけの会員制転職サ人だけの会員制転職サ人だけの会員制転職サ人だけの会員制転職サ人だけの会員制転職サ人だけの会員制転職サ人だけの会員制転職サ人だけの会',
+        OSCheck => 1,
     },
 
     # attachment with 120 character long Japanese FileName, have to cut name to create attachment file in FS backend
@@ -131,20 +134,29 @@ my @Tests = (
         Description => 'Japanese 120 characters',
         FileName =>
             '人だけの会員制転職サ人だけの会員制転職サ人だけの会員制転職サ人だけの会員制転職サ人だけの会員制転職サ人だけの会員制転職サ人だけの会員制転職サ人だけの会員制転職サ人だけの会員制転職サ人だけの会員制転職サ人だけの会員制転職サ人だけの会員制転職サ',
+        OSCheck => 1,
     },
 
     # attachment with 140 character long Japanese FileName, have to cut name to create attachment file in FS backend
     {
         Description => 'Japanese 140 characters',
         FileName =>
-            '人だけの会員制転職サ人だけの会員制転職サ人だけの会員制転職サ人だけの会員制転職サ人だけの会員制転職サ人だけの会員制転職サ人だけの会員制転職サ人だけの会員制転職サ人だけの会員制転職サ人だけの会員制転職サ',
+            '人だけの会員制転職サ人だけの会員制転職サ人だけの会員制転職サ人だけの会員制転職サ人だけの会員制転職サ人だけの会員制転職サ人だけの会員制転職サ人だけの会員制転職サ人だけの会員制転職サ人だけの会員制転職サ人だけの会員制転職サ人だけの会員制転職サ人だけの会員制転職サ人だけの会員制転職サ',
+        OSCheck => 1,
     },
 );
 
+TEST:
 for my $Test (@Tests) {
 
     # article attachment checks
     for my $Backend (qw(DB FS)) {
+
+        # check if distribution is Fedora and skip tests cases for 3 byte characters
+        if ( $Test->{OSCheck} ) {
+            my %OSInfo = $Kernel::OM->Get('Kernel::System::Environment')->OSInfoGet();
+            next TEST if $OSInfo{Distribution} eq 'fedora';
+        }
 
         # make sure that the TicketObject gets recreated for each loop.
         $Kernel::OM->ObjectsDiscard( Objects => ['Kernel::System::Ticket'] );

--- a/scripts/test/Ticket/ArticleStorageNameLenght.t
+++ b/scripts/test/Ticket/ArticleStorageNameLenght.t
@@ -19,6 +19,14 @@ my $ConfigObject = $Kernel::OM->Get('Kernel::Config');
 my $MainObject   = $Kernel::OM->Get('Kernel::System::Main');
 my $TicketObject = $Kernel::OM->Get('Kernel::System::Ticket');
 
+# get helper object
+$Kernel::OM->ObjectParamAdd(
+    'Kernel::System::UnitTest::Helper' => {
+        RestoreDatabase => 1,
+        }
+);
+my $Helper = $Kernel::OM->Get('Kernel::System::UnitTest::Helper');
+
 my $TicketID = $TicketObject->TicketCreate(
     Title        => 'Some Ticket_Title',
     Queue        => 'Raw',
@@ -112,38 +120,6 @@ my @Tests = (
             'шђпчћжђшпчшђпчћжђшпчшђпчћжђшпчшђпчћжђшпчшђпчћжђшпчшђпчћжђшпчшђпчћжђшпчшђпчћжђшпчшђпчћжђшпчшђпчћжђшпчшђпчћжђшпчшђпчћжђшпчшђпчћжђшпчшђпчћжђшпч',
     },
 
-    # Japanese charcters, 3 byte per character when encoding
-    # there are issues with some distributions when encoding 3 byte characters, conduct OS check for these tests
-    # attachment with 20 character long Japanese name,
-    {
-        Description => 'Japanese 20 characters',
-        FileName    => '人だけの会員制転職サ人だけの会員制転職サ',
-        OSCheck     => 1,
-    },
-
-# attachment with 75 character long Japanese FileName, approximately limit for Linux file name reaching 255 bytes after encoding Japanese letters
-    {
-        Description => 'Japanese 75 characters',
-        FileName =>
-            '人だけの会員制転職サ人だけの会員制転職サ人だけの会員制転職サ人だけの会員制転職サ人だけの会員制転職サ人だけの会員制転職サ人だけの会員制転職サ人だけの会',
-        OSCheck => 1,
-    },
-
-    # attachment with 120 character long Japanese FileName, have to cut name to create attachment file in FS backend
-    {
-        Description => 'Japanese 120 characters',
-        FileName =>
-            '人だけの会員制転職サ人だけの会員制転職サ人だけの会員制転職サ人だけの会員制転職サ人だけの会員制転職サ人だけの会員制転職サ人だけの会員制転職サ人だけの会員制転職サ人だけの会員制転職サ人だけの会員制転職サ人だけの会員制転職サ人だけの会員制転職サ',
-        OSCheck => 1,
-    },
-
-    # attachment with 140 character long Japanese FileName, have to cut name to create attachment file in FS backend
-    {
-        Description => 'Japanese 140 characters',
-        FileName =>
-            '人だけの会員制転職サ人だけの会員制転職サ人だけの会員制転職サ人だけの会員制転職サ人だけの会員制転職サ人だけの会員制転職サ人だけの会員制転職サ人だけの会員制転職サ人だけの会員制転職サ人だけの会員制転職サ人だけの会員制転職サ人だけの会員制転職サ人だけの会員制転職サ人だけの会員制転職サ',
-        OSCheck => 1,
-    },
 );
 
 TEST:
@@ -266,15 +242,6 @@ for my $Test (@Tests) {
     }
 }
 
-# the ticket is no longer needed
-$TicketObject->TicketDelete(
-    TicketID => $TicketID,
-    UserID   => 1,
-);
-
-$Self->True(
-    $TicketObject,
-    'TicketDelete()',
-);
+# cleanup is done by RestoreDatabase.
 
 1;


### PR DESCRIPTION
http://bugs.otrs.org/show_bug.cgi?id=11132

Hello @mgruner ,

Hereby is proposal for fixing bug #11132. Would like to elaborate on my research first. 

There is an issue with long Cyrillic attachment names (around, give or take, 99 characters) when using ArticleStorageFS. Linux limit for file names is 255 bytes. Cyrillic letter takes 2 bytes to encode. Having only file name of 99 chars in Cyrillic is fine, but when using ArticleStorageFS, files that are wrote by it goes over 255 bytes and Linux can't create them. E.g. $Filename.content-type , $Filename.content_alternative , ect. So the end result is that some files are created and some weren't. It gives false result in AgentTicketZoom, showing attachment but essentially without content.

With fix all attachment with name more then 100 character, are parsed to 80 chars. Now even with Cyrillic or some other characters that take 2 bytes and some different characters that takes 3 bytes to encode ArticleStorageFS will work.

Additionally while working on this bug, found out that attachment that have 2 characters extension were not working when parsed out, so added that as well.

If there are any question, issues regarding this PR or you want me to give more details around this problem please let me know.

Regards,
Sanjin
