### PR TITLE
[Rel-5_0 Bug 11327] - A dyn. DropDown field is not sort alphapetical, if you activate the treeview

### DIFF
--- a/var/httpd/htdocs/js/Core.UI.TreeSelection.js
+++ b/var/httpd/htdocs/js/Core.UI.TreeSelection.js
@@ -524,13 +524,13 @@ Core.UI.TreeSelection = (function (TargetNS) {
 
         SelectData.sort(function(a, b) {
 
-            var KeyA = a.Key.toLowerCase(),
-                KeyB = b.Key.toLowerCase();
+            var ValueA = a.Value.toLowerCase(),
+                ValueB = b.Value.toLowerCase();
 
-            if (KeyA < KeyB) {
+            if (ValueA < ValueB) {
                return -1;
             }
-            if (KeyA > KeyB) {
+            if (ValueA > ValueB) {
                return 1;
             }
             return 0;


### PR DESCRIPTION
http://bugs.otrs.org/show_bug.cgi?id=11327
Hi @carlosfrodriguez,

Here is our proposal for fixing, it is tested with TreeView and without  it, and without Modernize fields as well. All works fine now.
If you need master or OTRS4 PR please let me know.

Regards
Zoran