### PR TITLE
[ Rel-4_0 Bug 11304 ] - <OTRS_CUSTOMER_Subject> in "move"-notification is replaced with ticket-subject, not with article-subject 

### DIFF
--- a/Kernel/System/Ticket.pm
+++ b/Kernel/System/Ticket.pm
@@ -4554,11 +4554,9 @@ sub TicketOwnerSet {
             $Self->SendAgentNotification(
                 Type                  => 'OwnerUpdate',
                 RecipientID           => $Param{NewUserID},
-                CustomerMessageParams => {
-                    %Param,
-                },
-                TicketID => $Param{TicketID},
-                UserID   => $Param{UserID},
+                CustomerMessageParams => \%Param,
+                TicketID              => $Param{TicketID},
+                UserID                => $Param{UserID},
             );
         }
     }
@@ -4772,7 +4770,7 @@ sub TicketResponsibleSet {
             $Self->SendAgentNotification(
                 Type                  => 'ResponsibleUpdate',
                 RecipientID           => $Param{NewUserID},
-                CustomerMessageParams => {},
+                CustomerMessageParams => \%Param,
                 TicketID              => $Param{TicketID},
                 UserID                => $Param{UserID},
             );

--- a/Kernel/System/Ticket.pm
+++ b/Kernel/System/Ticket.pm
@@ -1945,7 +1945,6 @@ sub TicketQueueSet {
                     RecipientID           => $UserID,
                     CustomerMessageParams => {
                         Queue => $Queue,
-                        Body  => $Param{Comment} || '',
                     },
                     TicketID => $Param{TicketID},
                     UserID   => $Param{UserID},
@@ -4557,7 +4556,6 @@ sub TicketOwnerSet {
                 RecipientID           => $Param{NewUserID},
                 CustomerMessageParams => {
                     %Param,
-                    Body => $Param{Comment} || '',
                 },
                 TicketID => $Param{TicketID},
                 UserID   => $Param{UserID},
@@ -4774,7 +4772,7 @@ sub TicketResponsibleSet {
             $Self->SendAgentNotification(
                 Type                  => 'ResponsibleUpdate',
                 RecipientID           => $Param{NewUserID},
-                CustomerMessageParams => \%Param,
+                CustomerMessageParams => {},
                 TicketID              => $Param{TicketID},
                 UserID                => $Param{UserID},
             );

--- a/Kernel/System/Ticket/Article.pm
+++ b/Kernel/System/Ticket/Article.pm
@@ -560,7 +560,7 @@ sub ArticleCreate {
             $Self->SendAgentNotification(
                 Type                  => $Param{HistoryType},
                 RecipientID           => $UserID,
-                CustomerMessageParams => {%Param},
+                CustomerMessageParams => {},
                 TicketID              => $Param{TicketID},
                 Queue                 => $Param{Queue},
                 UserID                => $Param{UserID},
@@ -603,7 +603,7 @@ sub ArticleCreate {
             $Self->SendAgentNotification(
                 Type                  => $Param{HistoryType},
                 RecipientID           => $UserID,
-                CustomerMessageParams => {%Param},
+                CustomerMessageParams => {},
                 TicketID              => $Param{TicketID},
                 Queue                 => $Param{Queue},
                 UserID                => $Param{UserID},
@@ -756,7 +756,7 @@ sub ArticleCreate {
                 $Self->SendAgentNotification(
                     Type                  => $Param{HistoryType},
                     RecipientID           => $UserID,
-                    CustomerMessageParams => {%Param},
+                    CustomerMessageParams => {},
                     TicketID              => $Param{TicketID},
                     Queue                 => $Param{Queue},
                     UserID                => $Param{UserID},
@@ -819,7 +819,7 @@ sub ArticleCreate {
                     $Self->SendAgentNotification(
                         Type                  => $Param{HistoryType},
                         RecipientID           => $UserID,
-                        CustomerMessageParams => {%Param},
+                        CustomerMessageParams => {},
                         TicketID              => $Param{TicketID},
                         Queue                 => $Param{Queue},
                         UserID                => $Param{UserID},
@@ -850,7 +850,7 @@ sub ArticleCreate {
             $Self->SendAgentNotification(
                 Type                  => $Param{HistoryType},
                 RecipientID           => $UserID,
-                CustomerMessageParams => {%Param},
+                CustomerMessageParams => {},
                 TicketID              => $Param{TicketID},
                 UserID                => $Param{UserID},
             );

--- a/Kernel/System/Ticket/Article.pm
+++ b/Kernel/System/Ticket/Article.pm
@@ -708,7 +708,7 @@ sub ArticleCreate {
                 $Self->SendAgentNotification(
                     Type                  => $Param{HistoryType},
                     RecipientID           => $UserID,
-                    CustomerMessageParams => {%Param},
+                    CustomerMessageParams => \%Param,
                     TicketID              => $Param{TicketID},
                     Queue                 => $Param{Queue},
                     UserID                => $Param{UserID},


### PR DESCRIPTION
http://bugs.otrs.org/show_bug.cgi?id=11304

Hi @martin,

We worked on this bug. To be honest there is not enough clear what are <  OTRS_CUSTOMER_SUBJECT> and <  OTRS_CUSTOMER_BODY  >. In master there are ( OTRS_CUSTOMER_SUBJECT > and <  OTRS_CUSTOMER_BODY >) and
 ( <  OTRS_AGENT_SUBJECT > and < OTRS_AGENT_BODY > ) 
I suppose that something that is called OTRS_CUSTOMER_SUBJECT should be customer subject and in case agent notification instead of this tag there is replaced subject of last customer article. For follow up notification there are subject and body of follow up article, however for Note, MoveUpdate, OwnerUpdate, ServiceUpdate notifications I expect  on the place of <OTRS_CUSTOMER_SUBJECT> tag subject of last customer article.

Am I right. I am sure that we have different behavior for different type of notification. In this PR I apply example how it is solved for ServiceUpdate notification. I believe we should check all type of notification and make the same behavior for all. As I mentioned above in OTRS5 and master there is AGENTs tag and there is necessary check all type of notification as well. I provide another PR for master soon.

Please let me know what do you think about that. This is only proposal, I will be able to provide final solution after suggesting with you.

Regards
Zoran