### PR TITLE
Improvement of language selection in NotificationEvent

### DIFF
--- a/Kernel/System/TemplateGenerator.pm
+++ b/Kernel/System/TemplateGenerator.pm
@@ -859,10 +859,15 @@ sub NotificationEvent {
         # otherwise use default language
         $Language = $DefaultLanguage;
 
-        # if no message exists in default language, then take the first available language
+        # otherwise use English
         if ( !$Notification{Message}->{$Language} ) {
-            my @Languages = sort keys %{ $Notification{Message} };
-            $Language = $Languages[0];
+            $Language = 'en';
+
+            # if no message exists in default language, then take the first available language
+            if ( !$Notification{Message}->{$Language} ) {
+                my @Languages = sort keys %{ $Notification{Message} };
+                $Language = $Languages[0];
+            }
         }
     }
 


### PR DESCRIPTION
This PR Improves language selection in NotificationEvent.

Currently, e.g. if UserLanguage is 'ja' and DefaultLanguage in Config is 'cn' and only English is configured in notification event message.

English is required in AdminNotification.pm, but in this case, English won't be selected.

This PR changes into selected English if notification event message for neither UserLanguage nor DefaultLanguage is not found.

It meens that we can always find notification event message.
