### PR TITLE
[ Master - Bug 10998 ] - wrong translation displayed

### DIFF
--- a/Kernel/Modules/AdminCustomerUser.pm
+++ b/Kernel/Modules/AdminCustomerUser.pm
@@ -871,16 +871,17 @@ sub _Edit {
 
             # get the data of the current selection
             my $SelectionsData = $ConfigObject->Get( $Param{Source} )->{Selections}->{ $Entry->[0] };
+            my $SelectionsDataValues;
 
             # make sure the encoding stamp is set
-            for my $Key ( sort keys %{$SelectionsData} ) {
-                $SelectionsData->{$Key}
-                    = $Kernel::OM->Get('Kernel::System::Encode')->EncodeInput( $SelectionsData->{$Key} );
+            for my $Value ( sort values %{$SelectionsData} ) {
+                $SelectionsDataValues->{$Value}
+                    = $Kernel::OM->Get('Kernel::System::Encode')->EncodeInput( $Value );
             }
 
             # build option string
             $Param{Option} = $LayoutObject->BuildSelection(
-                Data        => $SelectionsData,
+                Data        => $SelectionsDataValues,
                 Name        => $Entry->[0],
                 Translation => 1,
                 SelectedID  => $Param{ $Entry->[0] },


### PR DESCRIPTION
http://bugs.otrs.org/show_bug.cgi?id=10998

Hi @mgruner 

There is our proposal for fixing this bug. However, to be honest I don't think that it is a bug. There is a problem if Selection is set as reporter mentioned on the bug report.

Selections => {
    UserVIP => {
        'true' => 'SÃ­',
        'false' => 'No',
    },
},
In that case in AdminCustomerUser screen are displayed good values, but after add/update in the DB is saved key and it will be showed AgentTicketZoom Customer information widget. 

We can suggest reporter of this bug that he should configure Selection in config on specific way as it is used with

<pre>
        Selections => {

           UserTitle => {
               'Mr.' => 'Mr.',
               'Mrs.' => 'Mrs.',
           },
        },
</pre>

and in that case reporter example would be something like that:
<pre>
Selections => {
    UserVIP => {
        'SÃ => 'SÃ',
        'No' => 'No',
    },
</pre>

In any case I provide another solution where the option box is builded, for such selection, on the way that it is taken value instead of key of configured  Selection. 
I prefer the first solution that we reject this bug with suggestion. Please let me know what do you think about that. 

Regards
Zoran