### PR TITLE
Bug 11688 - otrs.Console.pl Maint::Session::ListExpired doesn't list - it deletes! 

### DIFF
--- a/Kernel/System/Console/Command/Maint/Session/ListExpired.pm
+++ b/Kernel/System/Console/Command/Maint/Session/ListExpired.pm
@@ -30,13 +30,13 @@ sub Run {
 
     my @Expired = $Kernel::OM->Get('Kernel::System::AuthSession')->GetExpiredSessionIDs();
 
-    $Self->Print("<yellow>Deleting expired sessions...</yellow>\n");
+    $Self->Print("<yellow>List of expired sessions...</yellow>\n");
 
     for my $SessionID ( @{ $Expired[0] } ) {
         $Self->Print("  $SessionID\n");
     }
 
-    $Self->Print("<yellow>Deleting idle sessions...</yellow>\n");
+    $Self->Print("<yellow>List of idle sessions...</yellow>\n");
 
     for my $SessionID ( @{ $Expired[1] } ) {
         $Self->Print("  $SessionID\n");


### PR DESCRIPTION
http://bugs.otrs.org/show_bug.cgi?id=11688

Hi @mgruner,

As you can see there was a wrong message in the command, but behavior is good.

P.S. I have a suggestion. I have checked test for Session console command. There is only one test ( https://github.com/OTRS/otrs/blob/master/scripts/test/Console/Command/Maint/Sessions/Commands.t ) 
We can split it and make separate unit tests for each Session console command ( DeleteAll, DeleteExpired, ListAll and ListExpired)
Please let me know what do you think about that. We can do that in separate PR.

Regards
Zoran