### PR TITLE
[ Rel-5_0 Bug 11535 ] - Listed message for disabled languages in ticket notification management 

### DIFF
--- a/Kernel/Modules/AdminNotificationEvent.pm
+++ b/Kernel/Modules/AdminNotificationEvent.pm
@@ -1033,7 +1033,9 @@ sub _Edit {
 
     my $HTMLUtilsObject = $Kernel::OM->Get('Kernel::System::HTMLUtils');
 
+    LANGUAGEID:
     for my $LanguageID (@LanguageIDs) {
+        next LANGUAGEID if !defined $DefaultUsedLanguages{$LanguageID};
 
         # format the content according to the content type
         if ( $Param{RichText} ) {

--- a/Kernel/Modules/AdminNotificationEvent.pm
+++ b/Kernel/Modules/AdminNotificationEvent.pm
@@ -1035,7 +1035,6 @@ sub _Edit {
 
     LANGUAGEID:
     for my $LanguageID (@LanguageIDs) {
-        next LANGUAGEID if !defined $DefaultUsedLanguages{$LanguageID};
 
         # format the content according to the content type
         if ( $Param{RichText} ) {

--- a/Kernel/Output/HTML/Templates/Standard/AdminNotificationEvent.tt
+++ b/Kernel/Output/HTML/Templates/Standard/AdminNotificationEvent.tt
@@ -546,12 +546,18 @@ $('.NotificationDelete').bind('click', function (Event) {
 
 [% RenderBlockStart("NotificationLanguage") %]
                         <div class="NotificationLanguage">
-                            <div class="WidgetSimple SpacingTop">
+                            <div class="WidgetSimple SpacingTop [% IF !Data.Language %] Collapsed [% END %] ">
                                 <div class="Header">
                                     <div class="WidgetAction Toggle">
                                         <a href="#" title="[% Translate("Toggle this widget") | html %]"><i class="fa fa-caret-right"></i><i class="fa fa-caret-down"></i></a>
                                     </div>
-                                    <h2 class="Title">[% Translate(Data.Language) %]</h2>
+                                    <h2 class="Title">
+                                        [% IF Data.Language %]
+                                          [% Translate(Data.Language) %]
+                                        [% ELSE %]
+                                           <span class="Error">'[% Translate(Data.LanguageID) %]' - language does not exist. This notification could be deleted, if it is not needed anymore.</span>
+                                        [% END %]
+                                    </h2>
 [% RenderBlockStart("NotificationLanguageRemoveButton") %]
                                     <div class="AdditionalInformation">
                                         <a value="Remove Language" class="RemoveButton LanguageRemove" id="[% Data.LanguageID | html %]_Language_Remove" href="" name="Data.LanguageID_Language_Remove"><i class="fa fa-minus-square-o"></i><span class="InvisibleText">[% Translate("Remove Notification Language") | html %]</span></a>


### PR DESCRIPTION
http://bugs.otrs.org/show_bug.cgi?id=11535

Hi @mgruner, 

I believe that reporter of the bug is right. It is not needed that there is notification if the language is disabled.
I have some suggestions for improvement in this screen with languages, but it will be in another PR, where I will explain it.

Regards
Zoran 