### PR TITLE
[Rel-5_0 Bug 11604] - AgentTicketForward is still using the "old" select fields style

### DIFF
--- a/Kernel/Modules/AgentTicketBounce.pm
+++ b/Kernel/Modules/AgentTicketBounce.pm
@@ -261,6 +261,7 @@ $Param{Signature}";
             Data          => \%NextStates,
             Name          => 'BounceStateID',
             SelectedValue => $Config->{StateDefault},
+            Class         => 'Modernize',
         );
 
         # add rich text editor
@@ -388,6 +389,7 @@ $Param{Signature}";
                 Data       => \%NextStates,
                 Name       => 'BounceStateID',
                 SelectedID => $Param{BounceStateID},
+                Class      => 'Modernize',
             );
 
             # add rich text editor

--- a/Kernel/Modules/AgentTicketForward.pm
+++ b/Kernel/Modules/AgentTicketForward.pm
@@ -1342,6 +1342,7 @@ sub _Mask {
     $Param{NextStatesStrg} = $LayoutObject->BuildSelection(
         Data         => $Param{NextStates},
         Name         => 'ComposeStateID',
+        Class        => 'Modernize',
         PossibleNone => 1,
         %State,
     );
@@ -1373,8 +1374,9 @@ sub _Mask {
         }
 
         $Param{ArticleTypesStrg} = $LayoutObject->BuildSelection(
-            Data => \%ArticleTypeList,
-            Name => 'ArticleTypeID',
+            Data  => \%ArticleTypeList,
+            Name  => 'ArticleTypeID',
+            Class => 'Modernize',
             %Selected,
         );
 


### PR DESCRIPTION
http://bugs.otrs.org/show_bug.cgi?id=11604

Hello @mgruner ,

Hereby are added modernized fields for AgentTicketForward as Nils reported. Additionally found out that in AgentTicketBounce there was left 'old' field for state. Felt free to change that one as well.

Regards,
Sanjin