### PR TITLE
Master - proposal for adding translation for entities from DB in backend modules

### DIFF
--- a/Kernel/Output/HTML/Templates/Standard/AAATicket.tt
+++ b/Kernel/Output/HTML/Templates/Standard/AAATicket.tt
@@ -30,12 +30,6 @@
 [% Translate("4 high") | html %]
 [% Translate("5 very high") | html %]
 
-[% Translate("auto follow up") | html %]
-[% Translate("auto reject") | html %]
-[% Translate("auto remove") | html %]
-[% Translate("auto reply") | html %]
-[% Translate("auto reply/new ticket") | html %]
-
 # Templates
 [% Translate("Create") | html %]
 [% Translate("Answer") | html %]

--- a/Kernel/Output/HTML/Templates/Standard/AAATicket.tt
+++ b/Kernel/Output/HTML/Templates/Standard/AAATicket.tt
@@ -15,21 +15,6 @@
 [% Translate("sms") | html %]
 [% Translate("webrequest") | html %]
 
-[% Translate("lock") | html %]
-[% Translate("unlock") | html %]
-
-[% Translate("very low") | html %]
-[% Translate("low") | html %]
-[% Translate("normal") | html %]
-[% Translate("high") | html %]
-[% Translate("very high") | html %]
-
-[% Translate("1 very low") | html %]
-[% Translate("2 low") | html %]
-[% Translate("3 normal") | html %]
-[% Translate("4 high") | html %]
-[% Translate("5 very high") | html %]
-
 # Templates
 [% Translate("Create") | html %]
 [% Translate("Answer") | html %]

--- a/Kernel/System/AutoResponse.pm
+++ b/Kernel/System/AutoResponse.pm
@@ -356,12 +356,18 @@ Return example:
         '1' => 'default reply (after new ticket has been created)',
         '2' => 'default reject (after follow up and rejected of a closed ticket)',
         '3' => 'default follow up (after a ticket follow up has been added)',
+        '4' => 'default reject/new ticket created (after closed follow-up with new ticket creation)',
     );
 
 =cut
 
 sub AutoResponseList {
     my ( $Self, %Param ) = @_;
+
+    Translatable('default reply (after new ticket has been created)');
+    Translatable('default reject (after follow up and rejected of a closed ticket)');
+    Translatable('default follow up (after a ticket follow up has been added)');
+    Translatable('default reject/new ticket created (after closed follow-up with new ticket creation)');
 
     # get database object
     my $DBObject = $Kernel::OM->Get('Kernel::System::DB');

--- a/Kernel/System/AutoResponse.pm
+++ b/Kernel/System/AutoResponse.pm
@@ -11,6 +11,8 @@ package Kernel::System::AutoResponse;
 use strict;
 use warnings;
 
+use Kernel::Language qw(Translatable);
+
 our @ObjectDependencies = (
     'Kernel::System::DB',
     'Kernel::System::Log',
@@ -420,6 +422,12 @@ Return example:
 
 sub AutoResponseTypeList {
     my ( $Self, %Param ) = @_;
+
+    Translatable('auto reply');
+    Translatable('auto reject');
+    Translatable('auto follow up');
+    Translatable('auto reply/new ticket');
+    Translatable('auto remove');
 
     my $Valid = $Param{Valid} // 1;
 

--- a/Kernel/System/Lock.pm
+++ b/Kernel/System/Lock.pm
@@ -11,6 +11,8 @@ package Kernel::System::Lock;
 use strict;
 use warnings;
 
+use Kernel::Language qw(Translatable);
+
 our @ObjectDependencies = (
     'Kernel::Config',
     'Kernel::System::Cache',
@@ -206,6 +208,10 @@ Returns:
 
 sub LockList {
     my ( $Self, %Param ) = @_;
+
+    Translatable('unlock');
+    Translatable('lock');
+    Translatable('lock-tmp');
 
     # check needed stuff
     if ( !$Param{UserID} ) {

--- a/Kernel/System/Priority.pm
+++ b/Kernel/System/Priority.pm
@@ -66,10 +66,26 @@ return a priority list as hash
         Valid => 0,
     );
 
+Returns:
+
+    %List = (
+        1 => '1 very low',
+        2 => '2 low',
+        3 => '3 normal',
+        4 => '4 high',
+        5 => '5 very high',
+    );
+
 =cut
 
 sub PriorityList {
     my ( $Self, %Param ) = @_;
+
+    Translatable('1 very low');
+    Translatable('2 low');
+    Translatable('3 normal');
+    Translatable('4 high');
+    Translatable('5 very high');
 
     # check valid param
     if ( !defined $Param{Valid} ) {


### PR DESCRIPTION
Hi @mgruner 

I have one proposal here. What do you think about adding Translatable function in System backend modules for phrases and words which represent initial  entities in database. Of course, there are Translatable in otrs-initial_insert.xml, and maybe this one is unneeded. These are specific word and often there are not anywhere in code where they could be marked for transliteration. 

If you think otrs-initial_insert.xml is enough I can just remove them from AAATicket.tt

Please let me know what do you think about my proposal.

P.S. Additional note:
I think these are not used anywhere.
- [% Translate("very low") | html %]
- [% Translate("low") | html %]
- [% Translate("normal") | html %]
- [% Translate("high") | html %]
- [% Translate("very high") | html %]

only these ones are used:

- [% Translate("1 very low") | html %]
- [% Translate("2 low") | html %]
- [% Translate("3 normal") | html %]
- [% Translate("4 high") | html %]
- [% Translate("5 very high") | html %]


Regards
Zoran