### PR TITLE
[Rel-5_0 Bug 7301] - Customer can reply to merged tickets, wrong ticket will be reopened

### DIFF
--- a/Kernel/Modules/CustomerTicketZoom.pm
+++ b/Kernel/Modules/CustomerTicketZoom.pm
@@ -1732,7 +1732,7 @@ sub _Mask {
         )
         && (
             ( $FollowUpPossible !~ /(new ticket|reject)/i && $State{TypeName} =~ /^close/i )
-            || $State{TypeName} !~ /^close/i
+            || $State{TypeName} !~ /^close|merged/i
         )
         )
     {


### PR DESCRIPTION
http://bugs.otrs.org/show_bug.cgi?id=7301

Hi @mgruner ,

Hereby is proposed solution by Urlike in bug#11173 for solving this issue. Agree with his solution that reply button should be disabled for tickets that are in merged state. This way we can avoid having issues with customers replying on merged tickets and causing them to get reopened.

Please let me know what do you think about this proposal.

Regards,
Sanjin