### PR TITLE
In notifications, use HTML body only if RichText is enabled.

### DIFF
--- a/Kernel/System/TemplateGenerator.pm
+++ b/Kernel/System/TemplateGenerator.pm
@@ -1418,7 +1418,7 @@ sub _Replace {
 
                 my $Line = $2 || 2500;
                 my $NewOldBody = '';
-                if ( $Data{HTMLBody} ) {
+                if ( $Param{RichText} && $Data{HTMLBody} ) {
 
                     # comment
                     my $CharactersPerLine = $ConfigObject->Get('Notification::CharactersPerLine') || 80;


### PR DESCRIPTION
If `$Data{HTMLBody}` exists, but RichText is not enabled, don’t include the HTML body. This will prevent from displaying HTML tags in text/plain notifications.