### PR TITLE
Add `--sql-part` option to `Dev::Tools:Database::XMLExecute` console cmd

### DIFF
--- a/Kernel/System/Console/Command/Dev/Tools/Database/XMLExecute.pm
+++ b/Kernel/System/Console/Command/Dev/Tools/Database/XMLExecute.pm
@@ -31,6 +31,14 @@ sub Configure {
         ValueRegex  => qr/.*/smx,
     );
 
+    $Self->AddOption(
+        Name        => 'sql-part',
+        Description => "Generate only 'pre' or 'post' SQL",
+        Required    => 0,
+        HasValue    => 1,
+        ValueRegex  => qr/^(pre|post)$/smx,
+    );
+
     return;
 }
 
@@ -65,7 +73,19 @@ sub Run {
 
     my @SQLPost = $Kernel::OM->Get('Kernel::System::DB')->SQLProcessorPost();
 
-    for my $SQL ( @SQL, @SQLPost ) {
+    my $SQLPart = $Self->GetOption('sql-part') || 'both';
+    my @SQLCollection;
+    if ( $SQLPart eq 'both' ) {
+        push @SQLCollection, @SQL, @SQLPost;
+    }
+    elsif ( $SQLPart eq 'pre' ) {
+        push @SQLCollection, @SQL;
+    }
+    elsif ( $SQLPart eq 'post' ) {
+        push @SQLCollection, @SQLPost;
+    }
+
+    for my $SQL ( @SQLCollection ) {
         $Self->Print("$SQL\n");
         my $Success = $Kernel::OM->Get('Kernel::System::DB')->Do( SQL => $SQL );
         if ( !$Success ) {


### PR DESCRIPTION
This allows to only execute the 'pre' or 'post' part of an XML SQL
definition, as those often can't be executed at once due to foreign key
restrictions.
This is similar to the 'split-files' feature of the
`Dev::Tools::Database::XMLExecute` console command.