### PR TITLE
[Rel-4_0 Bug 11612]- Wrong order in the notification procedure

### DIFF
--- a/Kernel/Modules/AgentTicketActionCommon.pm
+++ b/Kernel/Modules/AgentTicketActionCommon.pm
@@ -705,26 +705,6 @@ sub Run {
             }
         }
 
-        # set new responsible
-        if ( $Self->{ConfigObject}->Get('Ticket::Responsible') && $Self->{Config}->{Responsible} ) {
-            if ( $GetParam{NewResponsibleID} ) {
-                my $BodyText = $Self->{LayoutObject}->RichText2Ascii(
-                    String => $GetParam{Body} || '',
-                );
-                my $Success = $Self->{TicketObject}->TicketResponsibleSet(
-                    TicketID  => $Self->{TicketID},
-                    UserID    => $Self->{UserID},
-                    NewUserID => $GetParam{NewResponsibleID},
-                    Comment   => $BodyText,
-                );
-
-                # remember to not notify responsible twice
-                if ( $Success && $Success eq 1 ) {
-                    push @NotifyDone, $GetParam{NewResponsibleID};
-                }
-            }
-        }
-
         # move ticket to a new queue, but only if the queue was changed
         if (
             $Self->{Config}->{Queue}
@@ -804,6 +784,26 @@ sub Run {
             # redirect parent window to last screen overview on closed tickets
             if ( $StateData{TypeName} =~ /^close/i ) {
                 $ReturnURL = $Self->{LastScreenOverview} || 'Action=AgentDashboard';
+            }
+        }
+
+        # set new responsible
+        if ( $Self->{ConfigObject}->Get('Ticket::Responsible') && $Self->{Config}->{Responsible} ) {
+            if ( $GetParam{NewResponsibleID} ) {
+                my $BodyText = $Self->{LayoutObject}->RichText2Ascii(
+                    String => $GetParam{Body} || '',
+                );
+                my $Success = $Self->{TicketObject}->TicketResponsibleSet(
+                    TicketID  => $Self->{TicketID},
+                    UserID    => $Self->{UserID},
+                    NewUserID => $GetParam{NewResponsibleID},
+                    Comment   => $BodyText,
+                );
+
+                # remember to not notify responsible twice
+                if ( $Success && $Success eq 1 ) {
+                    push @NotifyDone, $GetParam{NewResponsibleID};
+                }
             }
         }
 


### PR DESCRIPTION
http://bugs.otrs.org/show_bug.cgi?id=11612

Hi @mgruner ,

Moved 'set new responsible' to be called later in the code. This way it will catch all other changes before calling a NotificationResponsibleUpdate event. This fix reporter issue, but there are other cases that can cause similar problems, because of order of how code is executed and which events are called in what order.

Will create PR for rel-5_0 for this issue. Please let me know what do you think about this suggestion.

Regards,
Sanjin