### PR TITLE
 [Rel-5_0 - Bug 11511] - Text length for title is cut off after 50 characters

### DIFF
--- a/Kernel/Config/Files/Ticket.xml
+++ b/Kernel/Config/Files/Ticket.xml
@@ -17,7 +17,7 @@
         </Setting>
     </ConfigItem>
     <ConfigItem Name="Ticket::SubjectSize" Required="1" Valid="1">
-        <Description Translatable="1">Max size of the subjects in an email reply.</Description>
+        <Description Translatable="1">Max size of the subjects in an email reply and in some overview screens.</Description>
         <Group>Ticket</Group>
         <SubGroup>Core::Ticket</SubGroup>
         <Setting>

--- a/Kernel/Output/HTML/LinkObject/Ticket.pm
+++ b/Kernel/Output/HTML/LinkObject/Ticket.pm
@@ -20,6 +20,7 @@ our @ObjectDependencies = (
     'Kernel::System::State',
     'Kernel::System::Type',
     'Kernel::System::Web::Request',
+    'Kernel::System::Ticket',
 );
 
 =head1 NAME
@@ -57,7 +58,7 @@ sub new {
         $Self->{$Needed} = $Param{$Needed} || die "Got no $Needed!";
     }
 
-    # We need our own LayoutObject instance to avoid blockdata collisions
+    # We need our own LayoutObject instance to avoid block data collisions
     #   with the main page.
     $Self->{LayoutObject} = Kernel::Output::HTML::Layout->new( %{$Self} );
 
@@ -185,6 +186,11 @@ sub TableCreateComplex {
             $CssClass = 'StrikeThrough';
         }
 
+        my $CleanedSubject = $Kernel::OM->Get('Kernel::System::Ticket')->TicketSubjectClean(
+            TicketNumber => $Ticket->{TicketNumber},
+            Subject      => $Ticket->{Title},
+        );
+
         my @ItemColumns = (
             {
                 Type    => 'Link',
@@ -197,9 +203,8 @@ sub TableCreateComplex {
                 CssClass => $CssClass,
             },
             {
-                Type      => 'Text',
-                Content   => $Ticket->{Title},
-                MaxLength => 50,
+                Type    => 'Text',
+                Content => $CleanedSubject,
             },
             {
                 Type    => 'Text',

--- a/Kernel/Output/HTML/LinkObject/Ticket.pm
+++ b/Kernel/Output/HTML/LinkObject/Ticket.pm
@@ -20,7 +20,6 @@ our @ObjectDependencies = (
     'Kernel::System::State',
     'Kernel::System::Type',
     'Kernel::System::Web::Request',
-    'Kernel::System::Ticket',
 );
 
 =head1 NAME
@@ -186,11 +185,6 @@ sub TableCreateComplex {
             $CssClass = 'StrikeThrough';
         }
 
-        my $CleanedSubject = $Kernel::OM->Get('Kernel::System::Ticket')->TicketSubjectClean(
-            TicketNumber => $Ticket->{TicketNumber},
-            Subject      => $Ticket->{Title},
-        );
-
         my @ItemColumns = (
             {
                 Type    => 'Link',
@@ -203,8 +197,9 @@ sub TableCreateComplex {
                 CssClass => $CssClass,
             },
             {
-                Type    => 'Text',
-                Content => $CleanedSubject,
+                Type      => 'Text',
+                Content   => $Ticket->{Title},
+                MaxLength => $Kernel::OM->Get('Kernel::Config')->Get('Ticket::SubjectSize') || 50,
             },
             {
                 Type    => 'Text',

--- a/scripts/test/Selenium/Agent/AgentLinkObject.t
+++ b/scripts/test/Selenium/Agent/AgentLinkObject.t
@@ -28,7 +28,7 @@ $Selenium->RunTest(
         # get sysconfig object
         my $SysConfigObject = $Kernel::OM->Get('Kernel::System::SysConfig');
 
-        # do not check RichText
+        # set link object view mode to simple
         $SysConfigObject->ConfigItemUpdate(
             Valid => 1,
             Key   => 'LinkObject::ViewMode',
@@ -133,9 +133,60 @@ $Selenium->RunTest(
             "TicketNumber $TicketNumbers[0] - found",
         );
 
+        # test ticket title length in complex view for linked tickets, see bug #11511
+        # set link object view mode to complex
+        $SysConfigObject->ConfigItemUpdate(
+            Valid => 1,
+            Key   => 'LinkObject::ViewMode',
+            Value => 'Complex',
+        );
+
+        # update test ticket title to more then 50 characters
+        my $LongTicketTitle = 'This is long test ticket title with more then 50 characters in it';
+        my $Success         = $TicketObject->TicketTitleUpdate(
+            Title    => $LongTicketTitle,
+            TicketID => $TicketIDs[1],
+            UserID   => 1,
+        );
+        $Self->True(
+            $Success,
+            "Updated ticket title - $TicketIDs[1]"
+        );
+
+        # navigate to AgentTicketZoom screen
+        $Selenium->get("${ScriptAlias}index.pl?Action=AgentTicketZoom;TicketID=$TicketIDs[0]");
+
+        # check for updated ticket title in linked tickets complex view table
+        $Self->True(
+            index( $Selenium->get_page_source(), $LongTicketTitle ) > -1,
+            "$LongTicketTitle - found in AgentTicketZoom complex view mode",
+        );
+
+        # hover on menu bar on the misc cluster
+        $Selenium->WaitFor(
+            JavaScript =>
+                'return typeof($) === "function" && $("#nav-Miscellaneous ul").css({ "height": "auto", "opacity": "100" });'
+        );
+
+        # click on 'Link'
+        $Selenium->find_element("//a[contains(\@href, \'Action=AgentLinkObject;SourceObject=Ticket;' )]")->click();
+
+        # switch to link object window
+        $Handles = $Selenium->get_window_handles();
+        $Selenium->switch_to_window( $Handles->[1] );
+
+        # click on 'go to link delete screen'
+        $Selenium->find_element("//a[contains(\@href, \'Subaction=LinkDelete;' )]")->click();
+
+        # check for long ticket title in LinkDelete screen
+        $Self->True(
+            index( $Selenium->get_page_source(), $LongTicketTitle ) > -1,
+            "$LongTicketTitle - found in LinkDelete screen",
+        );
+
         # delete created test tickets
         for my $TicketID (@TicketIDs) {
-            my $Success = $TicketObject->TicketDelete(
+            $Success = $TicketObject->TicketDelete(
                 TicketID => $TicketID,
                 UserID   => $TestUserID,
             );

--- a/scripts/test/Selenium/Agent/AgentLinkObject.t
+++ b/scripts/test/Selenium/Agent/AgentLinkObject.t
@@ -35,6 +35,13 @@ $Selenium->RunTest(
             Value => 'Simple',
         );
 
+        # set Ticket::SubjectSize
+        $SysConfigObject->ConfigItemUpdate(
+            Valid => 1,
+            Key   => 'Ticket::SubjectSize',
+            Value => '60',
+        );
+
         # create and login test customer
         my $TestUserLogin = $Helper->TestUserCreate(
             Groups => [ 'admin', 'users' ],
@@ -141,9 +148,12 @@ $Selenium->RunTest(
             Value => 'Complex',
         );
 
-        # update test ticket title to more then 50 characters
+        # update test ticket title to more then 50 characters (there is 65)
         my $LongTicketTitle = 'This is long test ticket title with more then 50 characters in it';
-        my $Success         = $TicketObject->TicketTitleUpdate(
+
+        # Ticket::SubjectSize is set to 60 at the beginning of test
+        my $ShortTitle = substr( $LongTicketTitle, 0, 57 ) . "...";
+        my $Success = $TicketObject->TicketTitleUpdate(
             Title    => $LongTicketTitle,
             TicketID => $TicketIDs[1],
             UserID   => 1,
@@ -179,9 +189,16 @@ $Selenium->RunTest(
         $Selenium->find_element("//a[contains(\@href, \'Subaction=LinkDelete;' )]")->click();
 
         # check for long ticket title in LinkDelete screen
+        # this one is displayed on hover
         $Self->True(
-            index( $Selenium->get_page_source(), $LongTicketTitle ) > -1,
-            "$LongTicketTitle - found in LinkDelete screen",
+            index( $Selenium->get_page_source(), "title=\"$LongTicketTitle\"" ) > -1,
+            "\"title=$LongTicketTitle\" - found in LinkDelete screen - which is displayed on hover",
+        );
+
+        # check for short ticket title in LinkDelete screen
+        $Self->True(
+            index( $Selenium->get_page_source(), $ShortTitle ) > -1,
+            "$ShortTitle - found in LinkDelete screen",
         );
 
         # delete created test tickets


### PR DESCRIPTION
http://bugs.otrs.org/show_bug.cgi?id=11511

Hello @mgruner ,

Hereby is proposal to fix this bug. It was hard-coded on 50 chars for ticket subject in complex view linked tickets table and in LinkDelete screen. Changed it to use SysConfig Ticket::SubjectSize so users can change it to there needs. 

Updated selenium test to check for this change as well.

Regards,
Sanjin