### PR TITLE
Master - changed color for warning span

### DIFF
--- a/var/httpd/htdocs/skins/Agent/default/css/Core.Default.css
+++ b/var/httpd/htdocs/skins/Agent/default/css/Core.Default.css
@@ -212,7 +212,7 @@ dd {
 }
 
 .Warning {
-    color: #ff505e;
+    color: #ff9050;
 }
 
 .Notice {
@@ -1136,4 +1136,3 @@ iframe.PopupIframe {
         display: none !important;
     }
 }
-


### PR DESCRIPTION
Hi @mrcbnsls 

Carlos Garcia and I worked on some bug. I saw that there is the same color for Error and Warning class in Core.Default.css. For example, there has been added span with Warning class in https://github.com/OTRS/otrs/commit/7a495215c4dd78ac500c01d77212b607d39ac5c8 in case inform that language is removed or not enabled any more. 
I changed slightly the Warning class. I think it could be useful in some further case if there would be the both messages on the same screen.
I know that it is not so vital for functioning the system but this is my proposal, if you consider that it is good you can marge it.

Regards
Zoran
