### PR TITLE
[ Rel-5_0 Bug 11565 ] - New article notification(star) and entry created for agent that creates the ticket

### DIFF
--- a/Kernel/Config/Files/Ticket.xml
+++ b/Kernel/Config/Files/Ticket.xml
@@ -88,6 +88,17 @@
             </Option>
         </Setting>
     </ConfigItem>
+    <ConfigItem Name="Ticket::NewArticleIgnoreCurrentAgent" Required="1" Valid="1">
+        <Description Translatable="1">Ignore article flag for articles created by current logged agent.</Description>
+        <Group>Ticket</Group>
+        <SubGroup>Core::Ticket</SubGroup>
+        <Setting>
+            <Option SelectedID="0">
+                <Item Key="0" Translatable="1">No</Item>
+                <Item Key="1" Translatable="1">Yes</Item>
+            </Option>
+        </Setting>
+    </ConfigItem>
     <ConfigItem Name="Ticket::ChangeOwnerToEveryone" Required="1" Valid="1">
         <Description Translatable="1">Changes the owner of tickets to everyone (useful for ASP). Normally only agent with rw permissions in the queue of the ticket will be shown.</Description>
         <Group>Ticket</Group>

--- a/Kernel/System/Ticket/Event/TicketNewMessageUpdate.pm
+++ b/Kernel/System/Ticket/Event/TicketNewMessageUpdate.pm
@@ -67,7 +67,18 @@ sub Run {
             DynamicFields => 0,
         );
 
-        if ( %Article && $Article{SenderType} eq 'agent' ) {
+        my $IgnoreCurrentAgent = $Kernel::OM->Get('Kernel::Config')->Get('Ticket::NewArticleIgnoreCurrentAgent')
+            && $Article{CreatedBy} eq $Param{UserID};
+
+        if ( %Article && $Article{SenderType} eq 'agent' || $IgnoreCurrentAgent ) {
+
+            # set the seen flag to 1 for the agent who updated the ticket
+            $TicketObject->TicketFlagSet(
+                TicketID => $Param{Data}->{TicketID},
+                Key      => 'Seen',
+                Value    => 1,
+                UserID   => $Param{UserID},
+            );
 
             # set the seen flag to 1 for the agent who created the article
             $TicketObject->ArticleFlagSet(


### PR DESCRIPTION
http://bugs.otrs.org/show_bug.cgi?id=11565

Hi @carlosfrodriguez ,

Hereby is proposed solution for this reported issue. Added sysconfig that can control if agent want to receive 'flags' for there own action. Now agent who create articles will be flagged as seen upon article creation. Ticket is flagged just for that agent as well then.  

If there are any question or issues regarding this PR, please let me know.

Regards,
Sanjin