### PR TITLE
Optimize GenericAgent management

### DIFF
--- a/Kernel/System/GenericAgent.pm
+++ b/Kernel/System/GenericAgent.pm
@@ -1433,21 +1433,11 @@ sub _JobUpdateRunTime {
     # get database object
     my $DBObject = $Kernel::OM->Get('Kernel::System::DB');
 
-    # check if job name already exists
-    return if !$DBObject->Prepare(
-        SQL  => 'SELECT job_key, job_value FROM generic_agent_jobs WHERE job_name = ?',
-        Bind => [ \$Param{Name} ],
+    # delete old run times
+    return if !$DBObject->Do(
+        SQL  => 'DELETE FROM generic_agent_jobs WHERE job_name = ? AND job_key IN (?, ?)',
+        Bind => [ \$Param{Name}, \'ScheduleLastRun', \'ScheduleLastRunUnixTime' ],
     );
-    my @Data;
-    while ( my @Row = $DBObject->FetchrowArray() ) {
-        if ( $Row[0] =~ /^(ScheduleLastRun|ScheduleLastRunUnixTime)/ ) {
-            push @Data,
-                {
-                Key   => $Row[0],
-                Value => $Row[1]
-                };
-        }
-    }
 
     # get time object
     my $TimeObject = $Kernel::OM->Get('Kernel::System::Time');
@@ -1464,15 +1454,6 @@ sub _JobUpdateRunTime {
         $DBObject->Do(
             SQL  => 'INSERT INTO generic_agent_jobs (job_name,job_key, job_value) VALUES (?, ?, ?)',
             Bind => [ \$Param{Name}, \$Key, \$Insert{$Key} ],
-        );
-    }
-
-    # remove old times
-    for my $Time (@Data) {
-        $DBObject->Do(
-            SQL => 'DELETE FROM generic_agent_jobs WHERE '
-                . 'job_name = ? AND job_key = ? AND job_value = ?',
-            Bind => [ \$Param{Name}, \$Time->{Key}, \$Time->{Value} ],
         );
     }
 


### PR DESCRIPTION
The old way was to first query the last execution times, and then deletes them individually.
When several GenericAgent jobs run in parallel (for example in a cluster, and/or when several
E-Mails are delivered into the PostMaster in parallel), this produces a quadratic number
of DELETE statements (which caused an outages for us).

Instead, simply delete all old run time values in a single delete statement, which
keeps the quadratic run time out of OTRS (and confined to the database, which
handles it much better). As a bonus, the code is also shorter and simpler :-).