### PR TITLE
[Rel-5_0 Bug 11592] - NotificationArticleType ignored at notification for customer

### DIFF
--- a/Kernel/System/Ticket/Event/NotificationEvent/Transport/Email.pm
+++ b/Kernel/System/Ticket/Event/NotificationEvent/Transport/Email.pm
@@ -225,7 +225,12 @@ sub SendNotification {
             %Address = $QueueObject->GetSystemAddress( QueueID => $Ticket{QueueID} );
         }
 
-        my $ArticleType = $Recipient{NotificationArticleType} || 'email-notification-ext';
+        # get notification article type
+        my $NotificationArticleType = $TicketObject->ArticleTypeLookup(
+            ArticleTypeID => $Param{Notification}->{Data}->{NotificationArticleTypeID}->[0],
+        );
+
+        my $ArticleType = $Recipient{NotificationArticleType} || $NotificationArticleType || 'email-notification-ext';
         my $ArticleID = $TicketObject->ArticleSend(
             ArticleType    => $ArticleType,
             SenderType     => 'system',

--- a/scripts/test/Ticket/Event/NotificationEvent.t
+++ b/scripts/test/Ticket/Event/NotificationEvent.t
@@ -133,6 +133,9 @@ my $SetInvalid = $UserObject->UserUpdate(
     ChangeUserID => 1,
 );
 
+# create a new customer user for current test
+my $CustomerUserLogin = $HelperObject->TestCustomerUserCreate();
+
 # get a random id
 my $RandomID = int rand 1_000_000_000;
 
@@ -229,8 +232,8 @@ my $TicketID = $TicketObject->TicketCreate(
     Lock          => 'unlock',
     Priority      => '3 normal',
     State         => 'new',
-    CustomerID    => 'example.com',
-    CustomerUser  => 'customerOne@example.com',
+    CustomerID    => $CustomerUserLogin,
+    CustomerUser  => $CustomerUserLogin,
     OwnerID       => $UserID,
     ResponsibleID => $UserID,
     UserID        => $UserID,
@@ -270,6 +273,11 @@ my $SuccessWatcher = $TicketObject->TicketWatchSubscribe(
 $Self->True(
     $SuccessWatcher,
     "TicketWatchSubscribe() successful for Ticket ID $TicketID",
+);
+
+# get article types email-notification-int ID
+my $ArticleTypeIntID = $TicketObject->ArticleTypeLookup(
+    ArticleType => 'email-notification-int',
 );
 
 my @Tests = (
@@ -793,6 +801,29 @@ my @Tests = (
         ],
         Success => 1,
     },
+    {
+        Name => 'RecipientCustomer + NotificationArticleType email-notification-int',
+        Data => {
+            Events                    => [ 'TicketDynamicFieldUpdate_DFT1' . $RandomID . 'Update' ],
+            Recipients                => ['Customer'],
+            NotificationArticleTypeID => [$ArticleTypeIntID],
+        },
+        Config => {
+            Event => 'TicketDynamicFieldUpdate_DFT1' . $RandomID . 'Update',
+            Data  => {
+                TicketID => $TicketID,
+            },
+            Config => {},
+            UserID => 1,
+        },
+        ExpectedResults => [
+            {
+                Body    => "JobName $TicketID Kernel::System::Email::Test $UserData{UserFirstname}=\n",
+                ToArray => ["$CustomerUserLogin\@localunittest.com"],
+            },
+        ],
+        Success => 1,
+    },
 
 );
 
@@ -1031,6 +1062,21 @@ for my $Test (@Tests) {
         $Test->{ExpectedResults},
         "$Test->{Name} - Recipients",
     );
+
+    # check if there is email-notification-int article type when sending notification
+    # to customer see bug#11592
+    if ( $Test->{Name} =~ /RecipientCustomer/i ) {
+        my @ArticleBox = $TicketObject->ArticleContentIndex(
+            TicketID      => $TicketID,
+            UserID        => 1,
+            ArticleTypeID => [$ArticleTypeIntID],
+        );
+        $Self->Is(
+            scalar @ArticleBox,
+            1,
+            "$Test->{Name} - Article Type email-notification-int created for Customer recipient",
+        );
+    }
 }
 continue {
     # delete notification event


### PR DESCRIPTION
http://bugs.otrs.org/show_bug.cgi?id=11592

Hello @mgruner ,

Hereby is proposed solution for fixing reporters issue. When recipient for notification is customer and there is no additional email address ( $Recipient{NotificationArticleType} ), article type was hardcoded on 'email-notification-ext'.

With this proposal, article type is now correctly reading from notification data, and resolving for 'email-notification-ext' as last resort. In testing now it is possible to set article type as 'email-notification-int' while sending customer notification without additional email addresses.

Please let me know what do you think about this proposal. Other solution is to not allow internal notification type for customer and change description message for that field.

Regards,
Sanjin