### PR TITLE
[ Rel-5_0 Bug 9884 ] Solution Time counts wrong on daylight time changes

### DIFF
--- a/Kernel/System/Time.pm
+++ b/Kernel/System/Time.pm
@@ -682,7 +682,7 @@ sub DestinationTime {
     );
 
     my $LoopCounter;
-    my $NextDay;
+    my $DayLightSaving;
 
     LOOP:
     while ( $Param{Time} > 1 ) {
@@ -696,7 +696,7 @@ sub DestinationTime {
 
         # compensate for switching to/from daylight saving time
         # in case daylight saving time from 00:00:00 turned backward 1 hour to 23:00:00
-        if ( $NextDay && $Hour == 23 ) {
+        if ( $DayLightSaving && $Hour == 23 ) {
             $CTime += 3600;
             $CTime00 = $CTime;
 
@@ -771,7 +771,7 @@ sub DestinationTime {
         if ( $NewCTime != $CTime00 + 24 * 60 * 60 ) {
             my $Diff = $NewCTime - $CTime00 - 24 * 60 * 60;
             $DestinationTime += $Diff;
-            $NextDay = 1;
+            $DayLightSaving = 1;
         }
 
         # Set next loop time to 00:00:00 of next day.

--- a/Kernel/System/Time.pm
+++ b/Kernel/System/Time.pm
@@ -682,6 +682,7 @@ sub DestinationTime {
     );
 
     my $LoopCounter;
+    my $NextDay;
 
     LOOP:
     while ( $Param{Time} > 1 ) {
@@ -692,6 +693,20 @@ sub DestinationTime {
         $Year  += 1900;
         $Month += 1;
         my $CTime00 = $CTime - ( ( $Hour * 60 + $Minute ) * 60 + $Second );               # 00:00:00
+
+        # compensate for switching to/from daylight saving time
+        # in case daylight saving time from 00:00:00 turned backward 1 hour to 23:00:00
+        if ( $NextDay && $Hour == 23 ) {
+            $CTime += 3600;
+            $CTime00 = $CTime;
+
+            # there is needed next day, but $Day++ would be wrong in case it was end of month
+            ( $Second, $Minute, $Hour, $Day, $Month, $Year, $WDay ) = localtime $CTime + 1;
+            $Year  += 1900;
+            $Month += 1;
+
+            $DestinationTime += 3600;
+        }
 
         # Skip vacation days, or days without working hours, do not count.
         if (
@@ -756,6 +771,7 @@ sub DestinationTime {
         if ( $NewCTime != $CTime00 + 24 * 60 * 60 ) {
             my $Diff = $NewCTime - $CTime00 - 24 * 60 * 60;
             $DestinationTime += $Diff;
+            $NextDay = 1;
         }
 
         # Set next loop time to 00:00:00 of next day.

--- a/scripts/test/Time/DestinationTime.t
+++ b/scripts/test/Time/DestinationTime.t
@@ -28,7 +28,7 @@ my @Tests = (
         Name            => 'UTC',
         TimeStampStart  => '2015-02-17 12:00:00',
         ServerTZ        => 'UTC',
-        Time            => '7776000',                                                         # 90 days
+        Time            => 60 * 60 * 24 * 90,                                               # 90 days
         TimeDate        => '90 days',
         DestinationTime => '2015-05-19 12:00:00',
     },
@@ -36,15 +36,15 @@ my @Tests = (
         Name            => 'Europe/Berlin ( Daylight Saving Time UTC+1 => UTC+2 )',
         TimeStampStart  => '2015-02-17 12:00:00',
         ServerTZ        => 'Europe/Berlin',
-        Time            => '7779600',
-        TimeDate        => '90 days and 1h',                                                  # 90 days and 1h
+        Time            => 60 * 60 * 24 * 90 + 60 * 60,
+        TimeDate        => '90 days and 1h',                                                   # 90 days and 1h
         DestinationTime => '2015-05-19 13:00:00',
     },
     {
         Name            => 'UTC',
         TimeStampStart  => '2015-02-21 22:00:00',
         ServerTZ        => 'UTC',
-        Time            => '21600',                                                           # 6h
+        Time            => 60 * 60 * 6,                                                        # 6h
         TimeDate        => '6h',
         DestinationTime => '2015-02-22 04:00:00',
     },
@@ -52,7 +52,7 @@ my @Tests = (
         Name            => 'America/Sao_Paulo - end DST from 00 to 23  ( UTC-2 => UTC-3 )',
         TimeStampStart  => '2015-02-21 22:00:00',
         ServerTZ        => 'America/Sao_Paulo',
-        Time            => '18000',                                                           # 5h
+        Time            => 60 * 60 * 5,                                                        # 5h
         TimeDate        => '5h',
         DestinationTime => '2015-02-22 02:00:00',
     },
@@ -60,15 +60,15 @@ my @Tests = (
         Name            => 'UTC with min and sec',
         TimeStampStart  => '2015-02-20 22:10:05',
         ServerTZ        => 'UTC',
-        Time            => '368415',                                                          # 4 days 06:20:15
+        Time            => 60 * 60 * 24 * 4 + 60 * 60 * 6 + 60 * 20 + 15,                      # 4 days 06:20:15
         TimeDate        => '4 days 06:20:15',
         DestinationTime => '2015-02-25 04:30:20',
     },
     {
-        Name            => 'America/Sao_Paulo - end DST from 00 to 23 - with min and sec',
+        Name            => 'America/Sao_Paulo - end DST from 00 to 23 - with min and sec ( UTC-2 => UTC-3 )',
         TimeStampStart  => '2015-02-21 22:10:05',
         ServerTZ        => 'America/Sao_Paulo',
-        Time            => '364815',                                                          # 4 days 05:20:15
+        Time            => 60 * 60 * 24 * 4 + 60 * 60 * 5 + 60 * 20 + 15,                      # 4 days 05:20:15
         TimeDate        => '4 days 05:20:15',
         DestinationTime => '2015-02-26 02:30:20',
     },
@@ -76,15 +76,15 @@ my @Tests = (
         Name            => 'UTC',
         TimeStampStart  => '2015-10-17 22:00:00',
         ServerTZ        => 'UTC',
-        Time            => '21600',                                                           # 6h
-        TimeDate        => '6',
+        Time            => 60 * 60 * 6,                                                        # 6h
+        TimeDate        => '6h',
         DestinationTime => '2015-10-18 04:00:00',
     },
     {
         Name            => 'America/Sao_Paulo - start DST from 00 to 01 ( UTC-3 => UTC-2 )',
         TimeStampStart  => '2015-10-17 22:00:00',
         ServerTZ        => 'America/Sao_Paulo',
-        Time            => '25200',                                                            # 7h
+        Time            => 60 * 60 * 7,                                                        # 7h
         TimeDate        => '7h',
         DestinationTime => '2015-10-18 06:00:00',
     },
@@ -92,7 +92,7 @@ my @Tests = (
         Name            => 'UTC',
         TimeStampStart  => '2015-03-21 12:00:00',
         ServerTZ        => 'UTC',
-        Time            => '86400',                                                            # 24h
+        Time            => 60 * 60 * 24,                                                       # 24h
         TimeDate        => '24h',
         DestinationTime => '2015-03-22 12:00:00',
     },
@@ -100,7 +100,7 @@ my @Tests = (
         Name            => 'UTC',
         TimeStampStart  => '2015-09-21 12:00:00',
         ServerTZ        => 'UTC',
-        Time            => '57600',                                                            # 16h
+        Time            => 60 * 60 * 16,                                                       # 16h
         TimeDate        => '16h',
         DestinationTime => '2015-09-22 04:00:00',
     },
@@ -108,7 +108,7 @@ my @Tests = (
         Name            => 'Asia/Tehran - end DST from 00 to 23  ( UTC+3:30 => UTC+4:30 )',
         TimeStampStart  => '2015-09-21 12:00:00',
         ServerTZ        => 'Asia/Tehran',
-        Time            => '54000',                                                            # 15h
+        Time            => 60 * 60 * 15,                                                       # 15h
         TimeDate        => '15h',
         DestinationTime => '2015-09-22 02:00:00',
     },
@@ -116,7 +116,7 @@ my @Tests = (
         Name            => 'UTC',
         TimeStampStart  => '2015-03-21 12:00:00',
         ServerTZ        => 'UTC',
-        Time            => '57600',                                                            # 16h
+        Time            => 60 * 60 * 16,                                                       # 16h
         TimeDate        => '16h',
         DestinationTime => '2015-03-22 04:00:00',
     },
@@ -124,7 +124,7 @@ my @Tests = (
         Name            => 'Asia/Tehran - end DST from 00 to 01  ( UTC+4:30 => UTC+3:30 )',
         TimeStampStart  => '2015-03-21 12:00:00',
         ServerTZ        => 'Asia/Tehran',
-        Time            => '61200',                                                            # 17h
+        Time            => 60 * 60 * 17,                                                       # 17h
         TimeDate        => '17h',
         DestinationTime => '2015-03-22 06:00:00',
     },
@@ -132,7 +132,7 @@ my @Tests = (
         Name            => 'UTC',
         TimeStampStart  => '2015-01-21 12:00:00',
         ServerTZ        => 'UTC',
-        Time            => '7833600',                                                          # 90 days and 16h
+        Time            => 60 * 60 * 24 * 90 + 60 * 60 * 16,                                   # 90 days and 16h
         TimeDate        => '90 days and 16h',
         DestinationTime => '2015-04-22 04:00:00',
     },
@@ -140,14 +140,14 @@ my @Tests = (
         Name            => 'Australia/Sydney - end DST from 00 to 01  ( UTC+11 => UTC+10 )',
         TimeStampStart  => '2015-01-21 12:00:00',
         ServerTZ        => 'Asia/Tehran',
-        Time            => '7837200',                                                          # 90 days and 17h
+        Time            => 60 * 60 * 24 * 90 + 60 * 60 * 17,                                   # 90 days and 17h
         TimeDate        => '90 days and 17h',
         DestinationTime => '2015-04-22 06:00:00',
     },
 );
 
-# Use a calendar with the same business hours for every day so that the UT runs correctly
-#   on every day of the week and outside usual business hours.
+# use a calendar with the same business hours for every day so that the UT runs correctly
+# on every day of the week and outside usual business hours
 my %Week;
 my @Days = qw(Sun Mon Tue Wed Thu Fri Sat);
 for my $Day (@Days) {
@@ -168,7 +168,7 @@ for my $Test (@Tests) {
     # set the server time zone
     local $ENV{TZ} = $Test->{ServerTZ};
 
-    # Convert UTC timestamp to system time and set it.
+    # convert UTC timestamp to system time and set it
     $Test->{TimeStampStart} =~ m/(\d{4})-(\d{1,2})-(\d{1,2})\s(\d{1,2}):(\d{1,2}):(\d{1,2})/;
 
     my $TimeStart = Time::Local::timegm(
@@ -179,7 +179,7 @@ for my $Test (@Tests) {
         $TimeStart,
     );
 
-    # Set OTRS time zone to arbitrary value to make sure it is ignored.
+    # set OTRS time zone to arbitrary value to make sure it is ignored
     $ConfigObject->Set(
         Key   => 'TimeZone',
         Value => int rand 20 - 10,

--- a/scripts/test/Time/DestinationTime.t
+++ b/scripts/test/Time/DestinationTime.t
@@ -1,0 +1,216 @@
+# --
+# Copyright (C) 2001-2015 OTRS AG, http://otrs.com/
+# --
+# This software comes with ABSOLUTELY NO WARRANTY. For details, see
+# the enclosed file COPYING for license information (AGPL). If you
+# did not receive this file, see http://www.gnu.org/licenses/agpl.txt.
+# --
+
+## no critic (Modules::RequireExplicitPackage)
+use strict;
+use warnings;
+use utf8;
+
+use Time::Local;
+
+use vars (qw($Self));
+
+$Kernel::OM->ObjectParamAdd(
+    'Kernel::System::UnitTest::Helper' => {
+        RestoreSystemConfiguration => 1,
+    },
+);
+my $HelperObject = $Kernel::OM->Get('Kernel::System::UnitTest::Helper');
+my $ConfigObject = $Kernel::OM->Get('Kernel::Config');
+
+my @Tests = (
+    {
+        Name            => 'UTC',
+        TimeStampStart  => '2015-02-17 12:00:00',
+        ServerTZ        => 'UTC',
+        Time            => '7776000',                                                         # 90 days
+        TimeDate        => '90 days',
+        DestinationTime => '2015-05-19 12:00:00',
+    },
+    {
+        Name            => 'Europe/Berlin ( Daylight Saving Time UTC+1 => UTC+2 )',
+        TimeStampStart  => '2015-02-17 12:00:00',
+        ServerTZ        => 'Europe/Berlin',
+        Time            => '7779600',
+        TimeDate        => '90 days and 1h',                                                  # 90 days and 1h
+        DestinationTime => '2015-05-19 13:00:00',
+    },
+    {
+        Name            => 'UTC',
+        TimeStampStart  => '2015-02-21 22:00:00',
+        ServerTZ        => 'UTC',
+        Time            => '21600',                                                           # 6h
+        TimeDate        => '6h',
+        DestinationTime => '2015-02-22 04:00:00',
+    },
+    {
+        Name            => 'America/Sao_Paulo - end DST from 00 to 23  ( UTC-2 => UTC-3 )',
+        TimeStampStart  => '2015-02-21 22:00:00',
+        ServerTZ        => 'America/Sao_Paulo',
+        Time            => '18000',                                                           # 5h
+        TimeDate        => '5h',
+        DestinationTime => '2015-02-22 02:00:00',
+    },
+    {
+        Name            => 'UTC with min and sec',
+        TimeStampStart  => '2015-02-20 22:10:05',
+        ServerTZ        => 'UTC',
+        Time            => '368415',                                                          # 4 days 06:20:15
+        TimeDate        => '4 days 06:20:15',
+        DestinationTime => '2015-02-25 04:30:20',
+    },
+    {
+        Name            => 'America/Sao_Paulo - end DST from 00 to 23 - with min and sec',
+        TimeStampStart  => '2015-02-21 22:10:05',
+        ServerTZ        => 'America/Sao_Paulo',
+        Time            => '364815',                                                          # 4 days 05:20:15
+        TimeDate        => '4 days 05:20:15',
+        DestinationTime => '2015-02-26 02:30:20',
+    },
+    {
+        Name            => 'UTC',
+        TimeStampStart  => '2015-10-17 22:00:00',
+        ServerTZ        => 'UTC',
+        Time            => '21600',                                                           # 6h
+        TimeDate        => '6',
+        DestinationTime => '2015-10-18 04:00:00',
+    },
+    {
+        Name            => 'America/Sao_Paulo - start DST from 00 to 01 ( UTC-3 => UTC-2 )',
+        TimeStampStart  => '2015-10-17 22:00:00',
+        ServerTZ        => 'America/Sao_Paulo',
+        Time            => '25200',                                                            # 7h
+        TimeDate        => '7h',
+        DestinationTime => '2015-10-18 06:00:00',
+    },
+    {
+        Name            => 'UTC',
+        TimeStampStart  => '2015-03-21 12:00:00',
+        ServerTZ        => 'UTC',
+        Time            => '86400',                                                            # 24h
+        TimeDate        => '24h',
+        DestinationTime => '2015-03-22 12:00:00',
+    },
+    {
+        Name            => 'UTC',
+        TimeStampStart  => '2015-09-21 12:00:00',
+        ServerTZ        => 'UTC',
+        Time            => '57600',                                                            # 16h
+        TimeDate        => '16h',
+        DestinationTime => '2015-09-22 04:00:00',
+    },
+    {
+        Name            => 'Asia/Tehran - end DST from 00 to 23  ( UTC+3:30 => UTC+4:30 )',
+        TimeStampStart  => '2015-09-21 12:00:00',
+        ServerTZ        => 'Asia/Tehran',
+        Time            => '54000',                                                            # 15h
+        TimeDate        => '15h',
+        DestinationTime => '2015-09-22 02:00:00',
+    },
+    {
+        Name            => 'UTC',
+        TimeStampStart  => '2015-03-21 12:00:00',
+        ServerTZ        => 'UTC',
+        Time            => '57600',                                                            # 16h
+        TimeDate        => '16h',
+        DestinationTime => '2015-03-22 04:00:00',
+    },
+    {
+        Name            => 'Asia/Tehran - end DST from 00 to 01  ( UTC+4:30 => UTC+3:30 )',
+        TimeStampStart  => '2015-03-21 12:00:00',
+        ServerTZ        => 'Asia/Tehran',
+        Time            => '61200',                                                            # 17h
+        TimeDate        => '17h',
+        DestinationTime => '2015-03-22 06:00:00',
+    },
+    {
+        Name            => 'UTC',
+        TimeStampStart  => '2015-01-21 12:00:00',
+        ServerTZ        => 'UTC',
+        Time            => '7833600',                                                          # 90 days and 16h
+        TimeDate        => '90 days and 16h',
+        DestinationTime => '2015-04-22 04:00:00',
+    },
+    {
+        Name            => 'Australia/Sydney - end DST from 00 to 01  ( UTC+11 => UTC+10 )',
+        TimeStampStart  => '2015-01-21 12:00:00',
+        ServerTZ        => 'Asia/Tehran',
+        Time            => '7837200',                                                          # 90 days and 17h
+        TimeDate        => '90 days and 17h',
+        DestinationTime => '2015-04-22 06:00:00',
+    },
+);
+
+# Use a calendar with the same business hours for every day so that the UT runs correctly
+#   on every day of the week and outside usual business hours.
+my %Week;
+my @Days = qw(Sun Mon Tue Wed Thu Fri Sat);
+for my $Day (@Days) {
+    $Week{$Day} = [ 0 .. 23 ];
+}
+$Kernel::OM->Get('Kernel::Config')->Set(
+    Key   => 'TimeWorkingHours',
+    Value => \%Week,
+);
+$Kernel::OM->Get('Kernel::System::SysConfig')->ConfigItemUpdate(
+    Valid => 1,
+    Key   => 'TimeWorkingHours',
+    Value => \%Week,
+);
+
+for my $Test (@Tests) {
+
+    # set the server time zone
+    local $ENV{TZ} = $Test->{ServerTZ};
+
+    # Convert UTC timestamp to system time and set it.
+    $Test->{TimeStampStart} =~ m/(\d{4})-(\d{1,2})-(\d{1,2})\s(\d{1,2}):(\d{1,2}):(\d{1,2})/;
+
+    my $TimeStart = Time::Local::timegm(
+        $6, $5, $4, $3, ( $2 - 1 ), $1
+    );
+
+    $HelperObject->FixedTimeSet(
+        $TimeStart,
+    );
+
+    # Set OTRS time zone to arbitrary value to make sure it is ignored.
+    $ConfigObject->Set(
+        Key   => 'TimeZone',
+        Value => int rand 20 - 10,
+    );
+
+    $Kernel::OM->ObjectsDiscard(
+        Objects => ['Kernel::System::Time'],
+    );
+
+    # get time object
+    my $TimeObject = $Kernel::OM->Get('Kernel::System::Time');
+
+    my $StartTime = $TimeObject->TimeStamp2SystemTime(
+        String => $Test->{TimeStampStart},
+    );
+
+    my $DestinationTime = $TimeObject->DestinationTime(
+        StartTime => $StartTime,
+        Time      => $Test->{Time},
+    );
+    my $DestinationTimeStamp = $TimeObject->SystemTime2TimeStamp(
+        SystemTime => $DestinationTime,
+    );
+
+    $Self->Is(
+        $DestinationTimeStamp,
+        $Test->{DestinationTime},
+        "$Test->{Name} ($Test->{ServerTZ}) destination time ($Test->{TimeDate}) from $Test->{TimeStampStart}: ($Test->{DestinationTime})",
+    );
+
+    $HelperObject->FixedTimeUnset();
+}
+
+1;


### PR DESCRIPTION
http://bugs.otrs.org/show_bug.cgi?id=9884

Hi @carlosgarciac ,

Hereby is proposed solution to fix this issue. Destination time now is calculated correctly when there is a switch for daylight saving time for America/Sao_Paulo time zone. Created unit test with various scenarios for testing destination time in different time zones.

If there are any question or issues regarding this PR, please let me know.

Regards,
Sanjin