### PR TITLE
[Rel-5_0 Bug 9731] - Reply screen uses only email instead of full customer details 

### DIFF
--- a/Kernel/Modules/AgentTicketCompose.pm
+++ b/Kernel/Modules/AgentTicketCompose.pm
@@ -1873,10 +1873,16 @@ sub _Mask {
 
         # split To values
         for my $Email ( Mail::Address->parse( $Param{Cc} ) ) {
+
+            my $DataEmail = $Email->address();
+            if ( $Email->phrase() ) {
+                $DataEmail = $Email->phrase() . ' <' . $Email->address() . '>';
+            }
+
             $LayoutObject->Block(
                 Name => 'PreFilledCcRow',
                 Data => {
-                    Email => $Email->address(),
+                    Email => $DataEmail,
                 },
             );
         }
@@ -1891,10 +1897,16 @@ sub _Mask {
 
         # split To values
         for my $Email ( Mail::Address->parse( $Param{To} ) ) {
+
+            my $DataEmail = $Email->address();
+            if ( $Email->phrase() ) {
+                $DataEmail = $Email->phrase() . ' <' . $Email->address() . '>';
+            }
+
             $LayoutObject->Block(
                 Name => 'PreFilledToRow',
                 Data => {
-                    Email => $Email->address(),
+                    Email => $DataEmail,
                 },
             );
         }

--- a/scripts/test/Selenium/Agent/AgentTicketCompose.t
+++ b/scripts/test/Selenium/Agent/AgentTicketCompose.t
@@ -429,12 +429,32 @@ $Selenium->RunTest(
 
         # input required fields and submit compose
         my $AutoCompleteString = "\"$TestCustomer $TestCustomer\" <$TestCustomer\@localhost.com> ($TestCustomer)";
+
+        # add TO recipient
         $Selenium->find_element( "#ToCustomer", 'css' )->send_keys($TestCustomer);
-
         $Selenium->WaitFor( JavaScript => 'return typeof($) === "function" && $("li.ui-menu-item:visible").length' );
+        $Selenium->find_element("//*[text()='$AutoCompleteString']")->click();
 
-        $Selenium->find_element("//*[text()='$AutoCompleteString']")->VerifiedClick();
-        $Selenium->find_element( "#RichText",       'css' )->send_keys('Selenium Compose Text');
+        # add test text to body
+        my $ComposeText = "Selenium Compose Text";
+        $Selenium->find_element( "#RichText",       'css' )->send_keys($ComposeText);
+
+        # try to add customer again, expecting server error for duplicated entry, see bug #9731
+        $Selenium->find_element( "#ToCustomer", 'css' )->send_keys($TestCustomer);
+        $Selenium->WaitFor( JavaScript => 'return typeof($) === "function" && $("li.ui-menu-item:visible").length' );
+        $Selenium->find_element("//*[text()='$AutoCompleteString']")->click();
+        $Selenium->WaitFor( JavaScript => 'return typeof($) === "function" && $(".Dialog.Modal").length' );
+
+        $Self->Is(
+            $Selenium->execute_script('return $(".Dialog.Modal .Header h1").text().trim();'),
+            'Duplicated entry',
+            "Warning dialog for entry duplication is found",
+        );
+
+        # click 'Ok' for modal dialog 'Duplicated entry'
+        $Selenium->find_element("//button[\@id='DialogButton1'][\@type='button']")->click();
+
+        # submit form
         $Selenium->find_element( "#submitRichText", 'css' )->click();
 
         $Selenium->WaitFor( WindowCount => 1 );


### PR DESCRIPTION
http://bugs.otrs.org/show_bug.cgi?id=9731

Hello @mgruner , @carlosfrodriguez

Hereby is proposed solution for fixing this issue. On ticket reply fields 'To' and 'Cc' will now use full customer details when available. For cases when there are no customer details regular behaviour remains.

Please let me know what do you think about this solution.

Regards,
Sanjin
