### PR TITLE
[Rel-5_0 Bug 11605] - New ticket notification names are not translated in agent preferences

### DIFF
--- a/Kernel/Output/HTML/Templates/Standard/AdminNotificationEvent.tt
+++ b/Kernel/Output/HTML/Templates/Standard/AdminNotificationEvent.tt
@@ -102,7 +102,7 @@
 [% RenderBlockEnd("NoDataFoundMsg") %]
 [% RenderBlockStart("OverviewResultRow") %]
                         <tr [% IF Data.ValidID != 1%]class="Invalid"[% END %]>
-                            <td><a href="[% Env("Baselink") %]Action=[% Env("Action") %];Subaction=Change;ID=[% Data.ID | uri %]">[% Data.Name | html %]</a></td>
+                            <td><a href="[% Env("Baselink") %]Action=[% Env("Action") %];Subaction=Change;ID=[% Data.ID | uri %]">[% Translate(Data.Name) | html %]</a></td>
                             <td title="[% Data.Comment | html %]">[% Data.Comment | truncate(26) | html %]</td>
                             <td>[% Translate(Data.Valid) | html %]</td>
                             <td>[% Data.ChangeTime | Localize("TimeShort") %]</td>

--- a/Kernel/Output/HTML/Templates/Standard/PreferencesNotificationEvent.tt
+++ b/Kernel/Output/HTML/Templates/Standard/PreferencesNotificationEvent.tt
@@ -25,7 +25,7 @@
 [% RenderBlockEnd("NoDataFoundMsg") %]
 [% RenderBlockStart("BodyRow") %]
         <tr title="[% Data.NotificationTitle | html %]">
-            <td>[% Data.NotificationName | html %]</td>
+            <td>[% Translate(Data.NotificationName) | html %]</td>
 [% RenderBlockStart("BodyTransportColumn") %]
             <td class="Center">
 [% RenderBlockStart("BodyTransportColumnEnabled") %]

--- a/scripts/database/otrs-initial_insert.xml
+++ b/scripts/database/otrs-initial_insert.xml
@@ -1454,7 +1454,7 @@ Your OTRS Group
 
     <Insert Table="notification_event">
         <Data Key="id" Type="AutoIncrement">1</Data>
-        <Data Key="name" Type="Quote">Ticket create notification</Data>
+        <Data Key="name" Type="Quote" Translatable="1">Ticket create notification</Data>
         <Data Key="valid_id">1</Data>
         <Data Key="comments" Type="Quote"></Data>
         <Data Key="create_by">1</Data>
@@ -1505,7 +1505,7 @@ Your OTRS Group
 
     <Insert Table="notification_event">
         <Data Key="id" Type="AutoIncrement">2</Data>
-        <Data Key="name" Type="Quote">Ticket follow-up notification (unlocked)</Data>
+        <Data Key="name" Type="Quote" Translatable="1">Ticket follow-up notification (unlocked)</Data>
         <Data Key="valid_id">1</Data>
         <Data Key="comments" Type="Quote"></Data>
         <Data Key="create_by">1</Data>
@@ -1571,7 +1571,7 @@ Your OTRS Group
 
     <Insert Table="notification_event">
         <Data Key="id" Type="AutoIncrement">3</Data>
-        <Data Key="name" Type="Quote">Ticket follow-up notification (locked)</Data>
+        <Data Key="name" Type="Quote" Translatable="1">Ticket follow-up notification (locked)</Data>
         <Data Key="valid_id">1</Data>
         <Data Key="comments" Type="Quote"></Data>
         <Data Key="create_by">1</Data>
@@ -1637,7 +1637,7 @@ Your OTRS Group
 
     <Insert Table="notification_event">
         <Data Key="id" Type="AutoIncrement">4</Data>
-        <Data Key="name" Type="Quote">Ticket lock timeout notification</Data>
+        <Data Key="name" Type="Quote" Translatable="1">Ticket lock timeout notification</Data>
         <Data Key="valid_id">1</Data>
         <Data Key="comments" Type="Quote"></Data>
         <Data Key="create_by">1</Data>
@@ -1683,7 +1683,7 @@ Your OTRS Group
 
     <Insert Table="notification_event">
         <Data Key="id" Type="AutoIncrement">5</Data>
-        <Data Key="name" Type="Quote">Ticket owner update notification</Data>
+        <Data Key="name" Type="Quote" Translatable="1">Ticket owner update notification</Data>
         <Data Key="valid_id">1</Data>
         <Data Key="comments" Type="Quote"></Data>
         <Data Key="create_by">1</Data>
@@ -1714,7 +1714,7 @@ Your OTRS Group
 
     <Insert Table="notification_event">
         <Data Key="id" Type="AutoIncrement">6</Data>
-        <Data Key="name" Type="Quote">Ticket responsible update notification</Data>
+        <Data Key="name" Type="Quote" Translatable="1">Ticket responsible update notification</Data>
         <Data Key="valid_id">1</Data>
         <Data Key="comments" Type="Quote"></Data>
         <Data Key="create_by">1</Data>
@@ -1745,7 +1745,7 @@ Your OTRS Group
 
     <Insert Table="notification_event">
         <Data Key="id" Type="AutoIncrement">7</Data>
-        <Data Key="name" Type="Quote">Ticket new note notification</Data>
+        <Data Key="name" Type="Quote" Translatable="1">Ticket new note notification</Data>
         <Data Key="valid_id">1</Data>
         <Data Key="comments" Type="Quote"></Data>
         <Data Key="create_by">1</Data>
@@ -1786,7 +1786,7 @@ Your OTRS Group
 
     <Insert Table="notification_event">
         <Data Key="id" Type="AutoIncrement">8</Data>
-        <Data Key="name" Type="Quote">Ticket queue update notification</Data>
+        <Data Key="name" Type="Quote" Translatable="1">Ticket queue update notification</Data>
         <Data Key="valid_id">1</Data>
         <Data Key="comments" Type="Quote"></Data>
         <Data Key="create_by">1</Data>
@@ -1832,7 +1832,7 @@ Your OTRS Group
 
     <Insert Table="notification_event">
         <Data Key="id" Type="AutoIncrement">9</Data>
-        <Data Key="name" Type="Quote">Ticket pending reminder notification (locked)</Data>
+        <Data Key="name" Type="Quote" Translatable="1">Ticket pending reminder notification (locked)</Data>
         <Data Key="valid_id">1</Data>
         <Data Key="comments" Type="Quote"></Data>
         <Data Key="create_by">1</Data>
@@ -1883,7 +1883,7 @@ Your OTRS Group
 
     <Insert Table="notification_event">
         <Data Key="id" Type="AutoIncrement">10</Data>
-        <Data Key="name" Type="Quote">Ticket pending reminder notification (unlocked)</Data>
+        <Data Key="name" Type="Quote" Translatable="1">Ticket pending reminder notification (unlocked)</Data>
         <Data Key="valid_id">1</Data>
         <Data Key="comments" Type="Quote"></Data>
         <Data Key="create_by">1</Data>
@@ -1934,7 +1934,7 @@ Your OTRS Group
 
     <Insert Table="notification_event">
         <Data Key="id" Type="AutoIncrement">11</Data>
-        <Data Key="name" Type="Quote">Ticket escalation notification</Data>
+        <Data Key="name" Type="Quote" Translatable="1">Ticket escalation notification</Data>
         <Data Key="valid_id">1</Data>
         <Data Key="comments" Type="Quote"></Data>
         <Data Key="create_by">1</Data>
@@ -1975,7 +1975,7 @@ Your OTRS Group
 
     <Insert Table="notification_event">
         <Data Key="id" Type="AutoIncrement">12</Data>
-        <Data Key="name" Type="Quote">Ticket escalation warning notification</Data>
+        <Data Key="name" Type="Quote" Translatable="1">Ticket escalation warning notification</Data>
         <Data Key="valid_id">1</Data>
         <Data Key="comments" Type="Quote"></Data>
         <Data Key="create_by">1</Data>
@@ -2016,7 +2016,7 @@ Your OTRS Group
 
     <Insert Table="notification_event">
         <Data Key="id" Type="AutoIncrement">13</Data>
-        <Data Key="name" Type="Quote">Ticket service update notification</Data>
+        <Data Key="name" Type="Quote" Translatable="1">Ticket service update notification</Data>
         <Data Key="valid_id">1</Data>
         <Data Key="comments" Type="Quote"></Data>
         <Data Key="create_by">1</Data>


### PR DESCRIPTION
http://bugs.otrs.org/show_bug.cgi?id=11605

Hi @mgruner ,


In our opinion, as mentioned in bug report, we fear this is unnecessary addition when you can change names of the notification. Having this in mind, we would like to propose a solution that could solve reporter issue.

What we could offer is translatable names of initially added notifications in the system on install. This way, if there are translated strings, user can get notification name on preferred language, as long as it remain genuine. This has been done with other types of data thats created on initial install ( e.g. auto-response, salutation, signature; will create different PR that will also Translate(Data.Name) for this data, if we choose this way to proceed) 

Perhaps we can discuss more on this topic where your input is most welcome. Looking forward to your reply.

Regards,
Sanjin