### PR TITLE
Add new feature: define default headers for emails

### DIFF
--- a/Kernel/Config/Files/Framework.xml
+++ b/Kernel/Config/Files/Framework.xml
@@ -6841,7 +6841,7 @@ via the Preferences button after logging in.
     <ConfigItem Name="Email::DefaultHeaders" Required="0" Valid="0">
         <Description Translatable="1">Default headers for emails.</Description>
         <Group>Framework</Group>
-        <SubGroup>Core::Sendmai<l/SubGroup>
+        <SubGroup>Core::Sendmail</SubGroup>
         <Setting>
             <Hash>
                 <Item Key="Precedence">bulk</Item>

--- a/Kernel/Config/Files/Framework.xml
+++ b/Kernel/Config/Files/Framework.xml
@@ -6838,5 +6838,15 @@ via the Preferences button after logging in.
             <String Regex="[/|\w]+fetchmail$" Check="File">/usr/bin/fetchmail</String>
         </Setting>
     </ConfigItem>
-
+    <ConfigItem Name="Email::DefaultHeaders" Required="0" Valid="0">
+        <Description Translatable="1">Default headers for emails.</Description>
+        <Group>Framework</Group>
+        <SubGroup>Core::Sendmai<l/SubGroup>
+        <Setting>
+            <Hash>
+                <Item Key="Precedence">bulk</Item>
+                <Item Key="Auto-Submitted">auto-generated</Item>
+            </Hash>
+        </Setting>
+    </ConfigItem>
 </otrs_config>

--- a/Kernel/System/Email.pm
+++ b/Kernel/System/Email.pm
@@ -220,9 +220,18 @@ sub Send {
 
     # build header
     my %Header;
-    if ( IsHashRefWithData( $Param{CustomHeaders} ) ) {
-        %Header = %{ $Param{CustomHeaders} };
+    
+    my $DefaultHeaders = $ConfigObject->Get('Email::DefaultHeaders') || {};
+    if ( IsHashRefWithData($DefaultHeaders) ) {
+        %Header = %{$DefaultHeaders};
     }
+    
+    if ( IsHashRefWithData( $Param{CustomHeaders} ) ) {
+        for my $HeaderName ( keys %{ $Param{CustomHeaders} } ) {
+            $Header{$HeaderName} = $Param{CustomHeaders}->{$HeaderName};
+        }
+    }
+    
     ATTRIBUTE:
     for my $Attribute (qw(From To Cc Subject Charset Reply-To)) {
         next ATTRIBUTE if !$Param{$Attribute};


### PR DESCRIPTION
Sometimes someone might want to send some headers in *each* email sent via OTRS. Currently there is no way to define such headers. With this patch it would be possible...