### PR TITLE
[Rel-5_0 Bug 11286] - Default-Value "X-Envelope-To" instead of "Envelope-To" in PostmasterX-Header

### DIFF
--- a/Kernel/Config/Files/Ticket.xml
+++ b/Kernel/Config/Files/Ticket.xml
@@ -9737,6 +9737,7 @@
                 <Item>X-Original-To</Item>
                 <Item>Delivered-To</Item>
                 <Item>Envelope-To</Item>
+                <Item>X-Envelope-To</Item>
                 <Item>Return-Path</Item>
                 <Item>X-OTRS-Owner</Item>
                 <Item>X-OTRS-OwnerID</Item>

--- a/scripts/test/EmailParser.t
+++ b/scripts/test/EmailParser.t
@@ -879,14 +879,15 @@ $EmailParserObject = Kernel::System::EmailParser->new(
 $Self->Is(
     $EmailParserObject->GetParam( WHAT => 'To' ),
     'QBQB Евгений Васильев Новоподзалупинский <xxzzyy@gmail.com>',
-    "#21 GetParam(WHAT => 'To' Multiline encode)",
+    "#22 GetParam(WHAT => 'To' Multiline encode)",
 );
 $Self->Is(
     $EmailParserObject->GetParam( WHAT => 'Subject' ),
     'QBQB Евгений Васильев Новоподзалупинский <xxzzyy@gmail.com>',
-    "#21 GetParam(WHAT => 'Subject' Multiline encode)",
+    "#22 GetParam(WHAT => 'Subject' Multiline encode)",
 );
 
+# test #23
 @Array = ();
 open( $IN, "<", "$Home/scripts/test/sample/EmailParser/UTF-7.box" );    ## no critic
 while (<$IN>) {
@@ -901,7 +902,25 @@ $EmailParserObject = Kernel::System::EmailParser->new(
 $Self->Is(
     $EmailParserObject->GetParam( WHAT => 'To' ),
     'wop+autoreply=no@ticket.noris.net',
-    "#22 GetParam(WHAT => 'To') UTF-7 not decoded",
+    "#23 GetParam(WHAT => 'To') UTF-7 not decoded",
+);
+
+# test #24
+@Array = ();
+open( $IN, "<", "$Home/scripts/test/sample/EmailParser/UTF-7.box" );    ## no critic
+while (<$IN>) {
+    push( @Array, $_ );
+}
+close($IN);
+
+$EmailParserObject = Kernel::System::EmailParser->new(
+    Email => \@Array,
+);
+
+$Self->Is(
+    $EmailParserObject->GetParam( WHAT => 'Envelope-To' ),
+    'wop+autoreply=no@ticket.noris.net',
+    "#24 GetParam(WHAT => 'Envelope-To') UTF-7 not decoded",
 );
 
 1;

--- a/scripts/test/PostMaster.t
+++ b/scripts/test/PostMaster.t
@@ -33,6 +33,8 @@ my %NeededDynamicfields = (
     TicketFreeText5 => 1,
     TicketFreeKey5  => 1,
     TicketFreeText5 => 1,
+    TicketFreeKey6  => 1,
+    TicketFreeText6 => 1,
     TicketFreeTime1 => 1,
     TicketFreeTime2 => 1,
     TicketFreeTime3 => 1,
@@ -909,6 +911,143 @@ Some Content in Body
                 Key   => 'PostMaster::PreFilterModule###' . $Test->{Name},
                 Value => undef,
             );
+        }
+    }
+}
+
+# filter test Envelope-To and X-Envelope-To
+@Tests = (
+    {
+        Name  => '#1 - Envelope-To Test',
+        Email => 'From: Sender <sender@example.com>
+To: Some Name <recipient@example.com>
+Envelope-To: Some EnvelopeTo Name <envelopeto@example.com>
+Subject: some subject
+
+Some Content in Body
+',
+        Match => {
+            'Envelope-To' => 'envelopeto@example.com',
+        },
+        Set => {
+            'X-OTRS-Queue'        => 'Junk',
+            'X-OTRS-TicketKey5'   => 'Key5#1',
+            'X-OTRS-TicketValue5' => 'Text5#1',
+        },
+        Check => {
+            Queue                        => 'Junk',
+            DynamicField_TicketFreeKey5  => 'Key5#1',
+            DynamicField_TicketFreeText5 => 'Text5#1',
+        },
+    },
+    {
+        Name  => '#2 - X-Envelope-To Test',
+        Email => 'From: Sender <sender@example.com>
+To: Some Name <recipient@example.com>
+X-Envelope-To: Some XEnvelopeTo Name <xenvelopeto@example.com>
+Subject: some subject
+
+Some Content in Body
+',
+        Match => {
+            'X-Envelope-To' => 'xenvelopeto@example.com',
+        },
+        Set => {
+            'X-OTRS-Queue'        => 'Misc',
+            'X-OTRS-TicketKey6'   => 'Key6#1',
+            'X-OTRS-TicketValue6' => 'Text6#1',
+        },
+        Check => {
+            Queue                        => 'Misc',
+            DynamicField_TicketFreeKey6  => 'Key6#1',
+            DynamicField_TicketFreeText6 => 'Text6#1',
+        },
+    },
+);
+
+$Kernel::OM->ObjectsDiscard( Objects => ['Kernel::System::PostMaster::Filter'] );
+$PostMasterFilter = $Kernel::OM->Get('Kernel::System::PostMaster::Filter');
+
+for my $Test (@Tests) {
+    for my $Type (qw(Config DB)) {
+
+        if ( $Type eq 'DB' ) {
+            $PostMasterFilter->FilterAdd(
+                Name           => $Test->{Name},
+                StopAfterMatch => 0,
+                %{$Test},
+            );
+        }
+        else {
+            $ConfigObject->Set(
+                Key   => 'PostMaster::PreFilterModule###' . $Test->{Name},
+                Value => {
+                    %{$Test},
+                    Module => 'Kernel::System::PostMaster::Filter::Match',
+                },
+            );
+        }
+
+        my @Return;
+        {
+            my $PostMasterObject = Kernel::System::PostMaster->new(
+                Email => \$Test->{Email},
+            );
+
+            @Return = $PostMasterObject->Run();
+        }
+        $Self->Is(
+            $Return[0] || 0,
+            1,
+            "#Filter $Type Run() - NewTicket",
+        );
+        $Self->True(
+            $Return[1] || 0,
+            "#Filter $Type Run() - NewTicket/TicketID",
+        );
+
+        # new/clear ticket object
+        $Kernel::OM->ObjectsDiscard( Objects => ['Kernel::System::Ticket'] );
+        my $TicketObject = $Kernel::OM->Get('Kernel::System::Ticket');
+
+        my %Ticket = $TicketObject->TicketGet(
+            TicketID      => $Return[1],
+            DynamicFields => 1,
+        );
+
+        TEST:
+        for my $TestCheck ($Test) {
+            next TEST if !$TestCheck->{Check};
+            for my $Key ( sort keys %{ $TestCheck->{Check} } ) {
+                $Self->Is(
+                    $Ticket{$Key},
+                    $TestCheck->{Check}->{$Key},
+                    "#Filter $Type Run('$TestCheck->{Name}') - $Key",
+                );
+            }
+        }
+
+        # delete ticket
+        my $Delete = $TicketObject->TicketDelete(
+            TicketID => $Return[1],
+            UserID   => 1,
+        );
+        $Self->True(
+            $Delete || 0,
+            "#Filter $Type TicketDelete()",
+        );
+
+        # remove filter
+        for my $Test (@Tests) {
+            if ( $Type eq 'DB' ) {
+                $PostMasterFilter->FilterDelete( Name => $Test->{Name} );
+            }
+            else {
+                $ConfigObject->Set(
+                    Key   => 'PostMaster::PreFilterModule###' . $Test->{Name},
+                    Value => undef,
+                );
+            }
         }
     }
 }


### PR DESCRIPTION
http://bugs.otrs.org/show_bug.cgi?id=11286

Hello @mgruner ,

As reporter suggested email tag X-Envelope-To is used as well as Envelope-To, really depends on mail servers that users use. Instead of replacing it, added additional tag in SysConfig that users can choose for there needs.

Heres description taken from one of our sources used in researching this issue.
http://people.dsv.su.se/~jpalme/ietf/mail-headers/mail-headers.html

Description | Email Tag |  Note
------------ | -------------  | -------------
If the recipient in the envelope (SMTP "MAIL FROM") is not included in the CC list, some mail servers add this to the RFC 2822 header field as an aid to clients which would otherwise not be able to display the envelope recipients. | X-Envelope-To:, Envelope-To: | Non-standard.

Updated PostMaster and EmailParse unit test to include these tags now in testing.

If you think we should just keep X-Envelope-To tag (which is more used, when used then Envelope-To), i will update this PR accordingly. Please, let me know what do you think about this suggestion and PR.

Regards,
Sanjin