### PR TITLE
[ Rel-5_0 Bug 11513 ] - Out of Office is missing in owner dropdown

### DIFF
--- a/Kernel/System/User.pm
+++ b/Kernel/System/User.pm
@@ -560,11 +560,11 @@ sub UserUpdate {
 
     # update search profiles if the UserLogin changed
     if ( lc $OldUserLogin ne lc $Param{UserLogin} ) {
-       $Kernel::OM->Get('Kernel::System::SearchProfile')->SearchProfileUpdateUserLogin(
-           Base         => 'TicketSearch',
-           UserLogin    => $OldUserLogin,
-           NewUserLogin => $Param{UserLogin},
-       );
+        $Kernel::OM->Get('Kernel::System::SearchProfile')->SearchProfileUpdateUserLogin(
+            Base         => 'TicketSearch',
+            UserLogin    => $OldUserLogin,
+            NewUserLogin => $Param{UserLogin},
+        );
     }
 
     # get cache object
@@ -575,7 +575,7 @@ sub UserUpdate {
         Type => $Self->{CacheType},
     );
 
-    # TODO Not needed to delete the cache if ValidID or Name was nat changed
+    # TODO Not needed to delete the cache if ValidID or Name was not changed
 
     my $SystemPermissionConfig = $Kernel::OM->Get('Kernel::Config')->Get('System::Permission') || [];
 
@@ -759,7 +759,7 @@ sub SetPassword {
         $CryptedPw = $Pw;
     }
 
-    # crypt with unix crypt
+    # crypt with UNIX crypt
     elsif ( $CryptType eq 'crypt' ) {
 
         # encode output, needed by crypt() only non utf8 signs
@@ -1200,10 +1200,14 @@ sub SetPreferences {
         'GetUserData::UserID::' . $Param{UserID} . '::0::' . $FirstnameLastNameOrder . '::1',
         'GetUserData::UserID::' . $Param{UserID} . '::1::' . $FirstnameLastNameOrder . '::0',
         'GetUserData::UserID::' . $Param{UserID} . '::1::' . $FirstnameLastNameOrder . '::1',
-        'UserList::Short::0::' . $FirstnameLastNameOrder,
-        'UserList::Short::1::' . $FirstnameLastNameOrder,
-        'UserList::Long::0::' . $FirstnameLastNameOrder,
-        'UserList::Long::1::' . $FirstnameLastNameOrder,
+        'UserList::Short::0::' . $FirstnameLastNameOrder . '::0',
+        'UserList::Short::0::' . $FirstnameLastNameOrder . '::1',
+        'UserList::Short::1::' . $FirstnameLastNameOrder . '::0',
+        'UserList::Short::1::' . $FirstnameLastNameOrder . '::1',
+        'UserList::Long::0::' . $FirstnameLastNameOrder . '::0',
+        'UserList::Long::0::' . $FirstnameLastNameOrder . '::1',
+        'UserList::Long::1::' . $FirstnameLastNameOrder . '::0',
+        'UserList::Long::1::' . $FirstnameLastNameOrder . '::1',
     );
 
     # get cache object


### PR DESCRIPTION
http://bugs.otrs.org/show_bug.cgi?id=11513

Hi @mgruner,

Here is PR with a fix for this issue. Actually, it worked fine, but deleting cache date in SetPreferences was wrong.  @CacheKeys  is not configured well and it had made a problem. We conclude it when we deleted cache after update OutOfOfice in AgentPreferences. In this case all worked fine. Updating   OutOfOfice in AdminUser has worked fine before because in UpdateAgent delete entire cache.  

Regards
Zoran
