### PR TITLE
Master - Removed GetTableData from AdminQueue

### DIFF
--- a/Kernel/Modules/AdminQueue.pm
+++ b/Kernel/Modules/AdminQueue.pm
@@ -475,15 +475,11 @@ sub _Edit {
         Class      => 'Modernize Validate_Required ' . ( $Param{Errors}->{'ValidIDInvalid'} || '' ),
     );
 
-    my $DBObject = $Kernel::OM->Get('Kernel::System::DB');
-
     $Param{GroupOption} = $LayoutObject->BuildSelection(
         Data => {
-            $DBObject->GetTableData(
-                What  => 'id, name',
-                Table => 'groups',
+            $Kernel::OM->Get('Kernel::System::Group')->GroupList(
                 Valid => 1,
-            ),
+                )
         },
         Translation => 0,
         Name        => 'GroupID',
@@ -653,12 +649,11 @@ sub _Edit {
         SelectedID  => $Param{SalutationID},
         Class => 'Modernize Validate_Required ' . ( $Param{Errors}->{'SalutationIDInvalid'} || '' ),
     );
+
     $Param{FollowUpOption} = $LayoutObject->BuildSelection(
         Data => {
-            $DBObject->GetTableData(
-                What  => 'id, name',
-                Valid => 1,
-                Table => 'follow_up_possible',
+            $QueueObject->GetFollowUpOptionList(
+                Valid => 0,
             ),
         },
         Name       => 'FollowUpID',

--- a/Kernel/System/Group.pm
+++ b/Kernel/System/Group.pm
@@ -346,55 +346,39 @@ sub GroupList {
     );
     return %{$Cache} if $Cache;
 
-    # get valid ids
-    my @ValidIDs = $Kernel::OM->Get('Kernel::System::Valid')->ValidIDsGet();
+    # create the valid list
+    my $ValidIDs = join ', ', $Kernel::OM->Get('Kernel::System::Valid')->ValidIDsGet();
 
-    # get group data list
-    my %GroupDataList = $Self->GroupDataList();
+    # build SQL
+    my $SQL = 'SELECT id, name FROM groups';
 
-    my %GroupListValid;
-    my %GroupListAll;
-    KEY:
-    for my $Key ( sort keys %GroupDataList ) {
-
-        next KEY if !$Key;
-
-        # add group to the list of all groups
-        $GroupListAll{$Key} = $GroupDataList{$Key}->{Name};
-
-        my $Match;
-        VALIDID:
-        for my $ValidID (@ValidIDs) {
-
-            next VALIDID if $ValidID ne $GroupDataList{$Key}->{ValidID};
-
-            $Match = 1;
-
-            last VALIDID;
-        }
-
-        next KEY if !$Match;
-
-        # add group to the list of valid groups
-        $GroupListValid{$Key} = $GroupDataList{$Key}->{Name};
+    # add WHERE statement
+    if ($Valid) {
+        $SQL .= ' WHERE valid_id IN (' . $ValidIDs . ')';
     }
 
-    # set cache
-    $CacheObject->Set(
-        Type  => 'Group',
-        Key   => 'GroupList::0',
-        TTL   => 60 * 60 * 24 * 20,
-        Value => \%GroupListAll,
-    );
-    $CacheObject->Set(
-        Type  => 'Group',
-        Key   => 'GroupList::1',
-        TTL   => 60 * 60 * 24 * 20,
-        Value => \%GroupListValid,
+    # get database object
+    my $DBObject = $Kernel::OM->Get('Kernel::System::DB');
+
+    # get group data from database
+    return if !$DBObject->Prepare(
+        SQL => $SQL,
     );
 
-    return %GroupListValid if $Valid;
-    return %GroupListAll;
+    # fetch the result
+    my %GroupList;
+    while ( my @Row = $DBObject->FetchrowArray() ) {
+        $GroupList{ $Row[0] } = $Row[1];
+    }
+
+    $CacheObject->Set(
+        Type  => 'Group',
+        Key   => $CacheKey,
+        TTL   => 60 * 60 * 24 * 20,
+        Value => \%GroupList,
+    );
+
+    return %GroupList;
 }
 
 =item GroupDataList()

--- a/Kernel/System/Queue.pm
+++ b/Kernel/System/Queue.pm
@@ -636,6 +636,58 @@ sub GetFollowUpOption {
     return $Return;
 }
 
+=item GetFollowUpOptionList()
+
+get Follow-Up Option list
+
+    my %FollowUpOptionList = $QueueObject->GetFollowUpOptionList(
+        Valid => 0,             # (optional) default 1
+    );
+
+Return:
+
+    %FollowUpOptionList = (
+              '1' => 'possible',
+              '3' => 'new ticket',
+              '2' => 'reject'
+            )
+
+=cut
+
+sub GetFollowUpOptionList {
+    my ( $Self, %Param ) = @_;
+
+    # set default value
+    my $Valid = $Param{Valid} ? 1 : 0;
+
+    # create the valid list
+    my $ValidIDs = join ', ', $Kernel::OM->Get('Kernel::System::Valid')->ValidIDsGet();
+
+    # build SQL
+    my $SQL = 'SELECT id, name FROM follow_up_possible';
+
+    # add WHERE statement
+    if ($Valid) {
+        $SQL .= ' WHERE valid_id IN (' . $ValidIDs . ')';
+    }
+
+    # get database object
+    my $DBObject = $Kernel::OM->Get('Kernel::System::DB');
+
+    # get data from database
+    return if !$DBObject->Prepare(
+        SQL => $SQL,
+    );
+
+    # fetch the result
+    my %FollowUpOptionList;
+    while ( my @Row = $DBObject->FetchrowArray() ) {
+        $FollowUpOptionList{ $Row[0] } = $Row[1];
+    }
+
+    return %FollowUpOptionList;
+}
+
 =item GetFollowUpLockOption()
 
 get FollowUpLockOption for the given QueueID

--- a/scripts/test/Group/Group.t
+++ b/scripts/test/Group/Group.t
@@ -12,14 +12,17 @@ use utf8;
 
 use vars (qw($Self));
 
-our @ObjectDependencies = (
-    'Kernel::System::Group',
-    'Kernel::System::Time',
-);
-
 # get needed objects
 my $GroupObject = $Kernel::OM->Get('Kernel::System::Group');
 my $TimeObject  = $Kernel::OM->Get('Kernel::System::Time');
+
+# get helper object
+$Kernel::OM->ObjectParamAdd(
+    'Kernel::System::UnitTest::Helper' => {
+        RestoreDatabase => 1,
+    },
+);
+my $HelperObject = $Kernel::OM->Get('Kernel::System::UnitTest::Helper');
 
 #
 # Group tests
@@ -181,5 +184,29 @@ for my $GroupName ( sort keys %GroupIDByGroupName ) {
         'GroupUpdate() to set group ' . $GroupName . ' to invalid',
     );
 }
+
+# list valid groups
+%Groups = $GroupObject->GroupList( Valid => 1 );
+for my $GroupName ( sort keys %GroupIDByGroupName ) {
+    my $GroupID = $GroupIDByGroupName{$GroupName};
+
+    $Self->False(
+        exists $Groups{$GroupID},
+        'GroupList() does not contains group ' . $GroupName . ' with ID ' . $GroupID,
+    );
+}
+
+# list all groups
+%Groups = $GroupObject->GroupList( Valid => 0 );
+for my $GroupName ( sort keys %GroupIDByGroupName ) {
+    my $GroupID = $GroupIDByGroupName{$GroupName};
+
+    $Self->True(
+        exists $Groups{$GroupID} && $Groups{$GroupID} eq $GroupName,
+        'GroupList() contains group ' . $GroupName . ' with ID ' . $GroupID,
+    );
+}
+
+# Cleanup is done by RestoreDatabase.
 
 1;

--- a/scripts/test/Queue.t
+++ b/scripts/test/Queue.t
@@ -16,9 +16,16 @@ use Kernel::System::VariableCheck qw(:all);
 
 # get needed objects
 my $ConfigObject           = $Kernel::OM->Get('Kernel::Config');
-my $HelperObject           = $Kernel::OM->Get('Kernel::System::UnitTest::Helper');
 my $StandardTemplateObject = $Kernel::OM->Get('Kernel::System::StandardTemplate');
 my $QueueObject            = $Kernel::OM->Get('Kernel::System::Queue');
+
+# get helper object
+$Kernel::OM->ObjectParamAdd(
+    'Kernel::System::UnitTest::Helper' => {
+        RestoreDatabase => 1,
+    },
+);
+my $HelperObject = $Kernel::OM->Get('Kernel::System::UnitTest::Helper');
 
 my $QueueRand = 'Some::Queue' . int( rand(1000000) );
 my $QueueID   = $QueueObject->QueueAdd(
@@ -647,39 +654,6 @@ for my $Test (@Tests) {
     }
 }
 
-# cleanup
-my $Success = $StandardTemplateObject->StandardTemplateDelete(
-    ID => $TemplateID,
-);
-
-$Self->True(
-    $Success,
-    "StandardTemplateDelete() for QueueStandardTemplateMemeberAdd() | with True",
-);
-
-# Since there are no tickets that rely on our test queues, we can remove them again
-# from the DB.
-for my $ID (@IDs) {
-    my $Success = $Kernel::OM->Get('Kernel::System::DB')->Do(
-        SQL => "DELETE FROM queue_preferences WHERE queue_id = $ID",
-    );
-    $Self->True(
-        $Success,
-        "QueueDelete preferences - $ID",
-    );
-
-    $Success = $Kernel::OM->Get('Kernel::System::DB')->Do(
-        SQL => "DELETE FROM queue WHERE id = $ID",
-    );
-    $Self->True(
-        $Success,
-        "QueueDelete - $ID",
-    );
-}
-
-# Make sure the cache is correct.
-$Kernel::OM->Get('Kernel::System::Cache')->CleanUp(
-    Type => 'Queue',
-);
+# Cleanup is done by RestoreDatabase.
 
 1;

--- a/scripts/test/Queue.t
+++ b/scripts/test/Queue.t
@@ -166,6 +166,22 @@ $Self->True(
     'QueueUpdate() - a real scenario from AdminQueue.pm',
 );
 
+# check follow-up value for test queue
+my %FollowUpOptionList = reverse $QueueObject->GetFollowUpOptionList( Valid => 1 );
+my $FollowUpOption = $QueueObject->GetFollowUpOption( QueueID => $QueueID );
+
+for my $FollowUp ( 'possible', 'reject', 'new ticket' ) {
+    $Self->True(
+        exists $FollowUpOptionList{$FollowUp},
+        "Follow-up list contains the follow-up \'$FollowUp\ - ID $FollowUpOptionList{$FollowUp}'",
+    );
+}
+
+$Self->True(
+    exists $FollowUpOptionList{$FollowUpOption} && $FollowUpOptionList{$FollowUpOption} == 1,
+    "Follow-up list contains the follow-up \'$FollowUpOption\' of the queue $QueueID",
+);
+
 my $QueueUpdate1Name = $QueueRand . '1',;
 my $QueueUpdate1     = $QueueObject->QueueUpdate(
     QueueID             => $QueueID,


### PR DESCRIPTION
Hi @mgruner 

As we had spoken before about removing GetTableData, I removed it form AdminQueue. You can see I changed appropriate tests. I added RestoreDatabase instead manually delete.

I changed a little GroupList, now it is similar to other backend module function for get List of entities. Please check if it is good now. I run all test and it has the same behavior, but I removed extra cache and return statement.  Now it is set in cache only List which is used in that moment ( Valid or Invalid ones). 

For GetFollowUpOptionList I added new function, it could be update GetFollowUpOption, but new function in this moment seemed better. 

Please let me know what do you think about all of that.

Regards
Zoran

