### PR TITLE
Improved box sizing of input fields.

### DIFF
--- a/var/httpd/htdocs/skins/Agent/default/css/Core.Form.css
+++ b/var/httpd/htdocs/skins/Agent/default/css/Core.Form.css
@@ -61,6 +61,7 @@ textarea {
     padding: 3px;
     font-size: 12px;
     color: #333;
+    box-sizing: border-box;
 }
 
 input[type=text]:focus,


### PR DESCRIPTION
Hi there,

thanks to @mrflix for giving us a hint to use this CSS attribute to align the input fields properly. This has positive effects for all kind of fields like dropdown, text etc.

Before:
![before](https://cloud.githubusercontent.com/assets/3873515/11689185/0298b796-9e91-11e5-9b0c-30b6440281a0.png)

After:
![after](https://cloud.githubusercontent.com/assets/3873515/11689186/029b2e36-9e91-11e5-873b-5f6997a4e74b.png)

In case you will apply this PR it would be great if your could cherry-pick it for OTRS 3.3, 4 and 5, too.

Greetings,
  Thorsten