### PR TITLE
[ Rel-5 Bug 11269 ] - Admin Service: empty value for description field shows as () below the form field

### DIFF
--- a/Kernel/Output/HTML/Templates/Standard/AdminNotificationEvent.tt
+++ b/Kernel/Output/HTML/Templates/Standard/AdminNotificationEvent.tt
@@ -335,7 +335,7 @@ $('.NotificationDelete').bind('click', function (Event) {
                         <label for="ArticleTypeID">[% Translate("Article type") | html %]: </label>
                         <div class="Field">
                             [% Data.ArticleTypesStrg %]
-                            <p class="FieldExplanation">([% Translate("Only for ArticleCreate and ArticleSend event") | html %])</p>
+                            <p class="FieldExplanation">[% Translate("Only for ArticleCreate and ArticleSend event") | html %]</p>
                             <div id="ArticleTypeIDServerError" class="TooltipErrorMessage">
                                 <p>[% Translate("If ArticleCreate or ArticleSend is used as a trigger event, you need to specify an article filter as well. Please select at least one of the article filter fields.") | html %]</p>
                             </div>
@@ -345,7 +345,7 @@ $('.NotificationDelete').bind('click', function (Event) {
                         <label for="ArticleSenderTypeID">[% Translate("Article sender type") | html %]: </label>
                         <div class="Field">
                             [% Data.ArticleSenderTypesStrg %]
-                            <p class="FieldExplanation">([% Translate("Only for ArticleCreate and ArticleSend event") | html %])</p>
+                            <p class="FieldExplanation">[% Translate("Only for ArticleCreate and ArticleSend event") | html %]</p>
                             <div id="ArticleSenderTypeIDServerError" class="TooltipErrorMessage">
                                 <p>[% Translate("If ArticleCreate or ArticleSend is used as a trigger event, you need to specify an article filter as well. Please select at least one of the article filter fields.") | html %]</p>
                             </div>
@@ -355,7 +355,7 @@ $('.NotificationDelete').bind('click', function (Event) {
                         <label for="ArticleSubjectMatch">[% Translate("Subject match") | html %]: </label>
                         <div class="Field">
                             <input type="text" name="ArticleSubjectMatch" id="ArticleSubjectMatch" class="W75pc [% Data.ArticleSubjectMatchServerError %]" value="[% Data.ArticleSubjectMatch | html %]"/>
-                            <p class="FieldExplanation">([% Translate("Only for ArticleCreate and ArticleSend event") | html %])</p>
+                            <p class="FieldExplanation">[% Translate("Only for ArticleCreate and ArticleSend event") | html %]</p>
                             <div id="ArticleSubjectMatchServerError" class="TooltipErrorMessage">
                                 <p>[% Translate("If ArticleCreate or ArticleSend is used as a trigger event, you need to specify an article filter as well. Please select at least one of the article filter fields.") | html %]</p>
                             </div>
@@ -367,7 +367,7 @@ $('.NotificationDelete').bind('click', function (Event) {
                         </label>
                         <div class="Field">
                             <input type="text" name="ArticleBodyMatch" id="ArticleBodyMatch" class="W75pc [% Data.ArticleBodyMatchServerError %]" value="[% Data.ArticleBodyMatch | html %]"/>
-                            <p class="FieldExplanation">([% Translate("Only for ArticleCreate and ArticleSend event") | html %])</p>
+                            <p class="FieldExplanation">[% Translate("Only for ArticleCreate and ArticleSend event") | html %]</p>
                             <div id="ArticleBodyMatchServerError" class="TooltipErrorMessage">
                                 <p>[% Translate("If ArticleCreate or ArticleSend is used as a trigger event, you need to specify an article filter as well. Please select at least one of the article filter fields.") | html %]</p>
                             </div>
@@ -377,7 +377,7 @@ $('.NotificationDelete').bind('click', function (Event) {
                         <label for="ArticleAttachmentInclude">[% Translate("Include attachments to notification") | html %]: </label>
                         <div class="Field">
                             [% Data.ArticleAttachmentIncludeStrg %]
-                            <p class="FieldExplanation">([% Translate("Only for ArticleCreate and ArticleSend event") | html %])</p>
+                            <p class="FieldExplanation">[% Translate("Only for ArticleCreate and ArticleSend event") | html %]</p>
                         </div>
                         <div class="Clear"></div>
 

--- a/Kernel/Output/HTML/Templates/Standard/AdminService.tt
+++ b/Kernel/Output/HTML/Templates/Standard/AdminService.tt
@@ -130,7 +130,7 @@
                         <label for="[% Data.Name | html %]">[% Translate(Data.Label) | html %]: </label>
                         <div class="Field">
                             <input type="text" name="[% Data.Name | html %]" id="[% Data.Name | html %]" value="[% Data.SelectedID | html %]" class="W25pc"/>
-                            <p class="FieldExplanation">([% Translate(Data.Desc) | html %])</p>
+                            <p class="FieldExplanation">[% Translate(Data.Desc) | html %]</p>
                         </div>
                         <div class="Clear"></div>
 [% RenderBlockEnd("Input") %]
@@ -138,7 +138,7 @@
                         <label for="[% Data.Name | html %]">[% Translate(Data.Label) | html %]: </label>
                         <div class="Field">
                             <textarea name="[% Data.Name | html %]" id="[% Data.Name | html %]" rows="[% Data.Rows | html %]" cols="[% Data.Cols | html %]">[% Data.SelectedID | html %]</textarea>
-                            <p class="FieldExplanation">([% Translate(Data.Desc) | html %])</p>
+                            <p class="FieldExplanation">[% Translate(Data.Desc) | html %]</p>
                         </div>
                         <div class="Clear"></div>
 [% RenderBlockEnd("TextArea") %]
@@ -146,7 +146,7 @@
                         <label for="[% Data.Name | html %]">[% Translate(Data.Label) | html %] [% Translate(Data.Key) | html %]:</label>
                         <div class="Field">
                             [% Data.Option %]
-                            <p class="FieldExplanation">([% Translate(Data.Desc) | html %])</p>
+                            <p class="FieldExplanation">[% Translate(Data.Desc) | html %]</p>
                         </div>
                         <div class="Clear"></div>
 [% RenderBlockEnd("Option") %]


### PR DESCRIPTION
http://bugs.otrs.org/show_bug.cgi?id=11269

Hello @mgruner ,

Removed brackets from FieldExplanation value. Apart from AdminService.tt that reporter mentioned, cleared in AdminNotificationEvent.tt as well.

Regards,
Sanjin  