### PR TITLE
Updated files to be aligned with the other widgets

### DIFF
--- a/Kernel/Output/HTML/Standard/AgentDashboardCustomerUserList.tt
+++ b/Kernel/Output/HTML/Standard/AgentDashboardCustomerUserList.tt
@@ -55,14 +55,14 @@
             </td>
 [% RenderBlockStart("ContentLargeCustomerUserListRowCustomerUserTicketsOpen") %]
             <td>
-                <a href="[% Env("Baselink") %]Action=AgentTicketSearch;Subaction=Search;StateType=Open;CustomerUserLogin=[% Data.CustomerKey | uri %]" title="[% Translate("%s open ticket(s) of %s", Data.Count, Data.CustomerKey) | html %]" class="AsBlock">
+                <a href="[% Env("Baselink") %]Action=AgentTicketSearch;Subaction=Search;StateType=open;CustomerUserLogin=[% Data.CustomerKey | uri %]" title="[% Translate("%s open ticket(s) of %s", Data.Count, Data.CustomerKey) | html %]" class="AsBlock">
                     [% Data.Count | html %]
                 </a>
             </td>
 [% RenderBlockEnd("ContentLargeCustomerUserListRowCustomerUserTicketsOpen") %]
 [% RenderBlockStart("ContentLargeCustomerUserListRowCustomerUserTicketsClosed") %]
             <td>
-                <a href="[% Env("Baselink") %]Action=AgentTicketSearch;Subaction=Search;StateType=Closed;CustomerUserLogin=[% Data.CustomerKey | uri %]" title="[% Translate("%s closed ticket(s) of %s", Data.Count, Data.CustomerKey) | html %]" class="AsBlock">
+                <a href="[% Env("Baselink") %]Action=AgentTicketSearch;Subaction=Search;StateType=closed;CustomerUserLogin=[% Data.CustomerKey | uri %]" title="[% Translate("%s closed ticket(s) of %s", Data.Count, Data.CustomerKey) | html %]" class="AsBlock">
                     [% Data.Count | html %]
                 </a>
             </td>


### PR DESCRIPTION
We noticed today that in the customerinformation center, the sums of tickets don't add up.
For example, we have 2 open tickets and 3 in a "pending auto close+" statetype.
Searching for "StateType=Open" will INCLUDE those pending auto close+ states, whereas searching for "StateType=open" will not.

As the four widgets below this list (open tickets, escalated tickets, new tickets and pending reminder tickets) use the lowercase statetype, I want to propose to change it here as well.

This needs a change in the according .pm file also (for the COUNT), but I don't know how to include 2 files in a pull request - sorry.