### PR TITLE
 [ Master - Bug 11558 ] - Empty Agent preferences tooltip in AdminNotificationEvent

### DIFF
--- a/var/httpd/htdocs/js/Core.Agent.Admin.NotificationEvent.js
+++ b/var/httpd/htdocs/js/Core.Agent.Admin.NotificationEvent.js
@@ -53,7 +53,6 @@ Core.Agent.Admin.NotificationEvent = (function (TargetNS) {
 
             if ($('#VisibleForAgent').prop('checked')) {
                 TooltipObject.removeAttr('readonly');
-                TooltipObject.prop('value','');
 
                 // show default transport value
                 $('.AgentEnabledByDefault').show();


### PR DESCRIPTION
http://bugs.otrs.org/show_bug.cgi?id=11558

Hi @carlosgarciac ,

Hereby is solution for this bug. When 'VisibleForAgent' is checked it was removing value from 'VisibleForAgentTooltip', which was resulting in empty value on screen load as well.

Regards,
Sanjin