### PR TITLE
[Rel-5_0 Bug 9061] - Initial queues are set to "Ticket lock after follow-up: yes"

### DIFF
--- a/Kernel/Modules/AdminQueue.pm
+++ b/Kernel/Modules/AdminQueue.pm
@@ -618,7 +618,7 @@ sub _Edit {
     $Param{FollowUpLockYesNoOption} = $LayoutObject->BuildSelection(
         Data       => $ConfigObject->Get('YesNoOptions'),
         Name       => 'FollowUpLock',
-        SelectedID => $Param{FollowUpLock} || 0,
+        SelectedID => $Param{FollowUpLock} || 1,
         Class      => 'Modernize',
     );
 


### PR DESCRIPTION
http://bugs.otrs.org/show_bug.cgi?id=9061

Hi @mgruner ,

Although we think that this is not really a bug since you can change this parameter to suit your needs when creating queue, it's nice to see consistency through system. Changed default value for 'Ticket lock after a follow up' to 'Yes' on initial load of AdminQueue;Subaction=Add screen.

Regards,
Sanjin