### PR TITLE
Added ExternalTicketNumberRecognitionCompletion to outgoing mails

### DIFF
--- a/Kernel/Config/Files/Ticket.xml
+++ b/Kernel/Config/Files/Ticket.xml
@@ -52,6 +52,17 @@
             </Option>
         </Setting>
     </ConfigItem>
+    <ConfigItem Name="Ticket::ExternalTicketNumberCompletionFormat" Required="0" Valid="1">
+        <Group>Ticket</Group>
+        <SubGroup>Core::Ticket</SubGroup>
+        <Description Translatable="1">The format of the subject. 'Left' means '[ExternalTicketNumber] [TicketHook#:12345] Some Subject', 'Right' means 'Some Subject [TicketHook#:12345] [ExternalTicketNumber]'.</Description>
+        <Setting>
+            <Option SelectedID="Left">
+                <Item Key="Left" Translatable="1">Left</Item>
+                <Item Key="Right" Translatable="1">Right</Item>
+            </Option>
+        </Setting>
+    </ConfigItem>
     <ConfigItem Name="Ticket::MergeDynamicFields" Required="1" Valid="1">
         <Description Translatable="1">A list of dynamic fields that are merged into the main ticket during a merge operation. Only dynamic fields that are empty in the main ticket will be set.</Description>
         <Group>Ticket</Group>

--- a/Kernel/Config/Files/Ticket.xml
+++ b/Kernel/Config/Files/Ticket.xml
@@ -10235,6 +10235,101 @@ Thanks for your help!
             </Hash>
         </Setting>
     </ConfigItem>
+    <ConfigItem Name="PostMaster::PreFilterModule###000-ExternalTicketNumberRecognition5" Required="0" Valid="0">
+        <Description Translatable="1">Recognize if a ticket is a follow-up to an existing ticket using an external ticket number.</Description>
+        <Group>Ticket</Group>
+        <SubGroup>Core::PostMaster</SubGroup>
+        <Setting>
+            <Hash>
+                <Item Key="Module">Kernel::System::PostMaster::Filter::ExternalTicketNumberRecognition</Item>
+                <Item Key="Name">Some Description</Item>
+                <Item Key="FromAddressRegExp">\s*@example.com</Item>
+                <Item Key="NumberRegExp">\s*Incident-(\d.*)\s*</Item>
+                <Item Key="SearchInSubject">1</Item>
+                <Item Key="SearchInBody">1</Item>
+                <Item Key="TicketStateTypes">new;open</Item>
+                <Item Key="DynamicFieldName">Name_X</Item>
+                <Item Key="SenderType">system</Item>
+                <Item Key="ArticleType">note-report</Item>
+            </Hash>
+        </Setting>
+    </ConfigItem>
+    <ConfigItem Name="PostMaster::PreFilterModule###000-ExternalTicketNumberRecognition6" Required="0" Valid="0">
+        <Description Translatable="1">Recognize if a ticket is a follow-up to an existing ticket using an external ticket number.</Description>
+        <Group>Ticket</Group>
+        <SubGroup>Core::PostMaster</SubGroup>
+        <Setting>
+            <Hash>
+                <Item Key="Module">Kernel::System::PostMaster::Filter::ExternalTicketNumberRecognition</Item>
+                <Item Key="Name">Some Description</Item>
+                <Item Key="FromAddressRegExp">\s*@example.com</Item>
+                <Item Key="NumberRegExp">\s*Incident-(\d.*)\s*</Item>
+                <Item Key="SearchInSubject">1</Item>
+                <Item Key="SearchInBody">1</Item>
+                <Item Key="TicketStateTypes">new;open</Item>
+                <Item Key="DynamicFieldName">Name_X</Item>
+                <Item Key="SenderType">system</Item>
+                <Item Key="ArticleType">note-report</Item>
+            </Hash>
+        </Setting>
+    </ConfigItem>
+    <ConfigItem Name="PostMaster::PreFilterModule###000-ExternalTicketNumberRecognition7" Required="0" Valid="0">
+        <Description Translatable="1">Recognize if a ticket is a follow-up to an existing ticket using an external ticket number.</Description>
+        <Group>Ticket</Group>
+        <SubGroup>Core::PostMaster</SubGroup>
+        <Setting>
+            <Hash>
+                <Item Key="Module">Kernel::System::PostMaster::Filter::ExternalTicketNumberRecognition</Item>
+                <Item Key="Name">Some Description</Item>
+                <Item Key="FromAddressRegExp">\s*@example.com</Item>
+                <Item Key="NumberRegExp">\s*Incident-(\d.*)\s*</Item>
+                <Item Key="SearchInSubject">1</Item>
+                <Item Key="SearchInBody">1</Item>
+                <Item Key="TicketStateTypes">new;open</Item>
+                <Item Key="DynamicFieldName">Name_X</Item>
+                <Item Key="SenderType">system</Item>
+                <Item Key="ArticleType">note-report</Item>
+            </Hash>
+        </Setting>
+    </ConfigItem>
+    <ConfigItem Name="PostMaster::PreFilterModule###000-ExternalTicketNumberRecognition8" Required="0" Valid="0">
+        <Description Translatable="1">Recognize if a ticket is a follow-up to an existing ticket using an external ticket number.</Description>
+        <Group>Ticket</Group>
+        <SubGroup>Core::PostMaster</SubGroup>
+        <Setting>
+            <Hash>
+                <Item Key="Module">Kernel::System::PostMaster::Filter::ExternalTicketNumberRecognition</Item>
+                <Item Key="Name">Some Description</Item>
+                <Item Key="FromAddressRegExp">\s*@example.com</Item>
+                <Item Key="NumberRegExp">\s*Incident-(\d.*)\s*</Item>
+                <Item Key="SearchInSubject">1</Item>
+                <Item Key="SearchInBody">1</Item>
+                <Item Key="TicketStateTypes">new;open</Item>
+                <Item Key="DynamicFieldName">Name_X</Item>
+                <Item Key="SenderType">system</Item>
+                <Item Key="ArticleType">note-report</Item>
+            </Hash>
+        </Setting>
+    </ConfigItem>
+    <ConfigItem Name="PostMaster::PreFilterModule###000-ExternalTicketNumberRecognition9" Required="0" Valid="0">
+        <Description Translatable="1">Recognize if a ticket is a follow-up to an existing ticket using an external ticket number.</Description>
+        <Group>Ticket</Group>
+        <SubGroup>Core::PostMaster</SubGroup>
+        <Setting>
+            <Hash>
+                <Item Key="Module">Kernel::System::PostMaster::Filter::ExternalTicketNumberRecognition</Item>
+                <Item Key="Name">Some Description</Item>
+                <Item Key="FromAddressRegExp">\s*@example.com</Item>
+                <Item Key="NumberRegExp">\s*Incident-(\d.*)\s*</Item>
+                <Item Key="SearchInSubject">1</Item>
+                <Item Key="SearchInBody">1</Item>
+                <Item Key="TicketStateTypes">new;open</Item>
+                <Item Key="DynamicFieldName">Name_X</Item>
+                <Item Key="SenderType">system</Item>
+                <Item Key="ArticleType">note-report</Item>
+            </Hash>
+        </Setting>
+    </ConfigItem>
     <ConfigItem Name="PostMaster::CheckFollowUpModule###0100-Subject" Required="1" Valid="1">
         <Description Translatable="1">Checks if an E-Mail is a followup to an existing ticket by searching the subject for a valid ticket number.</Description>
         <Group>Ticket</Group>

--- a/Kernel/System/Ticket.pm
+++ b/Kernel/System/Ticket.pm
@@ -89,6 +89,7 @@ sub new {
 
     @ISA = qw(
         Kernel::System::Ticket::Article
+        Kernel::System::Ticket::Article::ExternalTicketNumberCompletion
         Kernel::System::Ticket::TicketACL
         Kernel::System::Ticket::TicketSearch
         Kernel::System::EventHandler

--- a/Kernel/System/Ticket/Article.pm
+++ b/Kernel/System/Ticket/Article.pm
@@ -15,6 +15,8 @@ use POSIX qw(ceil);
 
 use Kernel::System::EmailParser;
 
+use Kernel::System::Ticket::Article::ExternalTicketNumberCompletion;
+
 use Kernel::System::VariableCheck qw(:all);
 
 our $ObjectManagerDisabled = 1;
@@ -2204,6 +2206,10 @@ sub ArticleSend {
     $Kernel::OM->Get('Kernel::System::HTMLUtils')->EmbeddedImagesExtract(
         DocumentRef    => \$Param{Body},
         AttachmentsRef => $Param{Attachment} || [],
+    );
+
+    $Param{Subject} = $Self->ExternalTicketNumberCompletion(
+        %Param,
     );
 
     # create article

--- a/Kernel/System/Ticket/Article/ExternalTicketNumberCompletion.pm
+++ b/Kernel/System/Ticket/Article/ExternalTicketNumberCompletion.pm
@@ -1,0 +1,76 @@
+package Kernel::System::Ticket::Article::ExternalTicketNumberCompletion;
+use Kernel::System::VariableCheck qw(:all);
+
+use strict;
+use warnings;
+
+sub ExternalTicketNumberCompletion {
+
+    my ( $Self, %Param ) = @_;
+
+    # check needed stuff
+    for (qw(TicketID Subject)) {
+        if ( !$Param{$_} ) {
+            $Kernel::OM->Get('Kernel::System::Log')->Log(
+                Priority => 'error',
+                Message  => "Need $_!"
+            );
+            return;
+        }
+    }
+
+    # Exit if sender is not an agent
+    if ($Param{SenderType}) {
+        return $Param{Subject} if ($Param{SenderType} =~ /customer/ );
+    }
+    if ($Param{SenderTypeID}) {
+        return $Param{Subject} if ($Param{SenderTypeID} == 3 );
+    }
+
+    # Exit if article type is not external
+    if ($Param{ArticleType}) {
+        return $Param{Subject} unless ($Param{ArticleType} =~ /ext/ );
+    }
+    if ($Param{ArticleTypeID}) {
+        return $Param{Subject} unless ($Param{ArticleTypeID} == 1 || $Param{ArticleTypeID} == 3 );
+    }
+
+    # Exit if no external ticket number recognition is activated
+    my $ConfigObject = $Kernel::OM->Get('Kernel::Config');
+    my $RecognitionFilter = $ConfigObject->Get('PostMaster::PreFilterModule');
+    
+    # Remove the MatchDBSource from Hash - only interested in the recognition
+    delete $RecognitionFilter->{'000-MatchDBSource'};
+    return $Param{Subject} unless IsHashRefWithData($RecognitionFilter);
+
+    # Get ticket and exit if no external ticket number were saved
+    my $TicketObject = $Kernel::OM->Get('Kernel::System::Ticket');
+    my %Ticket = $TicketObject->TicketGet(
+        TicketID      => $Param{TicketID},
+        DynamicFields => 1,
+        UserID        => 1,
+    );
+
+    RECOGNITIONFILTER:
+    foreach my $Filter (keys $RecognitionFilter) {
+        my $DynamicFieldName = "DynamicField_$RecognitionFilter->{$Filter}->{DynamicFieldName}";
+        if (!$Ticket{$DynamicFieldName}) {
+            next RECOGNITIONFILTER;
+        }
+
+        # Found a valid filter that actually saved a number to the ticket
+        my $Orientation = $ConfigObject->Get('Ticket::ExternalTicketNumberCompletionFormat') || 0;
+        # If number is not yet in the subject, add it.
+        if ($Param{Subject} !~ m{ $RecognitionFilter->{$Filter}->{NumberRegExp} }msx ) {
+
+             if ($Orientation eq 'Left') {
+                 return $Ticket{$DynamicFieldName} . " " . $Param{Subject};
+             } else {
+                 return $Param{Subject} . " " . $Ticket{$DynamicFieldName};
+             }
+        }
+    }
+    return $Param{Subject};
+}
+
+1;


### PR DESCRIPTION
OTRS does have the feature to recognize ExternalTicketNumbers and merge incoming mails. One of the requests we faced was, to add this number to outgoing mails if it's not in the subject already.

This PR adds a module that checks on outgoing mails whether a previously recognized ticketnumber is included in the subject and adds it if it's not. It does nothing if:
- The sender is not an agent
- The Article is not external
- ExternalTicketNumberRecognition is not activated
- The number is already in the subject

The format (left / right) can be configured in the sysconfig.

Also in this pull request I increased the number of recognition filters from 4 to 9.

As this is my first pull request, so please let me know if I don't comply with OTRS best practises.