### PR TITLE
Bug 11694: various errors in GenericTicketConnectorSOAP.wsdl

### DIFF
--- a/development/webservices/GenericTicketConnectorSOAP.wsdl
+++ b/development/webservices/GenericTicketConnectorSOAP.wsdl
@@ -1035,7 +1035,7 @@
                     </xsd:element>
                     <xsd:element
                         name="UntilTime"
-                        type="xsd:positiveInteger"
+                        type="xsd:nonNegativeInteger"
                         minOccurs="1"
                         maxOccurs="1">
                     </xsd:element>
@@ -1384,7 +1384,7 @@
                     </xsd:element>
                     <xsd:element
                         name="UntilTime"
-                        type="xsd:positiveInteger"
+                        type="xsd:nonNegativeInteger"
                         minOccurs="1"
                         maxOccurs="1">
                     </xsd:element>

--- a/development/webservices/GenericTicketConnectorSOAP.wsdl
+++ b/development/webservices/GenericTicketConnectorSOAP.wsdl
@@ -965,7 +965,7 @@
                     <xsd:element
                         name="SolutionTime"
                         type="xsd:string"
-                        minOccurs="1">
+                        minOccurs="0">
                     </xsd:element>
                     <xsd:element
                         name="State"
@@ -1303,7 +1303,7 @@
                     <xsd:element
                         name="SolutionTime"
                         type="xsd:string"
-                        minOccurs="1">
+                        minOccurs="0">
                     </xsd:element>
                     <xsd:element
                         name="State"

--- a/development/webservices/GenericTicketConnectorSOAP.wsdl
+++ b/development/webservices/GenericTicketConnectorSOAP.wsdl
@@ -1270,12 +1270,12 @@
                     <xsd:element
                         name="SLA"
                         type="xsd:string"
-                        minOccurs="1">
+                        minOccurs="0">
                     </xsd:element>
                     <xsd:element
                         name="SLAID"
                         type="xsd:positiveInteger"
-                        minOccurs="1"
+                        minOccurs="0"
                         maxOccurs="1">
                     </xsd:element>
                     <xsd:element
@@ -1292,12 +1292,12 @@
                     <xsd:element
                         name="Service"
                         type="xsd:string"
-                        minOccurs="1">
+                        minOccurs="0">
                     </xsd:element>
                     <xsd:element
                         name="ServiceID"
                         type="xsd:positiveInteger"
-                        minOccurs="1"
+                        minOccurs="0"
                         maxOccurs="1">
                     </xsd:element>
                     <xsd:element

--- a/development/webservices/GenericTicketConnectorSOAP.wsdl
+++ b/development/webservices/GenericTicketConnectorSOAP.wsdl
@@ -943,23 +943,23 @@
                     <xsd:element
                         name="SLA"
                         type="xsd:string"
-                        minOccurs="1">
+                        minOccurs="0">
                     </xsd:element>
                     <xsd:element
                         name="SLAID"
                         type="xsd:positiveInteger"
-                        minOccurs="1"
+                        minOccurs="0"
                         maxOccurs="1">
                     </xsd:element>
                     <xsd:element
                         name="Service"
                         type="xsd:string"
-                        minOccurs="1">
+                        minOccurs="0">
                     </xsd:element>
                     <xsd:element
                         name="ServiceID"
                         type="xsd:positiveInteger"
-                        minOccurs="1"
+                        minOccurs="0"
                         maxOccurs="1">
                     </xsd:element>
                     <xsd:element


### PR DESCRIPTION
SLA, SLAID, Service, and ServiceID are not mandatory; They are not returned by OTRS when not using "Services"