### PR TITLE
Normalized HTML structure.

### DIFF
--- a/Kernel/Output/HTML/Templates/Standard/AgentTicketActionCommon.tt
+++ b/Kernel/Output/HTML/Templates/Standard/AgentTicketActionCommon.tt
@@ -340,13 +340,14 @@ $('#TypeID').bind('change', function (Event) {
                             </div>
                             <div class="Clear"></div>
 [% END %]
-                        </fieldset>
 [% RenderBlockStart("InformAdditionalAgents") %]
-                        <fieldset class="TableLike FixedLabel">
 [% RenderBlockStart("InformAgent") %]
                             <label for="InformUserID">[% Translate("Inform agents") | html %]:</label>
                             <div class="Field">
                             [% Data.OptionStrg %]
+                                <p class="FieldExplanation">
+                                    [% Translate("Here you can select additional agents which should receive a notification regarding the new article.") %]
+                                </p>
                             </div>
                             <div class="Clear"></div>
 [% RenderBlockEnd("InformAgent") %]
@@ -354,30 +355,23 @@ $('#TypeID').bind('change', function (Event) {
                             <label for="InvolvedUserID">[% Translate("Inform involved agents") | html %]:</label>
                             <div class="Field">
                             [% Data.InvolvedAgentStrg %]
-                            </div>
-                            <div class="Clear"></div>
-[% RenderBlockEnd("InvolvedAgent") %]
-                            <div class="Field">
                                 <p class="FieldExplanation">
                                     [% Translate("Here you can select additional agents which should receive a notification regarding the new article.") %]
                                 </p>
                             </div>
-                        </fieldset>
+                            <div class="Clear"></div>
+[% RenderBlockEnd("InvolvedAgent") %]
 [% RenderBlockEnd("InformAdditionalAgents") %]
 [% RenderBlockStart("InformAgentsWithoutSelection") %]
-                        <fieldset class="TableLike FixedLabel">
-                            <label>[% Translate("Text will also be received by:") | html %]:</label>
-                            <p class="Value">
+                            <label>[% Translate("Text will also be received by:") | html %]</label>
+                            <div class="Field">
                                 <input type="hidden" name="UserListWithoutSelection" value="[% Data.UserListWithoutSelection  | html %]" />
 [% RenderBlockStart("InformAgentsWithoutSelectionSingleUser") %]
                                 <span title="[% Data.UserEmail %]">[% Data.UserFullname %]</span>[% RenderBlockStart("InformAgentsWithoutSelectionSingleUserSeparator") %],[% RenderBlockEnd("InformAgentsWithoutSelectionSingleUserSeparator") %]
 [% RenderBlockEnd("InformAgentsWithoutSelectionSingleUser") %]
-                            </p>
+                            </div>
                             <div class="Clear"></div>
-                        </fieldset>
 [% RenderBlockEnd("InformAgentsWithoutSelection") %]
-
-                        <fieldset class="TableLike FixedLabel">
 [% RenderBlockStart("SubjectLabel") %]
                             <label for="Subject">[% Translate("Subject") | html %]:</label>
 [% RenderBlockEnd("SubjectLabel") %]


### PR DESCRIPTION
The HTML strucutre got somehow away from the OTRS standard HTML layout / structure. This PR contains the following changes to make it OTRS standard conform again:

- inflationary usage of fieldsets
- p class="FieldExplanation" have to be childs of a div class="Field".
- Translated "Text will also be received by:" is followed by a hardcoded "':" 
- p class="Value" should be a div class="Field"

It would be great if you could apply these changes to the rel-5_0 branch, too.

Thanks to @rolfschmidt 