### PR TITLE
Master - fixed dropdown for CustomerTicketOverview

### DIFF
--- a/Kernel/Config/Files/Ticket.xml
+++ b/Kernel/Config/Files/Ticket.xml
@@ -1918,8 +1918,8 @@
         <SubGroup>Frontend::Customer::TicketOverview</SubGroup>
         <Setting>
             <Option SelectedID="">
-                <Item Key="" Translatable="1">No</Item>
-                <Item Key="Sortable" Translatable="1">Yes</Item>
+                <Item Key="0" Translatable="1">No</Item>
+                <Item Key="1" Translatable="1">Yes</Item>
             </Option>
         </Setting>
     </ConfigItem>

--- a/Kernel/Config/Files/Ticket.xml
+++ b/Kernel/Config/Files/Ticket.xml
@@ -1919,7 +1919,7 @@
         <Setting>
             <Option SelectedID="">
                 <Item Key="0" Translatable="1">No</Item>
-                <Item Key="1" Translatable="1">Yes</Item>
+                <Item Key="Sortable" Translatable="1">Yes</Item>
             </Option>
         </Setting>
     </ConfigItem>

--- a/Kernel/Output/HTML/Templates/Standard/CustomerTicketOverview.tt
+++ b/Kernel/Output/HTML/Templates/Standard/CustomerTicketOverview.tt
@@ -5,7 +5,7 @@
 # the enclosed file COPYING for license information (AGPL). If you
 # did not receive this file, see http://www.gnu.org/licenses/agpl.txt.
 # --
-<div id="MainBox" class="TicketView ARIARoleMain [% IF Config("Ticket::Frontend::CustomerTicketOverviewSortable") %] Sortable [% END %]">
+<div id="MainBox" class="TicketView ARIARoleMain [% Config("Ticket::Frontend::CustomerTicketOverviewSortable") %] ">
 [% RenderBlockStart("Filled") %]
     <div class="ActionRow">
         <ul class="Filter Tabs">

--- a/Kernel/Output/HTML/Templates/Standard/CustomerTicketOverview.tt
+++ b/Kernel/Output/HTML/Templates/Standard/CustomerTicketOverview.tt
@@ -5,7 +5,7 @@
 # the enclosed file COPYING for license information (AGPL). If you
 # did not receive this file, see http://www.gnu.org/licenses/agpl.txt.
 # --
-<div id="MainBox" class="TicketView ARIARoleMain [% Config("Ticket::Frontend::CustomerTicketOverviewSortable") %]">
+<div id="MainBox" class="TicketView ARIARoleMain [% IF Config("Ticket::Frontend::CustomerTicketOverviewSortable") %] Sortable [% END %]">
 [% RenderBlockStart("Filled") %]
     <div class="ActionRow">
         <ul class="Filter Tabs">

--- a/Kernel/Output/HTML/Templates/Standard/CustomerTicketSearchResultShort.tt
+++ b/Kernel/Output/HTML/Templates/Standard/CustomerTicketSearchResultShort.tt
@@ -6,7 +6,7 @@
 # did not receive this file, see http://www.gnu.org/licenses/agpl.txt.
 # --
 
-<div id="MainBox" class="TicketView ARIARoleMain SearchResults [% Config("Ticket::Frontend::CustomerTicketOverviewSortable") %] Sortable">
+<div id="MainBox" class="TicketView ARIARoleMain SearchResults [% IF Config("Ticket::Frontend::CustomerTicketOverviewSortable") %] Sortable [% END %]">
     <div class="ActionRow">
         <ul class="Tabs">
             <li>

--- a/Kernel/Output/HTML/Templates/Standard/CustomerTicketSearchResultShort.tt
+++ b/Kernel/Output/HTML/Templates/Standard/CustomerTicketSearchResultShort.tt
@@ -6,7 +6,7 @@
 # did not receive this file, see http://www.gnu.org/licenses/agpl.txt.
 # --
 
-<div id="MainBox" class="TicketView ARIARoleMain SearchResults [% IF Config("Ticket::Frontend::CustomerTicketOverviewSortable") %] Sortable [% END %]">
+<div id="MainBox" class="TicketView ARIARoleMain SearchResults [% Config("Ticket::Frontend::CustomerTicketOverviewSortable") %] ">
     <div class="ActionRow">
         <ul class="Tabs">
             <li>

--- a/scripts/test/Selenium/Customer/CustomerTicketOverview.t
+++ b/scripts/test/Selenium/Customer/CustomerTicketOverview.t
@@ -47,6 +47,13 @@ $Selenium->RunTest(
             Value => 0
         );
 
+        # enable CustomerTicketOverviewSortable
+        $Kernel::OM->Get('Kernel::System::SysConfig')->ConfigItemUpdate(
+            Valid => 1,
+            Key   => 'Ticket::Frontend::CustomerTicketOverviewSortable',
+            Value => 'Sortable',
+        );
+
         # create test customer user and login
         my $TestUserLogin = $Helper->TestCustomerUserCreate(
             Groups => ['admin'],
@@ -100,6 +107,15 @@ $Selenium->RunTest(
             "Ticket with ticket number $TicketNumber is found on screen with All filter"
         );
 
+        # check if there is the header of overview table for sorting tickets
+        $Self->Is(
+            $Selenium->execute_script(
+                "return \$('#MainBox').hasClass('Sortable')"
+            ),
+            '1',
+            'There is the header of overview table for sorting tickets.',
+        );
+
         # check Close filter on CustomerTicketOverview screen
         # there is only one created ticket, and it should not be on screen with Close filter
         $Selenium->find_element(
@@ -115,6 +131,27 @@ $Selenium->RunTest(
         $Self->False(
             $Success,
             "Ticket with ticket number $TicketNumber is not found on screen with Close filter"
+        );
+
+        # disable CustomerTicketOverviewSortable
+        $Kernel::OM->Get('Kernel::System::SysConfig')->ConfigItemUpdate(
+            Valid => 1,
+            Key   => 'Ticket::Frontend::CustomerTicketOverviewSortable',
+            Value => 0
+        );
+
+        # check All filter on CustomerTicketOverview screen
+        $Selenium->find_element(
+            "//a[contains(\@href, \'Action=CustomerTicketOverview;Subaction=MyTickets;Filter=All' )]"
+        )->click();
+
+        # check if there is not the header of overview table for sorting tickets
+        $Self->Is(
+            $Selenium->execute_script(
+                "return \$('#MainBox').hasClass('Sortable')"
+            ),
+            '0',
+            'There is not the header of overview table for sorting tickets.',
         );
 
         # clean up test data from the DB


### PR DESCRIPTION
Hi @mgruner 

Working on some bugs we saw that there is wrong display in dropdown for CustomerTicketOverviewSortable SysConfig item in case there is set "No".

![screen shot 2015-11-23 at 4 15 01 pm](https://cloud.githubusercontent.com/assets/6348760/11340272/7c96f63e-91fd-11e5-81b2-28d1d7dec23b.png)

I suppose the problem occurs after adding  modernize input fields. This config was added for bug 
http://bugs.otrs.org/show_bug.cgi?id=5987 in commit https://github.com/OTRS/otrs/commit/a1fb55f776a6852b5a23b81e05166b316930f0a7

I fixed Customer ticket search screen as well, in my opinion there was bug. There was added Sortable twice if CustomerTicketOverviewSortable was "Yes".

Please let me know what do you think about this proposal

Regards
Zoran 

