### PR TITLE
[ Master Bug 10825 ] - <OTRS_CUSTOMER_Body> in Reply-Template

### DIFF
--- a/scripts/test/TemplateGenerator/Replace.t
+++ b/scripts/test/TemplateGenerator/Replace.t
@@ -225,7 +225,18 @@ my @Tests = (
         Result   => 'Test otrs',
     },
     {
-        Name => 'OTRS customer subject 3 letters',    # <OTRS_CUSTOMER_SUBJECT[20]>
+        Name => 'OTRS customer subject - not replaced',    # <OTRS_CUSTOMER_SUBJECT>
+        Data => {
+            From    => 'test@home.com',
+            Subject => 'otrs',
+        },
+        RichText                    => 0,
+        ReplaceAgentAndCustomerTags => 0,
+        Template                    => 'Test <OTRS_CUSTOMER_SUBJECT>',
+        Result                      => 'Test <OTRS_CUSTOMER_SUBJECT>',
+    },
+    {
+        Name => 'OTRS customer subject 3 letters',         # <OTRS_CUSTOMER_SUBJECT[20]>
         Data => {
             From    => 'test@home.com',
             Subject => 'otrs',
@@ -384,6 +395,20 @@ mailto-Link <a href="mailto:skywalker@otrs.org?body=From%3A%20%3COTRS_CUSTOMER_F
         Result   => "Test Line1\nLine2\nLine3 - Line1\nLine2\nLine3",
     },
     {
+        Name =>
+            'OTRS AGENT + CUSTOMER BODY - not replaced',
+        Data => {
+            Body => "Line1\nLine2\nLine3",
+        },
+        DataAgent => {
+            Body => "Line1\nLine2\nLine3",
+        },
+        RichText                    => 0,
+        ReplaceAgentAndCustomerTags => 0,
+        Template                    => 'Test <OTRS_AGENT_BODY> - <OTRS_CUSTOMER_BODY>',
+        Result                      => 'Test <OTRS_AGENT_BODY> - <OTRS_CUSTOMER_BODY>',
+    },
+    {
         Name => 'OTRS AGENT + CUSTOMER BODY[2]',
         Data => {
             Body => "Line1\nLine2\nLine3",
@@ -466,13 +491,14 @@ mailto-Link <a href="mailto:skywalker@otrs.org?body=From%3A%20%3COTRS_CUSTOMER_F
 
 for my $Test (@Tests) {
     my $Result = $TemplateGeneratorObject->_Replace(
-        Text        => $Test->{Template},
-        Data        => $Test->{Data},
-        DataAgent   => $Test->{DataAgent},
-        RichText    => $Test->{RichText},
-        TicketID    => $TicketID,
-        UserID      => $TestUser3{UserID},
-        RecipientID => $TestUser4{UserID},
+        Text                        => $Test->{Template},
+        Data                        => $Test->{Data},
+        DataAgent                   => $Test->{DataAgent},
+        RichText                    => $Test->{RichText},
+        TicketID                    => $TicketID,
+        UserID                      => $TestUser3{UserID},
+        ReplaceAgentAndCustomerTags => $Test->{ReplaceAgentAndCustomerTags},
+        RecipientID                 => $TestUser4{UserID},
     );
     $Self->Is(
         $Result,


### PR DESCRIPTION
http://bugs.otrs.org/show_bug.cgi?id=10825

Hi @mgruner 

As you can see on the bug report, reporter wanted to use notification in Reply-Template. It is not supported by now.  In my opinion there is a bug now because OTRS_CUSTOMER_BODY is replaced with HTML tags.  

Here is our proposal for solving it in this moment, we add a param in _Replace function to check if it is allowed replacing OTRS_AGENT_* and CUSTOMER_AGENT_* tags. It is the same for Signature and Salutation. I know that it is not the best solution, but I am not sure if you want replace all parameters for all modules.  In that case there should be more improvement in many functions ( e.g. Template(), Signature(), Salutation() ... in TemplateGenerator). In any case we shoul fix something because the current situation with replacing wrong date as it is mentioned in the bug report is not option.

Please let me know what do you think about that.

Regards
Zoran

