### PR TITLE
Master - fixed clean up for customer user by Helper RestoreDatabase

### DIFF
--- a/Kernel/System/UnitTest/Helper.pm
+++ b/Kernel/System/UnitTest/Helper.pm
@@ -438,11 +438,20 @@ sub DESTROY {
 
     # invalidate test customer users
     if ( ref $Self->{TestCustomerUsers} eq 'ARRAY' && @{ $Self->{TestCustomerUsers} } ) {
+        TESTCUSTOMERUSERS:
         for my $TestCustomerUser ( @{ $Self->{TestCustomerUsers} } ) {
 
             my %CustomerUser = $Kernel::OM->Get('Kernel::System::CustomerUser')->CustomerUserDataGet(
                 User => $TestCustomerUser,
             );
+
+            if ( !$CustomerUser{UserLogin} ) {
+
+                # if no such customer user exists, there is no need to set it to invalid;
+                # happens when the test customer user is created inside a transaction
+                # that is later rolled back.
+                next TESTCUSTOMERUSERS;
+            }
 
             my $Success = $Kernel::OM->Get('Kernel::System::CustomerUser')->CustomerUserUpdate(
                 %CustomerUser,

--- a/scripts/test/TemplateGenerator/Replace.t
+++ b/scripts/test/TemplateGenerator/Replace.t
@@ -14,7 +14,9 @@ use vars (qw($Self));
 
 # get needed objects
 my $ConfigObject       = $Kernel::OM->Get('Kernel::Config');
-my $HelperObject       = $Kernel::OM->Get('Kernel::System::UnitTest::Helper');
+my $HelperObject = Kernel::System::UnitTest::Helper->new(
+    RestoreDatabase => 1,
+);
 my $DynamicFieldObject = $Kernel::OM->Get('Kernel::System::DynamicField');
 my $BackendObject      = $Kernel::OM->Get('Kernel::System::DynamicField::Backend');
 my $TicketObject       = $Kernel::OM->Get('Kernel::System::Ticket');
@@ -480,32 +482,5 @@ for my $Test (@Tests) {
         "$Test->{Name} - _Replace()",
     );
 }
-
-# cleanup the system
-for my $DynamicFieldID ( sort keys %AddedDynamicFieldIds ) {
-
-    my $DynamicFieldConfig = $DynamicFieldObject->DynamicFieldGet(
-        Name => $AddedDynamicFieldIds{$DynamicFieldID},
-    );
-
-    my $Success = $BackendObject->AllValuesDelete(
-        DynamicFieldConfig => $DynamicFieldConfig,
-        UserID             => 1,
-    );
-    $Self->True(
-        $Success,
-        "DynamicField AllValuesDelete() - for DynamicFieldID '$DynamicFieldID' with true",
-    );
-}
-
-# the ticket is no longer needed
-$Success = $TicketObject->TicketDelete(
-    TicketID => $TicketID,
-    UserID   => 1,
-);
-$Self->True(
-    $Success,
-    "TicketDelete() - fort TicketID '$TicketID' with true",
-);
 
 1;


### PR DESCRIPTION
Hi @mgruner 

I tested a little bit Helper with RestoreDatabase and I saw that maybe there is a problem with setting CustomerUser to invalid if there is used RestoreDatabase.

There is PR with my fix. I updated Replace unit test as a  example for this fix.

It is my proposal, maybe I am wrong somewhere, please let me know what do you think about that.

Regards
Zoran 