### PR TITLE
[Master - bug 11553 ] In some languages the buttons to create a statistics have diffrent heights

### DIFF
--- a/var/httpd/htdocs/skins/Agent/default/css/Core.Agent.Statistics.css
+++ b/var/httpd/htdocs/skins/Agent/default/css/Core.Agent.Statistics.css
@@ -26,6 +26,7 @@
     border: 1px solid #ccc;
     border-bottom: 1px solid #bbb;
     margin-right: 15px;
+    vertical-align: top;
 }
 
 .BigButtons li a {
@@ -33,6 +34,7 @@
     padding: 20px;
     display: block;
     width: 150px;
+    min-height: 110px;
 	background: #eee;
     cursor: pointer;
     transition: all ease-in 0.2s;


### PR DESCRIPTION
Hi @mgruner,

Here is our proposal for fixing. There was a problem if some of texts are shorter. It could be a problem also if some of translated text is longer. However it is esthetic, not functional issue.
I think that there could be welcomed @mrcbnsls  opinion. 

Because this is proposal I have done in master, but if you want I will be able to provide PR for OTRS5.

Regards
Zoran