### PR TITLE
[Rel-5_0 Bug 11096] - action URL overwrites permission settings

### DIFF
--- a/Kernel/System/Web/InterfaceCustomer.pm
+++ b/Kernel/System/Web/InterfaceCustomer.pm
@@ -12,6 +12,7 @@ use strict;
 use warnings;
 
 use Kernel::System::Email;
+use Kernel::System::VariableCheck qw(IsArrayRefWithData);
 
 our @ObjectDependencies = (
     'Kernel::Config',
@@ -1071,7 +1072,7 @@ sub Run {
             return;
         }
 
-        # module permisson check
+        # module permisson check for action
         if ( !$ModuleReg->{GroupRo} && !$ModuleReg->{Group} ) {
             $Param{AccessRo} = 1;
             $Param{AccessRw} = 1;
@@ -1083,12 +1084,12 @@ sub Run {
                 my $Group    = $ModuleReg->{$Permission};
                 my $Key      = "UserIs$Permission";
                 next PERMISSION if !$Group;
-                if ( ref $Group eq 'ARRAY' ) {
+                if ( IsArrayRefWithData($Group) ) {
                     GROUP:
-                    for ( @{$Group} ) {
-                        next GROUP if !$_;
-                        next GROUP if !$UserData{ $Key . "[$_]" };
-                        next GROUP if $UserData{ $Key . "[$_]" } ne 'Yes';
+                    for my $Item ( @{$Group} ) {
+                        next GROUP if !$Item;
+                        next GROUP if !$UserData{ $Key . "[$Item]" };
+                        next GROUP if $UserData{ $Key . "[$Item]" } ne 'Yes';
                         $AccessOk = 1;
                         last GROUP;
                     }
@@ -1113,10 +1114,73 @@ sub Run {
                 my $LayoutObject = $Kernel::OM->Get('Kernel::Output::HTML::Layout');
                 $Kernel::OM->Get('Kernel::System::Log')->Log(
                     Priority => 'error',
-                    Message  => 'No Permission to use this frontend module!'
+                    Message  => 'No Permission to use this frontend action module!'
                 );
                 $LayoutObject->CustomerFatalError( Comment => 'Please contact your administrator' );
                 return;
+            }
+
+        }
+
+        # module permisson check for submenu item
+        if ( IsArrayRefWithData( $ModuleReg->{NavBar} ) ) {
+            LINKCHECK:
+            for my $Check ( @{ $ModuleReg->{NavBar} } ) {
+                next LINKCHECK if $Param{RequestedURL} !~ m/Subaction/i;
+                if ( $Check->{Link} =~ m/Subaction=/i && $Check->{Link} !~ m/$Param{Subaction}/i ) {
+                    next LINKCHECK;
+                }
+                $Param{AccessRo} = 0;
+                $Param{AccessRw} = 0;
+
+                # module permisson check for submenu item
+                if ( !$Check->{GroupRo} && !$Check->{Group} ) {
+                    $Param{AccessRo} = 1;
+                    $Param{AccessRw} = 1;
+                }
+                else {
+                    PERMISSION:
+                    for my $Permission (qw(GroupRo Group)) {
+                        my $AccessOk = 0;
+                        my $Group    = $Check->{$Permission};
+                        my $Key      = "UserIs$Permission";
+                        next PERMISSION if !$Group;
+                        if ( IsArrayRefWithData($Group) ) {
+                            GROUP:
+                            for my $Item ( @{$Group} ) {
+                                next GROUP if !$Item;
+                                next GROUP if !$UserData{ $Key . "[$Item]" };
+                                next GROUP if $UserData{ $Key . "[$Item]" } ne 'Yes';
+                                $AccessOk = 1;
+                                last GROUP;
+                            }
+                        }
+                        else {
+                            if ( $UserData{ $Key . "[$Group]" } && $UserData{ $Key . "[$Group]" } eq 'Yes' )
+                            {
+                                $AccessOk = 1;
+                            }
+                        }
+                        if ( $Permission eq 'Group' && $AccessOk ) {
+                            $Param{AccessRo} = 1;
+                            $Param{AccessRw} = 1;
+                        }
+                        elsif ( $Permission eq 'GroupRo' && $AccessOk ) {
+                            $Param{AccessRo} = 1;
+                        }
+                    }
+                    if ( !$Param{AccessRo} ) {
+
+                        # new layout object
+                        my $LayoutObject = $Kernel::OM->Get('Kernel::Output::HTML::Layout');
+                        $Kernel::OM->Get('Kernel::System::Log')->Log(
+                            Priority => 'error',
+                            Message  => 'No Permission to use this frontend subaction module!'
+                        );
+                        $LayoutObject->CustomerFatalError( Comment => 'Please contact your administrator' );
+                        return;
+                    }
+                }
             }
         }
 

--- a/Kernel/System/Web/InterfaceCustomer.pm
+++ b/Kernel/System/Web/InterfaceCustomer.pm
@@ -376,7 +376,7 @@ sub Run {
             SystemTime => ( $TimeObject->SystemTime() + 20 ),
         );
 
-        # add a asychronous executor scheduler task to count the concurrent user
+        # add a asynchronous executor scheduler task to count the concurrent user
         $Kernel::OM->Get('Kernel::System::Scheduler')->TaskAdd(
             ExecutionTime            => $ExecutionTime,
             Type                     => 'AsynchronousExecutor',
@@ -1072,42 +1072,18 @@ sub Run {
             return;
         }
 
-        # module permisson check for action
+        # module permission check for action
         if ( !$ModuleReg->{GroupRo} && !$ModuleReg->{Group} ) {
             $Param{AccessRo} = 1;
             $Param{AccessRw} = 1;
         }
         else {
-            PERMISSION:
-            for my $Permission (qw(GroupRo Group)) {
-                my $AccessOk = 0;
-                my $Group    = $ModuleReg->{$Permission};
-                my $Key      = "UserIs$Permission";
-                next PERMISSION if !$Group;
-                if ( IsArrayRefWithData($Group) ) {
-                    GROUP:
-                    for my $Item ( @{$Group} ) {
-                        next GROUP if !$Item;
-                        next GROUP if !$UserData{ $Key . "[$Item]" };
-                        next GROUP if $UserData{ $Key . "[$Item]" } ne 'Yes';
-                        $AccessOk = 1;
-                        last GROUP;
-                    }
-                }
-                else {
-                    if ( $UserData{ $Key . "[$Group]" } && $UserData{ $Key . "[$Group]" } eq 'Yes' )
-                    {
-                        $AccessOk = 1;
-                    }
-                }
-                if ( $Permission eq 'Group' && $AccessOk ) {
-                    $Param{AccessRo} = 1;
-                    $Param{AccessRw} = 1;
-                }
-                elsif ( $Permission eq 'GroupRo' && $AccessOk ) {
-                    $Param{AccessRo} = 1;
-                }
-            }
+
+            ( $Param{AccessRo}, $Param{AccessRw} ) = $Self->_CheckModulePermission(
+                ModuleReg => $ModuleReg,
+                %UserData,
+            );
+
             if ( !$Param{AccessRo} ) {
 
                 # new layout object
@@ -1122,53 +1098,29 @@ sub Run {
 
         }
 
-        # module permisson check for submenu item
+        # module permission check for submenu item
         if ( IsArrayRefWithData( $ModuleReg->{NavBar} ) ) {
             LINKCHECK:
-            for my $Check ( @{ $ModuleReg->{NavBar} } ) {
+            for my $ModuleReg ( @{ $ModuleReg->{NavBar} } ) {
                 next LINKCHECK if $Param{RequestedURL} !~ m/Subaction/i;
-                if ( $Check->{Link} =~ m/Subaction=/i && $Check->{Link} !~ m/$Param{Subaction}/i ) {
+                if ( $ModuleReg->{Link} =~ m/Subaction=/i && $ModuleReg->{Link} !~ m/$Param{Subaction}/i ) {
                     next LINKCHECK;
                 }
                 $Param{AccessRo} = 0;
                 $Param{AccessRw} = 0;
 
-                # module permisson check for submenu item
-                if ( !$Check->{GroupRo} && !$Check->{Group} ) {
+                # module permission check for submenu item
+                if ( !$ModuleReg->{GroupRo} && !$ModuleReg->{Group} ) {
                     $Param{AccessRo} = 1;
                     $Param{AccessRw} = 1;
                 }
                 else {
-                    PERMISSION:
-                    for my $Permission (qw(GroupRo Group)) {
-                        my $AccessOk = 0;
-                        my $Group    = $Check->{$Permission};
-                        my $Key      = "UserIs$Permission";
-                        next PERMISSION if !$Group;
-                        if ( IsArrayRefWithData($Group) ) {
-                            GROUP:
-                            for my $Item ( @{$Group} ) {
-                                next GROUP if !$Item;
-                                next GROUP if !$UserData{ $Key . "[$Item]" };
-                                next GROUP if $UserData{ $Key . "[$Item]" } ne 'Yes';
-                                $AccessOk = 1;
-                                last GROUP;
-                            }
-                        }
-                        else {
-                            if ( $UserData{ $Key . "[$Group]" } && $UserData{ $Key . "[$Group]" } eq 'Yes' )
-                            {
-                                $AccessOk = 1;
-                            }
-                        }
-                        if ( $Permission eq 'Group' && $AccessOk ) {
-                            $Param{AccessRo} = 1;
-                            $Param{AccessRw} = 1;
-                        }
-                        elsif ( $Permission eq 'GroupRo' && $AccessOk ) {
-                            $Param{AccessRo} = 1;
-                        }
-                    }
+
+                    ( $Param{AccessRo}, $Param{AccessRw} ) = $Self->_CheckModulePermission(
+                        ModuleReg => $ModuleReg,
+                        %UserData,
+                    );
+
                     if ( !$Param{AccessRo} ) {
 
                         # new layout object
@@ -1316,6 +1268,64 @@ sub Run {
     );
     return;
 }
+
+=begin Internal:
+
+=item _CheckModulePermission()
+
+module permission check
+
+    ($AccessRo, $AccessRw = $AutoResponseObject->_CheckModulePermission(
+        ModuleReg => $ModuleReg,
+        %UserData,
+    );
+
+=cut
+
+sub _CheckModulePermission {
+    my ( $Self, %Param ) = @_;
+
+    my $AccessRo = 0;
+    my $AccessRw = 0;
+
+    PERMISSION:
+    for my $Permission (qw(GroupRo Group)) {
+        my $AccessOk = 0;
+        my $Group    = $Param{ModuleReg}->{$Permission};
+
+        my $Key = "UserIs$Permission";
+        next PERMISSION if !$Group;
+        if ( IsArrayRefWithData($Group) ) {
+            GROUP:
+            for my $Item ( @{$Group} ) {
+                next GROUP if !$Item;
+                next GROUP if !$Param{ $Key . "[$Item]" };
+                next GROUP if $Param{ $Key . "[$Item]" } ne 'Yes';
+                $AccessOk = 1;
+                last GROUP;
+            }
+        }
+        else {
+            if ( $Param{ $Key . "[$Group]" } && $Param{ $Key . "[$Group]" } eq 'Yes' )
+            {
+                $AccessOk = 1;
+            }
+        }
+        if ( $Permission eq 'Group' && $AccessOk ) {
+            $AccessRo = 1;
+            $AccessRw = 1;
+        }
+        elsif ( $Permission eq 'GroupRo' && $AccessOk ) {
+            $AccessRo = 1;
+        }
+    }
+
+    return ( $AccessRo, $AccessRw );
+}
+
+=end Internal:
+
+=cut
 
 sub DESTROY {
     my $Self = shift;

--- a/scripts/test/Selenium/Customer/CustomerGroupPermission.t
+++ b/scripts/test/Selenium/Customer/CustomerGroupPermission.t
@@ -1,0 +1,159 @@
+# --
+# Copyright (C) 2001-2015 OTRS AG, http://otrs.com/
+# --
+# This software comes with ABSOLUTELY NO WARRANTY. For details, see
+# the enclosed file COPYING for license information (AGPL). If you
+# did not receive this file, see http://www.gnu.org/licenses/agpl.txt.
+# --
+
+use strict;
+use warnings;
+use utf8;
+
+use vars (qw($Self));
+
+# get selenium object
+my $Selenium = $Kernel::OM->Get('Kernel::System::UnitTest::Selenium');
+
+$Selenium->RunTest(
+    sub {
+
+        # get helper object
+        $Kernel::OM->ObjectParamAdd(
+            'Kernel::System::UnitTest::Helper' => {
+                RestoreSystemConfiguration => 1,
+            },
+        );
+        my $Helper          = $Kernel::OM->Get('Kernel::System::UnitTest::Helper');
+        my $SysConfigObject = $Kernel::OM->Get('Kernel::System::SysConfig');
+
+        # enable customer group support
+        $SysConfigObject->ConfigItemUpdate(
+            Valid => 1,
+            Key   => 'CustomerGroupSupport',
+            Value => 1,
+        );
+
+        # create test user and login
+        my $TestUserLogin = $Helper->TestUserCreate(
+            Groups => [ 'admin', 'users' ],
+        ) || die "Did not get test user";
+
+        $Selenium->Login(
+            Type     => 'Agent',
+            User     => $TestUserLogin,
+            Password => $TestUserLogin,
+        );
+
+        # reset CustomerFrontend::Module###CustomerTicketOverview sysconfig
+        $SysConfigObject->ConfigItemReset(
+            Name => 'CustomerFrontend::Module###CustomerTicketOverview',
+        );
+
+        # create test group
+        my $GroupName = 'Group' . $Helper->GetRandomID();
+        my $GroupID   = $Kernel::OM->Get('Kernel::System::Group')->GroupAdd(
+            Name    => $GroupName,
+            ValidID => 1,
+            UserID  => 1,
+        );
+
+        # get script alias
+        my $ScriptAlias = $Kernel::OM->Get('Kernel::Config')->Get('ScriptAlias');
+
+        # navigate to sysconfig CustomerFrontend::Module###CustomerTicketOverview screen
+        $Selenium->get(
+            "${ScriptAlias}index.pl?Action=AdminSysConfig;Subaction=Edit;SysConfigSubGroup=Frontend%3A%3ACustomer%3A%3AModuleRegistration;SysConfigGroup=Ticket"
+        );
+
+        # add test group as group restriction for company ticket subaction screen
+        $Selenium->find_element(
+            "//button[\@name='CustomerFrontend::Module###CustomerTicketOverview#NavBar3#NewGroupElement'][\@type='submit']"
+        )->click();
+
+        my $ConfigGroupElement = $Selenium->find_element(
+            "//input[\@name='CustomerFrontend::Module###CustomerTicketOverview#NavBar3#Group[]']");
+        $ConfigGroupElement->send_keys($GroupName);
+        $ConfigGroupElement->submit();
+
+        # create and login test customer
+        my $TestCustomerUserLogin = $Helper->TestCustomerUserCreate(
+        ) || die "Did not get test customer user";
+
+        $Selenium->Login(
+            Type     => 'Customer',
+            User     => $TestCustomerUserLogin,
+            Password => $TestCustomerUserLogin,
+        );
+
+        # get customer user ID
+        my @CustomerIDs = $Kernel::OM->Get('Kernel::System::CustomerUser')->CustomerIDs(
+            User => $TestCustomerUserLogin,
+        );
+
+        # navigate to CompanyTickets subaction screen
+        $Selenium->get("${ScriptAlias}customer.pl?Action=CustomerTicketOverview;Subaction=CompanyTickets");
+
+        # check for customer fatal error
+        my $ExpectedMsg = 'Please contact your administrator';
+        $Self->True(
+            index( $Selenium->get_page_source(), $ExpectedMsg ) > -1,
+            "Customer fatal error message - found",
+        );
+
+        # set customer user in test group with rw and ro permissions
+        my $Success = $Kernel::OM->Get('Kernel::System::CustomerGroup')->GroupMemberAdd(
+            GID        => $GroupID,
+            UID        => $CustomerIDs[0],
+            Permission => {
+                ro => 1,
+                rw => 1,
+            },
+            UserID => 1,
+        );
+        $Self->True(
+            $Success,
+            "CustomerUser $TestCustomerUserLogin added to test group $GroupName with ro and rw rights"
+        );
+
+        # login test customer user again
+        $Selenium->Login(
+            Type     => 'Customer',
+            User     => $TestCustomerUserLogin,
+            Password => $TestCustomerUserLogin,
+        );
+
+        # navigate to CompanyTickets subaction screen again
+        $Selenium->get("${ScriptAlias}customer.pl?Action=CustomerTicketOverview;Subaction=CompanyTickets");
+
+        # verify there is no more customer fatal message
+        $Self->True(
+            index( $Selenium->get_page_source(), $ExpectedMsg ) == -1,
+            "Customer fatal error message - not found",
+        );
+
+        # delete test created group
+        my $DBObject = $Kernel::OM->Get('Kernel::System::DB');
+        $Success = $DBObject->Do(
+            SQL => "DELETE FROM group_customer_user WHERE group_id = $GroupID",
+        );
+        if ($Success) {
+            $Self->True(
+                $Success,
+                "$GroupName - GroupCustomerUserDelete",
+            );
+        }
+
+        $GroupName = $DBObject->Quote($GroupName);
+        $Success   = $DBObject->Do(
+            SQL  => "DELETE FROM groups WHERE name = ?",
+            Bind => [ \$GroupName ],
+        );
+        $Self->True(
+            $Success,
+            "$GroupName - deleted",
+        );
+    }
+);
+
+1;


### PR DESCRIPTION
http://bugs.otrs.org/show_bug.cgi?id=11096

Hello @mgruner ,

Hereby is our proposal for fixing reporters issue. This could be solved in CustomerTicketOverview module as well, but with this proposal hopefully we can prevent other future potential similar issues with customer modules who branch into different subactions.

Added part where we go through each nav bar of customer module registration and searching if there are any subaction present in links. If some are found, matching it with current param subaction to check if that subaction module is accessible for current customer group.

Additionally there is Ticket::Frontend::CustomerDisableCompanyTicketAccess sysconfig that prevents customer to see company tickets that are not created by him. With this addition we can further limit it for certain groups and prevent 'force entry' by URL for desired subaction.

There is Selenium test to simulate this type of behaviour. Please let me know if there are any questions or issues regarding this PR.

Regards,
Sanjin 
