### PR TITLE
In AgentTicketBulk, merge first, and do the other actions only on the main ticket

### DIFF
--- a/Kernel/Modules/AgentTicketBulk.pm
+++ b/Kernel/Modules/AgentTicketBulk.pm
@@ -471,6 +471,20 @@ sub Run {
             # challenge token check for write action
             $LayoutObject->ChallengeTokenCheck();
 
+            # merge first, and do all the other actions only
+            # on the main ticket, to avoid a bunch of notifications
+            # for changes which, in the end, would be undone by the merge
+            # anyway
+            if ( $MainTicketID && $MainTicketID ne $TicketID ) {
+                $TicketObject->TicketMerge(
+                    MainTicketID  => $MainTicketID,
+                    MergeTicketID => $TicketID,
+                    UserID        => $Self->{UserID},
+                );
+                next TICKET_ID;
+            }
+
+
             # set owner
             if ( $Config->{Owner} && ( $GetParam{'OwnerID'} || $GetParam{'Owner'} ) ) {
                 $TicketObject->TicketOwnerSet(
@@ -743,15 +757,6 @@ sub Run {
                         UserID    => $Self->{UserID},
                     );
                 }
-            }
-
-            # merge
-            if ( $MainTicketID && $MainTicketID ne $TicketID ) {
-                $TicketObject->TicketMerge(
-                    MainTicketID  => $MainTicketID,
-                    MergeTicketID => $TicketID,
-                    UserID        => $Self->{UserID},
-                );
             }
 
             # get link object


### PR DESCRIPTION
Some of our users complained that using a bulk action to merge several tickets
into one and setting the owner (for example) at the same time sends a bunch of
redundant notifications.

Merging a ticket negates some changes (for example setting ticket state),
and make others (such as owner changes) irrelevant. So do it first, and
save the other actions for the ticket into which was merged.

If this isn't desirable in the general case, I could make this new behavior
configurable.