### PR TITLE
Rel-5_0 Updated and fixed tests - Vacation days

### DIFF
--- a/scripts/test/Selenium/Agent/AgentTicketCustomer.t
+++ b/scripts/test/Selenium/Agent/AgentTicketCustomer.t
@@ -64,22 +64,16 @@ $Selenium->RunTest(
             Password => $TestUserLogin,
         );
 
-        my $ScriptAlias = $Kernel::OM->Get('Kernel::Config')->Get('ScriptAlias');
-        $Selenium->get("${ScriptAlias}index.pl?Action=AgentTicketPhone");
-
-        # wait until form has loaded, if neccessary
-        $Selenium->WaitFor( JavaScript => 'return typeof($) === "function" && $("body").length' );
-
         # get test user ID
         my $TestUserID = $Kernel::OM->Get('Kernel::System::User')->UserLookup(
             UserLogin => $TestUserLogin,
         );
 
-        # add test customers for testing
+        # add test customer users for testing
         my @TestCustomers;
         for ( 1 .. 2 )
         {
-            my $TestCustomer = 'Customer' . $Helper->GetRandomID();
+            my $TestCustomer = 'CustomerUser' . $Helper->GetRandomID();
             my $UserLogin    = $Kernel::OM->Get('Kernel::System::CustomerUser')->CustomerUserAdd(
                 Source         => 'CustomerUser',
                 UserFirstname  => $TestCustomer,
@@ -91,55 +85,46 @@ $Selenium->RunTest(
                 UserID         => $TestUserID,
             );
 
+            $Self->True(
+                $UserLogin,
+                "Test customer user is created - $UserLogin",
+            );
+
             push @TestCustomers, $TestCustomer;
 
         }
 
-        # create test phone ticket
-        my $AutoCompleteString
-            = "\"$TestCustomers[0] $TestCustomers[0]\" <$TestCustomers[0]\@localhost.com> ($TestCustomers[0])";
-        my $TicketSubject = "Selenium Ticket";
-        my $TicketBody    = "Selenium body test";
-        $Selenium->find_element( "#FromCustomer", 'css' )->send_keys( $TestCustomers[0] );
-        $Selenium->WaitFor( JavaScript => 'return typeof($) === "function" && $("li.ui-menu-item:visible").length' );
+        # get ticket object
+        my $TicketObject = $Kernel::OM->Get('Kernel::System::Ticket');
 
-        $Selenium->find_element("//*[text()='$AutoCompleteString']")->click();
-        $Selenium->execute_script("\$('#Dest').val('2||Raw').trigger('redraw.InputField').trigger('change');");
-        $Selenium->find_element( "#Subject",  'css' )->send_keys($TicketSubject);
-        $Selenium->find_element( "#RichText", 'css' )->send_keys($TicketBody);
-        $Selenium->find_element( "#Subject",  'css' )->submit();
-
-        # Wait until form has loaded, if neccessary
-        $Selenium->WaitFor( JavaScript => 'return typeof($) === "function" && $("form").length' );
-
-        # search for new created ticket on AgentTicketZoom screen
-        my %TicketIDs = $Kernel::OM->Get('Kernel::System::Ticket')->TicketSearch(
-            Result         => 'HASH',
-            Limit          => 1,
-            CustomerUserID => $TestCustomers[0],
+        my $TicketNumber = $TicketObject->TicketCreateNumber();
+        my $TicketID     = $TicketObject->TicketCreate(
+            TN           => $TicketNumber,
+            Title        => 'Selenium Test Ticket',
+            Queue        => 'Raw',
+            Lock         => 'unlock',
+            Priority     => '3 normal',
+            State        => 'open',
+            CustomerID   => 'TestCustomer',
+            CustomerUser => $TestCustomers[0],
+            OwnerID      => $TestUserID,
+            UserID       => $TestUserID,
         );
-        my $TicketNumber = (%TicketIDs)[1];
-        my $TicketID     = (%TicketIDs)[0];
-
         $Self->True(
             $TicketID,
-            "Ticket created",
+            "Ticket is created - $TicketID",
         );
 
-        $Self->True(
-            index( $Selenium->get_page_source(), $TicketNumber ) > -1,
-            "Ticket with ticket id $TicketID ($TicketNumber) is created"
-        );
+        my $ScriptAlias = $Kernel::OM->Get('Kernel::Config')->Get('ScriptAlias');
+        $Selenium->VerifiedGet("${ScriptAlias}index.pl?Action=AgentTicketZoom;TicketID=$TicketID");
 
-        # go to ticket zoom page of created test ticket
-        $Selenium->find_element("//a[contains(\@href, \'Action=AgentTicketZoom' )]")->click();
-
+        # wait for displaying submenu items for 'People' ticket menu item
         $Selenium->WaitFor(
             JavaScript =>
                 'return typeof($) === "function" && $("#nav-People ul").css({ "height": "auto", "opacity": "100" });'
         );
 
-        # go to AgentTicketCustomer
+        # go to AgentTicketCustomer, it causes open popup screen, wait will be done by WaitFor
         $Selenium->find_element("//a[contains(\@href, \'Action=AgentTicketCustomer' )]")->click();
 
         # switch to another window
@@ -149,9 +134,6 @@ $Selenium->RunTest(
 
         # set size for small screens, because of sidebar with customer info overflow form for customer data
         $Selenium->set_window_size( 1000, 700 );
-
-        # wait until form has loaded, if neccessary
-        $Selenium->WaitFor( JavaScript => 'return typeof($) === "function" && $("#CustomerAutoComplete").length' );
 
         # check AgentTicketCustomer screen
         for my $ID (
@@ -163,28 +145,21 @@ $Selenium->RunTest(
             $Element->is_displayed();
         }
 
-        $AutoCompleteString
+        my $AutoCompleteString
             = "\"$TestCustomers[1] $TestCustomers[1]\" <$TestCustomers[1]\@localhost.com> ($TestCustomers[1])";
         $Selenium->find_element( "#CustomerAutoComplete", 'css' )->clear();
-        $Selenium->find_element( "#CustomerID",           'css' )->clear();
         $Selenium->find_element( "#CustomerAutoComplete", 'css' )->send_keys( $TestCustomers[1] );
         $Selenium->WaitFor( JavaScript => 'return typeof($) === "function" && $("li.ui-menu-item:visible").length' );
+        $Selenium->find_element("//*[text()='$AutoCompleteString']")->VerifiedClick();
 
-        $Selenium->find_element("//*[text()='$AutoCompleteString']")->click();
-
-        # wait until customer data is loading (CustomerID is filled after CustomerAutoComplete)
-        $Selenium->WaitFor( JavaScript => 'return typeof($) === "function" && $("#CustomerID").val().length' );
+        # submit customer data, it causes close popup screen, wait will be done by WaitFor
         $Selenium->find_element( "#CustomerAutoComplete", 'css' )->submit();
 
-        # Wait for update
+        # wait for update
         $Selenium->WaitFor( WindowCount => 1 );
         $Selenium->switch_to_window( $Handles->[0] );
-        sleep 1;
 
-        $Selenium->get("${ScriptAlias}index.pl?Action=AgentTicketHistory;TicketID=$TicketID");
-
-        # wait until form has loaded, if neccessary
-        $Selenium->WaitFor( JavaScript => 'return typeof($) === "function" && $("body").length' );
+        $Selenium->VerifiedGet("${ScriptAlias}index.pl?Action=AgentTicketHistory;TicketID=$TicketID");
 
         # verify that action worked as expected
         my $HistoryText = "CustomerID=$TestCustomers[1];CustomerUser=$TestCustomers[1]";
@@ -195,7 +170,7 @@ $Selenium->RunTest(
         );
 
         # delete created test ticket
-        my $Success = $Kernel::OM->Get('Kernel::System::Ticket')->TicketDelete(
+        my $Success = $TicketObject->TicketDelete(
             TicketID => $TicketID,
             UserID   => 1,
         );
@@ -219,8 +194,14 @@ $Selenium->RunTest(
         }
 
         # make sure the cache is correct.
-        $Kernel::OM->Get('Kernel::System::Cache')->CleanUp( Type => 'Ticket' );
-        $Kernel::OM->Get('Kernel::System::Cache')->CleanUp( Type => 'CustomerUser' );
+        for my $Cache (
+            qw (Ticket CustomerUser)
+            )
+        {
+            $Kernel::OM->Get('Kernel::System::Cache')->CleanUp(
+                Type => $Cache,
+            );
+        }
 
     }
 );

--- a/scripts/test/Selenium/Agent/AgentTicketEscalationView.t
+++ b/scripts/test/Selenium/Agent/AgentTicketEscalationView.t
@@ -26,26 +26,41 @@ $Selenium->RunTest(
         );
         my $Helper = $Kernel::OM->Get('Kernel::System::UnitTest::Helper');
 
-        $Kernel::OM->Get('Kernel::Config')->Set(
+        # get needed object
+        my $ConfigObject    = $Kernel::OM->Get('Kernel::Config');
+        my $SysConfigObject = $Kernel::OM->Get('Kernel::System::SysConfig');
+
+        $ConfigObject->Set(
             Key   => 'CheckEmailAddresses',
             Value => 0,
         );
 
-        # Use a calendar with the same business hours for every day so that the UT runs correctly
-        #   on every day of the week and outside usual business hours.
+        # use a calendar with the same business hours for every day so that the UT runs correctly
+        # on every day of the week and outside usual business hours.
         my %Week;
         my @Days = qw(Sun Mon Tue Wed Thu Fri Sat);
         for my $Day (@Days) {
             $Week{$Day} = [ 0 .. 23 ];
         }
-        $Kernel::OM->Get('Kernel::Config')->Set(
+        $ConfigObject->Set(
             Key   => 'TimeWorkingHours',
             Value => \%Week,
         );
-        $Kernel::OM->Get('Kernel::System::SysConfig')->ConfigItemUpdate(
+        $SysConfigObject->ConfigItemUpdate(
             Valid => 1,
             Key   => 'TimeWorkingHours',
             Value => \%Week,
+        );
+
+        # disable default Vacation days
+        $ConfigObject->Set(
+            Key   => 'TimeVacationDays',
+            Value => {},
+        );
+        $SysConfigObject->ConfigItemUpdate(
+            Valid => 1,
+            Key   => 'TimeVacationDays',
+            Value => {},
         );
 
         # create test user and login
@@ -80,7 +95,7 @@ $Selenium->RunTest(
         # create params for test tickets
         my @Tests = (
 
-            # default callendar is used for test
+            # default calendar is used for test
             # create queue that will escalate tickets in 1 working hour
             {
                 Name         => 'Today',
@@ -139,8 +154,11 @@ $Selenium->RunTest(
         # create test tickets
         my @TicketIDs;
         my $Tickets;
+        my $TicketNumbers;
         for my $TicketCreate (@Tests) {
-            my $TicketID = $TicketObject->TicketCreate(
+            my $TicketNumber = $TicketObject->TicketCreateNumber();
+            my $TicketID     = $TicketObject->TicketCreate(
+                TN           => $TicketNumber,
                 Title        => 'Selenium Test Ticket',
                 Queue        => $TicketCreate->{Queue},
                 Lock         => 'unlock',
@@ -160,16 +178,16 @@ $Selenium->RunTest(
             push @TicketIDs, $TicketID;
 
             # set helper parameter for verifying on what view certain tickets are expected
-            $Tickets->{$TicketID} = $TicketCreate->{Name};
+            $Tickets->{$TicketID}       = $TicketCreate->{Name};
+            $TicketNumbers->{$TicketID} = $TicketNumber;
 
         }
 
         # go to AgentTicketEscalationView
         my $ScriptAlias = $Kernel::OM->Get('Kernel::Config')->Get('ScriptAlias');
-        $Selenium->get("${ScriptAlias}index.pl?Action=AgentTicketEscalationView;SortBy=TicketNumber;OrderBy=Down");
-
-        # wait until page has loaded, if neccessary
-        $Selenium->WaitFor( JavaScript => 'return typeof($) === "function" && $("body").length' );
+        $Selenium->VerifiedGet(
+            "${ScriptAlias}index.pl?Action=AgentTicketEscalationView;SortBy=TicketNumber;OrderBy=Down"
+        );
 
         for my $Test (@Tests) {
 
@@ -179,7 +197,7 @@ $Selenium->RunTest(
                 $Filter = 'NextWeek';
             }
 
-            # Switch to "Tomorrow" if it is already past 22:00 to avoid day switch errors.
+            # switch to "Tomorrow" if it is already past 22:00 to avoid day switch errors.
             if ( $Filter eq 'Today' ) {
                 my $CurrentTimestamp = $Kernel::OM->Get('Kernel::System::Time')->SystemTime2TimeStamp(
                     SystemTime => $Kernel::OM->Get('Kernel::System::Time')->SystemTime(),
@@ -197,21 +215,15 @@ $Selenium->RunTest(
             );
             $Element->is_enabled();
             $Element->is_displayed();
-            $Element->click();
-
-            # wait until page has loaded, if neccessary
-            $Selenium->WaitFor( JavaScript => 'return typeof($) === "function" && $("body").length' );
+            $Element->VerifiedClick();
 
             # check different views
             for my $View (qw(Small Medium Preview)) {
 
                 # switch to view with correct sorting
-                $Selenium->get(
+                $Selenium->VerifiedGet(
                     "${ScriptAlias}index.pl?Action=AgentTicketEscalationView;SortBy=TicketNumber;OrderBy=Down;Filter=$Filter;View=$View"
                 );
-
-                # wait until page has loaded, if neccessary
-                $Selenium->WaitFor( JavaScript => 'return typeof($) === "function" && $("table").length' );
 
                 # check screen output
                 $Selenium->find_element( "table",             'css' );
@@ -222,36 +234,31 @@ $Selenium->RunTest(
 
                     if ( ( $Tickets->{$TicketID} eq $Test->{Name} ) ) {
 
-                        my $TicketNumber = $TicketObject->TicketNumberLookup(
-                            TicketID => $TicketID,
-                            UserID   => $TestUserID,
-                        );
-
                         if ( $Test->{Name} ne 'AfterNextWeek' ) {
 
                             $Self->True(
-                                index( $Selenium->get_page_source(), $TicketNumber ) > -1,
-                                "$Test->{Name}/$View: Ticket is found on page - $TicketNumber ",
+                                index( $Selenium->get_page_source(), $TicketNumbers->{$TicketID} ) > -1,
+                                "$Test->{Name}/$View: Ticket is found on page - $TicketNumbers->{$TicketID}",
                             );
                         }
                         else {
 
-                    # test created ticket that escalate in more then 1 week and therefore shouldn't be visible on screen
+                            # test created ticket that escalate in more then 1 week
+                            # and therefore shouldn't be visible on screen
                             $Self->True(
-                                index( $Selenium->get_page_source(), $TicketNumber ) == -1,
-                                "$Test->{Name}/$View: Ticket is not found on page - $TicketNumber ",
+                                index( $Selenium->get_page_source(), $TicketNumbers->{$TicketID} ) == -1,
+                                "$Test->{Name}/$View: Ticket is not found on page - $TicketNumbers->{$TicketID}",
                             );
                         }
-
                     }
                 }
             }
 
             # switch back to AgentTicketEscalationView
-            $Selenium->get("${ScriptAlias}index.pl?Action=AgentTicketEscalationView;SortBy=TicketNumber;OrderBy=Down");
+            $Selenium->VerifiedGet(
+                "${ScriptAlias}index.pl?Action=AgentTicketEscalationView;SortBy=TicketNumber;OrderBy=Down"
+            );
 
-            # wait until page has loaded, if neccessary
-            $Selenium->WaitFor( JavaScript => 'return typeof($) === "function" && $("body").length' );
         }
 
         # delete created test tickets

--- a/scripts/test/Selenium/Output/Dashboard/Calendar.t
+++ b/scripts/test/Selenium/Output/Dashboard/Calendar.t
@@ -30,7 +30,7 @@ $Selenium->RunTest(
         my $SysConfigObject = $Kernel::OM->Get('Kernel::System::SysConfig');
         my $ConfigObject    = $Kernel::OM->Get('Kernel::Config');
 
-        # Use a calendar with the same business hours for every day so that the UT runs correctly
+        # use a calendar with the same business hours for every day so that the UT runs correctly
         # on every day of the week and outside usual business hours.
         my %Week;
         my @Days = qw(Sun Mon Tue Wed Thu Fri Sat);
@@ -45,6 +45,17 @@ $Selenium->RunTest(
             Valid => 1,
             Key   => 'TimeWorkingHours',
             Value => \%Week,
+        );
+
+        # disable default Vacation days
+        $ConfigObject->Set(
+            Key   => 'TimeVacationDays',
+            Value => {},
+        );
+        $SysConfigObject->ConfigItemUpdate(
+            Valid => 1,
+            Key   => 'TimeVacationDays',
+            Value => {},
         );
 
         # disable other dashboard modules
@@ -106,7 +117,7 @@ $Selenium->RunTest(
             Lock         => 'unlock',
             Priority     => '3 normal',
             State        => 'open',
-            CustomerID   => '123465',
+            CustomerID   => 'TestCustomers',
             CustomerUser => 'customer@example.com',
             OwnerID      => $TestUserID,
             UserID       => $TestUserID,
@@ -121,7 +132,7 @@ $Selenium->RunTest(
 
         # go to dashboard screen
         my $ScriptAlias = $Kernel::OM->Get('Kernel::Config')->Get('ScriptAlias');
-        $Selenium->get("${ScriptAlias}index.pl?Action=AgentDashboard");
+        $Selenium->VerifiedGet("${ScriptAlias}index.pl?Action=AgentDashboard");
 
         # check for created test ticket on dashboard screen
         $Self->True(

--- a/scripts/test/Time/DestinationTime.t
+++ b/scripts/test/Time/DestinationTime.t
@@ -15,8 +15,13 @@ use Time::Local;
 
 use vars (qw($Self));
 
+# get helper object
+$Kernel::OM->ObjectParamAdd(
+    'Kernel::System::UnitTest::Helper' => {
+        RestoreSystemConfiguration => 1,
+    },
+);
 my $HelperObject = $Kernel::OM->Get('Kernel::System::UnitTest::Helper');
-my $ConfigObject = $Kernel::OM->Get('Kernel::Config');
 
 my @Tests = (
     {
@@ -25,7 +30,7 @@ my @Tests = (
         ServerTZ        => 'UTC',
         Time            => 60 * 60 * 24 * 90,       # 90 days
         TimeDate        => '90 days',
-        DestinationTime => '2015-05-19 12:00:00',
+        DestinationTime => '2015-05-18 12:00:00',
     },
     {
         Name            => 'Europe/Berlin ( Daylight Saving Time UTC+1 => UTC+2 )',
@@ -33,7 +38,7 @@ my @Tests = (
         ServerTZ        => 'Europe/Berlin',
         Time            => 60 * 60 * 24 * 90 + 60 * 60,
         TimeDate        => '90 days and 1h',                                          # 90 days and 1h
-        DestinationTime => '2015-05-19 13:00:00',
+        DestinationTime => '2015-05-18 13:00:00',
     },
     {
         Name            => 'UTC',
@@ -141,6 +146,9 @@ my @Tests = (
     },
 );
 
+# get config object
+my $ConfigObject = $Kernel::OM->Get('Kernel::Config');
+
 # use a calendar with the same business hours for every day so that the UT runs correctly
 # on every day of the week and outside usual business hours
 my %Week;
@@ -151,6 +159,12 @@ for my $Day (@Days) {
 $Kernel::OM->Get('Kernel::Config')->Set(
     Key   => 'TimeWorkingHours',
     Value => \%Week,
+);
+
+# disable default Vacation days
+$ConfigObject->Set(
+    Key   => 'TimeVacationDays',
+    Value => {},
 );
 
 for my $Test (@Tests) {

--- a/scripts/test/Time/WorkingTime.t
+++ b/scripts/test/Time/WorkingTime.t
@@ -15,14 +15,19 @@ use Time::Local;
 
 use vars (qw($Self));
 
+# get helper object
+$Kernel::OM->ObjectParamAdd(
+    'Kernel::System::UnitTest::Helper' => {
+        RestoreSystemConfiguration => 1,
+    },
+);
 my $HelperObject = $Kernel::OM->Get('Kernel::System::UnitTest::Helper');
-my $ConfigObject = $Kernel::OM->Get('Kernel::Config');
 
 my @Tests = (
     {
         Name              => 'UTC',
         TimeStampUTCStart => '2015-02-17 12:00:00',
-        TimeStampUTCStop  => '2015-05-19 12:00:00',
+        TimeStampUTCStop  => '2015-05-18 12:00:00',
         ServerTZ          => 'UTC',
         Result            => '7776000',               # 90 days
         ResultTime        => '90 days',
@@ -30,7 +35,7 @@ my @Tests = (
     {
         Name              => 'Europe/Berlin ( Daylight Saving Time UTC+1 => UTC+2 )',
         TimeStampUTCStart => '2015-02-17 12:00:00',
-        TimeStampUTCStop  => '2015-05-19 12:00:00',
+        TimeStampUTCStop  => '2015-05-18 12:00:00',
         ServerTZ          => 'Europe/Berlin',
         Result            => '7779600',                                                 # 90 days and 1h
         ResultTime        => '90 days and 1h',
@@ -141,16 +146,25 @@ my @Tests = (
     },
 );
 
-# Use a calendar with the same business hours for every day so that the UT runs correctly
-#   on every day of the week and outside usual business hours.
+# get config object
+my $ConfigObject = $Kernel::OM->Get('Kernel::Config');
+
+# use a calendar with the same business hours for every day so that the UT runs correctly
+# on every day of the week and outside usual business hours.
 my %Week;
 my @Days = qw(Sun Mon Tue Wed Thu Fri Sat);
 for my $Day (@Days) {
     $Week{$Day} = [ 0 .. 23 ];
 }
-$Kernel::OM->Get('Kernel::Config')->Set(
+$ConfigObject->Set(
     Key   => 'TimeWorkingHours',
     Value => \%Week,
+);
+
+# disable default Vacation days
+$ConfigObject->Set(
+    Key   => 'TimeVacationDays',
+    Value => {},
 );
 
 for my $Test (@Tests) {


### PR DESCRIPTION
Hi Martin,

I saw that there was a problem with some test (AgentTicketCustomer.t and AgentTicketEscalationView.t) on test server:
http://opms.otrs.com/otrs/public.pl?Action=PublicUnitTest;Subaction=ViewUnitTest;XMLKey=OTRS%206%20git_ut-ubuntu-1504.otrs.com_5.20.2_mysql%205.6.27;ShowSuccess=0

In AgentTicketEscalationView.t there was a problem with vacation days, I removed default Vacation days in sysconfig,
In AgentTicketCustomer.t there is a problem with changing that has done in meantime about readonly config for Customer field.

I fix these issues and I switched to Varied methods and add RestoreDatabase for Escalations.t unit test. Sorry that I mixed all this tasks in one PR, but It seemed connected for me and I have done it that we don't have to back on this again next days.

Regards
Zoran