### PR TITLE
[ Rel-5_0 Bug 8971 ] - NewPhoneTicket toolbar button - does not check group settings

### DIFF
--- a/Kernel/Config/Files/Ticket.xml
+++ b/Kernel/Config/Files/Ticket.xml
@@ -5716,7 +5716,7 @@
         </Setting>
     </ConfigItem>
     <ConfigItem Name="Frontend::ToolBarModule###1-Ticket::AgentTicketQueue" Required="0" Valid="0">
-        <Description Translatable="1">Toolbar Item for a shortcut.</Description>
+        <Description Translatable="1">Toolbar Item for a shortcut. Additional access control to show or not show this link can be done by using Key "Group" and Content like "rw:group1;move_into:group2".</Description>
         <Group>Ticket</Group>
         <SubGroup>Frontend::Agent::ToolBarModule</SubGroup>
         <Setting>
@@ -5733,7 +5733,7 @@
         </Setting>
     </ConfigItem>
     <ConfigItem Name="Frontend::ToolBarModule###2-Ticket::AgentTicketStatus" Required="0" Valid="0">
-        <Description Translatable="1">Toolbar Item for a shortcut.</Description>
+        <Description Translatable="1">Toolbar Item for a shortcut. Additional access control to show or not show this link can be done by using Key "Group" and Content like "rw:group1;move_into:group2".</Description>
         <Group>Ticket</Group>
         <SubGroup>Frontend::Agent::ToolBarModule</SubGroup>
         <Setting>
@@ -5750,7 +5750,7 @@
         </Setting>
     </ConfigItem>
     <ConfigItem Name="Frontend::ToolBarModule###3-Ticket::AgentTicketEscalation" Required="0" Valid="0">
-        <Description Translatable="1">Toolbar Item for a shortcut.</Description>
+        <Description Translatable="1">Toolbar Item for a shortcut. Additional access control to show or not show this link can be done by using Key "Group" and Content like "rw:group1;move_into:group2".</Description>
         <Group>Ticket</Group>
         <SubGroup>Frontend::Agent::ToolBarModule</SubGroup>
         <Setting>
@@ -5767,7 +5767,7 @@
         </Setting>
     </ConfigItem>
     <ConfigItem Name="Frontend::ToolBarModule###4-Ticket::AgentTicketPhone" Required="0" Valid="0">
-        <Description Translatable="1">Toolbar Item for a shortcut.</Description>
+        <Description Translatable="1">Toolbar Item for a shortcut. Additional access control to show or not show this link can be done by using Key "Group" and Content like "rw:group1;move_into:group2".</Description>
         <Group>Ticket</Group>
         <SubGroup>Frontend::Agent::ToolBarModule</SubGroup>
         <Setting>
@@ -5784,7 +5784,7 @@
         </Setting>
     </ConfigItem>
     <ConfigItem Name="Frontend::ToolBarModule###5-Ticket::AgentTicketEmail" Required="0" Valid="0">
-        <Description Translatable="1">Toolbar Item for a shortcut.</Description>
+        <Description Translatable="1">Toolbar Item for a shortcut. Additional access control to show or not show this link can be done by using Key "Group" and Content like "rw:group1;move_into:group2".</Description>
         <Group>Ticket</Group>
         <SubGroup>Frontend::Agent::ToolBarModule</SubGroup>
         <Setting>
@@ -5801,7 +5801,7 @@
         </Setting>
     </ConfigItem>
     <ConfigItem Name="Frontend::ToolBarModule###6-Ticket::AgentTicketProcess" Required="0" Valid="0">
-        <Description Translatable="1">Toolbar Item for a shortcut.</Description>
+        <Description Translatable="1">Toolbar Item for a shortcut. Additional access control to show or not show this link can be done by using Key "Group" and Content like "rw:group1;move_into:group2".</Description>
         <Group>Ticket</Group>
         <SubGroup>Frontend::Agent::ToolBarModule</SubGroup>
         <Setting>
@@ -5818,7 +5818,7 @@
         </Setting>
     </ConfigItem>
     <ConfigItem Name="Frontend::ToolBarModule###7-Ticket::TicketResponsible" Required="0" Valid="1">
-        <Description Translatable="1">Agent interface notification module to see the number of tickets an agent is responsible for.</Description>
+        <Description Translatable="1">Agent interface notification module to see the number of tickets an agent is responsible for. Additional access control to show or not show this link can be done by using Key "Group" and Content like "rw:group1;move_into:group2".</Description>
         <Group>Ticket</Group>
         <SubGroup>Frontend::Agent::ToolBarModule</SubGroup>
         <Setting>
@@ -5838,7 +5838,7 @@
         </Setting>
     </ConfigItem>
     <ConfigItem Name="Frontend::ToolBarModule###8-Ticket::TicketWatcher" Required="0" Valid="1">
-        <Description Translatable="1">Agent interface notification module to see the number of watched tickets.</Description>
+        <Description Translatable="1">Agent interface notification module to see the number of watched tickets. Additional access control to show or not show this link can be done by using Key "Group" and Content like "rw:group1;move_into:group2".</Description>
         <Group>Ticket</Group>
         <SubGroup>Frontend::Agent::ToolBarModule</SubGroup>
         <Setting>
@@ -5858,7 +5858,7 @@
         </Setting>
     </ConfigItem>
     <ConfigItem Name="Frontend::ToolBarModule###9-Ticket::TicketLocked" Required="0" Valid="1">
-        <Description Translatable="1">Agent interface notification module to see the number of locked tickets.</Description>
+        <Description Translatable="1">Agent interface notification module to see the number of locked tickets. Additional access control to show or not show this link can be done by using Key "Group" and Content like "rw:group1;move_into:group2".</Description>
         <Group>Ticket</Group>
         <SubGroup>Frontend::Agent::ToolBarModule</SubGroup>
         <Setting>
@@ -5881,7 +5881,7 @@
     the standard link module
     -->
     <ConfigItem Name="Frontend::ToolBarModule###10-Ticket::AgentTicketService" Required="0" Valid="0">
-        <Description Translatable="1">Agent interface notification module to see the number of tickets in My Services.</Description>
+        <Description Translatable="1">Agent interface notification module to see the number of tickets in My Services. Additional access control to show or not show this link can be done by using Key "Group" and Content like "rw:group1;move_into:group2".</Description>
         <Group>Ticket</Group>
         <SubGroup>Frontend::Agent::ToolBarModule</SubGroup>
         <Setting>
@@ -5894,7 +5894,7 @@
         </Setting>
     </ConfigItem>
     <ConfigItem Name="Frontend::ToolBarModule###11-Ticket::TicketSearchProfile" Required="0" Valid="0">
-        <Description Translatable="1">Agent interface module to access search profiles via nav bar.</Description>
+        <Description Translatable="1">Agent interface module to access search profiles via nav bar. Additional access control to show or not show this link can be done by using Key "Group" and Content like "rw:group1;move_into:group2".</Description>
         <Group>Ticket</Group>
         <SubGroup>Frontend::Agent::ToolBarModule</SubGroup>
         <Setting>
@@ -5909,7 +5909,7 @@
         </Setting>
     </ConfigItem>
     <ConfigItem Name="Frontend::ToolBarModule###12-Ticket::TicketSearchFulltext" Required="0" Valid="0">
-        <Description Translatable="1">Agent interface module to access fulltext search via nav bar.</Description>
+        <Description Translatable="1">Agent interface module to access fulltext search via nav bar. Additional access control to show or not show this link can be done by using Key "Group" and Content like "rw:group1;move_into:group2".</Description>
         <Group>Ticket</Group>
         <SubGroup>Frontend::Agent::ToolBarModule</SubGroup>
         <Setting>
@@ -5925,7 +5925,7 @@
         </Setting>
     </ConfigItem>
     <ConfigItem Name="Frontend::ToolBarModule###13-CICSearchCustomerID" Required="0" Valid="0">
-        <Description Translatable="1">Agent interface module to access CIC search via nav bar.</Description>
+        <Description Translatable="1">Agent interface module to access CIC search via nav bar. Additional access control to show or not show this link can be done by using Key "Group" and Content like "rw:group1;move_into:group2".</Description>
         <Group>Ticket</Group>
         <SubGroup>Frontend::Agent::ToolBarModule</SubGroup>
         <Setting>
@@ -5941,7 +5941,7 @@
         </Setting>
     </ConfigItem>
     <ConfigItem Name="Frontend::ToolBarModule###14-CICSearchCustomerUser" Required="0" Valid="0">
-        <Description Translatable="1">Agent interface module to access CIC search via nav bar.</Description>
+        <Description Translatable="1">Agent interface module to access CIC search via nav bar. Additional access control to show or not show this link can be done by using Key "Group" and Content like "rw:group1;move_into:group2".</Description>
         <Group>Ticket</Group>
         <SubGroup>Frontend::Agent::ToolBarModule</SubGroup>
         <Setting>

--- a/scripts/test/Selenium/Output/ToolBar/GroupRestriction.t
+++ b/scripts/test/Selenium/Output/ToolBar/GroupRestriction.t
@@ -1,0 +1,256 @@
+# --
+# Copyright (C) 2001-2015 OTRS AG, http://otrs.com/
+# --
+# This software comes with ABSOLUTELY NO WARRANTY. For details, see
+# the enclosed file COPYING for license information (AGPL). If you
+# did not receive this file, see http://www.gnu.org/licenses/agpl.txt.
+# --
+
+use strict;
+use warnings;
+use utf8;
+
+use vars (qw($Self));
+
+# get selenium object
+my $Selenium = $Kernel::OM->Get('Kernel::System::UnitTest::Selenium');
+
+$Selenium->RunTest(
+    sub {
+
+        # get helper object
+        $Kernel::OM->ObjectParamAdd(
+            'Kernel::System::UnitTest::Helper' => {
+                RestoreSystemConfiguration => 1,
+            },
+        );
+        my $Helper          = $Kernel::OM->Get('Kernel::System::UnitTest::Helper');
+        my $GroupObject     = $Kernel::OM->Get('Kernel::System::Group');
+        my $SysConfigObject = $Kernel::OM->Get('Kernel::System::SysConfig');
+        my $TicketObject    = $Kernel::OM->Get('Kernel::System::Ticket');
+        my $DBObject        = $Kernel::OM->Get('Kernel::System::DB');
+
+        # enable ticket responsible
+        $SysConfigObject->ConfigItemUpdate(
+            Valid => 1,
+            Key   => 'Ticket::Responsible',
+            Value => 1
+        );
+
+        # enable ticket watcher feature
+        $SysConfigObject->ConfigItemUpdate(
+            Valid => 1,
+            Key   => 'Ticket::Watcher',
+            Value => 1
+        );
+
+        # create test group
+        my $TestGroup   = 'Group' . $Helper->GetRandomID();
+        my $TestGroupID = $GroupObject->GroupAdd(
+            Name    => $TestGroup,
+            ValidID => 1,
+            UserID  => 1,
+        );
+        $Self->True(
+            $TestGroupID,
+            "$TestGroup - created",
+        );
+
+        # get test params
+        my @Tests = (
+            {
+                ToolBarModule => '1-Ticket::AgentTicketQueue',
+                CssClassCheck => 'QueueView',
+            },
+            {
+                ToolBarModule => '2-Ticket::AgentTicketStatus',
+                CssClassCheck => 'StatusView',
+            },
+            {
+                ToolBarModule => '3-Ticket::AgentTicketEscalation',
+                CssClassCheck => 'EscalationView',
+            },
+            {
+                ToolBarModule => '4-Ticket::AgentTicketPhone',
+                CssClassCheck => 'PhoneTicket',
+            },
+            {
+                ToolBarModule => '5-Ticket::AgentTicketEmail',
+                CssClassCheck => 'EmailTicket',
+            },
+            {
+                ToolBarModule => '6-Ticket::AgentTicketProcess',
+                CssClassCheck => 'ProcessTicket',
+            },
+            {
+                ToolBarModule => '7-Ticket::TicketResponsible',
+                CssClassCheck => 'Responsible',
+            },
+            {
+                ToolBarModule => '8-Ticket::TicketWatcher',
+                CssClassCheck => 'Watcher',
+            },
+            {
+                ToolBarModule => '9-Ticket::TicketLocked',
+                CssClassCheck => 'Locked',
+            },
+        );
+
+        # set group restriction for each toolbar module
+        for my $ConfigUpdate (@Tests) {
+            my %ToolBarConfig = $SysConfigObject->ConfigItemGet(
+                Name    => 'Frontend::ToolBarModule###' . $ConfigUpdate->{ToolBarModule},
+                Default => 1,
+            );
+
+            %ToolBarConfig = map { $_->{Key} => $_->{Content} }
+                grep { defined $_->{Key} } @{ $ToolBarConfig{Setting}->[1]->{Hash}->[1]->{Item} };
+
+            $ToolBarConfig{Group} = "ro:$TestGroup";
+
+            $SysConfigObject->ConfigItemUpdate(
+                Valid => 1,
+                Key   => 'Frontend::ToolBarModule###' . $ConfigUpdate->{ToolBarModule},
+                Value => \%ToolBarConfig,
+            );
+        }
+
+        # create test user
+        my $TestUserLogin = $Helper->TestUserCreate(
+            Groups => [ 'admin', 'users' ],
+        ) || die "Did not get test user";
+
+        # get test user ID
+        my $TestUserID = $Kernel::OM->Get('Kernel::System::User')->UserLookup(
+            UserLogin => $TestUserLogin,
+        );
+
+        # create test ticket
+        my $TicketID = $TicketObject->TicketCreate(
+            Title         => 'Some Ticket Title',
+            Queue         => 'Raw',
+            Lock          => 'lock',
+            Priority      => '3 normal',
+            State         => 'new',
+            CustomerID    => '123465',
+            CustomerUser  => 'customer@example.com',
+            OwnerID       => $TestUserID,
+            ResponsibleID => $TestUserID,
+            UserID        => $TestUserID,
+        );
+        $Self->True(
+            $TicketID,
+            "Ticket ID $TicketID - created"
+        );
+
+        # set test user watch subscription for test ticket
+        my $Success = $TicketObject->TicketWatchSubscribe(
+            TicketID    => $TicketID,
+            WatchUserID => $TestUserID,
+            UserID      => 1,
+        );
+        $Self->True(
+            $TicketID,
+            "User $TestUserLogin subscribed for test ticket ID $TicketID"
+        );
+
+        # give test user ro permission for test group
+        $Success = $GroupObject->PermissionGroupUserAdd(
+            GID        => $TestGroupID,
+            UID        => $TestUserID,
+            Permission => {
+                ro => 1,
+            },
+            UserID => 1,
+        );
+        $Self->True(
+            $Success,
+            "For User $TestUserLogin set 'ro' permission in group $TestGroup",
+        );
+
+        # login test user
+        $Selenium->Login(
+            Type     => 'Agent',
+            User     => $TestUserLogin,
+            Password => $TestUserLogin,
+        );
+
+        # first check all toolbar modules are visible for test user
+        for my $FirstCheck (@Tests) {
+
+            # verify toolbar module is loaded for user
+            my $ClassCheck = $FirstCheck->{CssClassCheck};
+            $Self->Is(
+                $Selenium->execute_script(
+                    "return \$('#ToolBar li').hasClass('$ClassCheck')"
+                ),
+                '1',
+                "ToolBar $FirstCheck->{ToolBarModule} for User $TestUserLogin - found",
+            );
+        }
+
+        # remove test user ro permission for test group
+        $Success = $GroupObject->PermissionGroupUserAdd(
+            GID        => $TestGroupID,
+            UID        => $TestUserID,
+            Permission => {
+                ro => 0,
+            },
+            UserID => 1,
+        );
+        $Self->True(
+            $Success,
+            "For User $TestUserLogin removed 'ro' permission in group $TestGroup",
+        );
+
+        # refresh screen
+        $Selenium->refresh();
+
+        # second check all toolbar modules are not visible for test user
+        for my $SecondCheck (@Tests) {
+
+            # verify toolbar is removed for test user
+            my $ClassCheck = $SecondCheck->{CssClassCheck};
+            $Self->Is(
+                $Selenium->execute_script(
+                    "return \$('#ToolBar li').hasClass('$ClassCheck')"
+                ),
+                '0',
+                "ToolBar $SecondCheck->{ToolBarModule} for User $TestUserLogin - removed",
+            );
+        }
+
+        # delete test group
+        $TestGroup = $DBObject->Quote($TestGroup);
+        $Success   = $DBObject->Do(
+            SQL  => "DELETE FROM groups WHERE name = ?",
+            Bind => [ \$TestGroup ],
+        );
+        $Self->True(
+            $Success,
+            "$TestGroup - deleted",
+        );
+
+        # delete test ticket
+        $Success = $TicketObject->TicketDelete(
+            TicketID => $TicketID,
+            UserID   => 1,
+        );
+        $Self->True(
+            $Success,
+            "Ticket ID $TicketID - deleted"
+        );
+
+        # make sure cache is correct
+        for my $Cache (
+            qw (Ticket Group)
+            )
+        {
+            $Kernel::OM->Get('Kernel::System::Cache')->CleanUp(
+                Type => $Cache,
+            );
+        }
+    }
+);
+
+1;


### PR DESCRIPTION
http://bugs.otrs.org/show_bug.cgi?id=8971

Hello @mgruner ,

Hereby is our proposal for fixing this issue. It could be advocated both ways as a bug and a new feature. IMO this is more of a new feature then a bug in system. Saying this, we thought that idea can have it's advantages so we implemented it.

Added in Header - Layout.pm check if Group key is set in SysConfig to confirm does user have permission to see that link and accordingly to show it or not. 
Additionally included more description for ToolBar modules in SysConfig, so user can be informed of feature and how to use it properly.
Lastly there is Selenium test in ToolBar/GroupRestriction.t for testing this functionality.

Please let me know if there are any question or issues regarding this PR.

Regards,
Sanjin