### PR TITLE
[ Rel-5_0 Bug 11320 ] Invalid customer user can update password

### DIFF
--- a/Kernel/System/Web/InterfaceAgent.pm
+++ b/Kernel/System/Web/InterfaceAgent.pm
@@ -636,7 +636,11 @@ sub Run {
             User  => $User,
             Valid => 1
         );
-        if ( !$UserData{UserID} ) {
+
+        # verify user is valid when requesting password reset
+        my @ValidIDs = $Kernel::OM->Get('Kernel::System::Valid')->ValidIDsGet();
+        my $UserIsValid = grep { $UserData{ValidID} == $_ } @ValidIDs;
+        if ( !$UserData{UserID} || !$UserIsValid ) {
 
             # Security: pretend that password reset instructions were actually sent to
             #   make sure that users cannot find out valid usernames by

--- a/Kernel/System/Web/InterfaceCustomer.pm
+++ b/Kernel/System/Web/InterfaceCustomer.pm
@@ -26,6 +26,7 @@ our @ObjectDependencies = (
     'Kernel::System::Scheduler',
     'Kernel::System::Time',
     'Kernel::System::Web::Request',
+    'Kernel::System::Valid',
 );
 
 =head1 NAME
@@ -582,7 +583,11 @@ sub Run {
 
         # get user data
         my %UserData = $UserObject->CustomerUserDataGet( User => $User );
-        if ( !$UserData{UserID} ) {
+
+        # verify customer user is valid when requesting password reset
+        my @ValidIDs = $Kernel::OM->Get('Kernel::System::Valid')->ValidIDsGet();
+        my $UserIsValid = grep { $UserData{ValidID} == $_ } @ValidIDs;
+        if ( !$UserData{UserID} || !$UserIsValid ) {
 
             # Security: pretend that password reset instructions were actually sent to
             #   make sure that users cannot find out valid usernames by

--- a/scripts/test/Selenium/Agent/AgentPasswordRecovery.t
+++ b/scripts/test/Selenium/Agent/AgentPasswordRecovery.t
@@ -1,0 +1,142 @@
+# --
+# Copyright (C) 2001-2015 OTRS AG, http://otrs.com/
+# --
+# This software comes with ABSOLUTELY NO WARRANTY. For details, see
+# the enclosed file COPYING for license information (AGPL). If you
+# did not receive this file, see http://www.gnu.org/licenses/agpl.txt.
+# --
+
+use strict;
+use warnings;
+use utf8;
+
+use vars (qw($Self));
+
+# get selenium object
+my $Selenium = $Kernel::OM->Get('Kernel::System::UnitTest::Selenium');
+
+$Selenium->RunTest(
+    sub {
+
+        # get needed objects
+        $Kernel::OM->ObjectParamAdd(
+            'Kernel::System::UnitTest::Helper' => {
+                RestoreSystemConfiguration => 1,
+            },
+        );
+        my $Helper          = $Kernel::OM->Get('Kernel::System::UnitTest::Helper');
+        my $ConfigObject    = $Kernel::OM->Get('Kernel::Config');
+        my $TestEmailObject = $Kernel::OM->Get('Kernel::System::Email::Test');
+
+        # use test email backend
+        $ConfigObject->Set(
+            Key   => 'SendmailModule',
+            Value => 'Kernel::System::Email::Test',
+        );
+
+        # clean up test email
+        my $Success = $TestEmailObject->CleanUp();
+        $Self->True(
+            $Success,
+            'Initial cleanup',
+        );
+
+        $Self->IsDeeply(
+            $TestEmailObject->EmailsGet(),
+            [],
+            'Test email empty after initial cleanup',
+        );
+
+        # create test user and login
+        my $TestUser = $Helper->TestUserCreate(
+            Groups => [ 'admin', 'users' ],
+        ) || die "Did not get test user";
+
+        # navigate to agent login screen
+        my $ScriptAlias = $ConfigObject->Get('ScriptAlias');
+        $Selenium->get("${ScriptAlias}index.pl?");
+
+        # click on 'Lost your password?'
+        $Selenium->find_element( "#LostPassword", 'css' )->click();
+
+        # request new password
+        $Selenium->find_element( "#PasswordUser", 'css' )->send_keys($TestUser);
+        $Selenium->find_element("//button[\@type='submit'][\@value='Request New Password']")->click();
+
+        # check for password recovery message
+        my $PasswordRecoveryMessage = 'Sent password reset instructions. Please check your email.';
+        $Self->True(
+            index( $Selenium->get_page_source(), $PasswordRecoveryMessage ) > -1,
+            "'$PasswordRecoveryMessage' - found on screen for valid user",
+        );
+
+        # check if password recovery email is sent to valid user
+        my $Emails = $TestEmailObject->EmailsGet();
+        $Self->Is(
+            scalar @{$Emails},
+            1,
+            "Password recovery email sent for valid user $TestUser",
+        );
+
+        # clean up test email again
+        $Success = $TestEmailObject->CleanUp();
+        $Self->True(
+            $Success,
+            'Second cleanup',
+        );
+
+        $Self->IsDeeply(
+            $TestEmailObject->EmailsGet(),
+            [],
+            'Test email empty after second cleanup',
+        );
+
+        # get user object
+        my $UserObject = $Kernel::OM->Get('Kernel::System::User');
+
+        # get test user ID
+        my $TestUserID = $UserObject->UserLookup(
+            UserLogin => $TestUser,
+        );
+
+        # update user to invalid
+        $Success = $UserObject->UserUpdate(
+            UserID        => $TestUserID,
+            UserFirstname => $TestUser,
+            UserLastname  => $TestUser,
+            UserLogin     => $TestUser,
+            UserPw        => $TestUser,
+            UserEmail     => $TestUser . '@localunittest.com',
+            ValidID       => 2,
+            ChangeUserID  => 1,
+        );
+        $Self->True(
+            $Success,
+            "$TestUser set to invalid",
+        );
+
+        # click on 'Lost your password?' again
+        $Selenium->find_element( "#LostPassword", 'css' )->click();
+
+        # request new password
+        $Selenium->find_element( "#PasswordUser", 'css' )->send_keys($TestUser);
+        $Selenium->find_element("//button[\@type='submit'][\@value='Request New Password']")->click();
+
+        # check for password recovery message for invalid user, for security meassures it
+        # should be visible
+        $Self->True(
+            index( $Selenium->get_page_source(), $PasswordRecoveryMessage ) > -1,
+            "'$PasswordRecoveryMessage' - found on screen for invalid user",
+        );
+
+        # check if password recovery email is sent to invalid user
+        $Emails = $TestEmailObject->EmailsGet();
+        $Self->Is(
+            scalar @{$Emails},
+            0,
+            "Password recovery email NOT sent for invalid user $TestUser",
+        );
+    }
+);
+
+1;

--- a/scripts/test/Selenium/Customer/CustomerPasswordRecovery.t
+++ b/scripts/test/Selenium/Customer/CustomerPasswordRecovery.t
@@ -1,0 +1,135 @@
+# --
+# Copyright (C) 2001-2015 OTRS AG, http://otrs.com/
+# --
+# This software comes with ABSOLUTELY NO WARRANTY. For details, see
+# the enclosed file COPYING for license information (AGPL). If you
+# did not receive this file, see http://www.gnu.org/licenses/agpl.txt.
+# --
+
+use strict;
+use warnings;
+use utf8;
+
+use vars (qw($Self));
+
+# get selenium object
+my $Selenium = $Kernel::OM->Get('Kernel::System::UnitTest::Selenium');
+
+$Selenium->RunTest(
+    sub {
+
+        # get needed objects
+        $Kernel::OM->ObjectParamAdd(
+            'Kernel::System::UnitTest::Helper' => {
+                RestoreSystemConfiguration => 1,
+            },
+        );
+        my $Helper          = $Kernel::OM->Get('Kernel::System::UnitTest::Helper');
+        my $ConfigObject    = $Kernel::OM->Get('Kernel::Config');
+        my $TestEmailObject = $Kernel::OM->Get('Kernel::System::Email::Test');
+
+        # use test email backend
+        $ConfigObject->Set(
+            Key   => 'SendmailModule',
+            Value => 'Kernel::System::Email::Test',
+        );
+
+        # clean up test email
+        my $Success = $TestEmailObject->CleanUp();
+        $Self->True(
+            $Success,
+            'Initial cleanup',
+        );
+
+        $Self->IsDeeply(
+            $TestEmailObject->EmailsGet(),
+            [],
+            'Test email empty after initial cleanup',
+        );
+
+        # create test customer user and login
+        my $TestCustomerUser = $Helper->TestCustomerUserCreate(
+        ) || die "Did not get test user";
+
+        # navigate to customer login screen
+        my $ScriptAlias = $ConfigObject->Get('ScriptAlias');
+        $Selenium->get("${ScriptAlias}customer.pl?");
+
+        # click on 'Forgot password?'
+        $Selenium->find_element( "#ForgotPassword", 'css' )->click();
+
+        # request new password
+        $Selenium->find_element( "#ResetUser", 'css' )->send_keys($TestCustomerUser);
+        $Selenium->find_element("//button[\@type='submit'][\@value='Submit']")->click();
+
+        # check for password recovery message
+        my $PasswordRecoveryMessage = 'Sent password reset instructions. Please check your email.';
+        $Self->True(
+            index( $Selenium->get_page_source(), $PasswordRecoveryMessage ) > -1,
+            "'$PasswordRecoveryMessage' - found on screen for valid customer",
+        );
+
+        # check if password recovery email is sent
+        my $Emails = $TestEmailObject->EmailsGet();
+        $Self->Is(
+            scalar @{$Emails},
+            1,
+            "Password recovery email sent for valid customer user $TestCustomerUser",
+        );
+
+        # clean up test email again
+        $Success = $TestEmailObject->CleanUp();
+        $Self->True(
+            $Success,
+            'Second cleanup',
+        );
+
+        $Self->IsDeeply(
+            $TestEmailObject->EmailsGet(),
+            [],
+            'Test email empty after second cleanup',
+        );
+
+        # update test customer to invalid status
+        $Success = $Kernel::OM->Get('Kernel::System::CustomerUser')->CustomerUserUpdate(
+            Source         => 'CustomerUser',
+            ID             => $TestCustomerUser,
+            UserCustomerID => $TestCustomerUser,
+            UserLogin      => $TestCustomerUser,
+            UserFirstname  => $TestCustomerUser,
+            UserLastname   => $TestCustomerUser,
+            UserPassword   => $TestCustomerUser,
+            UserEmail      => $TestCustomerUser . '@localunittest.com',
+            ValidID        => 2,
+            UserID         => 1,
+        );
+        $Self->True(
+            $Success,
+            "$TestCustomerUser set to invalid",
+        );
+
+        # click on 'Forgot password?' again
+        $Selenium->find_element( "#ForgotPassword", 'css' )->click();
+
+        # request new password
+        $Selenium->find_element( "#ResetUser", 'css' )->send_keys($TestCustomerUser);
+        $Selenium->find_element("//button[\@type='submit'][\@value='Submit']")->click();
+
+        # check for password recovery message for invalid customer user, for security meassures it
+        # should be visible
+        $Self->True(
+            index( $Selenium->get_page_source(), $PasswordRecoveryMessage ) > -1,
+            "'$PasswordRecoveryMessage' - found on screen for invalid customer",
+        );
+
+        # check if password recovery email is sent to invalid customer user
+        $Emails = $TestEmailObject->EmailsGet();
+        $Self->Is(
+            scalar @{$Emails},
+            0,
+            "Password recovery email NOT sent for invalid customer user $TestCustomerUser",
+        );
+    }
+);
+
+1;


### PR DESCRIPTION
http://bugs.otrs.org/show_bug.cgi?id=11320

Hello @mgruner ,

Here is proposal for fixing this bug. Used already existed security feature that get activated if customer try to request password for non existed customer. This way invalid customer will not receive email to reset there password but there will also be no notification that they are invalid for security reasons.

Please let me know what do you think about this suggestion, if you think there should be some additional message when customer try to request password reset for invalid customer, we can add some notification or some other message to follow that action.

Regards,
Sanjin