### PR TITLE
Master - follow up bug 11168

### DIFF
--- a/Kernel/Modules/AgentTicketSearch.pm
+++ b/Kernel/Modules/AgentTicketSearch.pm
@@ -305,8 +305,9 @@ sub Run {
         $GetParam{ResultForm} = '';
     }
 
-    # get user object
-    my $UserObject = $Kernel::OM->Get('Kernel::System::User');
+    # get needed objects
+    my $UserObject  = $Kernel::OM->Get('Kernel::System::User');
+    my $StateObject = $Kernel::OM->Get('Kernel::System::State');
 
     # show result site
     if ( $Self->{Subaction} eq 'Search' && !$Self->{EraseTemplate} ) {
@@ -339,28 +340,35 @@ sub Run {
                 my @StateIDs;
 
                 if ( $GetParam{StateType} eq 'Open' ) {
-                    @StateIDs = $Kernel::OM->Get('Kernel::System::State')->StateGetStatesByType(
+                    @StateIDs = $StateObject->StateGetStatesByType(
                         Type   => 'Viewable',
                         Result => 'ID',
                     );
                 }
-                elsif ( $Param{StateType} eq 'Closed' ) {
-                    @StateIDs = $Kernel::OM->Get('Kernel::System::State')->StateGetStatesByType(
+                elsif ( $GetParam{StateType} eq 'Closed' ) {
+                    my @ViewableStateOpen = $StateObject->StateGetStatesByType(
                         Type   => 'Viewable',
                         Result => 'ID',
                     );
+
+                    my %StateList = $StateObject->StateList( UserID => $Self->{UserID} );
+                    for my $Item ( sort keys %StateList ) {
+                        if ( !grep ( { $_ eq $Item } @ViewableStateOpen ) ) {
+                            push @StateIDs, $Item;
+                        }
+                    }
                 }
 
                 # current ticket state type
                 else {
-                    @StateIDs = $Kernel::OM->Get('Kernel::System::State')->StateGetStatesByType(
+                    @StateIDs = $StateObject->StateGetStatesByType(
                         StateType => $GetParam{StateType},
                         Result    => 'ID',
                     );
                 }
 
                 # merge with StateIDs
-                if ( @StateIDs && $GetParam{StateIDs} ) {
+                if ( @StateIDs && IsArrayRefWithData( $GetParam{StateIDs} ) ) {
                     my %StateIDs = map { $_ => 1 } @StateIDs;
                     @StateIDs = grep { exists $StateIDs{$_} } @{ $GetParam{StateIDs} };
                 }
@@ -480,7 +488,7 @@ sub Run {
 
         my $TicketObject = $Kernel::OM->Get('Kernel::System::Ticket');
 
-        # Special behaviour for the fulltext search toolbar module:
+        # Special behavior for the fulltext search toolbar module:
         # - Check full text string to see if contents is a ticket number.
         # - If exists and not in print or CSV mode, redirect to the ticket.
         # See http://bugs.otrs.org/show_bug.cgi?id=4238 for details.
@@ -530,7 +538,7 @@ sub Run {
 
         my %AttributeLookup;
 
-        # create attibute lookup table
+        # create attribute lookup table
         for my $Attribute ( @{ $GetParam{ShownAttributes} || [] } ) {
             $AttributeLookup{$Attribute} = 1;
         }
@@ -1068,7 +1076,7 @@ sub Run {
                 Value     => $URL,
             );
 
-            # start html page
+            # start HTML page
             my $Output = $LayoutObject->Header();
             $Output .= $LayoutObject->NavigationBar();
 
@@ -1570,7 +1578,7 @@ sub Run {
             PREFERENCE:
             for my $Preference ( @{$SearchFieldPreferences} ) {
 
-                # get field html
+                # get field HTML
                 $DynamicFieldHTML{ $DynamicFieldConfig->{Name} . $Preference->{Type} }
                     = $BackendObject->SearchFieldRender(
                     DynamicFieldConfig   => $DynamicFieldConfig,
@@ -1779,12 +1787,12 @@ sub Run {
             ID         => 'SearchProfile',
             SelectedID => $Profile,
 
-            # Do not modernize this field as this causes problems with the automatic focussing of the first element.
+            # Do not modernize this field as this causes problems with the automatic focusing of the first element.
         );
 
         $Param{StatesStrg} = $LayoutObject->BuildSelection(
             Data => {
-                $Kernel::OM->Get('Kernel::System::State')->StateList(
+                $StateObject->StateList(
                     UserID => $Self->{UserID},
                     Action => $Self->{Action},
                 ),
@@ -2225,7 +2233,7 @@ sub Run {
             my @OrderedDefaults;
             if (%Defaults) {
 
-                # ordering atributes on the same order like in Atributes
+                # ordering attributes on the same order like in Attributes
                 for my $Item (@Attributes) {
                     my $KeyAtr = $Item->{Key};
                     for my $Key ( sort keys %Defaults ) {

--- a/Kernel/Output/HTML/CustomerUser/GenericTicket.pm
+++ b/Kernel/Output/HTML/CustomerUser/GenericTicket.pm
@@ -11,6 +11,8 @@ package Kernel::Output::HTML::CustomerUser::GenericTicket;
 use strict;
 use warnings;
 
+use Kernel::System::VariableCheck qw(IsArrayRefWithData);
+
 our $ObjectManagerDisabled = 1;
 
 sub new {
@@ -54,8 +56,8 @@ sub Run {
         States => {
             Object => 'Kernel::System::State',
             Return => 'StateIDs',
-            Input  => '',
-            Method => '',
+            Input  => 'State',
+            Method => 'StateLookup',
         },
         Priorities => {
             Object => 'Kernel::System::Priority',
@@ -150,6 +152,51 @@ sub Run {
         $TicketSearch{CustomerUserLogin} = $CustomerUserLoginEscaped;
         $URL .= ';CustomerUserLogin='
             . $LayoutObject->LinkEncode($CustomerUserLoginEscaped);
+    }
+
+    my $StateObject = $Kernel::OM->Get('Kernel::System::State');
+
+    # replace StateType to StateIDs for the count numbers in customer informations links
+    if ( $TicketSearch{StateType} ) {
+        my @StateIDs;
+
+        if ( $TicketSearch{StateType} eq 'Open' ) {
+            @StateIDs = $StateObject->StateGetStatesByType(
+                Type   => 'Viewable',
+                Result => 'ID',
+            );
+        }
+        elsif ( $TicketSearch{StateType} eq 'Closed' ) {
+            my @ViewableStateOpen = $StateObject->StateGetStatesByType(
+                Type   => 'Viewable',
+                Result => 'ID',
+            );
+
+            my %StateList = $StateObject->StateList( UserID => $Self->{UserID} );
+            for my $Item ( sort keys %StateList ) {
+                if ( !grep ( { $_ eq $Item } @ViewableStateOpen ) ) {
+                    push @StateIDs, $Item;
+                }
+            }
+        }
+
+        # current ticket state type
+        else {
+            @StateIDs = $StateObject->StateGetStatesByType(
+                StateType => $TicketSearch{StateType},
+                Result    => 'ID',
+            );
+        }
+
+        # merge with StateIDs
+        if ( @StateIDs && IsArrayRefWithData( $TicketSearch{StateIDs} ) ) {
+            my %StateIDs = map { $_ => 1 } @StateIDs;
+            @StateIDs = grep { exists $StateIDs{$_} } @{ $TicketSearch{StateIDs} };
+        }
+
+        if (@StateIDs) {
+            $TicketSearch{StateIDs} = \@StateIDs;
+        }
     }
 
     my %TimeMap = (

--- a/Kernel/Output/HTML/CustomerUser/GenericTicket.pm
+++ b/Kernel/Output/HTML/CustomerUser/GenericTicket.pm
@@ -123,7 +123,7 @@ sub Run {
         }
     }
 
-    # build url
+    # build URL
 
     # note:
     # "special characters" in customer id have to be escaped, so that DB::QueryCondition works
@@ -156,7 +156,7 @@ sub Run {
 
     my $StateObject = $Kernel::OM->Get('Kernel::System::State');
 
-    # replace StateType to StateIDs for the count numbers in customer informations links
+    # replace StateType to StateIDs for the count numbers in customer information links
     if ( $TicketSearch{StateType} ) {
         my @StateIDs;
 

--- a/scripts/test/Selenium/Agent/AgentCustomerInformationCenter.t
+++ b/scripts/test/Selenium/Agent/AgentCustomerInformationCenter.t
@@ -38,7 +38,6 @@ $Selenium->RunTest(
 
         # create test customer user
         my $TestCustomerUserLogin = $Helper->TestCustomerUserCreate(
-            Groups => [ 'admin', 'users' ],
         ) || die "Did not get test customer user";
 
         # get test customer user ID
@@ -171,7 +170,8 @@ $Selenium->RunTest(
 
             # open CIC again for the next test case
             $Selenium->get(
-                "${ScriptAlias}index.pl?Action=AgentCustomerInformationCenter;CustomerID=$TestCustomerUserLogin");
+                "${ScriptAlias}index.pl?Action=AgentCustomerInformationCenter;CustomerID=$TestCustomerUserLogin"
+            );
 
         }
 

--- a/scripts/test/Selenium/Agent/AgentCustomerInformationCenter.t
+++ b/scripts/test/Selenium/Agent/AgentCustomerInformationCenter.t
@@ -50,7 +50,7 @@ $Selenium->RunTest(
         # get needed objects
         my $TicketObject = $Kernel::OM->Get('Kernel::System::Ticket');
 
-        # create test data parameteres
+        # create test data parameters
         my %TicketData = (
             'Open' => {
                 TicketState   => 'open',
@@ -143,7 +143,7 @@ $Selenium->RunTest(
                 "//a[contains(\@href, \'Subaction=Search;StateType=$TicketData{$TestLinks}->{TicketLink};CustomerID=$TestCustomerUserLogin' )]"
             )->click();
 
-            # wait until page has loaded, if neccessary
+            # wait until page has loaded, if necessary
             $Selenium->WaitFor( JavaScript => 'return typeof($) === "function" && $("body").length' );
 
             # check for test ticket numbers on search screen

--- a/scripts/test/Selenium/Output/CustomerUser/GenericTicket.t
+++ b/scripts/test/Selenium/Output/CustomerUser/GenericTicket.t
@@ -73,7 +73,6 @@ $Selenium->RunTest(
 
         # create test customer user
         my $TestCustomerUserLogin = $Helper->TestCustomerUserCreate(
-            Groups => [ 'admin', 'users' ],
         ) || die "Did not get test customer user";
 
         # get test customer user ID

--- a/scripts/test/Selenium/Output/CustomerUser/GenericTicket.t
+++ b/scripts/test/Selenium/Output/CustomerUser/GenericTicket.t
@@ -85,7 +85,7 @@ $Selenium->RunTest(
         # get needed objects
         my $TicketObject = $Kernel::OM->Get('Kernel::System::Ticket');
 
-        # create test data parameteres
+        # create test data parameters
         my %TicketData = (
             'Open' => {
                 TicketState   => 'open',
@@ -139,7 +139,7 @@ $Selenium->RunTest(
         my $ScriptAlias = $Kernel::OM->Get('Kernel::Config')->Get('ScriptAlias');
         $Selenium->get("${ScriptAlias}index.pl?Action=AgentTicketZoom;TicketID=$TicketData{Open}->{TicketIDs}->[0]");
 
-        # wait until page has loaded, if neccessary
+        # wait until page has loaded, if necessary
         $Selenium->WaitFor( JavaScript => 'return typeof($) === "function" && $("body").length' );
 
         # test CustomerUserGenericTicket module
@@ -163,7 +163,7 @@ $Selenium->RunTest(
             my $Handles = $Selenium->get_window_handles();
             $Selenium->switch_to_window( $Handles->[1] );
 
-            # wait until page has loaded, if neccessary
+            # wait until page has loaded, if necessary
             $Selenium->WaitFor( JavaScript => 'return typeof($) === "function" && $("body").length' );
 
             # check for test ticket numbers on search screen

--- a/scripts/test/Selenium/Output/CustomerUser/GenericTicket.t
+++ b/scripts/test/Selenium/Output/CustomerUser/GenericTicket.t
@@ -82,7 +82,7 @@ $Selenium->RunTest(
         );
         my $CustomerID = $CustomerIDs[0];
 
-        # get ticket object
+        # get needed objects
         my $TicketObject = $Kernel::OM->Get('Kernel::System::Ticket');
 
         # create test data parameteres
@@ -92,14 +92,14 @@ $Selenium->RunTest(
                 TicketCount   => '',
                 TicketNumbers => [],
                 TicketIDs     => [],
-                TicketLink    => 'StateType=Open',
+                TicketLink    => 'Open',
             },
             'Closed' => {
                 TicketState   => 'closed successful',
                 TicketCount   => '',
                 TicketNumbers => [],
                 TicketIDs     => [],
-                TicketLink    => 'StateType=Closed',
+                TicketLink    => 'Closed',
             },
         );
 
@@ -173,6 +173,18 @@ $Selenium->RunTest(
                     "TicketNumber $CheckTicketNumbers - found on screen"
                 );
             }
+
+            # click on 'Change search option'
+            $Selenium->find_element(
+                "//a[contains(\@href, \'AgentTicketSearch;Subaction=LoadProfile' )]"
+            )->click();
+
+            # link open in new window switch to it
+            $Handles = $Selenium->get_window_handles();
+            $Selenium->switch_to_window( $Handles->[2] );
+
+            # verify state search attributes are shown in search screen, see bug #10853
+            $Selenium->find_element( "#StateIDs", 'css' );
 
             # close current window and return to original
             $Selenium->close();


### PR DESCRIPTION
http://bugs.otrs.org/show_bug.cgi?id=11168
http://bugs.otrs.org/show_bug.cgi?id=10853

Hi @mgruner,

I tested behavior for the bug #10853 after fixing in the bug #11168. Actually there is a bug in fix:
There is a problem
https://github.com/OTRS/otrs/blob/master/Kernel/Modules/AgentTicketSearch.pm#L347

There are the same code in the both if  statement, for 'Open' and Closed 'StateType', and the second mistake is $Param{StateType} eq 'Closed' . It could be $GetParam{StateType} eq 'Closed'.

Fix that I have made for the bug #10853 is necessary bu only partially. There is a problem with the count numbers in customer information links in AgentTicketZoom (Open, Close)

Here are fix for this problem and updated tests as well. 

Regards
Zoran
