### PR TITLE
[Rel-5_0 10117 ] - Filter in queue view for customer userID shows only customers from given backend

### DIFF
--- a/Kernel/Config/Files/Ticket.xml
+++ b/Kernel/Config/Files/Ticket.xml
@@ -9315,6 +9315,17 @@
             </Option>
         </Setting>
     </ConfigItem>
+    <ConfigItem Name="Ticket::IncludeUnknownTicketCustomers" Required="1" Valid="1">
+        <Description Translatable="1">Include unknown customers in ticket filter.</Description>
+        <Group>Ticket</Group>
+        <SubGroup>Core::Ticket</SubGroup>
+        <Setting>
+            <Option SelectedID="0">
+                <Item Key="1" Translatable="1">Yes</Item>
+                <Item Key="0" Translatable="1">No</Item>
+            </Option>
+        </Setting>
+    </ConfigItem>
     <ConfigItem Name="Events###Ticket" Required="1" Valid="1">
         <Description Translatable="1">List of all ticket events to be displayed in the GUI.</Description>
         <Group>Ticket</Group>

--- a/Kernel/Config/Files/Ticket.xml
+++ b/Kernel/Config/Files/Ticket.xml
@@ -9309,7 +9309,7 @@
         <Group>Ticket</Group>
         <SubGroup>Core::Ticket</SubGroup>
         <Setting>
-            <Option SelectedID="0">
+            <Option SelectedID="1">
                 <Item Key="1" Translatable="1">Yes</Item>
                 <Item Key="0" Translatable="1">No</Item>
             </Option>

--- a/Kernel/Output/HTML/Templates/Standard/FooterJS.tt
+++ b/Kernel/Output/HTML/Templates/Standard/FooterJS.tt
@@ -42,6 +42,7 @@ Core.App.Ready(function () {
         MenuDragDropEnabled: parseInt('[% Config("Frontend::MenuDragDropEnabled") %]', 10),
         OpenMainMenuOnHover: parseInt('[% Config("OpenMainMenuOnHover") %]', 10),
         CustomerInfoSet: parseInt('[% Config("Ticket::Frontend::CustomerInfoCompose") %]', 10),
+        IncludeUnknownTicketCustomers: parseInt('[% Config("Ticket::IncludeUnknownTicketCustomers") %]', 10),
 [% RenderBlockStart("AutoCompleteConfig") %]
         Autocomplete: [% Data.AutocompleteConfig %],
 [% RenderBlockEnd("AutoCompleteConfig") %]

--- a/scripts/test/Selenium/Agent/AgentTicketCompose.t
+++ b/scripts/test/Selenium/Agent/AgentTicketCompose.t
@@ -62,6 +62,13 @@ $Selenium->RunTest(
             Value => 0
         );
 
+        # use test email backend
+        $SysConfigObject->ConfigItemUpdate(
+            Valid => 1,
+            Key   => 'SendmailModule',
+            Value => 'Kernel::System::Email::Test',
+        );
+
         # get standard template object
         my $StandardTemplateObject = $Kernel::OM->Get('Kernel::System::StandardTemplate');
 
@@ -138,11 +145,11 @@ $Selenium->RunTest(
             Lock     => 'unlock',
         );
         my $TicketID = $TicketObject->TicketCreate(
-            Title    => 'Selenium ticket',
-            QueueID  => 1,
-            Lock     => $TicketData{Lock},
-            Priority => $TicketData{Priority},
-            State    => $TicketData{State},
+            Title        => 'Selenium ticket',
+            QueueID      => 1,
+            Lock         => $TicketData{Lock},
+            Priority     => $TicketData{Priority},
+            State        => $TicketData{State},
             CustomerID   => 'SeleniumCustomer',
             CustomerUser => $TestCustomer,
             OwnerID      => 1,
@@ -213,9 +220,13 @@ $Selenium->RunTest(
 
         # test bug #11810 - http://bugs.otrs.org/show_bug.cgi?id=11810
         # translate ticket data tags (e.g. <OTRS_TICKET_State> ) in standard template
-        my $LanguageObject = Kernel::Language->new(
-            UserLanguage => $Language,
+        $Kernel::OM->ObjectParamAdd(
+            'Kernel::Language' => {
+                UserLanguage => $Language,
+            },
         );
+        my $LanguageObject = $Kernel::OM->Get('Kernel::Language');
+
         for my $Item ( sort keys %TicketData ) {
             my $TransletedStateValue = $LanguageObject->Translate( $TicketData{$Item} );
 

--- a/scripts/test/Selenium/Agent/AgentTicketCompose.t
+++ b/scripts/test/Selenium/Agent/AgentTicketCompose.t
@@ -12,8 +12,6 @@ use utf8;
 
 use vars (qw($Self));
 
-use Kernel::Language;
-
 # get selenium object
 my $Selenium = $Kernel::OM->Get('Kernel::System::UnitTest::Selenium');
 

--- a/scripts/test/Selenium/Output/Dashboard/TicketGenericFilter.t
+++ b/scripts/test/Selenium/Output/Dashboard/TicketGenericFilter.t
@@ -1,5 +1,5 @@
 # --
-# Copyright (C) 2001-2015 OTRS AG, http://otrs.com/
+# Copyright (C) 2001-2016 OTRS AG, http://otrs.com/
 # --
 # This software comes with ABSOLUTELY NO WARRANTY. For details, see
 # the enclosed file COPYING for license information (AGPL). If you
@@ -75,8 +75,6 @@ $Selenium->RunTest(
             };
         }
 
-        $Kernel::OM->Get('Kernel::System::Log')->Dumper( 'Debug - @Tickets', \@Tickets );
-
         # login test user
         $Selenium->Login(
             Type     => 'Agent',
@@ -100,7 +98,10 @@ $Selenium->RunTest(
         # find 'CustomerUserID' for TicketNew dashboard SysConfig and set it as default column
         $Selenium->find_element(
             "//input[\@name='DashboardBackend###0120-TicketNew##SubHash##DefaultColumnsKey[]'][\@title='CustomerUserID']"
-        )->send_keys( "\N{U+E004}", '2' );
+        )->send_keys("\N{U+E004}");
+        my $ActiveElement = $Selenium->get_active_element();
+        $ActiveElement->clear();
+        $ActiveElement->send_keys('2');
 
         # submit SysConfig
         $Selenium->find_element("//button[\@class='CallForAction'][\@value='Update']")->VerifiedClick();

--- a/scripts/test/Selenium/Output/Dashboard/TicketGenericFilter.t
+++ b/scripts/test/Selenium/Output/Dashboard/TicketGenericFilter.t
@@ -1,0 +1,125 @@
+# --
+# Copyright (C) 2001-2015 OTRS AG, http://otrs.com/
+# --
+# This software comes with ABSOLUTELY NO WARRANTY. For details, see
+# the enclosed file COPYING for license information (AGPL). If you
+# did not receive this file, see http://www.gnu.org/licenses/agpl.txt.
+# --
+
+use strict;
+use warnings;
+use utf8;
+
+use vars (qw($Self));
+
+# get selenium object
+my $Selenium = $Kernel::OM->Get('Kernel::System::UnitTest::Selenium');
+
+$Selenium->RunTest(
+    sub {
+
+        # get needed objects
+        $Kernel::OM->ObjectParamAdd(
+            'Kernel::System::UnitTest::Helper' => {
+                RestoreSystemConfiguration => 1,
+            },
+        );
+        my $Helper       = $Kernel::OM->Get('Kernel::System::UnitTest::Helper');
+        my $TicketObject = $Kernel::OM->Get('Kernel::System::Ticket');
+
+        # create test user
+        my $TestUserLogin = $Helper->TestUserCreate(
+            Groups => [ 'admin', 'users' ],
+        ) || die "Did not get test user";
+
+        # get test user ID
+        my $TestUserID = $Kernel::OM->Get('Kernel::System::User')->UserLookup(
+            UserLogin => $TestUserLogin,
+        );
+
+        # create test ticket
+        my $CustomerUserID = $Helper->GetRandomID() . '@localhost.com';
+        my $TicketNumber   = $TicketObject->TicketCreateNumber();
+        my $TicketID       = $TicketObject->TicketCreate(
+            TN           => $TicketNumber,
+            Title        => 'Selenium Test Ticket',
+            Queue        => 'Raw',
+            Lock         => 'unlock',
+            Priority     => '3 normal',
+            State        => 'new',
+            CustomerID   => '12345',
+            CustomerUser => $CustomerUserID,
+            OwnerID      => $TestUserID,
+            UserID       => $TestUserID,
+        );
+        $Self->True(
+            $TicketID,
+            "Ticket ID $TicketID - created"
+        );
+
+        # login test user
+        $Selenium->Login(
+            Type     => 'Agent',
+            User     => $TestUserLogin,
+            Password => $TestUserLogin,
+        );
+
+        # get script alias
+        my $ScriptAlias = $Kernel::OM->Get('Kernel::Config')->Get('ScriptAlias');
+
+        # navigate to SysConfig screen
+        $Selenium->get("${ScriptAlias}index.pl?Action=AdminSysConfig");
+
+        # search for 0120-TicketNew SysConfig
+        $Selenium->find_element("//input[\@id='SysConfigSearch'][\@title='Search']")->send_keys('0120-TicketNew');
+        $Selenium->find_element("//button[\@value='Search'][\@type='submit']")->click();
+
+        # click on found SysConfig
+        $Selenium->find_element("//a[contains(\@href, \'Action=AdminSysConfig;Subaction=Edit' )]")->click();
+
+        # find CustomerUserID for TicketNew dashboard SysConfig and set it as default column
+        $Selenium->find_element(
+            "//input[\@name='DashboardBackend###0120-TicketNew##SubHash##DefaultColumnsKey[]'][\@title='CustomerUserID']"
+        )->send_keys( "\N{U+E004}", '2' );
+
+        # submit SysConfig
+        $Selenium->find_element("//button[\@class='CallForAction'][\@value='Update']")->click();
+
+        # navigate to dashboard screen
+        $Selenium->get("${ScriptAlias}index.pl?");
+
+        # click on column setting filter for CustomerUserID in TicketNew generic dashboard overview
+        $Selenium->find_element("//a[contains(\@title, \'CustomerUserID\' )]")->click();
+
+        # select test CustomerUserID as filter for TicketNew generic dashboard overview
+        my $ParentElement = $Selenium->find_element( "div.ColumnSettingsBox", 'css' );
+        $Selenium->find_child_element( $ParentElement, "./input" )->send_keys($CustomerUserID);
+        $Selenium->execute_script(
+            "\$('#ColumnFilterCustomerUserID0120-TicketNew').val('$CustomerUserID').trigger('redraw.InputField').trigger('change');"
+        );
+
+        # verify we found test ticket by filtering with customer that is not in DB, see bug #10117
+        $Self->True(
+            index( $Selenium->get_page_source(), $TicketNumber ) > -1,
+            "Test ticket ID $TicketID with TN $TicketNumber - found on screen after filtering with unknown customer",
+        );
+
+        # delete test ticket
+        my $Success = $TicketObject->TicketDelete(
+            TicketID => $TicketID,
+            UserID   => 1,
+        );
+        $Self->True(
+            $Success,
+            "Ticket ID $TicketID - deleted"
+        );
+
+        # make sure cache is correct
+        $Kernel::OM->Get('Kernel::System::Cache')->CleanUp(
+            Type => 'Ticket',
+        );
+
+    }
+);
+
+1;

--- a/scripts/test/Selenium/Output/Dashboard/TicketGenericFilter.t
+++ b/scripts/test/Selenium/Output/Dashboard/TicketGenericFilter.t
@@ -137,8 +137,8 @@ $Selenium->RunTest(
             # wait for auto-complete action
             $Selenium->WaitFor(
                 JavaScript =>
-                    'return typeof($) === "function" && $("a[href*=\'TicketID='
-                    . $Tickets[0]->{TicketID}
+                    'return typeof($) === "function" && !$("a[href*=\'TicketID='
+                    . $Tickets[1]->{TicketID}
                     . '\']").length'
             );
 
@@ -167,8 +167,8 @@ $Selenium->RunTest(
             # wait for auto-complete action
             $Selenium->WaitFor(
                 JavaScript =>
-                    'return typeof($) === "function" && $("a[href*=\'TicketID='
-                    . $Tickets[1]->{TicketID}
+                    'return typeof($) === "function" && !$("a[href*=\'TicketID='
+                    . $Tickets[0]->{TicketID}
                     . '\']").length'
             );
 

--- a/var/httpd/htdocs/js/Core.Agent.Dashboard.js
+++ b/var/httpd/htdocs/js/Core.Agent.Dashboard.js
@@ -30,8 +30,8 @@ Core.Agent.Dashboard = (function (TargetNS) {
      */
     TargetNS.InitCustomerIDAutocomplete = function ($Input) {
         $Input.autocomplete({
-            minLength: Core.Config.Get('CustomerAutocomplete.MinQueryLength'),
-            delay: Core.Config.Get('CustomerAutocomplete.QueryDelay'),
+            minLength: Core.Config.Get('CustomerIDAutocomplete.MinQueryLength'),
+            delay: Core.Config.Get('CustomerIDAutocomplete.QueryDelay'),
             open: function() {
                 // force a higher z-index than the overlay/dialog
                 $(this).autocomplete('widget').addClass('ui-overlay-autocomplete');
@@ -41,8 +41,9 @@ Core.Agent.Dashboard = (function (TargetNS) {
                 var URL = Core.Config.Get('Baselink'), Data = {
                     Action: 'AgentCustomerInformationCenterSearch',
                     Subaction: 'SearchCustomerID',
+                    IncludeUnknownTicketCustomers: Core.Config.Get('IncludeUnknownTicketCustomers'),
                     Term: Request.term,
-                    MaxResults: Core.Config.Get('CustomerAutocomplete.MaxResultsDisplayed')
+                    MaxResults: Core.Config.Get('CustomerIDAutocomplete.MaxResultsDisplayed')
                 };
 
                 // if an old ajax request is already running, stop the old request and start the new one
@@ -96,6 +97,7 @@ Core.Agent.Dashboard = (function (TargetNS) {
             source: function (Request, Response) {
                 var URL = Core.Config.Get('Baselink'), Data = {
                     Action: 'AgentCustomerSearch',
+                    IncludeUnknownTicketCustomers: Core.Config.Get('IncludeUnknownTicketCustomers'),
                     Term: Request.term,
                     MaxResults: Core.Config.Get('CustomerUserAutocomplete.MaxResultsDisplayed')
                 };

--- a/var/httpd/htdocs/js/Core.Agent.TableFilters.js
+++ b/var/httpd/htdocs/js/Core.Agent.TableFilters.js
@@ -37,8 +37,8 @@ Core.Agent.TableFilters = (function (TargetNS) {
      */
     TargetNS.InitCustomerIDAutocomplete = function ($Input) {
         $Input.autocomplete({
-            minLength: Core.Config.Get('CustomerAutocomplete.MinQueryLength'),
-            delay: Core.Config.Get('CustomerAutocomplete.QueryDelay'),
+            minLength: Core.Config.Get('CustomerIDAutocomplete.MinQueryLength'),
+            delay: Core.Config.Get('CustomerIDAutocomplete.QueryDelay'),
             open: function() {
                 // force a higher z-index than the overlay/dialog
                 $(this).autocomplete('widget').addClass('ui-overlay-autocomplete');
@@ -48,8 +48,9 @@ Core.Agent.TableFilters = (function (TargetNS) {
                 var URL = Core.Config.Get('Baselink'), Data = {
                     Action: 'AgentCustomerInformationCenterSearch',
                     Subaction: 'SearchCustomerID',
+                    IncludeUnknownTicketCustomers: Core.Config.Get('IncludeUnknownTicketCustomers'),
                     Term: Request.term,
-                    MaxResults: Core.Config.Get('CustomerAutocomplete.MaxResultsDisplayed')
+                    MaxResults: Core.Config.Get('CustomerIDAutocomplete.MaxResultsDisplayed')
                 };
 
                 // if an old ajax request is already running, stop the old request and start the new one
@@ -103,6 +104,7 @@ Core.Agent.TableFilters = (function (TargetNS) {
             source: function (Request, Response) {
                 var URL = Core.Config.Get('Baselink'), Data = {
                     Action: 'AgentCustomerSearch',
+                    IncludeUnknownTicketCustomers: Core.Config.Get('IncludeUnknownTicketCustomers'),
                     Term: Request.term,
                     MaxResults: Core.Config.Get('CustomerUserAutocomplete.MaxResultsDisplayed')
                 };


### PR DESCRIPTION
http://bugs.otrs.org/show_bug.cgi?id=10117

Hi @mgruner 

We made again PR for the bug #10117. Now, we provided solution for  branch rel-5_0.  As you can see, we added new SysCongig item, which enable this type of search by unknow customers or doesn't.

There are typos in:
<pre> 
/opt/otrs/var/httpd/htdocs/js/Core.Agent.Dashboard.js:
   43                      Subaction: 'SearchCustomerID',
   44                      Term: Request.term,
   45:                     MaxResults: Core.Config.Get('CustomerAutocomplete.MaxResultsDisplayed')
   46                  };
   47  

/opt/otrs/var/httpd/htdocs/js/Core.Agent.TableFilters.js:
   50                      Subaction: 'SearchCustomerID',
   51                      Term: Request.term,
   52:                     MaxResults: Core.Config.Get('CustomerAutocomplete.MaxResultsDisplayed')
   53                  };
</pre>
because these param are set here:

<pre>
/opt/otrs/Kernel/Output/HTML/Templates/Standard/AgentDashboardTicketGeneric.tt:

  141: Core.Config.Set('CustomerIDAutocomplete.QueryDelay', "[% Data.queryDelay | html %]");
  142  Core.Config.Set('CustomerIDAutocomplete.MaxResultsDisplayed', "[% Data.maxResultsDisplayed | html %]");
  143  Core.Config.Set('CustomerIDAutocomplete.MinQueryLength', "[% Data.minQueryLength | html %]");

/opt/otrs/Kernel/Output/HTML/Templates/Standard/AgentTicketOverviewSmall.tt:

  147: Core.Config.Set('CustomerIDAutocomplete.QueryDelay', "[% Data.queryDelay | html %]");
  148  Core.Config.Set('CustomerIDAutocomplete.MaxResultsDisplayed', "[% Data.maxResultsDisplayed | html %]");

</pre>

There should be CustomerIDAutocomplete instead of CustomerAutocomplete. We fixed it also.

Please let me know if you have any suggestion.

Regards
Zoran