### PR TITLE
Bug 11570: Hide defunct link to AgentStatisticsReports

### DIFF
--- a/Kernel/Config/Files/Framework.xml
+++ b/Kernel/Config/Files/Framework.xml
@@ -5535,6 +5535,7 @@ via the Preferences button after logging in.
                     <Block>ItemArea</Block>
                     <AccessKey></AccessKey>
                 </NavBar>
+<!--
                 <NavBar>
                     <GroupRo>stats</GroupRo>
                     <Description Translatable="1"></Description>
@@ -5547,6 +5548,7 @@ via the Preferences button after logging in.
                     <Block></Block>
                     <AccessKey></AccessKey>
                 </NavBar>
+-->
                 <NavBar>
                     <GroupRo>stats</GroupRo>
                     <Description Translatable="1"></Description>


### PR DESCRIPTION
The advertising is not working due to the relevant file being placed in .gitignore

As I am fairly certain, that you would not want to remove the advertising completely, just commenting it, so it can be re-enabled once you feel comfortable shipping it.