### PR TITLE
[Rel-5_0 Bug 11654] - Internal server error with limit 0 in out-of-office-dashboard

### DIFF
--- a/Kernel/Output/HTML/Dashboard/UserOnline.pm
+++ b/Kernel/Output/HTML/Dashboard/UserOnline.pm
@@ -65,7 +65,7 @@ sub new {
     $Self->{PrefKey} = 'UserDashboardPref' . $Self->{Name} . '-Shown';
 
     $Self->{PageShown} = $Kernel::OM->Get('Kernel::Output::HTML::Layout')->{ $Self->{PrefKey} }
-        || $Self->{Config}->{Limit};
+        || $Self->{Config}->{Limit} || 10;
 
     $Self->{StartHit} = int( $ParamObject->GetParam( Param => 'StartHit' ) || 1 );
 

--- a/Kernel/Output/HTML/Dashboard/UserOutOfOffice.pm
+++ b/Kernel/Output/HTML/Dashboard/UserOutOfOffice.pm
@@ -35,7 +35,7 @@ sub new {
     $Self->{PrefKey} = 'UserDashboardPref' . $Self->{Name} . '-Shown';
 
     $Self->{PageShown} = $Kernel::OM->Get('Kernel::Output::HTML::Layout')->{ $Self->{PrefKey} }
-        || $Self->{Config}->{Limit};
+        || $Self->{Config}->{Limit} || 10;
 
     $Self->{StartHit} = int( $ParamObject->GetParam( Param => 'StartHit' ) || 1 );
 


### PR DESCRIPTION
http://bugs.otrs.org/show_bug.cgi?id=11654

Hi @mgruner , 

It was possible to send param PageShown value 0 to Layout/PageNavBar function resulting in fatal error. With this small fix, we bypass it and use default value when 0 is set as limit in SysConfig.

Regards,
Sanjin