### PR TITLE
Added Translatable attribute for several strings

### DIFF
--- a/Kernel/Config/Files/CloudServices.xml
+++ b/Kernel/Config/Files/CloudServices.xml
@@ -24,7 +24,7 @@
         <Setting>
             <FrontendModuleReg>
                 <Group>admin</Group>
-                <Description>Admin</Description>
+                <Description Translatable="1">Admin</Description>
                 <Title Translatable="1">Support data collector</Title>
                 <Loader>
                     <CSS>Core.Agent.Admin.CloudService.SupportDataCollector.css</CSS>

--- a/Kernel/Config/Files/Daemon.xml
+++ b/Kernel/Config/Files/Daemon.xml
@@ -8,7 +8,7 @@
         <Setting>
             <FrontendModuleReg>
                 <Group>admin</Group>
-                <Description>Admin</Description>
+                <Description Translatable="1">Admin</Description>
                 <Title Translatable="1">Shows information on how to start OTRS Daemon</Title>
             </FrontendModuleReg>
         </Setting>

--- a/Kernel/Config/Files/Framework.xml
+++ b/Kernel/Config/Files/Framework.xml
@@ -39,9 +39,9 @@
         <SubGroup>Core</SubGroup>
         <Setting>
             <Option SelectedID="100">
-                <Item Key="100">100 (Expert)</Item>
-                <Item Key="200">200 (Advanced)</Item>
-                <Item Key="300">300 (Beginner)</Item>
+                <Item Key="100" Translatable="1">100 (Expert)</Item>
+                <Item Key="200" Translatable="1">200 (Advanced)</Item>
+                <Item Key="300" Translatable="1">300 (Beginner)</Item>
             </Option>
         </Setting>
     </ConfigItem>
@@ -120,7 +120,7 @@
         <Group>Framework</Group>
         <SubGroup>Core</SubGroup>
         <Setting>
-            <String Regex="">Example Company</String>
+            <String Regex="" Translatable="1">Example Company</String>
         </Setting>
     </ConfigItem>
     <ConfigItem Name="DefaultLanguage" Required="1" Valid="1">
@@ -244,7 +244,7 @@
         <Group>Framework</Group>
         <SubGroup>Core</SubGroup>
         <Setting>
-            <String Regex="">Standard</String>
+            <String Regex="" Translatable="1">Standard</String>
         </Setting>
     </ConfigItem>
     <ConfigItem Name="DefaultTheme::HostBased" Required="0" Valid="0" ConfigLevel="200">
@@ -263,7 +263,7 @@
         <Group>Framework</Group>
         <SubGroup>Frontend::Customer</SubGroup>
         <Setting>
-            <String Regex="">Example Company</String>
+            <String Regex="" Translatable="1">Example Company</String>
         </Setting>
     </ConfigItem>
     <ConfigItem Name="CustomerLogo" Required="0" Valid="0">
@@ -524,8 +524,8 @@
         <SubGroup>Core::Web</SubGroup>
         <Setting>
             <Option SelectedID="attachment">
-                <Item Key="inline">inline</Item>
-                <Item Key="attachment">attachment</Item>
+                <Item Key="inline" Translatable="1">inline</Item>
+                <Item Key="attachment" Translatable="1">attachment</Item>
             </Option>
         </Setting>
     </ConfigItem>
@@ -581,8 +581,8 @@
         <SubGroup>Core::LinkObject</SubGroup>
         <Setting>
             <Option SelectedID="Simple">
-                <Item Key="Simple">Simple</Item>
-                <Item Key="Complex">Complex</Item>
+                <Item Key="Simple" Translatable="1">Simple</Item>
+                <Item Key="Complex" Translatable="1">Complex</Item>
             </Option>
         </Setting>
     </ConfigItem>
@@ -672,10 +672,10 @@
         <SubGroup>Core::Log</SubGroup>
         <Setting>
             <Option SelectedID="error">
-                <Item Key="error">error</Item>
-                <Item Key="notice">notice</Item>
-                <Item Key="info">info</Item>
-                <Item Key="debug">debug</Item>
+                <Item Key="error" Translatable="1">error</Item>
+                <Item Key="notice" Translatable="1">notice</Item>
+                <Item Key="info" Translatable="1">info</Item>
+                <Item Key="debug" Translatable="1">debug</Item>
             </Option>
         </Setting>
     </ConfigItem>
@@ -1250,7 +1250,7 @@
         <Group>Framework</Group>
         <SubGroup>Core::Time::Calendar1</SubGroup>
         <Setting>
-            <String Regex="">Calendar Name 1</String>
+            <String Regex="" Translatable="1">Calendar Name 1</String>
         </Setting>
     </ConfigItem>
     <ConfigItem Name="TimeZone::Calendar1" Required="1" Valid="1">
@@ -1421,7 +1421,7 @@
         <Group>Framework</Group>
         <SubGroup>Core::Time::Calendar2</SubGroup>
         <Setting>
-            <String Regex="">Calendar Name 2</String>
+            <String Regex="" Translatable="1">Calendar Name 2</String>
         </Setting>
     </ConfigItem>
     <ConfigItem Name="TimeZone::Calendar2" Required="1" Valid="1">
@@ -1592,7 +1592,7 @@
         <Group>Framework</Group>
         <SubGroup>Core::Time::Calendar3</SubGroup>
         <Setting>
-            <String Regex="">Calendar Name 3</String>
+            <String Regex="" Translatable="1">Calendar Name 3</String>
         </Setting>
     </ConfigItem>
     <ConfigItem Name="TimeZone::Calendar3" Required="1" Valid="1">
@@ -1763,7 +1763,7 @@
         <Group>Framework</Group>
         <SubGroup>Core::Time::Calendar4</SubGroup>
         <Setting>
-            <String Regex="">Calendar Name 4</String>
+            <String Regex="" Translatable="1">Calendar Name 4</String>
         </Setting>
     </ConfigItem>
     <ConfigItem Name="TimeZone::Calendar4" Required="1" Valid="1">
@@ -1934,7 +1934,7 @@
         <Group>Framework</Group>
         <SubGroup>Core::Time::Calendar5</SubGroup>
         <Setting>
-            <String Regex="">Calendar Name 5</String>
+            <String Regex="" Translatable="1">Calendar Name 5</String>
         </Setting>
     </ConfigItem>
     <ConfigItem Name="TimeZone::Calendar5" Required="1" Valid="1">
@@ -2105,7 +2105,7 @@
         <Group>Framework</Group>
         <SubGroup>Core::Time::Calendar6</SubGroup>
         <Setting>
-            <String Regex="">Calendar Name 6</String>
+            <String Regex="" Translatable="1">Calendar Name 6</String>
         </Setting>
     </ConfigItem>
     <ConfigItem Name="TimeZone::Calendar6" Required="1" Valid="1">
@@ -2276,7 +2276,7 @@
         <Group>Framework</Group>
         <SubGroup>Core::Time::Calendar7</SubGroup>
         <Setting>
-            <String Regex="">Calendar Name 7</String>
+            <String Regex="" Translatable="1">Calendar Name 7</String>
         </Setting>
     </ConfigItem>
     <ConfigItem Name="TimeZone::Calendar7" Required="1" Valid="1">
@@ -2447,7 +2447,7 @@
         <Group>Framework</Group>
         <SubGroup>Core::Time::Calendar8</SubGroup>
         <Setting>
-            <String Regex="">Calendar Name 8</String>
+            <String Regex="" Translatable="1">Calendar Name 8</String>
         </Setting>
     </ConfigItem>
     <ConfigItem Name="TimeZone::Calendar8" Required="1" Valid="1">
@@ -2618,7 +2618,7 @@
         <Group>Framework</Group>
         <SubGroup>Core::Time::Calendar9</SubGroup>
         <Setting>
-            <String Regex="">Calendar Name 9</String>
+            <String Regex="" Translatable="1">Calendar Name 9</String>
         </Setting>
     </ConfigItem>
     <ConfigItem Name="TimeZone::Calendar9" Required="1" Valid="1">
@@ -2942,7 +2942,7 @@
         <Group>Framework</Group>
         <SubGroup>Core::SpellChecker</SubGroup>
         <Setting>
-            <String Regex="">english</String>
+            <String Regex="" Translatable="1">english</String>
         </Setting>
     </ConfigItem>
     <ConfigItem Name="SpellCheckerIgnore" Required="1" Valid="1">
@@ -3369,7 +3369,7 @@
         <Group>Framework</Group>
         <SubGroup>Core</SubGroup>
         <Setting>
-            <String Regex="">OTRS Notifications</String>
+            <String Regex="" Translatable="1">OTRS Notifications</String>
         </Setting>
     </ConfigItem>
     <ConfigItem Name="NotificationSenderEmail" Required="1" Valid="1">
@@ -3385,7 +3385,7 @@
         <Group>Framework</Group>
         <SubGroup>Frontend::Agent</SubGroup>
         <Setting>
-            <String Regex="">New OTRS password request</String>
+            <String Regex="" Translatable="1">New OTRS password request</String>
         </Setting>
     </ConfigItem>
     <ConfigItem Name="NotificationBodyLostPasswordToken" Required="1" Valid="1">
@@ -3411,7 +3411,7 @@ If you did not request a new password, please ignore this email.
         <Group>Framework</Group>
         <SubGroup>Frontend::Agent</SubGroup>
         <Setting>
-            <String Regex="">New OTRS password</String>
+            <String Regex="" Translatable="1">New OTRS password</String>
         </Setting>
     </ConfigItem>
     <ConfigItem Name="NotificationBodyLostPassword" Required="1" Valid="1">
@@ -4013,7 +4013,7 @@ You can log in via the following URL:
         <Group>Framework</Group>
         <SubGroup>Frontend::Customer</SubGroup>
         <Setting>
-            <String Regex="">New OTRS password request</String>
+            <String Regex="" Translatable="1">New OTRS password request</String>
         </Setting>
     </ConfigItem>
     <ConfigItem Name="CustomerPanelBodyLostPasswordToken" Required="1" Valid="1">
@@ -4039,7 +4039,7 @@ If you did not request a new password, please ignore this email.
         <Group>Framework</Group>
         <SubGroup>Frontend::Customer</SubGroup>
         <Setting>
-            <String Regex="">New OTRS password</String>
+            <String Regex="" Translatable="1">New OTRS password</String>
         </Setting>
     </ConfigItem>
     <ConfigItem Name="CustomerPanelBodyLostPassword" Required="1" Valid="1">
@@ -4061,7 +4061,7 @@ New password: &lt;OTRS_NEWPW&gt;
         <Group>Framework</Group>
         <SubGroup>Frontend::Customer</SubGroup>
         <Setting>
-            <String Regex="">New OTRS Account!</String>
+            <String Regex="" Translatable="1">New OTRS Account!</String>
         </Setting>
     </ConfigItem>
     <ConfigItem Name="CustomerPanelBodyNewAccount" Required="1" Valid="1">
@@ -4506,7 +4506,7 @@ via the Preferences button after logging in.
         <SubGroup>Frontend::Agent::ModuleRegistration</SubGroup>
         <Setting>
             <FrontendModuleReg>
-                <Description>Logout</Description>
+                <Description Translatable="1">Logout</Description>
                 <Title></Title>
                 <NavBarName></NavBarName>
             </FrontendModuleReg>
@@ -4518,7 +4518,7 @@ via the Preferences button after logging in.
         <SubGroup>Frontend::Agent::ModuleRegistration</SubGroup>
         <Setting>
             <FrontendModuleReg>
-                <Description>Agent Dashboard</Description>
+                <Description Translatable="1">Agent Dashboard</Description>
                 <Title></Title>
                 <NavBarName>Dashboard</NavBarName>
                 <NavBar>
@@ -4561,7 +4561,7 @@ via the Preferences button after logging in.
         <SubGroup>Frontend::Agent::ModuleRegistration</SubGroup>
         <Setting>
             <FrontendModuleReg>
-                <Description>Customer Information Center</Description>
+                <Description Translatable="1">Customer Information Center</Description>
                 <Title></Title>
                 <NavBarName>Customers</NavBarName>
                 <NavBar>
@@ -4601,7 +4601,7 @@ via the Preferences button after logging in.
         <SubGroup>Frontend::Agent::ModuleRegistration</SubGroup>
         <Setting>
             <FrontendModuleReg>
-                <Description>Customer Information Center Search</Description>
+                <Description Translatable="1">Customer Information Center Search</Description>
                 <Title></Title>
             </FrontendModuleReg>
         </Setting>
@@ -4659,7 +4659,7 @@ via the Preferences button after logging in.
         <SubGroup>Frontend::Agent::ModuleRegistration</SubGroup>
         <Setting>
             <FrontendModuleReg>
-                <Description>Agent Preferences</Description>
+                <Description Translatable="1">Agent Preferences</Description>
                 <Title></Title>
                 <NavBarName>Preferences</NavBarName>
                 <Loader>
@@ -4674,8 +4674,8 @@ via the Preferences button after logging in.
         <SubGroup>Frontend::Agent::ModuleRegistration</SubGroup>
         <Setting>
             <FrontendModuleReg>
-                <Description>Picture upload module</Description>
-                <Title>Picture-Upload</Title>
+                <Description Translatable="1">Picture upload module</Description>
+                <Title Translatable="1">Picture Upload</Title>
                 <NavBarName>Ticket</NavBarName>
             </FrontendModuleReg>
         </Setting>
@@ -4686,8 +4686,8 @@ via the Preferences button after logging in.
         <SubGroup>Frontend::Agent::ModuleRegistration</SubGroup>
         <Setting>
             <FrontendModuleReg>
-                <Description>Spell checker</Description>
-                <Title>Spell Checker</Title>
+                <Description Translatable="1">Spell checker</Description>
+                <Title Translatable="1">Spell Checker</Title>
                 <NavBarName></NavBarName>
                 <Loader>
                     <JavaScript>Core.Agent.TicketAction.js</JavaScript>
@@ -4701,8 +4701,8 @@ via the Preferences button after logging in.
         <SubGroup>Frontend::Agent::ModuleRegistration</SubGroup>
         <Setting>
             <FrontendModuleReg>
-                <Description>Spell checker</Description>
-                <Title>Spell Checker</Title>
+                <Description Translatable="1">Spell checker</Description>
+                <Title Translatable="1">Spell Checker</Title>
                 <NavBarName></NavBarName>
             </FrontendModuleReg>
         </Setting>
@@ -4713,8 +4713,8 @@ via the Preferences button after logging in.
         <SubGroup>Frontend::Agent::ModuleRegistration</SubGroup>
         <Setting>
             <FrontendModuleReg>
-                <Description>Address book of CustomerUser sources</Description>
-                <Title>Address Book</Title>
+                <Description Translatable="1">Address book of CustomerUser sources</Description>
+                <Title Translatable="1">Address Book</Title>
                 <NavBarName></NavBarName>
                 <Loader>
                     <JavaScript>Core.Agent.CustomerSearch.js</JavaScript>
@@ -4729,8 +4729,8 @@ via the Preferences button after logging in.
         <SubGroup>Frontend::Agent::ModuleRegistration</SubGroup>
         <Setting>
             <FrontendModuleReg>
-                <Description>Link Object</Description>
-                <Title>Link Object</Title>
+                <Description Translatable="1">Link Object</Description>
+                <Title Translatable="1">Link Object</Title>
                 <NavBarName></NavBarName>
             </FrontendModuleReg>
         </Setting>
@@ -4741,8 +4741,8 @@ via the Preferences button after logging in.
         <SubGroup>Frontend::Agent::ModuleRegistration</SubGroup>
         <Setting>
             <FrontendModuleReg>
-                <Description>Generic Info module</Description>
-                <Title>Info</Title>
+                <Description Translatable="1">Generic Info module</Description>
+                <Title Translatable="1">Info</Title>
                 <NavBarName></NavBarName>
             </FrontendModuleReg>
         </Setting>
@@ -4753,7 +4753,7 @@ via the Preferences button after logging in.
         <SubGroup>Frontend::Agent::ModuleRegistration</SubGroup>
         <Setting>
             <FrontendModuleReg>
-                <Description>Global Search Module</Description>
+                <Description Translatable="1">Global Search Module</Description>
                 <Title Translatable="1">Search</Title>
                 <NavBarName></NavBarName>
             </FrontendModuleReg>
@@ -4774,7 +4774,7 @@ via the Preferences button after logging in.
         <Setting>
             <FrontendModuleReg>
                 <Group>admin</Group>
-                <Description>Admin-Area</Description>
+                <Description Translatable="1">Admin-Area</Description>
                 <Title></Title>
                 <NavBarName>Admin</NavBarName>
                 <NavBar>
@@ -4805,8 +4805,8 @@ via the Preferences button after logging in.
         <Setting>
             <FrontendModuleReg>
                 <Group>admin</Group>
-                <Description>Admin</Description>
-                <Title>Init</Title>
+                <Description Translatable="1">Admin</Description>
+                <Title Translatable="1">Init</Title>
                 <NavBarName></NavBarName>
             </FrontendModuleReg>
         </Setting>
@@ -4818,7 +4818,7 @@ via the Preferences button after logging in.
         <Setting>
             <FrontendModuleReg>
                 <Group>admin</Group>
-                <Description>Create and manage agents.</Description>
+                <Description Translatable="1">Create and manage agents.</Description>
                 <Title Translatable="1">Agents</Title>
                 <NavBarName>Admin</NavBarName>
                 <NavBarModule>
@@ -4838,7 +4838,7 @@ via the Preferences button after logging in.
         <Setting>
             <FrontendModuleReg>
                 <Group>admin</Group>
-                <Description>Admin</Description>
+                <Description Translatable="1">Admin</Description>
                 <Title Translatable="1">Groups</Title>
                 <NavBarName>Admin</NavBarName>
                 <NavBarModule>
@@ -4858,7 +4858,7 @@ via the Preferences button after logging in.
         <Setting>
             <FrontendModuleReg>
                 <Group>admin</Group>
-                <Description>Admin</Description>
+                <Description Translatable="1">Admin</Description>
                 <Title Translatable="1">Agents &lt;-&gt; Groups</Title>
                 <NavBarName>Admin</NavBarName>
                 <NavBarModule>
@@ -4957,7 +4957,7 @@ via the Preferences button after logging in.
         <Setting>
             <FrontendModuleReg>
                 <Group>admin</Group>
-                <Description>Admin</Description>
+                <Description Translatable="1">Admin</Description>
                 <Title Translatable="1">Customers &lt;-&gt; Groups</Title>
                 <NavBarName>Admin</NavBarName>
                 <NavBarModule>
@@ -4977,7 +4977,7 @@ via the Preferences button after logging in.
         <Setting>
             <FrontendModuleReg>
                 <Group>admin</Group>
-                <Description>Admin</Description>
+                <Description Translatable="1">Admin</Description>
                 <Title Translatable="1">Customer User &lt;-&gt; Services</Title>
                 <NavBarName>Admin</NavBarName>
                 <NavBarModule>
@@ -4997,7 +4997,7 @@ via the Preferences button after logging in.
         <Setting>
             <FrontendModuleReg>
                 <Group>admin</Group>
-                <Description>Admin</Description>
+                <Description Translatable="1">Admin</Description>
                 <Title Translatable="1">Roles</Title>
                 <NavBarName>Admin</NavBarName>
                 <NavBarModule>
@@ -5017,7 +5017,7 @@ via the Preferences button after logging in.
         <Setting>
             <FrontendModuleReg>
                 <Group>admin</Group>
-                <Description>Admin</Description>
+                <Description Translatable="1">Admin</Description>
                 <Title Translatable="1">Agents &lt;-&gt; Roles</Title>
                 <NavBarName>Admin</NavBarName>
                 <NavBarModule>
@@ -5037,7 +5037,7 @@ via the Preferences button after logging in.
         <Setting>
             <FrontendModuleReg>
                 <Group>admin</Group>
-                <Description>Admin</Description>
+                <Description Translatable="1">Admin</Description>
                 <Title Translatable="1">Roles &lt;-&gt; Groups</Title>
                 <NavBarName>Admin</NavBarName>
                 <NavBarModule>
@@ -5057,7 +5057,7 @@ via the Preferences button after logging in.
         <Setting>
             <FrontendModuleReg>
                 <Group>admin</Group>
-                <Description>Admin</Description>
+                <Description Translatable="1">Admin</Description>
                 <Title Translatable="1">S/MIME Management</Title>
                 <NavBarName>Admin</NavBarName>
                 <NavBarModule>
@@ -5077,7 +5077,7 @@ via the Preferences button after logging in.
         <Setting>
             <FrontendModuleReg>
                 <Group>admin</Group>
-                <Description>Admin</Description>
+                <Description Translatable="1">Admin</Description>
                 <Title Translatable="1">PGP Key Management</Title>
                 <NavBarName>Admin</NavBarName>
                 <NavBarModule>
@@ -5097,7 +5097,7 @@ via the Preferences button after logging in.
         <Setting>
             <FrontendModuleReg>
                 <Group>admin</Group>
-                <Description>Admin</Description>
+                <Description Translatable="1">Admin</Description>
                 <Title Translatable="1">Mail Accounts</Title>
                 <NavBarName>Admin</NavBarName>
                 <NavBarModule>
@@ -5117,7 +5117,7 @@ via the Preferences button after logging in.
         <Setting>
             <FrontendModuleReg>
                 <Group>admin</Group>
-                <Description>Admin</Description>
+                <Description Translatable="1">Admin</Description>
                 <Title Translatable="1">PostMaster Filters</Title>
                 <NavBarName>Admin</NavBarName>
                 <NavBarModule>
@@ -5137,7 +5137,7 @@ via the Preferences button after logging in.
         <Setting>
             <FrontendModuleReg>
                 <Group>admin</Group>
-                <Description>Admin</Description>
+                <Description Translatable="1">Admin</Description>
                 <Title Translatable="1">Admin Notification</Title>
                 <NavBarName>Admin</NavBarName>
                 <NavBarModule>
@@ -5157,7 +5157,7 @@ via the Preferences button after logging in.
         <Setting>
             <FrontendModuleReg>
                 <Group>admin</Group>
-                <Description>Admin</Description>
+                <Description Translatable="1">Admin</Description>
                 <Title Translatable="1">Session Management</Title>
                 <NavBarName>Admin</NavBarName>
                 <NavBarModule>
@@ -5177,7 +5177,7 @@ via the Preferences button after logging in.
         <Setting>
             <FrontendModuleReg>
                 <Group>admin</Group>
-                <Description>Admin</Description>
+                <Description Translatable="1">Admin</Description>
                 <Title Translatable="1">Performance Log</Title>
                 <NavBarName>Admin</NavBarName>
                 <NavBarModule>
@@ -5200,7 +5200,7 @@ via the Preferences button after logging in.
         <Setting>
             <FrontendModuleReg>
                 <Group>admin</Group>
-                <Description>Admin</Description>
+                <Description Translatable="1">Admin</Description>
                 <Title Translatable="1">System Registration</Title>
                 <NavBarName>Admin</NavBarName>
                 <NavBarModule>
@@ -5223,7 +5223,7 @@ via the Preferences button after logging in.
         <Setting>
             <FrontendModuleReg>
                 <Group>admin</Group>
-                <Description>Admin</Description>
+                <Description Translatable="1">Admin</Description>
                 <Title>OTRS Business Solution™</Title>
                 <NavBarName>Admin</NavBarName>
                 <NavBarModule>
@@ -5246,7 +5246,7 @@ via the Preferences button after logging in.
         <Setting>
             <FrontendModuleReg>
                 <Group>admin</Group>
-                <Description>Admin</Description>
+                <Description Translatable="1">Admin</Description>
                 <Title Translatable="1">Support Data Collector</Title>
                 <NavBarName>Admin</NavBarName>
                 <NavBarModule>
@@ -5269,7 +5269,7 @@ via the Preferences button after logging in.
         <Setting>
             <FrontendModuleReg>
                 <Group>admin</Group>
-                <Description>Admin</Description>
+                <Description Translatable="1">Admin</Description>
                 <Title Translatable="1">Cloud Services</Title>
                 <NavBarName>Admin</NavBarName>
                 <NavBarModule>
@@ -5292,7 +5292,7 @@ via the Preferences button after logging in.
         <Setting>
             <FrontendModuleReg>
                 <Group>admin</Group>
-                <Description>Admin</Description>
+                <Description Translatable="1">Admin</Description>
                 <Title Translatable="1">System Log</Title>
                 <NavBarName>Admin</NavBarName>
                 <NavBarModule>
@@ -5312,7 +5312,7 @@ via the Preferences button after logging in.
         <Setting>
             <FrontendModuleReg>
                 <Group>admin</Group>
-                <Description>Admin</Description>
+                <Description Translatable="1">Admin</Description>
                 <Title Translatable="1">SQL Box</Title>
                 <NavBarName>Admin</NavBarName>
                 <NavBarModule>
@@ -5352,7 +5352,7 @@ via the Preferences button after logging in.
         <Setting>
             <FrontendModuleReg>
                 <Group>admin</Group>
-                <Description>Admin</Description>
+                <Description Translatable="1">Admin</Description>
                 <Title Translatable="1">System Maintenance</Title>
                 <NavBarName>Admin</NavBarName>
                 <NavBarModule>
@@ -5494,10 +5494,10 @@ via the Preferences button after logging in.
         <SubGroup>Frontend::Agent::ModuleRegistration</SubGroup>
         <Setting>
             <FrontendModuleReg>
-                <Title>HTML Reference</Title>
+                <Title Translatable="1">HTML Reference</Title>
                 <Group>users</Group>
                 <GroupRo>users</GroupRo>
-                <Description>HTML Reference</Description>
+                <Description Translatable="1">HTML Reference</Description>
                 <NavBarName></NavBarName>
                 <Loader>
                     <CSS>Core.Agent.HTMLReference.css</CSS>
@@ -6449,8 +6449,8 @@ via the Preferences button after logging in.
         <Setting>
             <Hash>
                 <Item Key="InternalName">default</Item>
-                <Item Key="VisibleName">Default</Item>
-                <Item Key="Description">This is the default orange - black skin.</Item>
+                <Item Key="VisibleName" Translatable="1">Default</Item>
+                <Item Key="Description" Translatable="1">This is the default orange - black skin.</Item>
                 <Item Key="HomePage">www.otrs.org</Item>
             </Hash>
         </Setting>
@@ -6462,8 +6462,8 @@ via the Preferences button after logging in.
         <Setting>
             <Hash>
                 <Item Key="InternalName">slim</Item>
-                <Item Key="VisibleName">Default (Slim)</Item>
-                <Item Key="Description">"Slim" skin which tries to save screen space for power users.</Item>
+                <Item Key="VisibleName" Translatable="1">Default (Slim)</Item>
+                <Item Key="Description" Translatable="1">"Slim" skin which tries to save screen space for power users.</Item>
                 <Item Key="HomePage">www.otrs.org</Item>
             </Hash>
         </Setting>
@@ -6475,8 +6475,8 @@ via the Preferences button after logging in.
         <Setting>
             <Hash>
                 <Item Key="InternalName">ivory</Item>
-                <Item Key="VisibleName">Ivory</Item>
-                <Item Key="Description">Balanced white skin by Felix Niklas.</Item>
+                <Item Key="VisibleName" Translatable="1">Ivory</Item>
+                <Item Key="Description" Translatable="1">Balanced white skin by Felix Niklas.</Item>
                 <Item Key="HomePage">www.felixniklas.de</Item>
             </Hash>
         </Setting>
@@ -6488,8 +6488,8 @@ via the Preferences button after logging in.
         <Setting>
             <Hash>
                 <Item Key="InternalName">ivory-slim</Item>
-                <Item Key="VisibleName">Ivory (Slim)</Item>
-                <Item Key="Description">Balanced white skin by Felix Niklas (slim version).</Item>
+                <Item Key="VisibleName" Translatable="1">Ivory (Slim)</Item>
+                <Item Key="Description" Translatable="1">Balanced white skin by Felix Niklas (slim version).</Item>
                 <Item Key="HomePage">www.felixniklas.de</Item>
             </Hash>
         </Setting>
@@ -6520,8 +6520,8 @@ via the Preferences button after logging in.
         <Setting>
             <Hash>
                 <Item Key="InternalName">default</Item>
-                <Item Key="VisibleName">Default</Item>
-                <Item Key="Description">This is the default orange - black skin for the customer interface.</Item>
+                <Item Key="VisibleName" Translatable="1">Default</Item>
+                <Item Key="Description" Translatable="1">This is the default orange - black skin for the customer interface.</Item>
                 <Item Key="HomePage">www.otrs.org</Item>
             </Hash>
         </Setting>

--- a/Kernel/Config/Files/GenericInterface.xml
+++ b/Kernel/Config/Files/GenericInterface.xml
@@ -103,7 +103,7 @@
         <Setting>
             <FrontendModuleReg>
                 <Group>admin</Group>
-                <Description>Admin</Description>
+                <Description Translatable="1">Admin</Description>
                 <Title Translatable="1">GenericInterface Debugger GUI</Title>
                 <Loader>
                     <CSS>Core.Agent.Admin.GenericInterface.css</CSS>
@@ -119,7 +119,7 @@
         <Setting>
             <FrontendModuleReg>
                 <Group>admin</Group>
-                <Description>Admin</Description>
+                <Description Translatable="1">Admin</Description>
                 <Title Translatable="1">GenericInterface Web Service GUI</Title>
                 <NavBarName>Admin</NavBarName>
                 <NavBarModule>
@@ -143,7 +143,7 @@
         <Setting>
             <FrontendModuleReg>
                 <Group>admin</Group>
-                <Description>Admin</Description>
+                <Description Translatable="1">Admin</Description>
                 <Title Translatable="1">GenericInterface TransportHTTPSOAP GUI</Title>
                 <Loader>
                     <CSS>Core.Agent.Admin.GenericInterface.css</CSS>
@@ -160,7 +160,7 @@
         <Setting>
             <FrontendModuleReg>
                 <Group>admin</Group>
-                <Description>Admin</Description>
+                <Description Translatable="1">Admin</Description>
                 <Title Translatable="1">GenericInterface TransportHTTPREST GUI</Title>
                 <Loader>
                     <CSS>Core.Agent.Admin.GenericInterface.css</CSS>
@@ -175,7 +175,7 @@
         <Setting>
             <FrontendModuleReg>
                 <Group>admin</Group>
-                <Description>Admin</Description>
+                <Description Translatable="1">Admin</Description>
                 <Title Translatable="1">GenericInterface Webservice History GUI</Title>
                 <Loader>
                     <CSS>Core.Agent.Admin.GenericInterface.css</CSS>
@@ -192,7 +192,7 @@
         <Setting>
             <FrontendModuleReg>
                 <Group>admin</Group>
-                <Description>Admin</Description>
+                <Description Translatable="1">Admin</Description>
                 <Title Translatable="1">GenericInterface Operation GUI</Title>
                 <Loader>
                     <CSS>Core.Agent.Admin.GenericInterface.css</CSS>
@@ -209,7 +209,7 @@
         <Setting>
             <FrontendModuleReg>
                 <Group>admin</Group>
-                <Description>Admin</Description>
+                <Description Translatable="1">Admin</Description>
                 <Title Translatable="1">GenericInterface Invoker GUI</Title>
                 <Loader>
                     <CSS>Core.Agent.Admin.GenericInterface.css</CSS>
@@ -309,7 +309,7 @@
         <Setting>
             <FrontendModuleReg>
                 <Group>admin</Group>
-                <Description>Admin</Description>
+                <Description Translatable="1">Admin</Description>
                 <Title Translatable="1">GenericInterface Webservice Mapping GUI</Title>
                 <Loader>
                     <CSS>Core.Agent.Admin.GenericInterface.css</CSS>
@@ -337,7 +337,7 @@
         <Setting>
             <FrontendModuleReg>
                 <Group>admin</Group>
-                <Description>Admin</Description>
+                <Description Translatable="1">Admin</Description>
                 <Title Translatable="1">GenericInterface Webservice Mapping GUI</Title>
                 <Loader>
                     <CSS>Core.Agent.Admin.GenericInterface.css</CSS>

--- a/Kernel/Config/Files/ProcessManagement.xml
+++ b/Kernel/Config/Files/ProcessManagement.xml
@@ -7,7 +7,7 @@
         <Setting>
             <FrontendModuleReg>
                 <Group>admin</Group>
-                <Description>Admin</Description>
+                <Description Translatable="1">Admin</Description>
                 <Title Translatable="1">Process Management</Title>
                 <NavBarName>Admin</NavBarName>
                 <Loader>
@@ -37,7 +37,7 @@
         <Setting>
             <FrontendModuleReg>
                 <Group>admin</Group>
-                <Description>Admin</Description>
+                <Description Translatable="1">Admin</Description>
                 <Title Translatable="1">Process Management Activity GUI</Title>
                 <Loader>
                     <CSS>Core.Agent.Admin.ProcessManagement.css</CSS>
@@ -55,7 +55,7 @@
         <Setting>
             <FrontendModuleReg>
                 <Group>admin</Group>
-                <Description>Admin</Description>
+                <Description Translatable="1">Admin</Description>
                 <Title Translatable="1">Process Management Activity Dialog GUI</Title>
                 <Loader>
                     <CSS>Core.Agent.Admin.ProcessManagement.css</CSS>
@@ -73,7 +73,7 @@
         <Setting>
             <FrontendModuleReg>
                 <Group>admin</Group>
-                <Description>Admin</Description>
+                <Description Translatable="1">Admin</Description>
                 <Title Translatable="1">Process Management Transition GUI</Title>
                 <Loader>
                     <CSS>Core.Agent.Admin.ProcessManagement.css</CSS>
@@ -89,7 +89,7 @@
         <Setting>
             <FrontendModuleReg>
                 <Group>admin</Group>
-                <Description>Admin</Description>
+                <Description Translatable="1">Admin</Description>
                 <Title Translatable="1">Process Management Transition Action GUI</Title>
                 <Loader>
                     <CSS>Core.Agent.Admin.ProcessManagement.css</CSS>
@@ -105,7 +105,7 @@
         <Setting>
             <FrontendModuleReg>
                 <Group>admin</Group>
-                <Description>Admin</Description>
+                <Description Translatable="1">Admin</Description>
                 <Title Translatable="1">Process Management Path GUI</Title>
                 <Loader>
                     <CSS>Core.Agent.Admin.ProcessManagement.css</CSS>
@@ -135,8 +135,8 @@
         <SubGroup>Frontend::Agent::ModuleRegistration</SubGroup>
         <Setting>
             <FrontendModuleReg>
-                <Description>Create new process ticket</Description>
-                <Title>New process ticket</Title>
+                <Description Translatable="1">Create new process ticket</Description>
+                <Title Translatable="1">New process ticket</Title>
                 <NavBarName>Ticket</NavBarName>
                 <NavBar>
                     <Description Translatable="1">Create New process ticket</Description>
@@ -273,9 +273,9 @@
         <SubGroup>Frontend::Customer::ModuleRegistration</SubGroup>
         <Setting>
             <FrontendModuleReg>
-                <Description>Process Ticket</Description>
+                <Description Translatable="1">Process Ticket</Description>
                 <NavBarName>Ticket</NavBarName>
-                <Title>Process ticket</Title>
+                <Title Translatable="1">Process ticket</Title>
                 <NavBar>
                     <Description Translatable="1">Create new process ticket</Description>
                     <Name Translatable="1">New process ticket</Name>
@@ -377,10 +377,10 @@
         <SubGroup>Core::Transition</SubGroup>
         <Setting>
             <Option SelectedID="debug">
-                <Item Key="debug">Debug</Item>
-                <Item Key="info">Info</Item>
-                <Item Key="notice">Notice</Item>
-                <Item Key="error">Error</Item>
+                <Item Key="debug" Translatable="1">Debug</Item>
+                <Item Key="info" Translatable="1">Info</Item>
+                <Item Key="notice" Translatable="1">Notice</Item>
+                <Item Key="error" Translatable="1">Error</Item>
             </Option>
         </Setting>
     </ConfigItem>
@@ -403,7 +403,7 @@
             <Hash>
                 <Item Key="Module">Kernel::Output::HTML::Dashboard::TicketGeneric</Item>
                 <Item Key="Title" Translatable="1">Running Process Tickets</Item>
-                <Item Key="Description">All tickets with a reminder set where the reminder date has been reached</Item>
+                <Item Key="Description" Translatable="1">All tickets with a reminder set where the reminder date has been reached</Item>
                 <Item Key="Attributes">StateType=new;StateType=open;StateType=pending reminder;StateType=pending auto</Item>
                 <Item Key="Time">UntilTime</Item>
                 <Item Key="IsProcessWidget">1</Item>

--- a/Kernel/Config/Files/Ticket.xml
+++ b/Kernel/Config/Files/Ticket.xml
@@ -534,7 +534,7 @@
         </Setting>
     </ConfigItem>
     <ConfigItem Name="Ticket::SearchIndex::StopWords###en" Required="0" Valid="1" ConfigLevel="200">
-        <Description Translatable="1">German stop words for fulltext index. These words will be removed from the search index.</Description>
+        <Description Translatable="1">English stop words for fulltext index. These words will be removed from the search index.</Description>
         <Group>Ticket</Group>
         <SubGroup>Core::FulltextSearch</SubGroup>
         <Setting>
@@ -3161,7 +3161,7 @@
         </Setting>
     </ConfigItem>
     <ConfigItem Name="Ticket::Frontend::NewQueueSelectionType" Required="1" Valid="1">
-        <Description Translatable="1">Defines the receipent target of the phone ticket and the sender of the email ticket ("Queue" shows all queues, "System address" displays all system addresses) in the agent interface.</Description>
+        <Description Translatable="1">Defines the recipient target of the phone ticket and the sender of the email ticket ("Queue" shows all queues, "System address" displays all system addresses) in the agent interface.</Description>
         <Group>Ticket</Group>
         <SubGroup>Frontend::Agent</SubGroup>
         <Setting>
@@ -3172,7 +3172,7 @@
         </Setting>
     </ConfigItem>
     <ConfigItem Name="Ticket::Frontend::NewQueueSelectionString" Required="1" Valid="1">
-        <Description Translatable="1">Determines the strings that will be shown as recipient (To:) of the phone ticket and as sender (From:) of the email ticket in the agent interface. For Queue as NewQueueSelectionType "&lt;Queue&gt;" shows the names of the queues and for SystemAddress "&lt;Realname&gt; &lt;&lt;Email&gt;&gt;" shows the name and email of the receipent.</Description>
+        <Description Translatable="1">Determines the strings that will be shown as recipient (To:) of the phone ticket and as sender (From:) of the email ticket in the agent interface. For Queue as NewQueueSelectionType "&lt;Queue&gt;" shows the names of the queues and for SystemAddress "&lt;Realname&gt; &lt;&lt;Email&gt;&gt;" shows the name and email of the recipient.</Description>
         <Group>Ticket</Group>
         <SubGroup>Frontend::Agent</SubGroup>
         <Setting>
@@ -7832,7 +7832,7 @@
         </Setting>
     </ConfigItem>
     <ConfigItem Name="CustomerPanelSelectionType" Required="1" Valid="1">
-        <Description Translatable="1">Defines the receipent target of the tickets ("Queue" shows all queues, "SystemAddress" displays all system addresses) in the customer interface.</Description>
+        <Description Translatable="1">Defines the recipient target of the tickets ("Queue" shows all queues, "SystemAddress" displays all system addresses) in the customer interface.</Description>
         <Group>Ticket</Group>
         <SubGroup>Frontend::Customer::Ticket::ViewNew</SubGroup>
         <Setting>
@@ -7843,7 +7843,7 @@
         </Setting>
     </ConfigItem>
     <ConfigItem Name="CustomerPanelSelectionString" Required="0" Valid="1">
-        <Description Translatable="1">Determines the strings that will be shown as receipent (To:) of the ticket in the customer interface. For Queue as CustomerPanelSelectionType, "&lt;Queue&gt;" shows the names of the queues, and for SystemAddress, "&lt;Realname&gt; &lt;&lt;Email&gt;&gt;" shows the name and email of the receipent.</Description>
+        <Description Translatable="1">Determines the strings that will be shown as recipient (To:) of the ticket in the customer interface. For Queue as CustomerPanelSelectionType, "&lt;Queue&gt;" shows the names of the queues, and for SystemAddress, "&lt;Realname&gt; &lt;&lt;Email&gt;&gt;" shows the name and email of the recipient.</Description>
         <Group>Ticket</Group>
         <SubGroup>Frontend::Customer::Ticket::ViewNew</SubGroup>
         <Setting>
@@ -8498,7 +8498,7 @@
         <SubGroup>Frontend::Agent::ModuleRegistration</SubGroup>
         <Setting>
             <FrontendModuleReg>
-                <Description>compat module for AgentZoom to AgentTicketZoom</Description>
+                <Description Translatable="1">compat module for AgentZoom to AgentTicketZoom</Description>
                 <NavBarName>Ticket</NavBarName>
                 <Title></Title>
             </FrontendModuleReg>
@@ -8510,8 +8510,8 @@
         <SubGroup>Frontend::Agent::ModuleRegistration</SubGroup>
         <Setting>
             <FrontendModuleReg>
-                <Description>Ticket Zoom</Description>
-                <Title>Zoom</Title>
+                <Description Translatable="1">Ticket Zoom</Description>
+                <Title Translatable="1">Zoom</Title>
                 <NavBarName>Ticket</NavBarName>
                 <Loader>
                     <CSS>Core.Agent.TicketProcess.css</CSS>
@@ -8625,8 +8625,8 @@
         <SubGroup>Frontend::Agent::ModuleRegistration</SubGroup>
         <Setting>
             <FrontendModuleReg>
-                <Description>Ticket Lock</Description>
-                <Title>Lock</Title>
+                <Description Translatable="1">Ticket Lock</Description>
+                <Title Translatable="1">Lock</Title>
                 <NavBarName>Ticket</NavBarName>
             </FrontendModuleReg>
         </Setting>
@@ -8856,7 +8856,7 @@
         <Setting>
             <FrontendModuleReg>
                 <Description Translatable="1">Ticket bulk module.</Description>
-                <Title>Bulk-Action</Title>
+                <Title Translatable="1">Bulk-Action</Title>
                 <NavBarName>Ticket</NavBarName>
                 <Loader>
                     <JavaScript>Core.Agent.TicketAction.js</JavaScript>
@@ -8871,7 +8871,7 @@
         <Setting>
             <FrontendModuleReg>
                 <Group>admin</Group>
-                <Description>Admin</Description>
+                <Description Translatable="1">Admin</Description>
                 <Title Translatable="1">Access Control Lists (ACL)</Title>
                 <NavBarName>Admin</NavBarName>
                 <Loader>
@@ -8895,7 +8895,7 @@
         <Setting>
             <FrontendModuleReg>
                 <Group>admin</Group>
-                <Description>Admin</Description>
+                <Description Translatable="1">Admin</Description>
                 <Title Translatable="1">Queues</Title>
                 <NavBarName>Admin</NavBarName>
                 <NavBarModule>
@@ -8915,8 +8915,8 @@
         <Setting>
             <FrontendModuleReg>
                 <Group>admin</Group>
-                <Description>Admin</Description>
-                <Title>Templates</Title>
+                <Description Translatable="1">Admin</Description>
+                <Title Translatable="1">Templates</Title>
                 <NavBarName>Admin</NavBarName>
                 <NavBarModule>
                     <Module>Kernel::Output::HTML::NavBar::ModuleAdmin</Module>
@@ -8935,7 +8935,7 @@
         <Setting>
             <FrontendModuleReg>
                 <Group>admin</Group>
-                <Description>Admin</Description>
+                <Description Translatable="1">Admin</Description>
                 <Title Translatable="1">Templates &lt;-&gt; Queues</Title>
                 <NavBarName>Admin</NavBarName>
                 <NavBarModule>
@@ -8955,7 +8955,7 @@
         <Setting>
             <FrontendModuleReg>
                 <Group>admin</Group>
-                <Description>Admin</Description>
+                <Description Translatable="1">Admin</Description>
                 <Title Translatable="1">Auto Responses</Title>
                 <NavBarName>Admin</NavBarName>
                 <NavBarModule>
@@ -8975,8 +8975,8 @@
         <Setting>
             <FrontendModuleReg>
                 <Group>admin</Group>
-                <Description>Admin</Description>
-                <Title>Auto Responses &lt;-&gt; Queues</Title>
+                <Description Translatable="1">Admin</Description>
+                <Title Translatable="1">Auto Responses &lt;-&gt; Queues</Title>
                 <NavBarName>Admin</NavBarName>
                 <NavBarModule>
                     <Module>Kernel::Output::HTML::NavBar::ModuleAdmin</Module>
@@ -8995,7 +8995,7 @@
         <Setting>
             <FrontendModuleReg>
                 <Group>admin</Group>
-                <Description>Admin</Description>
+                <Description Translatable="1">Admin</Description>
                 <Title Translatable="1">Attachments</Title>
                 <NavBarName>Admin</NavBarName>
                 <NavBarModule>
@@ -9015,7 +9015,7 @@
         <Setting>
             <FrontendModuleReg>
                 <Group>admin</Group>
-                <Description>Admin</Description>
+                <Description Translatable="1">Admin</Description>
                 <Title Translatable="1">Attachments &lt;-&gt; Templates</Title>
                 <NavBarName>Admin</NavBarName>
                 <NavBarModule>
@@ -9035,7 +9035,7 @@
         <Setting>
             <FrontendModuleReg>
                 <Group>admin</Group>
-                <Description>Admin</Description>
+                <Description Translatable="1">Admin</Description>
                 <Title Translatable="1">Salutations</Title>
                 <NavBarName>Admin</NavBarName>
                 <NavBarModule>
@@ -9055,7 +9055,7 @@
         <Setting>
             <FrontendModuleReg>
                 <Group>admin</Group>
-                <Description>Admin</Description>
+                <Description Translatable="1">Admin</Description>
                 <Title Translatable="1">Signatures</Title>
                 <NavBarName>Admin</NavBarName>
                 <NavBarModule>
@@ -9075,7 +9075,7 @@
         <Setting>
             <FrontendModuleReg>
                 <Group>admin</Group>
-                <Description>Admin</Description>
+                <Description Translatable="1">Admin</Description>
                 <Title Translatable="1">Email Addresses</Title>
                 <NavBarName>Admin</NavBarName>
                 <NavBarModule>
@@ -9095,7 +9095,7 @@
         <Setting>
             <FrontendModuleReg>
                 <Group>admin</Group>
-                <Description>Admin</Description>
+                <Description Translatable="1">Admin</Description>
                 <Title Translatable="1">Ticket Notifications</Title>
                 <NavBarName>Admin</NavBarName>
                 <NavBarModule>
@@ -9119,7 +9119,7 @@
         <Setting>
             <FrontendModuleReg>
                 <Group>admin</Group>
-                <Description>Admin</Description>
+                <Description Translatable="1">Admin</Description>
                 <Title Translatable="1">Services</Title>
                 <NavBarName>Admin</NavBarName>
                 <NavBarModule>
@@ -9139,7 +9139,7 @@
         <Setting>
             <FrontendModuleReg>
                 <Group>admin</Group>
-                <Description>Admin</Description>
+                <Description Translatable="1">Admin</Description>
                 <Title Translatable="1">Service Level Agreements</Title>
                 <NavBarName>Admin</NavBarName>
                 <NavBarModule>
@@ -9159,7 +9159,7 @@
         <Setting>
             <FrontendModuleReg>
                 <Group>admin</Group>
-                <Description>Admin</Description>
+                <Description Translatable="1">Admin</Description>
                 <Title Translatable="1">Types</Title>
                 <NavBarName>Admin</NavBarName>
                 <NavBarModule>
@@ -9179,7 +9179,7 @@
         <Setting>
             <FrontendModuleReg>
                 <Group>admin</Group>
-                <Description>Admin</Description>
+                <Description Translatable="1">Admin</Description>
                 <Title Translatable="1">States</Title>
                 <NavBarName>Admin</NavBarName>
                 <NavBarModule>
@@ -9199,7 +9199,7 @@
         <Setting>
             <FrontendModuleReg>
                 <Group>admin</Group>
-                <Description>Admin</Description>
+                <Description Translatable="1">Admin</Description>
                 <Title Translatable="1">Priorities</Title>
                 <NavBarName>Admin</NavBarName>
                 <NavBarModule>
@@ -9219,7 +9219,7 @@
         <Setting>
             <FrontendModuleReg>
                 <Group>admin</Group>
-                <Description>Admin</Description>
+                <Description Translatable="1">Admin</Description>
                 <Title Translatable="1">GenericAgent</Title>
                 <NavBarName>Admin</NavBarName>
                 <NavBarModule>
@@ -9473,9 +9473,9 @@
         <SubGroup>Frontend::Customer::ModuleRegistration</SubGroup>
         <Setting>
             <FrontendModuleReg>
-                <Description>Overview of customer tickets</Description>
+                <Description Translatable="1">Overview of customer tickets</Description>
                 <NavBarName>Ticket</NavBarName>
-                <Title>Overview</Title>
+                <Title Translatable="1">Overview</Title>
                 <NavBar>
                     <Description Translatable="1">Tickets</Description>
                     <Name Translatable="1">Tickets</Name>
@@ -9518,9 +9518,9 @@
         <SubGroup>Frontend::Customer::ModuleRegistration</SubGroup>
         <Setting>
             <FrontendModuleReg>
-                <Description>Create tickets</Description>
+                <Description Translatable="1">Create tickets</Description>
                 <NavBarName>Ticket</NavBarName>
-                <Title>New Ticket</Title>
+                <Title Translatable="1">New Ticket</Title>
                 <NavBar>
                     <Description Translatable="1">Create new Ticket</Description>
                     <Name Translatable="1">New Ticket</Name>
@@ -9541,9 +9541,9 @@
         <SubGroup>Frontend::Customer::ModuleRegistration</SubGroup>
         <Setting>
             <FrontendModuleReg>
-                <Description>Ticket zoom view</Description>
+                <Description Translatable="1">Ticket zoom view</Description>
                 <NavBarName>Ticket</NavBarName>
-                <Title>Zoom</Title>
+                <Title Translatable="1">Zoom</Title>
                 <Loader>
                     <JavaScript>Core.Customer.TicketZoom.js</JavaScript>
                     <JavaScript>Core.UI.Popup.js</JavaScript>
@@ -9557,9 +9557,9 @@
         <SubGroup>Frontend::Customer::ModuleRegistration</SubGroup>
         <Setting>
             <FrontendModuleReg>
-                <Description>Customer Ticket Print Module</Description>
+                <Description Translatable="1">Customer Ticket Print Module</Description>
                 <NavBarName></NavBarName>
-                <Title>Print</Title>
+                <Title Translatable="1">Print</Title>
             </FrontendModuleReg>
         </Setting>
     </ConfigItem>
@@ -9569,7 +9569,7 @@
         <SubGroup>Frontend::Customer::ModuleRegistration</SubGroup>
         <Setting>
             <FrontendModuleReg>
-                <Description>To download attachments</Description>
+                <Description Translatable="1">To download attachments</Description>
                 <NavBarName></NavBarName>
                 <Title></Title>
             </FrontendModuleReg>
@@ -9581,9 +9581,9 @@
         <SubGroup>Frontend::Customer::ModuleRegistration</SubGroup>
         <Setting>
             <FrontendModuleReg>
-                <Description>Customer ticket search</Description>
+                <Description Translatable="1">Customer ticket search</Description>
                 <NavBarName>Ticket</NavBarName>
-                <Title>Search</Title>
+                <Title Translatable="1">Search</Title>
                 <NavBar>
                     <Description Translatable="1">Search</Description>
                     <Name Translatable="1">Search</Name>
@@ -9793,10 +9793,10 @@
         <SubGroup>Core::TicketACL</SubGroup>
         <Setting>
             <Option SelectedID="debug">
-                <Item Key="debug">Debug</Item>
-                <Item Key="info">Info</Item>
-                <Item Key="notice">Notice</Item>
-                <Item Key="error">Error</Item>
+                <Item Key="debug" Translatable="1">Debug</Item>
+                <Item Key="info" Translatable="1">Info</Item>
+                <Item Key="notice" Translatable="1">Notice</Item>
+                <Item Key="error" Translatable="1">Error</Item>
             </Option>
         </Setting>
     </ConfigItem>
@@ -10430,8 +10430,8 @@ Thanks for your help!
         <SubGroup>Frontend::Agent::Ticket::ViewZoom</SubGroup>
         <Setting>
             <Option SelectedID="1">
-                <Item Key="0">Based on global RichText setting</Item>
-                <Item Key="1">Always show RichText if available</Item>
+                <Item Key="0" Translatable="1">Based on global RichText setting</Item>
+                <Item Key="1" Translatable="1">Always show RichText if available</Item>
             </Option>
         </Setting>
     </ConfigItem>
@@ -10443,7 +10443,7 @@ Thanks for your help!
         <Setting>
             <FrontendModuleReg>
                 <Group>admin</Group>
-                <Description>Admin</Description>
+                <Description Translatable="1">Admin</Description>
                 <Title Translatable="1">Dynamic Fields GUI</Title>
                 <NavBarName>Admin</NavBarName>
                 <NavBarModule>
@@ -10494,7 +10494,7 @@ Thanks for your help!
         <Setting>
             <FrontendModuleReg>
                 <Group>admin</Group>
-                <Description>Admin</Description>
+                <Description Translatable="1">Admin</Description>
                 <Title Translatable="1">Dynamic Fields Text Backend GUI</Title>
                 <Loader>
                     <JavaScript>Core.Agent.Admin.DynamicField.js</JavaScript>
@@ -10510,7 +10510,7 @@ Thanks for your help!
         <Setting>
             <FrontendModuleReg>
                 <Group>admin</Group>
-                <Description>Admin</Description>
+                <Description Translatable="1">Admin</Description>
                 <Title Translatable="1">Dynamic Fields Checkbox Backend GUI</Title>
                 <Loader>
                     <JavaScript>Core.Agent.Admin.DynamicField.js</JavaScript>
@@ -10525,7 +10525,7 @@ Thanks for your help!
         <Setting>
             <FrontendModuleReg>
                 <Group>admin</Group>
-                <Description>Admin</Description>
+                <Description Translatable="1">Admin</Description>
                 <Title Translatable="1">Dynamic Fields Drop-down Backend GUI</Title>
                 <Loader>
                     <CSS>Core.Agent.Admin.DynamicField.css</CSS>
@@ -10542,7 +10542,7 @@ Thanks for your help!
         <Setting>
             <FrontendModuleReg>
                 <Group>admin</Group>
-                <Description>Admin</Description>
+                <Description Translatable="1">Admin</Description>
                 <Title Translatable="1">Dynamic Fields Date Time Backend GUI</Title>
                 <Loader>
                     <CSS>Core.Agent.Admin.DynamicField.css</CSS>
@@ -10560,7 +10560,7 @@ Thanks for your help!
         <Setting>
             <FrontendModuleReg>
                 <Group>admin</Group>
-                <Description>Admin</Description>
+                <Description Translatable="1">Admin</Description>
                 <Title Translatable="1">Dynamic Fields Multiselect Backend GUI</Title>
                 <Loader>
                     <CSS>Core.Agent.Admin.DynamicField.css</CSS>


### PR DESCRIPTION
To find all &lt;Description&gt; and &lt;Title&gt; tags, which have no Translatable="1" attribute, use the following command in a terminal:
<code>grep -Hn '&lt;Description\\|&lt;Title' Kernel/Config/Files/*.xml | grep -v 'Translatable'</code>