### PR TITLE
Fix bug#11517 - Error in password of customer user is blank with Oracle Database

### DIFF
--- a/Kernel/System/CustomerAuth/DB.pm
+++ b/Kernel/System/CustomerAuth/DB.pm
@@ -119,7 +119,7 @@ sub Auth {
     );
 
     while ( my @Row = $Self->{DBObject}->FetchrowArray() ) {
-        $GetPw  = $Row[0];
+        $GetPw  = $Row[0] || '';
         $UserID = $Row[1];
     }
 


### PR DESCRIPTION
This PR is fix for bug#11517 (http://bugs.otrs.org/show_bug.cgi?id=11517)
