### PR TITLE
Unlock tickets from invalid agents

### DIFF
--- a/Kernel/Config/Files/Ticket.xml
+++ b/Kernel/Config/Files/Ticket.xml
@@ -121,6 +121,18 @@
             </Option>
         </Setting>
     </ConfigItem>
+    <ConfigItem Name="Ticket::InvalidOwner::StateChange" Required="0" Valid="1">
+        <Description Translatable="1">Automatically change the state of a ticket with an invalid
+        owner once it is unlocked. Maps from a state type to a new ticket state.</Description>
+        <Group>Ticket</Group>
+        <SubGroup>Core::Ticket</SubGroup>
+        <Setting>
+            <Hash>
+                <Item Key="pending reminder">open</Item>
+                <Item Key="pending auto">open</Item>
+            </Hash>
+        </Setting>
+    </ConfigItem>
     <ConfigItem Name="Ticket::Type" Required="1" Valid="1">
         <Description Translatable="1">Allows defining new types for ticket (if ticket type feature is enabled).</Description>
         <Group>Ticket</Group>

--- a/Kernel/System/Console/Command/Maint/Ticket/InvalidUserCleanup.pm
+++ b/Kernel/System/Console/Command/Maint/Ticket/InvalidUserCleanup.pm
@@ -129,7 +129,7 @@ sub _CleanupLocks {
             UserID              => $Ticket{OwnerID},
             SendNoNotification  => 1,
         );
-        if ( my $NewState = $StateMap->{ $Ticket{ $Ticket{StateType} } } ) {
+        if ( my $NewState = $StateMap->{ $Ticket{StateType} } ) {
             $TicketObject->TicketStateSet(
                 TicketID        => $TicketID,
                 State           => $NewState,

--- a/scripts/test/Console/Command/Maint/Ticket/InvalidUserCleanup.t
+++ b/scripts/test/Console/Command/Maint/Ticket/InvalidUserCleanup.t
@@ -12,7 +12,44 @@ use utf8;
 
 use vars (qw($Self));
 
+$Kernel::OM->ObjectParamAdd(
+    'Kernel::System::UnitTest::Helper' => {
+        RestoreSystemConfiguration => 1,
+        RestoreDatabase            => 1,
+    }
+);
+
+my $HelperObject  = $Kernel::OM->Get('Kernel::System::UnitTest::Helper');
 my $CommandObject = $Kernel::OM->Get('Kernel::System::Console::Command::Maint::Ticket::InvalidUserCleanup');
+my $TicketObject  = $Kernel::OM->Get('Kernel::System::Ticket');
+my $UserObject    = $Kernel::OM->Get('Kernel::System::User');
+
+$Kernel::OM->Get('Kernel::Config')->Set(
+    Key   => 'CheckMXRecord',
+    Value => 0,
+);
+
+my $UserName = $HelperObject->TestUserCreate();
+my %User     = $UserObject->GetUserData( User => $UserName );
+my $UserID   = $User{UserID};
+
+my $TicketID = $TicketObject->TicketCreate(
+    Title        => 'A test for ticket unlocking',
+    Queue        => 'Raw',
+    Lock         => 'lock',
+    Priority     => '3 normal',
+    State        => 'pending reminder',
+    CustomerNo   => '123465',
+    CustomerUser => 'customer@example.com',
+    OwnerID      => $UserID,
+    UserID       => 1,
+);
+
+$Kernel::OM->Get('Kernel::System::User')->UserUpdate(
+    %User,
+    ValidID      => 2,
+    ChangeUserID => 1,
+);
 
 my $ExitCode = $CommandObject->Execute();
 
@@ -22,5 +59,24 @@ $Self->Is(
     0,
     "Maint::Ticket::InvalidUserCleanup exit code",
 );
+
+my %Ticket = $TicketObject->TicketGet(
+    UserID   => 1,
+    TicketID => $TicketID,
+
+);
+
+$Self->Is(
+    $Ticket{Lock},
+    'unlock',
+    'Ticket from invalid owner was unlocked',
+);
+
+$Self->Is(
+    $Ticket{State},
+    'open',
+    'Ticket from invalid owner was set to "open"',
+);
+
 
 1;


### PR DESCRIPTION
Extends the console command `Maint::Ticket::InvalidUserCleanup` to unlock the tickets owned by invalid agents, and optionally changes the state.

The idea is that when an agent becomes invalid, other members of his team (or his superior) must take over his tasks. This is much more visible when the tickets are open and unlocked.