### PR TITLE
_DBGroupRoleGet: Return correct permissions

### DIFF
--- a/Kernel/System/Group.pm
+++ b/Kernel/System/Group.pm
@@ -2604,7 +2604,7 @@ sub _DBGroupRoleGet {
 
     # get all data from table group_role
     $DBObject->Prepare(
-        SQL => 'SELECT role_id, group_id, permission_key FROM group_role',
+        SQL => 'SELECT role_id, group_id, permission_key FROM group_role WHERE permission_value=1',
     );
 
     # fetch the result


### PR DESCRIPTION
_DBGroupRoleGet would return all permissions listed for a group_role regardless
of the permission_value column. Previous versions of OTRS would set the
permission value column to 0 when permissions were taken away from a group.
OTRS 5.0.x seems to delete the entire line. That and the SQL query in line 2607
signify a switch from a behavior of "flag checking" to "presence checking".
That is all good, however databases upgraded from OTRS 4.0.x or earlier might
however have lines in the group_role table with permission_value set to 0. In
that case, after the upgrade to 5.0.x, agents will be implicitly given
permissions they did not have prior to the upgrade.

This constitutes a regression from at least 4.0.x, 3.3.x and 3.2.x versions.
IMHO, this also constitutes a security bug