### PR TITLE
[ Rel-5_0 Bug 11557 ] - Ticket Notifications in personal preferences is sorted badly

### DIFF
--- a/Kernel/Output/HTML/Preferences/NotificationEvent.pm
+++ b/Kernel/Output/HTML/Preferences/NotificationEvent.pm
@@ -119,7 +119,10 @@ sub Param {
         );
 
         NOTIFICATION:
-        for my $NotificationID ( sort keys %{ $Self->{NotificationList} } ) {
+        for my $NotificationID (
+            sort { $Self->{NotificationList}->{$a}->{Name} cmp $Self->{NotificationList}->{$b}->{Name} }
+            keys %{ $Self->{NotificationList} } )
+        {
 
             next NOTIFICATION if !$Self->{NotificationList}->{$NotificationID};
 


### PR DESCRIPTION
http://bugs.otrs.org/show_bug.cgi?id=11557

Hi @carlosfrodriguez, @mgruner  ,

Here is fix for the bug. The reporter was right that sorting in the agent preferences was different than sorting in the admin notification event. With this fix there is the same sorting in the both screen ( by the name of notification)

Regards
Zoran