### PR TITLE
[Rel-5_0 Bug 10931] - Reply to note does not use the origin note subject

### DIFF
--- a/Kernel/Modules/AgentTicketActionCommon.pm
+++ b/Kernel/Modules/AgentTicketActionCommon.pm
@@ -1298,14 +1298,9 @@ sub Run {
         # set Body var to calculated content
         $GetParam{Body} = $Body;
 
-        if ( $Self->{ReplyToArticle} && $Config->{Subject} ) {
-            my $TicketSubjectRe = $ConfigObject->Get('Ticket::SubjectRe');
-            if ($TicketSubjectRe) {
-                $GetParam{Subject} = $TicketSubjectRe . ': ' . $Self->{ReplyToArticleContent}{Subject};
-            }
-            else {
-                $GetParam{Subject} = 'Re: ' . $Self->{ReplyToArticleContent}{Subject};
-            }
+        if ( $Self->{ReplyToArticle} ) {
+            my $TicketSubjectRe = $ConfigObject->Get('Ticket::SubjectRe') || 'Re';
+            $GetParam{Subject} = $TicketSubjectRe . ': ' . $Self->{ReplyToArticleContent}{Subject};
         }
         elsif ( !defined $GetParam{Subject} && $Config->{Subject} ) {
             $GetParam{Subject} = $LayoutObject->Output(


### PR DESCRIPTION
http://bugs.otrs.org/show_bug.cgi?id=r

Hi @mgruner ,

Hereby is proposal for fixing this issue. Removed in IF condition to check for $Config->{Subject}. This way 'Reply to note' can take subject from original note it replies to, nevertheless if it's default value is set in sys config or not ( since default value was not used when creating subject for 'Reply to note' )

Updated Selenium test to check for subject value in 'Reply to note' and generally improved test.

If there are any issues regarding this PR, please let me know.

Regards,
Sanjin