### PR TITLE
[ Rel-5_0 Bug 11575 ] - Logo overwrites toolbar 

### DIFF
--- a/var/httpd/htdocs/js/Core.Agent.Responsive.js
+++ b/var/httpd/htdocs/js/Core.Agent.Responsive.js
@@ -198,6 +198,7 @@ Core.Agent.Responsive = (function (TargetNS) {
 
         // re-add toolbar to header
         $('#ToolBar').detach().prependTo('#Header');
+        $('#Logo').detach().prependTo('#Header');
 
         // reset field widths
         $('.FormScreen select').each(function() {

--- a/var/httpd/htdocs/js/Core.Agent.js
+++ b/var/httpd/htdocs/js/Core.Agent.js
@@ -494,11 +494,6 @@ Core.Agent = (function (TargetNS) {
         var NavigationBarWidth = 0,
             NewContainerWidth;
 
-        // navigation resizing only possible in ScreenXL mode
-        if (!$('body').hasClass('Visible-ScreenXL')) {
-            return;
-        }
-
         // set the original width (from css) of #NavigationContainer to have it available later
         if (!$('#NavigationContainer').attr('data-original-width')) {
             $('#NavigationContainer').attr('data-original-width', parseInt(parseInt($('#NavigationContainer').css('width'), 10) / $('body').width() * 100, 10) + '%');


### PR DESCRIPTION
http://bugs.otrs.org/show_bug.cgi?id=11575

Hi @mrcbnsls 

Here is our proposal for fixing this bug. After testing it we saw that the issue was happened during re-adding #ToolBar. In the Header.tt at first there is #Logo and then #ToolBar. Because of that Logo in slim skins caused such problem. In OTRS4 there is not this problem. 

I saw another problem here. The fix in Core.Agent.Responsive.js 

<pre> $('#Logo').detach().prependTo('#Header'); </pre>
was not enough. On reloading the page, width of navigation bar (z-index=20) is 98% so in slim skins it is above the toolbar menu (z-index=10). In that case it is not possible to click on items of toolbar menu ( actually it is possible on top of any item, if you have enough patience :) )
I saw also that after resizing the screens the menu items are available again. It is solved with Core.Agent.ResizeNavigationBar. However, the problem was with checking the class 'Visible-ScreenXL'. I removed this checking and it works fine now. I don't know is it will cause some bad side effect.

Please, follow up the PR and let me know what is your opinion about that. 

Regards
Zoran

