### PR TITLE
Fix mouse scrolling issues with new positioning scheme (Input Fields)

### DIFF
--- a/var/httpd/htdocs/js/Core.UI.InputFields.js
+++ b/var/httpd/htdocs/js/Core.UI.InputFields.js
@@ -1209,9 +1209,9 @@ Core.UI.InputFields = (function (TargetNS) {
                         // This checks, if an inner element is scrolled (e.g. dialog)
                         // we only need to hide the list in this case, because scrolling the main window
                         // will hide the dropdown list anyway from viewport
-                        if (Event.srcElement !== document) {
+                        if (Event.target !== document && !$(Event.target).hasClass('InputField_TreeContainer')) {
                             if (
-                                $InputContainerObj.position().top + $InputContainerObj.outerHeight() - $(Event.srcElement).outerHeight()
+                                $InputContainerObj.position().top + $InputContainerObj.outerHeight() - $(Event.target).outerHeight()
                                 >= 0
                             )
                             {


### PR DESCRIPTION
The reason why issues were popping up only in FF is because `Event.srcElement` property was Chrome-only and not defined in FF. I substituted it for `Event.target`, and also introduced additional check if drop down list is scrolled.