### PR TITLE
[ Rel-5 Bug 11528 ] - Group Name like 'test::Support::1st Line' is not possible to use for group restrictions

### DIFF
--- a/Kernel/Output/HTML/TicketMenu/Generic.pm
+++ b/Kernel/Output/HTML/TicketMenu/Generic.pm
@@ -1,5 +1,5 @@
 # --
-# Copyright (C) 2001-2015 OTRS AG, http://otrs.com/
+# Copyright (C) 2001-2016 OTRS AG, http://otrs.com/
 # --
 # This software comes with ABSOLUTELY NO WARRANTY. For details, see
 # the enclosed file COPYING for license information (AGPL). If you
@@ -93,8 +93,17 @@ sub Run {
         ITEM:
         for my $Item (@Items) {
 
-            my ( $Permission, $Name ) = split /:/, $Item;
+            # get index for first colon (:) into the item
+            my $IndexSeparator = index ($Item, ':');
 
+            # take the part for the permission from string
+            my $Permission = substr($Item, 0, $IndexSeparator);
+
+            # increase the index for skipping the seperator
+            $IndexSeparator++;
+
+            # get the Group name
+            my $Name = substr($Item, $IndexSeparator);
             if ( !$Permission || !$Name ) {
                 $LogObject->Log(
                     Priority => 'error',

--- a/Kernel/System/Group.pm
+++ b/Kernel/System/Group.pm
@@ -120,6 +120,15 @@ sub GroupAdd {
         }
     }
 
+    # check group name
+    if ( $Param{Name} =~ m{ : }xms ) {
+        $Kernel::OM->Get('Kernel::System::Log')->Log(
+            Priority => 'error',
+            Message  => "Can't add group! Don't use : (colon) in group name!",
+        );
+        return;
+    }
+
     # get database object
     my $DBObject = $Kernel::OM->Get('Kernel::System::DB');
 

--- a/Kernel/System/Group.pm
+++ b/Kernel/System/Group.pm
@@ -251,6 +251,15 @@ sub GroupUpdate {
         }
     }
 
+    # check group name
+    if ( $Param{Name} =~ m{ : }xms ) {
+        $Kernel::OM->Get('Kernel::System::Log')->Log(
+            Priority => 'error',
+            Message  => "Can't update group! Don't use : (colon) in group name!",
+        );
+        return;
+    }
+
     # set default value
     $Param{Comment} ||= '';
 


### PR DESCRIPTION
http://bugs.otrs.org/show_bug.cgi?id=11528

Hi @mgruner ,

Hereby is proposal for fixing this issue. Added check when creating group to deny any names that contain ":" (colon) in it. This way in case that reporter mentioned, there will be no issue if group is used in restriction context.

Please let me know what do you think about this proposal.

Regards,
Sanjin