### PR TITLE
Fix `bin/otrs.SetPermissions.pl` when the application directory is accessed through a symlink

### DIFF
--- a/bin/otrs.SetPermissions.pl
+++ b/bin/otrs.SetPermissions.pl
@@ -21,6 +21,7 @@
 use strict;
 use warnings;
 
+use Cwd qw(abs_path);
 use File::Basename;
 use FindBin qw($RealBin);
 use lib dirname($RealBin);
@@ -31,7 +32,7 @@ use File::Find();
 use File::stat();
 use Getopt::Long();
 
-my $OTRSDirectory       = dirname($RealBin);
+my $OTRSDirectory       = abs_path(dirname($RealBin));
 my $OTRSDirectoryLength = length($OTRSDirectory);
 
 my $OtrsUser   = 'otrs';    # default otrs


### PR DESCRIPTION
When the path, which is used to execute `bin/otrs.SetPermissions.pl`
contains a symlink component, the permissions will only be set for the
symlink itself, but `bin/otrs.SetPermissions.pl` won't recurse into the
OTRS directory itself, e.g. `/opt/otrs` points to `/opt/otrs-5.0.3` and
for the execution `/opt/otrs/bin/otrs.SetPermissions.pl` is used, then
the usage of `dirname` in `bin/otrs.SetPermissions.pl` will only dissect
the path of the executed script (to `/opt/otrs`), but won't resolve the symlink.

Any further mode/permission changes will now only be carried on the
symlink itself, which is just a file to those. By resolving the symlink
to the actual application directory first using `Cwd::abs_path()`, this problem
will be circumvented.