### PR TITLE
[Rel-5_0 Bug 9950] - Ticket Split takes uses system address as the customer

### DIFF
--- a/Kernel/Modules/AgentTicketPhone.pm
+++ b/Kernel/Modules/AgentTicketPhone.pm
@@ -315,9 +315,20 @@ sub Run {
                 }
 
                 my %QueueLookup = reverse %Queues;
-                if ( !defined $QueueLookup{ $Article{To} } ) {
+                my %SystemAddressLookup
+                    = reverse $Kernel::OM->Get('Kernel::System::SystemAddress')->SystemAddressList();
+                my @ArticleFromAddress;
+                my $SystemAddressEmail;
+
+                if ($ArticleFrom) {
+                    @ArticleFromAddress = Mail::Address->parse($ArticleFrom);
+                    $SystemAddressEmail = $ArticleFromAddress[0]->address();
+                }
+
+                if ( !defined $QueueLookup{ $Article{To} } && defined $SystemAddressLookup{$SystemAddressEmail} ) {
                     $ArticleFrom = $Article{To};
                 }
+
             }
 
             # body preparation for plain text processing

--- a/Kernel/Modules/AgentTicketPhone.pm
+++ b/Kernel/Modules/AgentTicketPhone.pm
@@ -302,7 +302,9 @@ sub Run {
             # save article from for addresses list
             $ArticleFrom = $Article{From};
 
-            # if To is present and is no a queue
+            # if To is present
+            # and is no a queue
+            # and also is no a system address
             # set To as article from
             if ( IsStringWithData( $Article{To} ) ) {
                 my %Queues = $QueueObject->QueueList();

--- a/scripts/test/Selenium/Agent/AgentTicketSplit.t
+++ b/scripts/test/Selenium/Agent/AgentTicketSplit.t
@@ -1,5 +1,5 @@
 # --
-# Copyright (C) 2001-2015 OTRS AG, http://otrs.com/
+# Copyright (C) 2001-2016 OTRS AG, http://otrs.com/
 # --
 # This software comes with ABSOLUTELY NO WARRANTY. For details, see
 # the enclosed file COPYING for license information (AGPL). If you
@@ -53,21 +53,24 @@ $Selenium->RunTest(
         );
 
         # get create article data
+        my $Customer     = 'customer' . $Helper->GetRandomID();
+        my $ToCustomer   = "to$Customer\@example.com";
+        my $FromCustomer = "from$Customer\@example.com";
         my @TestArticles = (
             {
                 SenderType => 'customer',
-                From       => 'From Customer <fromcustomer@example.com>',
+                From       => "From Customer <$FromCustomer>",
                 To         => 'Raw',
             },
             {
                 SenderType => 'system',
                 From       => 'SeleniumSystemAddress <systemaddress@example.com>',
-                To         => 'To Customer <tocustomer@example.com>',
+                To         => "To Customer <$ToCustomer>",
             },
             {
                 SenderType => 'customer',
-                From       => 'From Customer <fromcustomer@example.com>',
-                To         => 'To Customer <tocustomer@example.com>',
+                From       => "From Customer <$FromCustomer>",
+                To         => "To Customer <$ToCustomer>",
             },
         );
 
@@ -113,17 +116,17 @@ $Selenium->RunTest(
         my @Tests = (
             {
                 ArticleID      => $ArticleIDs[0],
-                ToValueOnSplit => 'fromcustomer@example.com',
+                ToValueOnSplit => $FromCustomer,
                 ResultMessage  => 'From is Customer, To is Queue',
             },
             {
                 ArticleID      => $ArticleIDs[1],
-                ToValueOnSplit => 'tocustomer@example.com',
+                ToValueOnSplit => $ToCustomer,
                 ResultMessage  => 'From is SystemAddress, To is Customer'
             },
             {
                 ArticleID      => $ArticleIDs[2],
-                ToValueOnSplit => 'fromcustomer@example.com',
+                ToValueOnSplit => $FromCustomer,
                 ResultMessage  => 'From is Customer, To is Customer'
             },
         );

--- a/scripts/test/Selenium/Agent/AgentTicketSplit.t
+++ b/scripts/test/Selenium/Agent/AgentTicketSplit.t
@@ -1,0 +1,168 @@
+# --
+# Copyright (C) 2001-2015 OTRS AG, http://otrs.com/
+# --
+# This software comes with ABSOLUTELY NO WARRANTY. For details, see
+# the enclosed file COPYING for license information (AGPL). If you
+# did not receive this file, see http://www.gnu.org/licenses/agpl.txt.
+# --
+
+use strict;
+use warnings;
+use utf8;
+
+use vars (qw($Self));
+
+# get selenium object
+my $Selenium = $Kernel::OM->Get('Kernel::System::UnitTest::Selenium');
+
+$Selenium->RunTest(
+    sub {
+
+        # get needed objects
+        my $Helper              = $Kernel::OM->Get('Kernel::System::UnitTest::Helper');
+        my $TicketObject        = $Kernel::OM->Get('Kernel::System::Ticket');
+        my $SystemAddressObject = $Kernel::OM->Get('Kernel::System::SystemAddress');
+
+        my @TicketIDs;
+
+        # create test system address
+        my $SystemAddressID = $SystemAddressObject->SystemAddressAdd(
+            Name     => 'systemaddress@example.com',
+            Realname => 'SeleniumSystemAddress',
+            ValidID  => 1,
+            QueueID  => 1,
+            Comment  => 'Selenium test address',
+            UserID   => 1,
+        );
+
+        # create test ticket
+        my $TicketID = $TicketObject->TicketCreate(
+            Title        => 'First test ticket',
+            Queue        => 'Raw',
+            Lock         => 'unlock',
+            Priority     => '3 normal',
+            State        => 'new',
+            CustomerID   => '123465',
+            CustomerUser => 'customer@example.com',
+            OwnerID      => 1,
+            UserID       => 1,
+        );
+        $Self->True(
+            $TicketID,
+            "TicketID $TicketID - created",
+        );
+
+        # get create article data
+        my @TestArticles = (
+            {
+                SenderType => 'customer',
+                From       => 'From Customer <fromcustomer@example.com>',
+                To         => 'Raw',
+            },
+            {
+                SenderType => 'system',
+                From       => 'SeleniumSystemAddress <systemaddress@example.com>',
+                To         => 'To Customer <tocustomer@example.com>',
+            },
+            {
+                SenderType => 'customer',
+                From       => 'From Customer <fromcustomer@example.com>',
+                To         => 'To Customer <tocustomer@example.com>',
+            },
+        );
+
+        # create test articles for test ticket
+        my @ArticleIDs;
+        for my $TestArticle (@TestArticles) {
+            my $ArticleID = $TicketObject->ArticleCreate(
+                TicketID       => $TicketID,
+                ArticleType    => 'email-external',
+                SenderType     => $TestArticle->{SenderType},
+                From           => $TestArticle->{From},
+                To             => $TestArticle->{To},
+                Subject        => 'Selenium test',
+                Body           => 'Just a test body for selenium testing',
+                Charset        => 'ISO-8859-15',
+                MimeType       => 'text/plain',
+                HistoryType    => 'PhoneCallCustomer',
+                HistoryComment => 'Selenium testing',
+                UserID         => 1,
+            );
+            $Self->True(
+                $ArticleID,
+                "ArticleID $ArticleID - created",
+            );
+            push @ArticleIDs, $ArticleID;
+        }
+
+        # create and login test user
+        my $TestUserLogin = $Helper->TestUserCreate(
+            Groups => [ 'admin', 'users' ],
+        ) || die "Did not get test user";
+
+        $Selenium->Login(
+            Type     => 'Agent',
+            User     => $TestUserLogin,
+            Password => $TestUserLogin,
+        );
+
+        # get script alias
+        my $ScriptAlias = $Kernel::OM->Get('Kernel::Config')->Get('ScriptAlias');
+
+        # get test data
+        my @Tests = (
+            {
+                ArticleID      => $ArticleIDs[0],
+                ToValueOnSplit => 'fromcustomer@example.com',
+                ResultMessage  => 'From is Customer, To is Queue',
+            },
+            {
+                ArticleID      => $ArticleIDs[1],
+                ToValueOnSplit => 'tocustomer@example.com',
+                ResultMessage  => 'From is SystemAddress, To is Customer'
+            },
+            {
+                ArticleID      => $ArticleIDs[2],
+                ToValueOnSplit => 'fromcustomer@example.com',
+                ResultMessage  => 'From is Customer, To is Customer'
+            },
+        );
+
+        # run test scenarios
+        for my $Test (@Tests) {
+
+            # navigate to split ticket of test ticket first article
+            $Selenium->get(
+                "${ScriptAlias}index.pl?Action=AgentTicketPhone;TicketID=$TicketID;ArticleID=$Test->{ArticleID};LinkTicketID=$TicketID"
+            );
+
+            $Self->Is(
+                $Selenium->find_element("//input[\@type='text'][\@name='CustomerTicketText_1']")->get_value(),
+                "$Test->{ToValueOnSplit}",
+                "$Test->{ResultMessage} - on article split value From",
+            );
+        }
+
+        # delete test system address
+        my $DBObject = $Kernel::OM->Get('Kernel::System::DB');
+        my $Success  = $DBObject->Do(
+            SQL => "DELETE FROM system_address WHERE id= $SystemAddressID",
+        );
+        $Self->True(
+            $Success,
+            "SystemAddressID $SystemAddressID - deleted",
+        );
+
+        # delete test created ticket
+        $Success = $TicketObject->TicketDelete(
+            TicketID => $TicketID,
+            UserID   => 1,
+        );
+        $Self->True(
+            $Success,
+            "TicketID $TicketID - deleted",
+        );
+    }
+);
+
+1;


### PR DESCRIPTION
http://bugs.otrs.org/show_bug.cgi?id=9950

Hello,

Hereby is our proposal for fixing this issue. Next to already existing queue check, added to check if system address is in Article{From} parameter when Article{To} is not a Queue.

Created Selenium test to simulate three different split article cases covering different scenarios. 

Please let me know if there are any questions or issue regarding this PR. 

Regards,
Sanjin