### PR TITLE
[Master Bug 11574] - Dashboard - Queue - Attributes of the Widget are not used in the 'Tickets in my Service' view

### DIFF
--- a/Kernel/Output/HTML/Dashboard/TicketGeneric.pm
+++ b/Kernel/Output/HTML/Dashboard/TicketGeneric.pm
@@ -2116,7 +2116,7 @@ sub _SearchParamsGet {
 
     if ( defined $TicketSearch{QueueIDs} || defined $TicketSearch{Queues} ) {
         delete $TicketSearchSummary{MyQueues};
-        delete $TicketSearchSummary{MyServices};
+        delete $TicketSearchSummary{MyServices}{QueueIDs};
     }
 
     if ( !$Self->{UseTicketService} ) {

--- a/Kernel/Output/HTML/Dashboard/TicketGeneric.pm
+++ b/Kernel/Output/HTML/Dashboard/TicketGeneric.pm
@@ -2116,6 +2116,7 @@ sub _SearchParamsGet {
 
     if ( defined $TicketSearch{QueueIDs} || defined $TicketSearch{Queues} ) {
         delete $TicketSearchSummary{MyQueues};
+        delete $TicketSearchSummary{MyServices};
     }
 
     if ( !$Self->{UseTicketService} ) {


### PR DESCRIPTION
http://bugs.otrs.org/show_bug.cgi?id=11574

Hi,

Here is our proposal for fixing. We solved it similar to if Queue is added in SySconfig for param Attributes.
Please, let me know what do you mean about that.

P.S. We are planning to provide new PR with our suggestion for solving same casees if in Attributes is added Owner, Responsible, WatchUser or something like that. We will add in another PR because it is only our proposal for now, and this is not subject of this bug.

Regards
Zoran