### PR TITLE
[ Rel-5 Bug 11350 ] - Translation for string Created not working at Dashboard widget

### DIFF
--- a/Kernel/Modules/AgentDashboardCommon.pm
+++ b/Kernel/Modules/AgentDashboardCommon.pm
@@ -135,7 +135,7 @@ sub Run {
         my $Name = $ParamObject->GetParam( Param => 'Name' );
         my $Key = $UserSettingsKey . $Name;
 
-        # update ssession
+        # update session
         $SessionObject->UpdateSessionID(
             SessionID => $Self->{SessionID},
             Key       => $Key,
@@ -190,7 +190,7 @@ sub Run {
             # update runtime vars
             $LayoutObject->{ $Param->{Name} } = $Value;
 
-            # update ssession
+            # update session
             $SessionObject->UpdateSessionID(
                 SessionID => $Self->{SessionID},
                 Key       => $Param->{Name},
@@ -243,7 +243,7 @@ sub Run {
             }
             my $Key = $UserSettingsKey . $Name;
 
-            # update ssession
+            # update session
             $SessionObject->UpdateSessionID(
                 SessionID => $Self->{SessionID},
                 Key       => $Key,
@@ -286,7 +286,7 @@ sub Run {
             $Data .= $Backend . ';';
         }
 
-        # update ssession
+        # update session
         $SessionObject->UpdateSessionID(
             SessionID => $Self->{SessionID},
             Key       => $Key,
@@ -518,6 +518,9 @@ sub Run {
         push @Order, $Name;
     }
 
+    # get default columns
+    my $Columns = $Self->{Config}->{DefaultColumns} || $ConfigObject->Get('DefaultOverviewColumns') || {};
+
     # try every backend to load and execute it
     NAME:
     for my $Name (@Order) {
@@ -560,6 +563,13 @@ sub Run {
                     NameHTML => $NameHTML,
                 },
             );
+        }
+
+        # if column is not a default column, add it for translation
+        for my $Column ( sort keys %{ $Element{Config}{DefaultColumns} } ) {
+            if ( !defined $Columns->{$Column} ) {
+                $Columns->{$Column} = $Element{Config}{DefaultColumns}{$Column}
+            }
         }
 
         # show settings link if preferences are available
@@ -639,7 +649,6 @@ sub Run {
     }
 
     # add translations for the allocation lists for regular columns
-    my $Columns = $Self->{Config}->{DefaultColumns} || $ConfigObject->Get('DefaultOverviewColumns') || {};
     if ( $Columns && IsHashRefWithData($Columns) ) {
 
         COLUMN:

--- a/var/httpd/htdocs/js/Core.Agent.TableFilters.js
+++ b/var/httpd/htdocs/js/Core.Agent.TableFilters.js
@@ -277,7 +277,7 @@ Core.Agent.TableFilters = (function (TargetNS) {
                 // get field translation
                 Translation = Core.Config.Get('Column' + Field) || Field;
 
-                $FieldObj = $('<li />').attr('title', Field).attr('data-fieldname', Field).text(Translation);
+                $FieldObj = $('<li />').attr('title', Translation).attr('data-fieldname', Field).text(Translation);
                 $ContainerObj.find('.AssignedFields').append($FieldObj);
             });
             $.each(DataAvailable, function(Index, Field) {
@@ -285,7 +285,7 @@ Core.Agent.TableFilters = (function (TargetNS) {
                 // get field translation
                 Translation = Core.Config.Get('Column' + Field) || Field;
 
-                $FieldObj = $('<li />').attr('title', Field).attr('data-fieldname', Field).text(Translation);
+                $FieldObj = $('<li />').attr('title', Translation).attr('data-fieldname', Field).text(Translation);
                 $ContainerObj.find('.AvailableFields').append($FieldObj);
             });
 


### PR DESCRIPTION
http://bugs.otrs.org/show_bug.cgi?id=11350

Hello @mgruner ,

Hereby is proposal for fixing this bug. There was missing part where columns that are added via sysconfig were not translated in widget option. 
Added translation for column title in widget option and cleaned some typo in AgentDashboardCommon as well.

If you have any remarks or suggestion regarding this fix, please let me know.

Regards,
Sanjin