### PR TITLE
[Rel-5_0 Bug 10319] - Link screen does not show all matching tickets for the search values

### DIFF
--- a/Kernel/Config/Files/Ticket.xml
+++ b/Kernel/Config/Files/Ticket.xml
@@ -10115,6 +10115,14 @@ Thanks for your help!
             </Array>
         </Setting>
     </ConfigItem>
+    <ConfigItem Name="LinkObject::TicketLinkSearchLimit" Required="0" Valid="1">
+        <Description Translatable="1">Maximum number of tickets to be displayed in the result of a search in AgentLinkObject.</Description>
+        <Group>Ticket</Group>
+        <SubGroup>Core::LinkObject</SubGroup>
+        <Setting>
+            <String Regex="^[0-9]{1,5}$">50</String>
+        </Setting>
+    </ConfigItem>
     <ConfigItem Name="Stats::DynamicObjectRegistration###Ticket" Required="0" Valid="1">
         <Description Translatable="1">Module to generate ticket statistics.</Description>
         <Group>Ticket</Group>

--- a/Kernel/System/LinkObject/Ticket.pm
+++ b/Kernel/System/LinkObject/Ticket.pm
@@ -291,7 +291,7 @@ sub ObjectSearch {
     my @TicketIDs = $TicketObject->TicketSearch(
         %{ $Param{SearchParams} },
         %Search,
-        Limit               => 50,
+        Limit => $Kernel::OM->Get('Kernel::Config')->Get('LinkObject::TicketLinkSearchLimit') || 50,
         Result              => 'ARRAY',
         ConditionInline     => 1,
         ContentSearchPrefix => '*',


### PR DESCRIPTION
http://bugs.otrs.org/show_bug.cgi?id=10319

Hi @mgruner ,

Hereby is proposal for solving this issue. Created sysconfig to limit maximum number of displayed tickets in the result of search in AgentLinkObject. Left default on 50 as it was hard-coded before, leaving users choice to set limit that suits there needs.

Please let me know, what do you think about this proposal.

Regards,
Sanjin