### PR TITLE
Master - changed Language::Get function to Language::Translate

### DIFF
--- a/Kernel/Language.pm
+++ b/Kernel/Language.pm
@@ -404,9 +404,9 @@ sub FormatTimeString {
         $ReturnString =~ s/\%M/$M/g;
         $ReturnString =~ s/\%Y/$Y/g;
 
-        $ReturnString =~ s{(\%A)}{defined $WD ? $Self->Get($DAYS[$WD]) : '';}egx;
+        $ReturnString =~ s{(\%A)}{defined $WD ? $Self->Translate($DAYS[$WD]) : '';}egx;
         $ReturnString
-            =~ s{(\%B)}{(defined $M && $M =~ m/^\d+$/) ? $Self->Get($MONS[$M-1]) : '';}egx;
+            =~ s{(\%B)}{(defined $M && $M =~ m/^\d+$/) ? $Self->Translate($MONS[$M-1]) : '';}egx;
 
         if ( $Self->{TimeZone} && $Config ne 'DateFormatShort' ) {
             return $ReturnString . " ($Self->{TimeZone})";
@@ -561,9 +561,9 @@ sub Time {
         $ReturnString =~ s/\%M/$M/g;
         $ReturnString =~ s/\%Y/$Y/g;
         $ReturnString =~ s/\%Y/$Y/g;
-        $ReturnString =~ s{(\%A)}{defined $WD ? $Self->Get($DAYS[$WD]) : '';}egx;
+        $ReturnString =~ s{(\%A)}{defined $WD ? $Self->Translate($DAYS[$WD]) : '';}egx;
         $ReturnString
-            =~ s{(\%B)}{(defined $M && $M =~ m/^\d+$/) ? $Self->Get($MONS[$M-1]) : '';}egx;
+            =~ s{(\%B)}{(defined $M && $M =~ m/^\d+$/) ? $Self->Translate($MONS[$M-1]) : '';}egx;
         return $ReturnString;
     }
 

--- a/scripts/test/Selenium/Agent/Admin/AdminEmail.t
+++ b/scripts/test/Selenium/Agent/Admin/AdminEmail.t
@@ -105,7 +105,7 @@ $Selenium->RunTest(
             UserLanguage => $Language,
         );
 
-        my $Expected = $LanguageObject->Get(
+        my $Expected = $LanguageObject->Translate(
             "Your message was sent to"
         ) . ": $TestUserLogin\@localunittest.com";
 

--- a/scripts/test/Selenium/Agent/Admin/AdminRole.t
+++ b/scripts/test/Selenium/Agent/Admin/AdminRole.t
@@ -54,7 +54,7 @@ $Selenium->RunTest(
             $Self->True(
                 index(
                     $Selenium->get_page_source(),
-                    $LanguageObject->Get(
+                    $LanguageObject->Translate(
                         "There are no roles defined. Please use the 'Add' button to create a new role."
                         )
                     ) > -1,

--- a/scripts/test/Selenium/Agent/Language.t
+++ b/scripts/test/Selenium/Agent/Language.t
@@ -40,7 +40,6 @@ $Selenium->RunTest(
 
         my @Languages = sort keys %{ $ConfigObject->Get('DefaultUsedLanguages') };
 
-        Language:
         for my $Language (@Languages) {
 
             # check for the language selection box
@@ -57,14 +56,14 @@ $Selenium->RunTest(
             my $Element = $Selenium->find_element( 'Label[for=UserLanguage]', 'css' );
             $Self->Is(
                 substr( $Element->get_text(), 0, -1 ),
-                $LanguageObject->Get('Language'),
+                $LanguageObject->Translate('Language'),
                 "String 'Language' in $Language",
             );
 
             $Self->True(
                 index(
                     $Selenium->get_page_source(),
-                    $LanguageObject->Get('Preferences updated successfully!')
+                    $LanguageObject->Translate('Preferences updated successfully!')
                     ) > -1,
                 "Success notification in $Language",
             );


### PR DESCRIPTION
Hi @mgruner 

Working on dummy translate template files I saw that there were in some places Get instead Translate function from Language module.  I fixed this here. If you want you can merge it.

regards
Zoran  