### PR TITLE
[Rel-5_0 Bug 10938] - Missing translation 'Linked As' in OTRS Interface

### DIFF
--- a/Kernel/Output/HTML/Layout/LinkObject.pm
+++ b/Kernel/Output/HTML/Layout/LinkObject.pm
@@ -179,7 +179,7 @@ sub LinkObjectTableCreateComplex {
 
         # define the headline column
         my $Column = {
-            Content => 'Linked as',
+            Content => $Kernel::OM->Get('Kernel::Language')->Translate('Linked as'),
         };
 
         # add new column to the headline


### PR DESCRIPTION
http://bugs.otrs.org/show_bug.cgi?id=10938

Hi @mgruner ,

Added translate for 'Linked as' header column in AgentLinkObject.

Regards,
Sanjin