### PR TITLE
[ Master - Bug 11365 ] - ACLs don't work in the customer interface

### DIFF
--- a/Kernel/Modules/CustomerTicketPrint.pm
+++ b/Kernel/Modules/CustomerTicketPrint.pm
@@ -58,6 +58,30 @@ sub Run {
         return $LayoutObject->CustomerNoPermission( WithHeader => 'yes' );
     }
 
+    # get ACL restrictions
+    my %PossibleActions = ( 1 => $Self->{Action} );
+
+    my $ACL = $TicketObject->TicketAcl(
+        Data          => \%PossibleActions,
+        Action        => $Self->{Action},
+        TicketID      => $Self->{TicketID},
+        ReturnType    => 'Action',
+        ReturnSubType => '-',
+        UserID        => $Self->{UserID},
+    );
+    my %AclAction = $TicketObject->TicketAclActionData();
+
+    # check if ACL restrictions exist
+    if ( $ACL || IsHashRefWithData( \%AclAction ) ) {
+
+        my %AclActionLookup = reverse %AclAction;
+
+        # show error screen if ACL prohibits this action
+        if ( !$AclActionLookup{ $Self->{Action} } ) {
+            return $LayoutObject->NoPermission( WithHeader => 'yes' );
+        }
+    }
+
     # get content
     my %Ticket = $TicketObject->TicketGet(
         TicketID      => $Self->{TicketID},
@@ -435,7 +459,7 @@ sub _PDFOutputTicketDynamicFields {
 
         my $BackendObject = $Kernel::OM->Get('Kernel::System::DynamicField::Backend');
 
-        # skip dynamic field if is not desinged for customer interface
+        # skip dynamic field if is not designed for customer interface
         my $IsCustomerInterfaceCapable = $BackendObject->HasBehavior(
             DynamicFieldConfig => $DynamicFieldConfig,
             Behavior           => 'IsCustomerInterfaceCapable',
@@ -723,7 +747,7 @@ sub _PDFOutputArticles {
 
             my $BackendObject = $Kernel::OM->Get('Kernel::System::DynamicField::Backend');
 
-            # skip the dynamic field if is not desinged for customer interface
+            # skip the dynamic field if is not designed for customer interface
             my $IsCustomerInterfaceCapable = $BackendObject->HasBehavior(
                 DynamicFieldConfig => $DynamicFieldConfig,
                 Behavior           => 'IsCustomerInterfaceCapable',

--- a/Kernel/Modules/CustomerTicketPrint.pm
+++ b/Kernel/Modules/CustomerTicketPrint.pm
@@ -62,12 +62,12 @@ sub Run {
     my %PossibleActions = ( 1 => $Self->{Action} );
 
     my $ACL = $TicketObject->TicketAcl(
-        Data          => \%PossibleActions,
-        Action        => $Self->{Action},
-        TicketID      => $Self->{TicketID},
-        ReturnType    => 'Action',
-        ReturnSubType => '-',
-        UserID        => $Self->{UserID},
+        Data           => \%PossibleActions,
+        Action         => $Self->{Action},
+        TicketID       => $Self->{TicketID},
+        ReturnType     => 'Action',
+        ReturnSubType  => '-',
+        CustomerUserID => $Self->{UserID},
     );
     my %AclAction = $TicketObject->TicketAclActionData();
 

--- a/Kernel/Modules/CustomerTicketZoom.pm
+++ b/Kernel/Modules/CustomerTicketZoom.pm
@@ -94,12 +94,12 @@ sub Run {
     }
 
     my $ACL = $TicketObject->TicketAcl(
-        Data          => \%PossibleActions,
-        Action        => $Self->{Action},
-        TicketID      => $Self->{TicketID},
-        ReturnType    => 'Action',
-        ReturnSubType => '-',
-        UserID        => $Self->{UserID},
+        Data           => \%PossibleActions,
+        Action         => $Self->{Action},
+        TicketID       => $Self->{TicketID},
+        ReturnType     => 'Action',
+        ReturnSubType  => '-',
+        CustomerUserID => $Self->{UserID},
     );
 
     my %AclAction = %PossibleActions;


### PR DESCRIPTION
http://bugs.otrs.org/show_bug.cgi?id=11365

Hi @carlosfrodriguez ,

Hereby is proposal for fixing this issue. Previously there was no ACL restriction for actions in CustomerTicketZoom, so added that. Currently only CustomerTicketPrint action is restricted with ACL, but there is left space, if need be, to restrict other customer action in future. 

Additionally cleaned some typos in code.

Please let me know what do you think about this suggestion and PR.

Regards,
Sanjin