### PR TITLE
[ Rel-5_0 Bug 5946 ] - The ticket count for closed tickets in status view is blocked to 10000

### DIFF
--- a/Kernel/Config/Files/Ticket.xml
+++ b/Kernel/Config/Files/Ticket.xml
@@ -1410,6 +1410,14 @@
             <String Regex="^[0-9]$">5</String>
         </Setting>
     </ConfigItem>
+    <ConfigItem Name="Ticket::Frontend::Overview::TicketShownLimit" Required="1" Valid="1">
+        <Description Translatable="1">Set the limit of tickets that will be shown in view screens.</Description>
+        <Group>Ticket</Group>
+        <SubGroup>Frontend::Agent::TicketOverview</SubGroup>
+        <Setting>
+            <String Regex="^[0-9]{1,6}$">10000</String>
+        </Setting>
+    </ConfigItem>
     <ConfigItem Name="Ticket::Frontend::Overview::PreviewArticleTypeExpanded" Required="0" Valid="0">
         <Description Translatable="1">Defines wich article type should be expanded when entering the overview. If nothing defined, latest article will be expanded.</Description>
         <Group>Ticket</Group>

--- a/Kernel/Modules/AgentTicketEscalationView.pm
+++ b/Kernel/Modules/AgentTicketEscalationView.pm
@@ -230,7 +230,7 @@ sub Run {
 
     # do shown tickets lookup
     my $Limit = $ParamObject->GetParam( Param => 'Limit' ) || 2000;
-    my $OriginalLimit = 10_000;
+    my $OriginalLimit = $ConfigObject->Get("Ticket::Frontend::Overview::TicketShownLimit") || 10_000;
 
     my $ElementChanged = $ParamObject->GetParam( Param => 'ElementChanged' ) || '';
     my $HeaderColumn = $ElementChanged;

--- a/Kernel/Modules/AgentTicketLockedView.pm
+++ b/Kernel/Modules/AgentTicketLockedView.pm
@@ -234,7 +234,7 @@ sub Run {
     }
 
     # do shown tickets lookup
-    my $Limit = 10_000;
+    my $Limit = $ConfigObject->Get("Ticket::Frontend::Overview::TicketShownLimit") || 10_000;
 
     my $ElementChanged = $ParamObject->GetParam( Param => 'ElementChanged' ) || '';
     my $HeaderColumn = $ElementChanged;

--- a/Kernel/Modules/AgentTicketQueue.pm
+++ b/Kernel/Modules/AgentTicketQueue.pm
@@ -280,7 +280,7 @@ sub Run {
     my $PageShown = $Self->{$PageShownPreferencesKey} || 10;
 
     # do shown tickets lookup
-    my $Limit = 10_000;
+    my $Limit = $ConfigObject->Get("Ticket::Frontend::Overview::TicketShownLimit") || 10_000;
 
     my $ElementChanged = $ParamObject->GetParam( Param => 'ElementChanged' ) || '';
     my $HeaderColumn = $ElementChanged;

--- a/Kernel/Modules/AgentTicketResponsibleView.pm
+++ b/Kernel/Modules/AgentTicketResponsibleView.pm
@@ -227,7 +227,7 @@ sub Run {
     }
 
     # do shown tickets lookup
-    my $Limit = 10_000;
+    my $Limit = $ConfigObject->Get("Ticket::Frontend::Overview::TicketShownLimit") || 10_000;
 
     my $ElementChanged = $ParamObject->GetParam( Param => 'ElementChanged' ) || '';
     my $HeaderColumn = $ElementChanged;

--- a/Kernel/Modules/AgentTicketService.pm
+++ b/Kernel/Modules/AgentTicketService.pm
@@ -301,7 +301,7 @@ sub Run {
     my $PageShown = $Self->{$PageShownPreferencesKey} || 10;
 
     # do shown tickets lookup
-    my $Limit = 10_000;
+    my $Limit = $ConfigObject->Get("Ticket::Frontend::Overview::TicketShownLimit") || 10_000;
 
     my $ElementChanged = $ParamObject->GetParam( Param => 'ElementChanged' ) || '';
     my $HeaderColumn = $ElementChanged;

--- a/Kernel/Modules/AgentTicketStatusView.pm
+++ b/Kernel/Modules/AgentTicketStatusView.pm
@@ -191,7 +191,7 @@ sub Run {
     }
 
     # do shown tickets lookup
-    my $Limit = 10_000;
+    my $Limit = $ConfigObject->Get("Ticket::Frontend::Overview::TicketShownLimit") || 10_000;
 
     my $ElementChanged = $ParamObject->GetParam( Param => 'ElementChanged' ) || '';
     my $HeaderColumn = $ElementChanged;

--- a/Kernel/Modules/AgentTicketWatchView.pm
+++ b/Kernel/Modules/AgentTicketWatchView.pm
@@ -259,7 +259,7 @@ sub Run {
     }
 
     # do shown tickets lookup
-    my $Limit = 10_000;
+    my $Limit = $ConfigObject->Get("Ticket::Frontend::Overview::TicketShownLimit") || 10_000;
 
     my $ElementChanged = $ParamObject->GetParam( Param => 'ElementChanged' ) || '';
     my $HeaderColumn = $ElementChanged;


### PR DESCRIPTION
http://bugs.otrs.org/show_bug.cgi?id=5946

Hello,

Hereby is proposal for solving this issue. It was hard-coded on 10_000 tickets to be shown in view screens. Added sysconfig that now gives users a choice to set up amount of tickets they would like to see in there overview screens.

if there are any questions or issues regarding this PR, please let me know.

Regards,
Sanjin