### PR TITLE
Add new config options to define hour and minute for pending time

### DIFF
--- a/Kernel/Config/Files/Ticket.xml
+++ b/Kernel/Config/Files/Ticket.xml
@@ -11470,4 +11470,20 @@ Thanks for your help!
             </Option>
         </Setting>
     </ConfigItem>
+    <ConfigItem Name="Ticket::Frontend::PendingTimeHour" Required="0" Valid="0">
+        <Description Translatable="1">Exact hour for pending time.</Description>
+        <Group>Ticket</Group>
+        <SubGroup>Frontend::Agent</SubGroup>
+        <Setting>
+            <String Regex="^\d+$">8</String>
+        </Setting>
+    </ConfigItem>
+    <ConfigItem Name="Ticket::Frontend::PendingTimeMinute" Required="0" Valid="0">
+        <Description Translatable="1">Exact hour for pending time.</Description>
+        <Group>Ticket</Group>
+        <SubGroup>Frontend::Agent</SubGroup>
+        <Setting>
+            <String Regex="^\d+$">00</String>
+        </Setting>
+    </ConfigItem>
 </otrs_config>

--- a/Kernel/Modules/AgentTicketActionCommon.pm
+++ b/Kernel/Modules/AgentTicketActionCommon.pm
@@ -1819,8 +1819,21 @@ sub _Mask {
             my $Calendar = $TicketObject->TicketCalendarGet(
                 %Ticket,
             );
+            
+            my %PendingOpts;
+            my $Hour = $ConfigObject->Get('Ticket::Frontend::PendingTimeHour');
+            if ( defined $Hour ) {
+                $PendingOpts{Hour} = $Hour;
+            }
 
-            $Param{DateString} = $LayoutObject->BuildDateSelection(
+            my $Minute = $ConfigObject->Get('Ticket::Frontend::PendingTimeMinute');
+            if ( defined $Minute ) {
+                $PendingOpts{Minute} = $Minute;
+            }
+
+            # pending data string
+            $Param{PendingDateString} = $LayoutObject->BuildDateSelection(
+                %PendingOpts,
                 %Param,
                 Format           => 'DateInputFormatLong',
                 YearPeriodPast   => 0,

--- a/Kernel/Modules/AgentTicketBulk.pm
+++ b/Kernel/Modules/AgentTicketBulk.pm
@@ -953,7 +953,21 @@ sub _Mask {
             next STATE_ID if !$StateID;
             my %StateData = $StateObject->StateGet( ID => $StateID );
             next STATE_ID if $StateData{TypeName} !~ /pending/i;
-            $Param{DateString} = $LayoutObject->BuildDateSelection(
+            
+            my %PendingOpts;
+            my $Hour = $ConfigObject->Get('Ticket::Frontend::PendingTimeHour');
+            if ( defined $Hour ) {
+                $PendingOpts{Hour} = $Hour;
+            }
+
+            my $Minute = $ConfigObject->Get('Ticket::Frontend::PendingTimeMinute');
+            if ( defined $Minute ) {
+                $PendingOpts{Minute} = $Minute;
+            }
+
+            # pending data string
+            $Param{PendingDateString} = $LayoutObject->BuildDateSelection(
+                %PendingOpts,
                 %Param,
                 Format               => 'DateInputFormatLong',
                 DiffTime             => $ConfigObject->Get('Ticket::Frontend::PendingDiffTime') || 0,

--- a/Kernel/Modules/AgentTicketCompose.pm
+++ b/Kernel/Modules/AgentTicketCompose.pm
@@ -1684,8 +1684,20 @@ sub _Mask {
         SLAID   => $Param{SLAID},
     );
 
+    my %PendingOpts;
+    my $Hour = $ConfigObject->Get('Ticket::Frontend::PendingTimeHour');
+    if ( defined $Hour ) {
+        $PendingOpts{Hour} = $Hour;
+    }
+
+    my $Minute = $ConfigObject->Get('Ticket::Frontend::PendingTimeMinute');
+    if ( defined $Minute ) {
+        $PendingOpts{Minute} = $Minute;
+    }
+
     # pending data string
     $Param{PendingDateString} = $LayoutObject->BuildDateSelection(
+        %PendingOpts,
         %Param,
         Format               => 'DateInputFormatLong',
         YearPeriodPast       => 0,

--- a/Kernel/Modules/AgentTicketEmail.pm
+++ b/Kernel/Modules/AgentTicketEmail.pm
@@ -2503,9 +2503,21 @@ sub _MaskEmailNew {
         SelectedValue => $Param{Priority},
         Translation   => 1,
     );
+    
+    my %PendingOpts;
+    my $Hour = $ConfigObject->Get('Ticket::Frontend::PendingTimeHour');
+    if ( defined $Hour ) {
+        $PendingOpts{Hour} = $Hour;
+    }
+
+    my $Minute = $ConfigObject->Get('Ticket::Frontend::PendingTimeMinute');
+    if ( defined $Minute ) {
+        $PendingOpts{Minute} = $Minute;
+    }
 
     # pending data string
     $Param{PendingDateString} = $LayoutObject->BuildDateSelection(
+        %PendingOpts,
         %Param,
         Format               => 'DateInputFormatLong',
         YearPeriodPast       => 0,

--- a/Kernel/Modules/AgentTicketEmailOutbound.pm
+++ b/Kernel/Modules/AgentTicketEmailOutbound.pm
@@ -1536,8 +1536,20 @@ sub _Mask {
         }
     }
 
+    my %PendingOpts;
+    my $Hour = $ConfigObject->Get('Ticket::Frontend::PendingTimeHour');
+    if ( defined $Hour ) {
+        $PendingOpts{Hour} = $Hour;
+    }
+
+    my $Minute = $ConfigObject->Get('Ticket::Frontend::PendingTimeMinute');
+    if ( defined $Minute ) {
+        $PendingOpts{Minute} = $Minute;
+    }
+
     # pending data string
     $Param{PendingDateString} = $LayoutObject->BuildDateSelection(
+        %PendingOpts,
         %Param,
         YearPeriodPast       => 0,
         YearPeriodFuture     => 5,

--- a/Kernel/Modules/AgentTicketForward.pm
+++ b/Kernel/Modules/AgentTicketForward.pm
@@ -1404,8 +1404,20 @@ sub _Mask {
         SLAID   => $Param{SLAID},
     );
 
+    my %PendingOpts;
+    my $Hour = $ConfigObject->Get('Ticket::Frontend::PendingTimeHour');
+    if ( defined $Hour ) {
+        $PendingOpts{Hour} = $Hour;
+    }
+
+    my $Minute = $ConfigObject->Get('Ticket::Frontend::PendingTimeMinute');
+    if ( defined $Minute ) {
+        $PendingOpts{Minute} = $Minute;
+    }
+
     # pending data string
     $Param{PendingDateString} = $LayoutObject->BuildDateSelection(
+        %PendingOpts,
         %Param,
         YearPeriodPast       => 0,
         YearPeriodFuture     => 5,

--- a/Kernel/Modules/AgentTicketMove.pm
+++ b/Kernel/Modules/AgentTicketMove.pm
@@ -1235,8 +1235,21 @@ sub AgentMove {
                 QueueID => $Param{QueueID},
                 SLAID   => $Param{SLAID},
             );
+            
+            my %PendingOpts;
+            my $Hour = $ConfigObject->Get('Ticket::Frontend::PendingTimeHour');
+            if ( defined $Hour ) {
+                $PendingOpts{Hour} = $Hour;
+            }
 
-            $Param{DateString} = $LayoutObject->BuildDateSelection(
+            my $Minute = $ConfigObject->Get('Ticket::Frontend::PendingTimeMinute');
+            if ( defined $Minute ) {
+                $PendingOpts{Minute} = $Minute;
+            }
+
+            # pending data string
+            $Param{PendingDateString} = $LayoutObject->BuildDateSelection(
+                %PendingOpts,
                 Format           => 'DateInputFormatLong',
                 YearPeriodPast   => 0,
                 YearPeriodFuture => 5,

--- a/Kernel/Modules/AgentTicketPhone.pm
+++ b/Kernel/Modules/AgentTicketPhone.pm
@@ -2531,8 +2531,20 @@ sub _MaskPhoneNew {
         Translation   => 1,
     );
 
+    my %PendingOpts;
+    my $Hour = $ConfigObject->Get('Ticket::Frontend::PendingTimeHour');
+    if ( defined $Hour ) {
+        $PendingOpts{Hour} = $Hour;
+    }
+
+    my $Minute = $ConfigObject->Get('Ticket::Frontend::PendingTimeMinute');
+    if ( defined $Minute ) {
+        $PendingOpts{Minute} = $Minute;
+    }
+
     # pending data string
     $Param{PendingDateString} = $LayoutObject->BuildDateSelection(
+        %PendingOpts,
         %Param,
         Format               => 'DateInputFormatLong',
         YearPeriodPast       => 0,

--- a/Kernel/Modules/AgentTicketPhoneCommon.pm
+++ b/Kernel/Modules/AgentTicketPhoneCommon.pm
@@ -1144,8 +1144,20 @@ sub _MaskPhone {
         SLAID   => $Param{SLAID},
     );
 
+    my %PendingOpts;
+    my $Hour = $ConfigObject->Get('Ticket::Frontend::PendingTimeHour');
+    if ( defined $Hour ) {
+        $PendingOpts{Hour} = $Hour;
+    }
+
+    my $Minute = $ConfigObject->Get('Ticket::Frontend::PendingTimeMinute');
+    if ( defined $Minute ) {
+        $PendingOpts{Minute} = $Minute;
+    }
+
     # pending data string
     $Param{PendingDateString} = $LayoutObject->BuildDateSelection(
+        %PendingOpts,
         %Param,
         Format               => 'DateInputFormatLong',
         YearPeriodPast       => 0,

--- a/Kernel/Modules/AgentTicketProcess.pm
+++ b/Kernel/Modules/AgentTicketProcess.pm
@@ -2203,8 +2203,21 @@ sub _RenderPendingTime {
             %{ $Param{Ticket} },
         );
     }
+    
+    my %PendingOpts;
+    my $Hour = $ConfigObject->Get('Ticket::Frontend::PendingTimeHour');
+    if ( defined $Hour ) {
+        $PendingOpts{Hour} = $Hour;
+    }
 
-    $Data{Content} = $LayoutObject->BuildDateSelection(
+    my $Minute = $ConfigObject->Get('Ticket::Frontend::PendingTimeMinute');
+    if ( defined $Minute ) {
+        $PendingOpts{Minute} = $Minute;
+    }
+
+    # pending data string
+    $Param{PendingDateString} = $LayoutObject->BuildDateSelection(
+        %PendingOpts,
         Prefix => 'PendingTime',
         PendingTimeRequired =>
             (


### PR DESCRIPTION
Until now one can define the a time difference for the pending time. But in many cases, one want to set the pending time to the start of the office times to be reminded at the start of the work day.

This pull request adds exactly this. One can define the hour and minute of the pending time.
