### PR TITLE
[ Rel-5 Bug 11348 ] - Error handling in AgentTicketForward

### DIFF
--- a/Kernel/Modules/AgentTicketForward.pm
+++ b/Kernel/Modules/AgentTicketForward.pm
@@ -814,7 +814,7 @@ sub SendEmail {
                 Address => $Email->address()
             );
             if ($IsLocal) {
-                $Error{ "$Line" . "Invalid" } = 'ServerError';
+                $Error{ "$Line" . "IsLocalAddress" } = 'ServerError';
             }
         }
     }
@@ -1520,6 +1520,11 @@ sub _Mask {
     if ( $Param{ToInvalid} && $Param{Errors} && !$Param{Errors}->{ToErrorType} ) {
         $LayoutObject->Block(
             Name => 'ToServerErrorMsg',
+        );
+    }
+    if ( $Param{ToIsLocalAddress} && $Param{Errors} && !$Param{Errors}->{ToErrorType} ) {
+        $LayoutObject->Block(
+            Name => 'ToIsLocalAddressServerErrorMsg',
         );
     }
 

--- a/Kernel/Output/HTML/Templates/Standard/AgentTicketForward.tt
+++ b/Kernel/Output/HTML/Templates/Standard/AgentTicketForward.tt
@@ -49,12 +49,15 @@
 
                 <label for="ToCustomer" class="Mandatory"><span class="Marker">*</span>[% Translate("To") | html %]:</label>
                 <div class="Field">
-                    <input id="ToCustomer" type="text" name="ToCustomer" value="" class="CustomerAutoComplete W75pc [% Data.ToInvalid | html %]" autocomplete="off" />
+                    <input id="ToCustomer" type="text" name="ToCustomer" value="" class="CustomerAutoComplete W75pc [% Data.ToIsLocalAddress | html %] [% Data.ToInvalid | html %]" autocomplete="off" />
 
                     <div id="ToCustomerServerError" class="TooltipErrorMessage">
 [% RenderBlockStart("ToServerErrorMsg") %]
                         <p>[% Translate("Please include at least one recipient") | html %]</p>
 [% RenderBlockEnd("ToServerErrorMsg") %]
+[% RenderBlockStart("ToIsLocalAddressServerErrorMsg") %]
+                        <p>[% Translate("This address is registered as system address.") | html %]</p>
+[% RenderBlockEnd("ToIsLocalAddressServerErrorMsg") %]
                     </div>
                 </div>
                 <div class="Clear"></div>


### PR DESCRIPTION
http://bugs.otrs.org/show_bug.cgi?id=11348

Hello @mgruner ,

This issue is reported as bug, yet in AgentTicketForward ( line 813) there is check if 'To' is a system addresses. But same error handling was used as for other errors.

Since i am not certain if this is expected behavior, should we allow system address as 'To' or not, I added at least correct message and information for that error.

What do you think about this? If this check is unnecessary here i will remove it and adept code accordingly. Additionally error handling is not working best in AgentTicketForward but that's bigger task to be done in future.

Please if you have any further questions or issues regarding this PR, let me know.

Regards,
Sanjin