### PR TITLE
[Rel-5_0 Bug 10477] - Printing: numbering of article does not equal to the numbering of PDF

### DIFF
--- a/Kernel/Modules/AgentTicketPrint.pm
+++ b/Kernel/Modules/AgentTicketPrint.pm
@@ -30,10 +30,11 @@ sub Run {
 
     # get ticket object
     my $TicketObject = $Kernel::OM->Get('Kernel::System::Ticket');
+    my $ParamObject  = $Kernel::OM->Get('Kernel::System::Web::Request');
 
     my $Output;
     my $QueueID = $TicketObject->TicketQueueID( TicketID => $Self->{TicketID} );
-    my $ArticleID = $Kernel::OM->Get('Kernel::System::Web::Request')->GetParam( Param => 'ArticleID' );
+    my $ArticleID = $ParamObject->GetParam( Param => 'ArticleID' );
 
     # get layout object
     my $LayoutObject = $Kernel::OM->Get('Kernel::Output::HTML::Layout');
@@ -291,8 +292,9 @@ sub Run {
 
     # output articles
     $Self->_PDFOutputArticles(
-        PageData    => \%Page,
-        ArticleData => \@ArticleBox,
+        PageData      => \%Page,
+        ArticleData   => \@ArticleBox,
+        ArticleNumber => $ParamObject->GetParam( Param => 'ArticleNumber' ),
     );
 
     # get ticket object
@@ -972,7 +974,14 @@ sub _PDFOutputArticles {
             Y    => -6,
         );
 
-        my $ArticleNumber = $ZoomExpandSort eq 'reverse' ? $ArticleCount - $ArticleCounter + 1 : $ArticleCounter;
+        # get article number
+        my $ArticleNumber;
+        if ( $Param{ArticleNumber} ) {
+            $ArticleNumber = $Param{ArticleNumber};
+        }
+        else {
+            $ArticleNumber = $ZoomExpandSort eq 'reverse' ? $ArticleCount - $ArticleCounter + 1 : $ArticleCounter;
+        }
 
         # article number tag
         $PDFObject->Text(

--- a/Kernel/Modules/AgentTicketZoom.pm
+++ b/Kernel/Modules/AgentTicketZoom.pm
@@ -3362,7 +3362,7 @@ sub _ArticleMenu {
                 Name        => 'Print',
                 Class       => 'AsPopup PopupType_TicketAction',
                 Link =>
-                    "Action=AgentTicketPrint;TicketID=$Ticket{TicketID};ArticleID=$Article{ArticleID}"
+                    "Action=AgentTicketPrint;TicketID=$Ticket{TicketID};ArticleID=$Article{ArticleID};ArticleNumber=$Article{Count}"
             };
         }
     }


### PR DESCRIPTION
http://bugs.otrs.org/show_bug.cgi?id=10477

Hi @mgruner ,

Hereby is proposal for fixing this bug. Added 'ArticleNumber' for single article print link, thats taken from Article{Count}. Using this param in AgentTicketPrint, distinguishing when it's single article or whole ticket print and creating correct article numbering in PDF output accordingly.

Reporter also mentioned wrong article numbering when reverse sorting order is in action in AgentTicketZoom, but this was not reproducible in my test environment, it must have been fixed somewhere along the way. 

If there are any questions or issues regarding this PR, please let me know.

Regards,
Sanjin