### PR TITLE
[Rel-5_0 - Bug 11393] -  ACL not hiding Process NavBar link when Type is Menu

### DIFF
--- a/Kernel/Output/HTML/NavBar/CustomerTicketProcess.pm
+++ b/Kernel/Output/HTML/NavBar/CustomerTicketProcess.pm
@@ -144,6 +144,9 @@ sub Run {
     # remove CustomerTicketProcess from the TicketMenu
     delete $Return{$NavBarName}->{$Priority};
 
+    # remove CustomerTicketProcess from the Menu if set outside of the TicketMenu, see bug #11393
+    delete $Param{NavBarModule}->{$Priority};
+
     return ( Sub => \%Return );
 }
 


### PR DESCRIPTION
http://bugs.otrs.org/show_bug.cgi?id=11393

Hello @mgruner ,

Hereby is proposal to fix this bug. When you set sysconfig so CustomerTicketProcess is shown in Menu instead of TicketMenu, there was no part to hide it when process is not available to respective customer. 

Added part of code that will remove button in a same fashion as it is done when it's in TicketMenu.

Please let me know if there any questions or issues regarding this proposal.

Regards,
Sanjin