### PR TITLE
[Rel-5_0 Bug 11657] - Since upgrade Ticket::Frontend::AgentTicket*###Subject is empty

### DIFF
--- a/Kernel/Config/Files/Ticket.xml
+++ b/Kernel/Config/Files/Ticket.xml
@@ -2849,7 +2849,7 @@
         <Group>Ticket</Group>
         <SubGroup>Frontend::Agent::Ticket::ViewFreeText</SubGroup>
         <Setting>
-            <String Regex=""></String>
+            <String Regex="">[% Translate("Note") | html %]</String>
         </Setting>
     </ConfigItem>
     <ConfigItem Name="Ticket::Frontend::AgentTicketFreeText###Body" Required="0" Valid="1">
@@ -2989,7 +2989,7 @@
         <Group>Ticket</Group>
         <SubGroup>Frontend::Agent::Ticket::ViewPhoneOutbound</SubGroup>
         <Setting>
-            <String Regex=""></String>
+            <String Regex="">[% Translate("Phone call") | html %]!</String>
         </Setting>
     </ConfigItem>
     <ConfigItem Name="Ticket::Frontend::AgentTicketPhoneOutbound###Body" Required="1" Valid="1">
@@ -3078,7 +3078,7 @@
         <Group>Ticket</Group>
         <SubGroup>Frontend::Agent::Ticket::ViewPhoneInbound</SubGroup>
         <Setting>
-            <String Regex=""></String>
+            <String Regex="">[% Translate("Phone call") | html %]!</String>
         </Setting>
     </ConfigItem>
     <ConfigItem Name="Ticket::Frontend::AgentTicketPhoneInbound###Body" Required="1" Valid="1">
@@ -3596,7 +3596,7 @@
         <Group>Ticket</Group>
         <SubGroup>Frontend::Agent::Ticket::ViewClose</SubGroup>
         <Setting>
-            <String Regex=""></String>
+            <String Regex="">[% Translate("Close") | html %]</String>
         </Setting>
     </ConfigItem>
     <ConfigItem Name="Ticket::Frontend::AgentTicketClose###Body" Required="0" Valid="1">
@@ -3866,7 +3866,7 @@
         <Group>Ticket</Group>
         <SubGroup>Frontend::Agent::Ticket::ViewNote</SubGroup>
         <Setting>
-            <String Regex=""></String>
+            <String Regex="">[% Translate("Note") | html %]</String>
         </Setting>
     </ConfigItem>
     <ConfigItem Name="Ticket::Frontend::AgentTicketNote###Body" Required="0" Valid="1">
@@ -4135,7 +4135,7 @@
         <Group>Ticket</Group>
         <SubGroup>Frontend::Agent::Ticket::ViewOwner</SubGroup>
         <Setting>
-            <String Regex=""></String>
+            <String Regex="">[% Translate("Owner Update") | html %]!</String>
         </Setting>
     </ConfigItem>
     <ConfigItem Name="Ticket::Frontend::AgentTicketOwner###Body" Required="0" Valid="1">
@@ -4402,7 +4402,7 @@
         <Group>Ticket</Group>
         <SubGroup>Frontend::Agent::Ticket::ViewPending</SubGroup>
         <Setting>
-            <String Regex=""></String>
+            <String Regex="">[% Translate("Pending") | html %]!</String>
         </Setting>
     </ConfigItem>
     <ConfigItem Name="Ticket::Frontend::AgentTicketPending###Body" Required="0" Valid="1">
@@ -4671,7 +4671,7 @@
         <Group>Ticket</Group>
         <SubGroup>Frontend::Agent::Ticket::ViewPriority</SubGroup>
         <Setting>
-            <String Regex=""></String>
+            <String Regex="">[% Translate("Priority Update") | html %]!</String>
         </Setting>
     </ConfigItem>
     <ConfigItem Name="Ticket::Frontend::AgentTicketPriority###Body" Required="0" Valid="1">
@@ -4940,7 +4940,7 @@
         <Group>Ticket</Group>
         <SubGroup>Frontend::Agent::Ticket::ViewResponsible</SubGroup>
         <Setting>
-            <String Regex=""></String>
+            <String Regex="">[% Translate("Responsible Update") | html %]!</String>
         </Setting>
     </ConfigItem>
     <ConfigItem Name="Ticket::Frontend::AgentTicketResponsible###Body" Required="0" Valid="1">
@@ -8579,7 +8579,7 @@
         <Group>Ticket</Group>
         <SubGroup>Frontend::Agent::Ticket::ViewMove</SubGroup>
         <Setting>
-            <String Regex=""></String>
+            <String Regex="">[% Translate("Change Queue") | html %]</String>
         </Setting>
     </ConfigItem>
     <ConfigItem Name="Ticket::Frontend::AgentTicketMove###Body" Required="0" Valid="1">


### PR DESCRIPTION
http://bugs.otrs.org/show_bug.cgi?id=11657

Hi @mgruner ,

There were missing default values in SysConfig for Subject fields. Added them in same fashion as it was used in 4.0.

Please let me know if you disagree with this and if these default values were left empty for a reason.

Regards,
Sanjin