### PR TITLE
[ Master Bug 11728 ] - Dashboard Widget: Attributes OwnerIDs is not working

### DIFF
--- a/Kernel/Output/HTML/Dashboard/TicketGeneric.pm
+++ b/Kernel/Output/HTML/Dashboard/TicketGeneric.pm
@@ -676,8 +676,8 @@ sub Run {
     # get config object
     my $ConfigObject = $Kernel::OM->Get('Kernel::Config');
 
-    # show also watcher if feature is enabled
-    if ( $ConfigObject->Get('Ticket::Watcher') ) {
+    # show also watcher if feature is enabled and there is a watcher filter
+    if ( $ConfigObject->Get('Ticket::Watcher') && $TicketSearchSummary{Watcher} ) {
         $LayoutObject->Block(
             Name => 'ContentLargeTicketGenericFilterWatcher',
             Data => {
@@ -689,8 +689,8 @@ sub Run {
         );
     }
 
-    # show also responsible if feature is enabled
-    if ( $ConfigObject->Get('Ticket::Responsible') ) {
+    # show also responsible if feature is enabled and there is a responsible filter
+    if ( $ConfigObject->Get('Ticket::Responsible') && $TicketSearchSummary{Responsible} ) {
         $LayoutObject->Block(
             Name => 'ContentLargeTicketGenericFilterResponsible',
             Data => {
@@ -2103,16 +2103,16 @@ sub _SearchParamsGet {
 
     my %TicketSearchSummary = (
         Locked => {
-            OwnerIDs => [ $Self->{UserID}, ],
-            LockIDs  => [ '2', '3' ],           # 'lock' and 'tmp_lock'
+            OwnerIDs => $TicketSearch{OwnerIDs} // [ $Self->{UserID}, ],
+            LockIDs => [ '2', '3' ],    # 'lock' and 'tmp_lock'
         },
         Watcher => {
-            WatchUserIDs => [ $Self->{UserID}, ],
-            LockIDs      => $TicketSearch{LockIDs} // undef,
+            WatchUserIDs => $TicketSearch{OwnerIDs} // [ $Self->{UserID}, ],
+            LockIDs      => $TicketSearch{LockIDs}  // undef,
         },
         Responsible => {
-            ResponsibleIDs => [ $Self->{UserID}, ],
-            LockIDs        => $TicketSearch{LockIDs} // undef,
+            ResponsibleIDs => $TicketSearch{OwnerIDs} // [ $Self->{UserID}, ],
+            LockIDs        => $TicketSearch{LockIDs}  // undef,
         },
         MyQueues => {
             QueueIDs => \@MyQueues,
@@ -2124,13 +2124,21 @@ sub _SearchParamsGet {
             LockIDs    => $TicketSearch{LockIDs} // undef,
         },
         All => {
-            OwnerIDs => undef,
-            LockIDs  => $TicketSearch{LockIDs} // undef,
+            OwnerIDs => $TicketSearch{OwnerIDs} // undef,
+            LockIDs  => $TicketSearch{LockIDs}  // undef,
         },
     );
 
     if ( defined $TicketSearch{LockIDs} || defined $TicketSearch{Locks} ) {
         delete $TicketSearchSummary{Locked};
+    }
+
+    if ( defined $TicketSearch{WatchUserIDs} ) {
+        delete $TicketSearchSummary{Watcher};
+    }
+
+    if ( defined $TicketSearch{ResponsibleIDs} ) {
+        delete $TicketSearchSummary{Responsible};
     }
 
     if ( defined $TicketSearch{QueueIDs} || defined $TicketSearch{Queues} ) {


### PR DESCRIPTION
http://bugs.otrs.org/show_bug.cgi?id=11728

Hi @mgruner ,

There is our proposal for fixing this bug. As you know there were many bugs similar to this one. I think that, with this possibility there you can add as many attributes as you want in SySConfig, it could cause many another problems with the filters on the Dashboard. Maybe there is needed big refactoring this code. 
I am not sure if we can do that, but for example if we add in atributes OwnerIDs, ResponsibleIDs, WatchUserIDs in the same time this filters will not be usable at all. I know this is extreme case but I saw that we fix this  TicketSearchSummary in any case when somebody want to add new attribute in SysConfig :) 

Maybe it is not so important and does not have top priority, but this is time for thinking about that and exchange ideas. Please let me know if we can help about that.


P.S. 
There is another PR which maybe could made merge conflict because the changes are on the same file. 
https://github.com/OTRS/otrs/pull/853/files 
If there will be need rebase PR please let me know.

Regards
Zoran