### PR TITLE
Fix bug#11558 - Empty Agent preferences tooltip in AdminNotificationEvent

### DIFF
--- a/var/httpd/htdocs/js/Core.Agent.Admin.NotificationEvent.js
+++ b/var/httpd/htdocs/js/Core.Agent.Admin.NotificationEvent.js
@@ -53,7 +53,6 @@ Core.Agent.Admin.NotificationEvent = (function (TargetNS) {
 
             if ($('#VisibleForAgent').prop('checked')) {
                 TooltipObject.removeAttr('readonly');
-                TooltipObject.prop('value','');
 
                 // show default transport value
                 $('.AgentEnabledByDefault').show();


### PR DESCRIPTION
This PR is fix for bug#11558.
See http://bugs.otrs.org/show_bug.cgi?id=11558
