### PR TITLE
[Rel-5_0 Bug 11593] - Inconsistency in ticketsearch of the customer information center

### DIFF
--- a/Kernel/Config/Files/Ticket.xml
+++ b/Kernel/Config/Files/Ticket.xml
@@ -6776,7 +6776,7 @@
                 <Item Key="Module">Kernel::Output::HTML::Dashboard::TicketGeneric</Item>
                 <Item Key="Title" Translatable="1">Open Tickets / Need to be answered</Item>
                 <Item Key="Description" Translatable="1">All open tickets, these tickets have already been worked on, but need a response</Item>
-                <Item Key="Attributes">StateType=open;</Item>
+                <Item Key="Attributes">StateType=Open;</Item>
                 <Item Key="Filter">All</Item>
                 <Item Key="Time">Age</Item>
                 <Item Key="Limit">10</Item>
@@ -7132,7 +7132,7 @@
                 <Item Key="Module">Kernel::Output::HTML::Dashboard::TicketGeneric</Item>
                 <Item Key="Title" Translatable="1">Open Tickets / Need to be answered</Item>
                 <Item Key="Description" Translatable="1">All open tickets, these tickets have already been worked on, but need a response</Item>
-                <Item Key="Attributes">StateType=open;</Item>
+                <Item Key="Attributes">StateType=Open;</Item>
                 <Item Key="Filter">All</Item>
                 <Item Key="Time">Age</Item>
                 <Item Key="Limit">10</Item>

--- a/Kernel/Output/HTML/Dashboard/TicketGeneric.pm
+++ b/Kernel/Output/HTML/Dashboard/TicketGeneric.pm
@@ -1990,7 +1990,10 @@ sub _SearchParamsGet {
             =~ /^(StateType|StateTypeIDs|Queues|QueueIDs|Types|TypeIDs|States|StateIDs|Priorities|PriorityIDs|Services|ServiceIDs|SLAs|SLAIDs|Locks|LockIDs|OwnerIDs|ResponsibleIDs|WatchUserIDs|ArchiveFlags)$/
             )
         {
-            if ( $Value =~ m{,}smx ) {
+            if ( $Key eq 'StateType' && $Value =~ /Open|Close/ ) {
+                $TicketSearch{$Key} = $Value;
+            }
+            elsif ( $Value =~ m{,}smx ) {
                 push @{ $TicketSearch{$Key} }, split( /,/, $Value );
             }
             else {


### PR DESCRIPTION
http://bugs.otrs.org/show_bug.cgi?id=11593
Hi @carlosfrodriguez and @mgruner,

Here is our proposal for fixing this bug. There was problem because some widget have attribute StateType=open, but for example, in Company Status widget in CIC is used StateType=Open. We could fix it on two ways: 
* we can change SysConfig param (DashboardBackend###0130-TicketOpen, AgentCustomerInformationCenter::Backend###0130-CIC-TicketOpen) or
* adapt all modules that use 'open' instead 'Open' ( AgentDashboardCustomerIDStatus, AgentDashboardCustomerUserList, CustomerUserList, TicketGeneric ...)
The same is with StateType=close and StateType=Close.

We can agree that the both cases is possible, however I believe that there was intention that there  is behavior of system where there will be listed all open tickets in sens of  explanation in TicketSearch
<pre>
    # NOTE: Open and Closed are not valid state types. It's for compat.
    # Open   -> All states which are grouped as open (new, open, pending, ...)
    # Closed -> All states which are grouped as closed (closed successful, closed unsuccessful) 
</pre>

P.S.
In some hand, this bug and PR is connected to this one: https://github.com/OTRS/otrs/pull/734. It is not a duplicate, it is only connected to this one. 

Please, let me know what do you think about that.

Regards
Zoran