### PR TITLE
Master - fixed the list of agent and customer users for invalid entities

### DIFF
--- a/Kernel/Output/HTML/Templates/Standard/AdminCustomerUser.tt
+++ b/Kernel/Output/HTML/Templates/Standard/AdminCustomerUser.tt
@@ -108,7 +108,7 @@
 [% RenderBlockEnd("NoDataFoundMsg") %]
 
 [% RenderBlockStart("OverviewResultRow") %]
-                        <tr [% IF Data.ValidID != 1 %]class="Invalid"[% END %]>
+                        <tr [% IF Data.ValidID && Data.ValidID != 1 %]class="Invalid"[% END %]>
 [% RenderBlockStart("OverviewResultRowLink") %]
                             <td><a class="AsBlock" href="[% Env("Baselink") %]Action=[% Env("Action") %];Subaction=Change;ID=[% Data.CustomerKey | uri %];Search=[% Data.Search | uri %];Nav=[% Data.Nav | uri %]">[% Data.UserLogin | html %]</a></td>
 [% RenderBlockEnd("OverviewResultRowLink") %]

--- a/Kernel/Output/HTML/Templates/Standard/AdminUser.tt
+++ b/Kernel/Output/HTML/Templates/Standard/AdminUser.tt
@@ -104,7 +104,7 @@
                         </tr>
 [% RenderBlockEnd("NoDataFoundMsg") %]
 [% RenderBlockStart("OverviewResultRow") %]
-                        <tr [% IF Data.ValidID != 1 %]class="Invalid"[% END %]>
+                        <tr [% IF Data.ValidID && Data.ValidID != 1 %]class="Invalid"[% END %]>
                             <td>
                                 <a class="AsBlock" href="[% Env("Baselink") %]Action=[% Env("Action") %];Subaction=Change;UserID=[% Data.UserID | uri %];Search=[% Data.Search | uri %]">[% Data.UserLogin | html %]</a>
                             </td>


### PR DESCRIPTION
Hi @mgruner 

Working on some bug with LDAP I saw that we forgotten fix format for invalid entities if there is not column Valid for users (agent and customer) 

In the following commit was fixed only for Customer Company 
https://github.com/OTRS/otrs/commit/70eb6efb8c164b613a18e43d24c8658ba90d6a3f

I thought it could be merged in master as well.

Regards
Zoran