### PR TITLE
Master - translate error and worning message

### DIFF
--- a/Kernel/Modules/AgentTicketBulk.pm
+++ b/Kernel/Modules/AgentTicketBulk.pm
@@ -11,6 +11,8 @@ package Kernel::Modules::AgentTicketBulk;
 use strict;
 use warnings;
 
+use Kernel::Language qw(Translatable);
+
 our $ObjectManagerDisabled = 1;
 
 sub new {
@@ -42,8 +44,8 @@ sub Run {
         # check needed stuff
         if ( !@TicketIDs ) {
             return $LayoutObject->ErrorScreen(
-                Message => 'Can\'t lock Tickets, no TicketIDs are given!',
-                Comment => 'Please contact the admin.',
+                Message => Translatable('Can\'t lock Tickets, no TicketIDs are given!'),
+                Comment => Translatable('Please contact the admin.'),
             );
         }
 
@@ -76,7 +78,7 @@ sub Run {
 
         if ( $Message ne '' ) {
             return $LayoutObject->ErrorScreen(
-                Message => "Ticket ($Message) is not unlocked!",
+                Message => $LayoutObject->{LanguageObject}->Translate( "Ticket (%s) is not unlocked!", $Message ),
             );
         }
 
@@ -92,7 +94,7 @@ sub Run {
     # check if bulk feature is enabled
     if ( !$ConfigObject->Get('Ticket::Frontend::BulkFeature') ) {
         return $LayoutObject->ErrorScreen(
-            Message => 'Bulk feature is not enabled!',
+            Message => Translatable('Bulk feature is not enabled!'),
         );
     }
 
@@ -132,15 +134,15 @@ sub Run {
     if ( !@ValidTicketIDs ) {
         if ( $Config->{RequiredLock} ) {
             return $LayoutObject->ErrorScreen(
-                Message => 'No selectable TicketID is given!',
+                Message => Translatable('No selectable TicketID is given!'),
                 Comment =>
-                    'You either selected no ticket or only tickets which are locked by other agents',
+                    Translatable('You either selected no ticket or only tickets which are locked by other agents'),
             );
         }
         else {
             return $LayoutObject->ErrorScreen(
-                Message => 'No TicketID is given!',
-                Comment => 'You need to select at least one ticket',
+                Message => Translatable('No TicketID is given!'),
+                Comment => Translatable('You need to select at least one ticket'),
             );
         }
     }

--- a/Kernel/Output/HTML/Templates/Standard/CustomerError.tt
+++ b/Kernel/Output/HTML/Templates/Standard/CustomerError.tt
@@ -9,10 +9,10 @@
 <div id="MainBox">
     <div class="Content">
         <h2>
-            [% Translate("Error") | html %]: [% Data.Message | html %]
+            [% Translate("Error") | html %]: [% Translate(Data.Message) | html %]
         </h2>
         <p>
-            [% Translate("Comment") | html %]: [% Data.Comment | html %]
+            [% Translate("Comment") | html %]: [% Translate(Data.Message) | html %]
         </p>
         <p>
             [% Translate("Traceback") | html %]:

--- a/Kernel/Output/HTML/Templates/Standard/Error.tt
+++ b/Kernel/Output/HTML/Templates/Standard/Error.tt
@@ -15,10 +15,10 @@
             </div>
             <div class="Content">
                 <h4>
-                    [% Translate("Error Message") | html %]: <span class="Error">[% Data.Message | html %]</span>
+                    [% Translate("Error Message") | html %]: <span class="Error">[% Translate(Data.Message) | html %]</span>
                 </h4>
                 <p class="SpacingTop">
-                    [% Data.Comment | html %].
+                    [% Translate(Data.Comment) | html %].
                 </p>
 
                 <form action="http://bugs.otrs.org/enter_bug.cgi">

--- a/Kernel/Output/HTML/Templates/Standard/Motd.tt
+++ b/Kernel/Output/HTML/Templates/Standard/Motd.tt
@@ -11,6 +11,6 @@
         <h2 class="Center">[% Translate("Message of the Day") | html %]</h2>
     </div>
     <div class="Content">
-        <p>This is the message of the day. You can edit this in Kernel/Output/HTML/Templates/Standard/Motd.tt.</p>
+        <p>[% Translate("This is the message of the day. You can edit this in") | html %] - Kernel/Output/HTML/Templates/Standard/Motd.tt.</p>
     </div>
 </div>

--- a/Kernel/Output/HTML/Templates/Standard/NoPermission.tt
+++ b/Kernel/Output/HTML/Templates/Standard/NoPermission.tt
@@ -15,12 +15,11 @@
             </div>
             <div class="Content">
                 <h4>
-                    [% Translate("Message") | html %]: <span class="Error">[% Data.Message %]</span>
+                    [% Translate("Message") | html %]: <span class="Error">[% Translate(Data.Message) | html %]</span>
                 </h4>
 
                 <p class="SpacingTop">
-                    [% Data.Comment %]
-                </p>
+                    [% Translate(Data.Comment) | html %]
 
                 <p class="SpacingTop">
                     <a href="#" id="GoBack">[% Translate("Back to the previous page") | html %]</a>

--- a/Kernel/Output/HTML/Templates/Standard/Warning.tt
+++ b/Kernel/Output/HTML/Templates/Standard/Warning.tt
@@ -15,11 +15,11 @@
             </div>
             <div class="Content">
                 <h4>
-                    [% Translate("Message") | html %]: <span class="Error">[% Data.Message | html %]</span>
+                    [% Translate("Message") | html %]: <span class="Error">[% Translate(Data.Message) | html %]</span>
                 </h4>
 
                 <p class="SpacingTop">
-                    [% Data.Comment | html %]
+                    [% Translate(Data.Comment) | html %]
                 </p>
 
                 <p class="SpacingTop">


### PR DESCRIPTION
Hi @mgruner 

Working on translate dummy files, I saw that there is not used translate in Error, Warning and similar ones views. Only in CustomerWarning.tt is used Translate for Message and Comment data. I added it for other views in this PR.

I change AgentTicketBulk.pm as an example how it could be done for all modules. It could be next task when I finish task with AAA*.tt dummy files.
If you like it you can merge to master.

Please let me know what do you think about that.

Regards
Zoran
