### PR TITLE
Fix AutoResponseSet if AutoResponseForWebTickets is set 0

### DIFF
--- a/scripts/test/AutoResponseSent.t
+++ b/scripts/test/AutoResponseSent.t
@@ -171,9 +171,7 @@ for my $Test (@Tests) {
         HistoryComment   => 'Some free text!',
         UserID           => 1,
         UnlockOnAway     => 1,
-        AutoResponseType => ( $ConfigObject->Get('AutoResponseForWebTickets') )
-        ? $Test->{AutoResponseType}
-        : '',
+        AutoResponseType => $Test->{AutoResponseType},
         OrigHeader => {
             From    => '"test" <test@localunittest.com>',
             To      => $QueueName,
@@ -260,9 +258,7 @@ for my $Test (@Tests) {
         HistoryComment   => 'Some free text!',
         UserID           => 1,
         UnlockOnAway     => 1,
-        AutoResponseType => ( $ConfigObject->Get('AutoResponseForWebTickets') )
-        ? $Test->{AutoResponseType}
-        : '',
+        AutoResponseType => $Test->{AutoResponseType},
         OrigHeader => {
             From    => '"test" <test@localunittest.com>',
             To      => $QueueName,


### PR DESCRIPTION
With this patch, the test passes regardless of the AutoResponseForWebTickets setting.