### PR TITLE
[ Master Bug 11304 ] - <OTRS_CUSTOMER_Subject> in "move"-notification is replaced with ticket-subject, not with article-subject 

### DIFF
--- a/Kernel/System/Ticket.pm
+++ b/Kernel/System/Ticket.pm
@@ -1928,7 +1928,6 @@ sub TicketQueueSet {
                 TicketID              => $Param{TicketID},
                 CustomerMessageParams => {
                     Queue => $Queue,
-                    Body  => $Param{Comment} || '',
                 },
                 Recipients => \@UserIDs,
             },

--- a/Kernel/System/Ticket/Article.pm
+++ b/Kernel/System/Ticket/Article.pm
@@ -528,7 +528,7 @@ sub ArticleCreate {
                 Queue                 => $Param{Queue},
                 Recipients            => $ExtraRecipients,
                 SkipRecipients        => \@SkipRecipients,
-                CustomerMessageParams => {%Param},
+                CustomerMessageParams => {},
             },
             UserID => $Param{UserID},
         );


### PR DESCRIPTION
http://bugs.otrs.org/show_bug.cgi?id=11304

Hi @mgruner 

I mentioned this issue in PR for the branch rel-4 ( https://github.com/OTRS/otrs/pull/758 )

Here is proposal for fixing in master. This is not final version as I said, but in this moment you opinion will be helpful. 

Regards
Zoran 