### PR TITLE
[ Master Bug 9038 ] - Default Ticket Type in Emails

### DIFF
--- a/Kernel/Config/Files/Ticket.xml
+++ b/Kernel/Config/Files/Ticket.xml
@@ -143,6 +143,14 @@
             </Option>
         </Setting>
     </ConfigItem>
+    <ConfigItem Name="Ticket::Type::Default" Required="1" Valid="1">
+        <Description Translatable="1">Defines the default ticket type.</Description>
+        <Group>Ticket</Group>
+        <SubGroup>Core::Ticket</SubGroup>
+        <Setting>
+            <String Regex="" Translatable="1">Unclassified</String>
+        </Setting>
+    </ConfigItem>
     <ConfigItem Name="Ticket::Service" Required="1" Valid="1">
         <Description Translatable="1">Allows defining services and SLAs for tickets (e. g. email, desktop, network, ...), and escalation attributes for SLAs (if ticket service/SLA feature is enabled).</Description>
         <Group>Ticket</Group>

--- a/Kernel/Modules/AgentTicketZoom.pm
+++ b/Kernel/Modules/AgentTicketZoom.pm
@@ -1105,9 +1105,18 @@ sub MaskAgentZoom {
 
     # ticket type
     if ( $ConfigObject->Get('Ticket::Type') ) {
+
+        my %Type = $Kernel::OM->Get('Kernel::System::Type')->TypeGet(
+            ID => $Ticket{TypeID},
+        );
+
         $LayoutObject->Block(
             Name => 'Type',
-            Data => { %Ticket, %AclAction },
+            Data => {
+                Valid => $Type{ValidID},
+                %Ticket,
+                %AclAction
+            },
         );
     }
 

--- a/Kernel/Modules/CustomerTicketZoom.pm
+++ b/Kernel/Modules/CustomerTicketZoom.pm
@@ -1004,9 +1004,17 @@ sub _Mask {
 
     # ticket type
     if ( $ConfigObject->Get('Ticket::Type') && $Config->{AttributesView}->{Type} ) {
+
+        my %Type = $Kernel::OM->Get('Kernel::System::Type')->TypeGet(
+            Name => $Param{Type},
+        );
+
         $LayoutObject->Block(
             Name => 'Type',
-            Data => \%Param,
+            Data => {
+                Valid => $Type{ValidID},
+                %Param,
+                }
         );
     }
 

--- a/Kernel/Output/HTML/Templates/Standard/AgentTicketZoom.tt
+++ b/Kernel/Output/HTML/Templates/Standard/AgentTicketZoom.tt
@@ -160,7 +160,9 @@
 [% RenderBlockEnd("ArchiveFlag") %]
 [% RenderBlockStart("Type") %]
                         <label>[% Translate("Type") | html %]:</label>
-                        <p class="Value" title="[% Data.Type | html %]">[% Data.Type | html %]</p>
+                        <p class="Value FixedValueSmall" title="[% Data.Type | html %]">[% Data.Type | html %]
+                            [% IF Data.Valid != 1 %] <em class="Error">[% Translate("Note: Type is invalid!") | html %]</em> [% END %]
+                        </p>
                         <div class="Clear"></div>
 [% RenderBlockEnd("Type") %]
 

--- a/Kernel/Output/HTML/Templates/Standard/CustomerTicketZoom.tt
+++ b/Kernel/Output/HTML/Templates/Standard/CustomerTicketZoom.tt
@@ -193,11 +193,7 @@
                     <li><span class="Key">[% Data.Hook | html %]:</span> <span>[% Data.TicketNumber | html %]</span></li>
 
 [% RenderBlockStart("Type") %]
-                    <li>
-                        <span class="Key">[% Translate("Type") | html %]:</span>
-                        <span title="[% Data.Type | html %]">[% Data.Type | html %]</span>
-                        [% IF Data.Valid != 1 %] - <em class="ErrorNote">[% Translate("Note: Type is invalid!") | html %]</em> [% END %]
-                    </li>
+                    <li><span class="Key">[% Translate("Type") | html %]:</span> <span title="[% Data.Type | html %]">[% Data.Type | html %]</span></li>
 [% RenderBlockEnd("Type") %]
 [% RenderBlockStart("Service") %]
                     <li><span class="Key">[% Translate("Service") | html %]:</span> <span title="[% Translate(Data.Service) | html %]">[% Translate(Data.Service) | html %]</span></li>

--- a/Kernel/Output/HTML/Templates/Standard/CustomerTicketZoom.tt
+++ b/Kernel/Output/HTML/Templates/Standard/CustomerTicketZoom.tt
@@ -193,7 +193,11 @@
                     <li><span class="Key">[% Data.Hook | html %]:</span> <span>[% Data.TicketNumber | html %]</span></li>
 
 [% RenderBlockStart("Type") %]
-                    <li><span class="Key">[% Translate("Type") | html %]:</span> <span title="[% Data.Type | html %]">[% Data.Type | html %]</span></li>
+                    <li>
+                        <span class="Key">[% Translate("Type") | html %]:</span>
+                        <span title="[% Data.Type | html %]">[% Data.Type | html %]</span>
+                        [% IF Data.Valid != 1 %] - <em class="ErrorNote">[% Translate("Note: Type is invalid!") | html %]</em> [% END %]
+                    </li>
 [% RenderBlockEnd("Type") %]
 [% RenderBlockStart("Service") %]
                     <li><span class="Key">[% Translate("Service") | html %]:</span> <span title="[% Translate(Data.Service) | html %]">[% Translate(Data.Service) | html %]</span></li>

--- a/Kernel/System/Ticket.pm
+++ b/Kernel/System/Ticket.pm
@@ -263,7 +263,7 @@ or
         Lock          => 'unlock',
         Priority      => '3 normal',         # or PriorityID => 2,
         State         => 'new',              # or StateID => 5,
-        Type          => 'Incident',         # or TypeID => 1, not required
+        Type          => 'Incident',         # or Ticket type default (Ticket::Type::Default), not required
         Service       => 'Service A',        # or ServiceID => 1, not required
         SLA           => 'SLA A',            # or SLAID => 1, not required
         CustomerID    => '123465',
@@ -304,7 +304,7 @@ sub TicketCreate {
     $Param{ResponsibleID} ||= 1;
 
     if ( !$Param{TypeID} && !$Param{Type} ) {
-        $Param{TypeID} = 1;
+        $Param{Type} = $Kernel::OM->Get('Kernel::Config')->Get('Ticket::Type::Default');
     }
 
     # get type object

--- a/Kernel/System/Ticket.pm
+++ b/Kernel/System/Ticket.pm
@@ -263,7 +263,7 @@ or
         Lock          => 'unlock',
         Priority      => '3 normal',         # or PriorityID => 2,
         State         => 'new',              # or StateID => 5,
-        Type          => 'Incident',         # or Ticket type default (Ticket::Type::Default), not required
+        Type          => 'Incident',         # or TypeID = 1 or Ticket type default (Ticket::Type::Default), not required
         Service       => 'Service A',        # or ServiceID => 1, not required
         SLA           => 'SLA A',            # or SLAID => 1, not required
         CustomerID    => '123465',
@@ -303,12 +303,24 @@ sub TicketCreate {
 
     $Param{ResponsibleID} ||= 1;
 
-    if ( !$Param{TypeID} && !$Param{Type} ) {
-        $Param{Type} = $Kernel::OM->Get('Kernel::Config')->Get('Ticket::Type::Default');
-    }
-
     # get type object
     my $TypeObject = $Kernel::OM->Get('Kernel::System::Type');
+
+    if ( !$Param{TypeID} && !$Param{Type} ) {
+
+        # get default ticket type
+        my $DefaultTicketType = $Kernel::OM->Get('Kernel::Config')->Get('Ticket::Type::Default');
+
+        # check if default ticket type exists
+        my $DefaultTicketTypeID = $TypeObject->TypeLookup( Type => $DefaultTicketType );
+
+        if ( defined $DefaultTicketTypeID ) {
+            $Param{Type} = $DefaultTicketType;
+        }
+        else {
+            $Param{TypeID} = 1;
+        }
+    }
 
     # TypeID/Type lookup!
     if ( !$Param{TypeID} && $Param{Type} ) {

--- a/Kernel/System/Ticket/Article.pm
+++ b/Kernel/System/Ticket/Article.pm
@@ -1666,9 +1666,14 @@ sub ArticleGet {
     }
 
     # get type
-    $Ticket{Type} = $Kernel::OM->Get('Kernel::System::Type')->TypeLookup(
-        TypeID => $Ticket{TypeID} || 1,
-    );
+    if ( defined $Ticket{TypeID} ) {
+        $Ticket{Type} = $Kernel::OM->Get('Kernel::System::Type')->TypeLookup(
+            TypeID => $Ticket{TypeID}
+        );
+    }
+    else {
+        $Ticket{Type} = $Kernel::OM->Get('Kernel::Config')->Get('Ticket::Type::Default');
+    }
 
     # get user object
     my $UserObject = $Kernel::OM->Get('Kernel::System::User');

--- a/Kernel/System/Ticket/Article.pm
+++ b/Kernel/System/Ticket/Article.pm
@@ -1665,14 +1665,28 @@ sub ArticleGet {
         return;
     }
 
+    # get type object
+    my $TypeObject = $Kernel::OM->Get('Kernel::System::Type');
+
+    # get default ticket type
+    my $DefaultTicketType = $Kernel::OM->Get('Kernel::Config')->Get('Ticket::Type::Default');
+
+    # check if default ticket type exists
+    my $DefaultTicketTypeID = $TypeObject->TypeLookup( Type => $DefaultTicketType );
+
     # get type
     if ( defined $Ticket{TypeID} ) {
-        $Ticket{Type} = $Kernel::OM->Get('Kernel::System::Type')->TypeLookup(
+        $Ticket{Type} = $TypeObject->TypeLookup(
             TypeID => $Ticket{TypeID}
         );
     }
+    elsif ( defined $DefaultTicketTypeID ) {
+        $Ticket{Type} = $DefaultTicketType;
+    }
     else {
-        $Ticket{Type} = $Kernel::OM->Get('Kernel::Config')->Get('Ticket::Type::Default');
+        $Ticket{Type} = $TypeObject->TypeLookup(
+            TypeID => 1
+        );
     }
 
     # get user object

--- a/Kernel/System/Type.pm
+++ b/Kernel/System/Type.pm
@@ -13,6 +13,7 @@ use warnings;
 
 our @ObjectDependencies = (
     'Kernel::Config',
+    'Kernel::System::SysConfig',
     'Kernel::System::Cache',
     'Kernel::System::DB',
     'Kernel::System::Log',
@@ -282,11 +283,14 @@ sub TypeUpdate {
     );
 
     # check if the type is set as a default ticket type
-    if ( $Kernel::OM->Get('Kernel::Config')->Get('Ticket::Type::Default') eq $Type{Name} )
+    if (
+        $Kernel::OM->Get('Kernel::Config')->Get('Ticket::Type::Default') eq $Type{Name}
+        && $Param{ValidID} != 1
+        )
     {
         $Kernel::OM->Get('Kernel::System::Log')->Log(
             Priority => 'error',
-            Message  => "The ticket type is set as a default ticket type, so it cannot be changed!"
+            Message  => "The ticket type is set as a default ticket type, so it cannot be set to invalid!"
         );
         return;
     }
@@ -299,6 +303,22 @@ sub TypeUpdate {
             \$Param{Name}, \$Param{ValidID}, \$Param{UserID}, \$Param{ID},
         ],
     );
+
+    # check if the name of the default ticket type is updated
+    if (
+        $Kernel::OM->Get('Kernel::Config')->Get('Ticket::Type::Default') eq $Type{Name}
+        && $Type{Name} ne $Param{Name}
+        )
+    {
+
+        # update default ticket type SySConfig item
+        $Kernel::OM->Get('Kernel::System::SysConfig')->ConfigItemUpdate(
+            Valid => 1,
+            Key   => 'Ticket::Type::Default',
+            Value => $Param{Name}
+        );
+
+    }
 
     # reset cache
     $Kernel::OM->Get('Kernel::System::Cache')->CleanUp(

--- a/Kernel/System/Type.pm
+++ b/Kernel/System/Type.pm
@@ -12,6 +12,7 @@ use strict;
 use warnings;
 
 our @ObjectDependencies = (
+    'Kernel::Config',
     'Kernel::System::Cache',
     'Kernel::System::DB',
     'Kernel::System::Log',
@@ -272,6 +273,20 @@ sub TypeUpdate {
         $Kernel::OM->Get('Kernel::System::Log')->Log(
             Priority => 'error',
             Message  => "A type with name '$Param{Name}' already exists!"
+        );
+        return;
+    }
+
+    my %Type = $Self->TypeGet(
+        ID => $Param{ID},
+    );
+
+    # check if the type is set as a default ticket type
+    if ( $Kernel::OM->Get('Kernel::Config')->Get('Ticket::Type::Default') eq $Type{Name} )
+    {
+        $Kernel::OM->Get('Kernel::System::Log')->Log(
+            Priority => 'error',
+            Message  => "The ticket type is set as a default ticket type, so it cannot be changed!"
         );
         return;
     }

--- a/scripts/test/Type.t
+++ b/scripts/test/Type.t
@@ -206,11 +206,8 @@ $Self->False(
     "NameExistsCheck() - Another type \'$TypeNameRand0\' for ID=$TypeID does not exists!",
 );
 
-# get needed objects
-my $ConfigObject = $Kernel::OM->Get('Kernel::Config');
-
-# configure auth backend to db
-$ConfigObject->Set(
+# set Ticket::Type::Default config item
+$Kernel::OM->Get('Kernel::Config')->Set(
     Key   => 'Ticket::Type::Default',
     Value => $TypeSecondName,
 );

--- a/scripts/test/Type.t
+++ b/scripts/test/Type.t
@@ -12,7 +12,15 @@ use utf8;
 
 use vars (qw($Self));
 
-use Kernel::System::ObjectManager;
+$Kernel::OM->ObjectParamAdd(
+    'Kernel::System::UnitTest::Helper' => {
+        RestoreSystemConfiguration => 1,
+        RestoreDatabase            => 1,
+        }
+);
+
+my $HelperObject = $Kernel::OM->Get('Kernel::System::UnitTest::Helper');
+
 my @IDs;
 
 # get needed objects
@@ -198,6 +206,28 @@ $Self->False(
     "NameExistsCheck() - Another type \'$TypeNameRand0\' for ID=$TypeID does not exists!",
 );
 
+# get needed objects
+my $ConfigObject = $Kernel::OM->Get('Kernel::Config');
+
+# configure auth backend to db
+$ConfigObject->Set(
+    Key   => 'Ticket::Type::Default',
+    Value => $TypeSecondName,
+);
+
+# update the default ticket type
+$TypeUpdateWrong = $TypeObject->TypeUpdate(
+    ID      => $TypeIDSecond,
+    Name    => $TypeSecondName,
+    ValidID => 2,
+    UserID  => 1,
+);
+
+$Self->False(
+    $TypeUpdateWrong,
+    "The ticket type is set as a default ticket type, so it cannot be changed! - $TypeSecondName",
+);
+
 # perform 2 different TypeLists to check the caching
 my %TypeListValid = $TypeObject->TypeList( Valid => 1 );
 
@@ -225,21 +255,6 @@ $Self->True(
     'TypeList() - all types',
 );
 
-# Since there are no tickets that rely on our test types, we can remove them again
-#   from the DB.
-for my $ID (@IDs) {
-    my $Success = $Kernel::OM->Get('Kernel::System::DB')->Do(
-        SQL => "DELETE FROM ticket_type WHERE id = $ID",
-    );
-    $Self->True(
-        $Success,
-        "TypeDelete() - $ID",
-    );
-}
-
-# Make sure the cache is correct.
-$Kernel::OM->Get('Kernel::System::Cache')->CleanUp(
-    Type => 'Type',
-);
+# cleanup is done by RestoreDatabase.
 
 1;

--- a/var/httpd/htdocs/skins/Customer/default/css/Core.Default.css
+++ b/var/httpd/htdocs/skins/Customer/default/css/Core.Default.css
@@ -281,6 +281,10 @@ div.Clear {
     display: none;
 }
 
+.ErrorNote {
+    color: #FF505E;
+}
+
 /**
  * @subsection  Datepicker
  */


### PR DESCRIPTION
Hi @mgruner,

There is our proposal for fixing this bug. Actually, we did not fix the bug, we added not for invalid ticket types. We used ideas as this is fixed with invalid customer company for ticket information widget.
Maybe, we can change  style for customer note.

The problem is because ticket type is hardcore if it is not defined.
https://github.com/OTRS/otrs/blob/master/Kernel/System/Ticket.pm#L306

Generally, there could be such problems for other entities which is in meantime set to invalid. (e.g for Queue:Raw, for State:open ... and other entities which are often set as default )


Please, let me know what do you think about that. 

Regards
Zoran