### PR TITLE
[ Rel-5_0 Bug 9241 ] - Ticket searching in GenericAgent not working as expected

### DIFF
--- a/Kernel/Modules/AdminGenericAgent.pm
+++ b/Kernel/Modules/AdminGenericAgent.pm
@@ -1258,23 +1258,27 @@ sub _MaskRun {
 
     # perform ticket search
     my $Counter = $TicketObject->TicketSearch(
-        Result          => 'COUNT',
-        SortBy          => 'Age',
-        OrderBy         => 'Down',
-        UserID          => 1,
-        Limit           => 60_000,
-        ConditionInline => 1,
+        Result              => 'COUNT',
+        SortBy              => 'Age',
+        OrderBy             => 'Down',
+        UserID              => 1,
+        Limit               => 60_000,
+        ConditionInline     => 1,
+        ContentSearchPrefix => '*',
+        ContentSearchSuffix => '*',
         %JobData,
         %DynamicFieldSearchParameters,
     ) || 0;
 
     my @TicketIDs = $TicketObject->TicketSearch(
-        Result          => 'ARRAY',
-        SortBy          => 'Age',
-        OrderBy         => 'Down',
-        UserID          => 1,
-        Limit           => 30,
-        ConditionInline => 1,
+        Result              => 'ARRAY',
+        SortBy              => 'Age',
+        OrderBy             => 'Down',
+        UserID              => 1,
+        Limit               => 30,
+        ConditionInline     => 1,
+        ContentSearchPrefix => '*',
+        ContentSearchSuffix => '*',
         %JobData,
         %DynamicFieldSearchParameters,
     );

--- a/Kernel/System/GenericAgent.pm
+++ b/Kernel/System/GenericAgent.pm
@@ -453,9 +453,11 @@ sub JobRun {
             %Tickets = $TicketObject->TicketSearch(
                 %Job,
                 %DynamicFieldSearchParameters,
-                ConditionInline => 1,
-                Limit           => $Param{Limit} || $RunLimit,
-                UserID          => $Param{UserID},
+                ConditionInline     => 1,
+                Limit               => $Param{Limit} || $RunLimit,
+                ContentSearchPrefix => '*',
+                ContentSearchSuffix => '*',
+                UserID              => $Param{UserID},
             );
         }
         elsif ( ref $Job{Queue} eq 'ARRAY' ) {

--- a/scripts/test/Selenium/Agent/Admin/AdminGenericAgent.t
+++ b/scripts/test/Selenium/Agent/Admin/AdminGenericAgent.t
@@ -54,7 +54,8 @@ $Selenium->RunTest(
         my $ScriptAlias = $ConfigObject->Get('ScriptAlias');
 
         # create test tickets
-        my $TestTicketTitle = 'TestTicketGenericAgent';
+        my $TestTicketRandomID = $Helper->GetRandomID();
+        my $TestTicketTitle    = "Test Ticket $TestTicketRandomID Generic Agent";
         my @TicketNumbers;
         for ( 1 .. 20 ) {
 
@@ -99,8 +100,9 @@ $Selenium->RunTest(
         $Selenium->execute_script('$(".WidgetSimple.Collapsed .WidgetAction.Toggle a").click();');
 
         # create test job
+        my $GenericTicketSearch = "*Ticket $TestTicketRandomID Generic*";
         $Selenium->find_element( "#Profile", 'css' )->send_keys($RandomID);
-        $Selenium->find_element( "#Title",   'css' )->send_keys($TestTicketTitle);
+        $Selenium->find_element( "#Title",   'css' )->send_keys($GenericTicketSearch);
         $Selenium->find_element( "#Profile", 'css' )->submit();
 
         $Selenium->WaitFor( JavaScript => 'return typeof($) === "function" && $("i.fa-trash-o").length' );


### PR DESCRIPTION
http://bugs.otrs.org/show_bug.cgi?id=9241

Hello @mgruner ,

Hereby is our proposal for fixing this issue. There were no ContentSearch params when calling TicketSearch() in AdminGenericAgent.pm resulting in broken results when trying to search by part of a string. Added in backend part as well those parameters, so found tickets can be processed. Generic agent with these changes behave in same fashion as AgentTicketSearch allowing results by partial search.

Updated Selenium test to simulate this kind of behaviour. Please let me know what do you think about this proposal.

Regards,
Sanjin