### PR TITLE
Removing trailing semicolon from grant command

### DIFF
--- a/Kernel/Modules/Installer.pm
+++ b/Kernel/Modules/Installer.pm
@@ -544,7 +544,7 @@ sub Run {
 
                 @Statements = (
                     "CREATE DATABASE `$DB{DBName}` charset utf8",
-                    "GRANT ALL PRIVILEGES ON `$DB{DBName}`.* TO `$DB{OTRSDBUser}`\@`$DB{Host}` IDENTIFIED BY '$DB{OTRSDBPassword}' WITH GRANT OPTION;",
+                    "GRANT ALL PRIVILEGES ON `$DB{DBName}`.* TO `$DB{OTRSDBUser}`\@`$DB{Host}` IDENTIFIED BY '$DB{OTRSDBPassword}' WITH GRANT OPTION",
                     "FLUSH PRIVILEGES",
                 );
             }


### PR DESCRIPTION
The semicolon at the end of the grant command (line 547) was causing error on remote database installation (error on granting permissions). Getting rid of it fix the issue.