### PR TITLE
[ Rel 5 0 Bug 11710 ] - Using ArticleFilter causes numeration issues 

### DIFF
--- a/Kernel/Modules/AgentTicketZoom.pm
+++ b/Kernel/Modules/AgentTicketZoom.pm
@@ -782,26 +782,40 @@ sub MaskAgentZoom {
         $Pages = ceil( $ArticleCount / $Limit );
     }
 
-    # add counter
-    my $Count = ( $Page - 1 ) * $Limit;
+    # get all articles
+    my @ArticleContentArgsAll = (
+        TicketID                   => $Self->{TicketID},
+        StripPlainBodyAsAttachment => $Self->{StripPlainBodyAsAttachment},
+        UserID                     => $Self->{UserID},
+        Order                      => $Order,
+        DynamicFields => 0,    # fetch later only for the article(s) to display
+    );
+    my @ArticleBoxAll = $TicketObject->ArticleContentIndex( @ArticleContentArgsAll );
 
-    # in case of reverse sorting, count top-down
+    my $Count;
     if ( $ConfigObject->Get('Ticket::Frontend::ZoomExpandSort') eq 'reverse' ) {
-        $Count = $ArticleCount - ( ( $Page - 1 ) * $Limit ) + 1;
+        $Count = scalar @ArticleBoxAll + 1;
+    }
+    else {
+        $Count = 0;
     }
 
-    my $ArticleIDFound = 0;
-    ARTICLE:
-    for my $Article (@ArticleBox) {
-
+    for my $Article (@ArticleBoxAll) {
         if ( $ConfigObject->Get('Ticket::Frontend::ZoomExpandSort') eq 'reverse' ) {
             $Count--;
         }
         else {
             $Count++;
         }
-
         $Article->{Count} = $Count;
+    }
+
+    my $ArticleIDFound = 0;
+    ARTICLE:
+    for my $Article (@ArticleBox) {
+
+        my @ArticleOnPage = grep { $_->{ArticleID} =~ $Article->{ArticleID} } @ArticleBoxAll;
+        $Article->{Count} = $ArticleOnPage[0]->{Count};
 
         next ARTICLE if !$Self->{ArticleID};
         next ARTICLE if !$Article->{ArticleID};

--- a/scripts/test/Selenium/Agent/AgentTicketZoomArticleFilter.t
+++ b/scripts/test/Selenium/Agent/AgentTicketZoomArticleFilter.t
@@ -210,7 +210,15 @@ $Selenium->RunTest(
         $Selenium->execute_script("\$('.InputField_ListContainer').css('display', 'none');");
 
         # apply filter
-        $Selenium->find_element("//button[\@id='DialogButton1']")->VerifiedClick();
+        $Selenium->find_element("//button[\@id='DialogButton1']")->click();
+
+        # wait for dialog to disappear
+        $Selenium->WaitFor(
+            JavaScript => 'return typeof($) === "function" && $(".Dialog:visible").length === 0;'
+        );
+
+        # refresh screen
+        $Selenium->VerifiedRefresh();
 
         # verify we now only have first and fourth article on screen and there numeration is intact
         my @ArticlesFilterOn = ( 'Article #1 – First Test Article', 'Article #4 – Fourth Test Article' );

--- a/scripts/test/Selenium/Agent/AgentTicketZoomArticleFilter.t
+++ b/scripts/test/Selenium/Agent/AgentTicketZoomArticleFilter.t
@@ -185,7 +185,7 @@ $Selenium->RunTest(
             );
         }
 
-        # click on article filter
+        # click on article filter, open popup dialog
         $Selenium->find_element( "#SetArticleFilter", 'css' )->click();
 
         # get phone ArticleTypeID
@@ -226,7 +226,7 @@ $Selenium->RunTest(
         );
 
         # reset filter
-        $Selenium->find_element( "#ResetArticleFilter", 'css' )->click();
+        $Selenium->find_element( "#ResetArticleFilter", 'css' )->VerifiedClick();
 
         # click on first page
         $Selenium->find_element("//a[contains(\@href, \'TicketID=$TicketID;ArticlePage=1')]")->VerifiedClick();

--- a/scripts/test/Selenium/Agent/AgentTicketZoomArticleFilter.t
+++ b/scripts/test/Selenium/Agent/AgentTicketZoomArticleFilter.t
@@ -1,0 +1,119 @@
+# --
+# Copyright (C) 2001-2015 OTRS AG, http://otrs.com/
+# --
+# This software comes with ABSOLUTELY NO WARRANTY. For details, see
+# the enclosed file COPYING for license information (AGPL). If you
+# did not receive this file, see http://www.gnu.org/licenses/agpl.txt.
+# --
+
+use strict;
+use warnings;
+use utf8;
+
+use vars (qw($Self));
+
+# get selenium object
+my $Selenium = $Kernel::OM->Get('Kernel::System::UnitTest::Selenium');
+
+$Selenium->RunTest(
+    sub {
+
+        # get helper object
+        $Kernel::OM->ObjectParamAdd(
+            'Kernel::System::UnitTest::Helper' => {
+                RestoreSystemConfiguration => 1,
+            },
+        );
+        my $Helper = $Kernel::OM->Get('Kernel::System::UnitTest::Helper');
+
+        # enable article filter
+        $Kernel::OM->Get('Kernel::System::SysConfig')->ConfigItemUpdate(
+            Valid => 1,
+            Key   => 'Ticket::Frontend::TicketArticleFilter',
+            Value => 1,
+        );
+
+        # get test data
+        my @Tests = (
+            {
+                ArticleType => 'phone',
+                SenderType  => 'customer',
+                Subject     => 'First Test Article',
+            },
+            {
+                ArticleType => 'email-external',
+                SenderType  => 'system',
+                Subject     => 'Second Test Article',
+            },
+            {
+                ArticleType => 'note-internal',
+                SenderType  => 'agent',
+                Subject     => 'Third Test Article',
+            },
+
+        );
+
+        # create and login test user
+        my $TestUserLogin = $Helper->TestUserCreate(
+            Groups => [ 'admin', 'users' ],
+        ) || die "Did not get test user";
+
+        $Selenium->Login(
+            Type     => 'Agent',
+            User     => $TestUserLogin,
+            Password => $TestUserLogin,
+        );
+
+        # get test user ID
+        my $TestUserID = $Kernel::OM->Get('Kernel::System::User')->UserLookup(
+            UserLogin => $TestUserLogin,
+        );
+
+        # get ticket object
+        my $TicketObject = $Kernel::OM->Get('Kernel::System::Ticket');
+
+        # create test ticket
+        my $TicketID = $TicketObject->TicketCreate(
+            Title      => 'Test Selenium Ticket',
+            Queue      => 'Raw',
+            Lock       => 'unlock',
+            Priority   => '3 normal',
+            State      => 'open',
+            CustomerID => '12345',
+            OwnerID    => $TestUserID,
+            UserID     => $TestUserID,
+        );
+        $Self->True(
+            $TicketID,
+            "Ticket ID $TicketID - created",
+        );
+
+        # create test articles
+
+        for(1..5){
+
+            for my $Test ( @Tests ) {
+                my $ArticleID = $TicketObject->ArticleCreate(
+                    TicketID       => $TicketID,
+                    ArticleType    => $Test->{ArticleType},
+                    SenderType     => $Test->{SenderType},
+                    Subject        => $Test->{Subject},
+                    Body           => 'Selenium body article',
+                    Charset        => 'ISO-8859-15',
+                    MimeType       => 'text/plain',
+                    HistoryType    => 'AddNote',
+                    HistoryComment => 'Some free text!',
+                    UserID         => $TestUserID,
+                );
+                $Self->True(
+                    $ArticleID,
+                    "Article $Test->{Subject} - created",
+                );
+            }
+        }
+
+    }
+
+);
+
+1;

--- a/scripts/test/Selenium/Agent/AgentTicketZoomArticleFilter.t
+++ b/scripts/test/Selenium/Agent/AgentTicketZoomArticleFilter.t
@@ -1,5 +1,5 @@
 # --
-# Copyright (C) 2001-2015 OTRS AG, http://otrs.com/
+# Copyright (C) 2001-2016 OTRS AG, http://otrs.com/
 # --
 # This software comes with ABSOLUTELY NO WARRANTY. For details, see
 # the enclosed file COPYING for license information (AGPL). If you
@@ -206,6 +206,9 @@ $Selenium->RunTest(
             "\$('#ArticleSenderTypeFilter').val('$CustomerSenderTypeID').trigger('redraw.InputField').trigger('change');"
         );
 
+        # close dropdown menu
+        $Selenium->execute_script("\$('.InputField_ListContainer').css('display', 'none');");
+
         # apply filter
         $Selenium->find_element("//button[\@id='DialogButton1']")->VerifiedClick();
 
@@ -219,14 +222,20 @@ $Selenium->RunTest(
         }
 
         # set ZoomExpandSort to normal
-        $SysConfigObject->ConfigItemUpdate(
+        $Helper->ConfigSettingChange(
             Valid => 1,
             Key   => 'Ticket::Frontend::ZoomExpandSort',
             Value => 'normal',
         );
 
+        # refresh screen
+        $Selenium->VerifiedRefresh();
+
         # reset filter
-        $Selenium->find_element( "#ResetArticleFilter", 'css' )->VerifiedClick();
+        $Selenium->find_element( "#ResetArticleFilter", 'css' )->click();
+
+        # wait until reset filter button has gone
+        $Selenium->WaitFor( JavaScript => 'return typeof($) === "function" && !$("#ResetArticleFilter").length' );
 
         # click on first page
         $Selenium->find_element("//a[contains(\@href, \'TicketID=$TicketID;ArticlePage=1')]")->VerifiedClick();

--- a/scripts/test/Selenium/Agent/AgentTicketZoomArticleFilter.t
+++ b/scripts/test/Selenium/Agent/AgentTicketZoomArticleFilter.t
@@ -36,6 +36,13 @@ $Selenium->RunTest(
             Value => 1,
         );
 
+        # set ZoomExpandSort to reverse
+        $SysConfigObject->ConfigItemUpdate(
+            Valid => 1,
+            Key   => 'Ticket::Frontend::ZoomExpandSort',
+            Value => 'reverse',
+        );
+
         # set 3 max article per page
         $SysConfigObject->ConfigItemUpdate(
             Valid => 1,
@@ -136,45 +143,45 @@ $Selenium->RunTest(
         my $ScriptAlias = $Kernel::OM->Get('Kernel::Config')->Get('ScriptAlias');
 
         # navigate to AgentTicketZoom for test created ticket
-        $Selenium->get("${ScriptAlias}index.pl?Action=AgentTicketZoom;TicketID=$TicketID");
+        $Selenium->VerifiedGet("${ScriptAlias}index.pl?Action=AgentTicketZoom;TicketID=$TicketID");
 
         # click on expand view
-        $Selenium->find_element("//a[contains(\@href, \'ZoomExpand=1')]")->click();
+        $Selenium->find_element("//a[contains(\@href, \'ZoomExpand=1')]")->VerifiedClick();
 
         # verify there are last 3 created articles on first page
-        my @FirstPageArticles = (
+        my @FirstArticles = (
             'Article #4 – Fourth Test Article',
             'Article #5 – Fifth Test Article',
             'Article #6 – Sixth Test Article',
         );
-        for my $FirstPage (@FirstPageArticles) {
+        for my $Article (@FirstArticles) {
             $Self->True(
-                index( $Selenium->get_page_source(), $FirstPage ) > -1,
-                "$FirstPage found on first page - article filter off",
+                index( $Selenium->get_page_source(), $Article ) > -1,
+                "ZoomExpandSort: reverse - $Article found on first page - article filter off",
             );
         }
 
         # verify first 3 articles are not visible, they are on second page
-        my @SecondPageArticles = (
+        my @SecondArticles = (
             'Article #1 – First Test Article',
             'Article #2 – Second Test Article',
             'Article #3 – Third Test Article',
         );
-        for my $SecondPage (@SecondPageArticles) {
+        for my $Article (@SecondArticles) {
             $Self->True(
-                index( $Selenium->get_page_source(), $SecondPage ) == -1,
-                "$SecondPage not found first on page - article filter off",
+                index( $Selenium->get_page_source(), $Article ) == -1,
+                "ZoomExpandSort: reverse - $Article not found first on page - article filter off",
             );
         }
 
         # click on second page
-        $Selenium->find_element("//a[contains(\@href, \'TicketID=$TicketID;ArticlePage=2')]")->click();
+        $Selenium->find_element("//a[contains(\@href, \'TicketID=$TicketID;ArticlePage=2')]")->VerifiedClick();
 
         # verify there are first 3 created articles on second page
-        for my $SecondPage (@SecondPageArticles) {
+        for my $Article (@SecondArticles) {
             $Self->True(
-                index( $Selenium->get_page_source(), $SecondPage ) > -1,
-                "$SecondPage found on second page - article filter off",
+                index( $Selenium->get_page_source(), $Article ) > -1,
+                "ZoomExpandSort: reverse - $Article found on second page - article filter off",
             );
         }
 
@@ -200,14 +207,42 @@ $Selenium->RunTest(
         );
 
         # apply filter
-        $Selenium->find_element("//button[\@id='DialogButton1']")->click();
+        $Selenium->find_element("//button[\@id='DialogButton1']")->VerifiedClick();
 
         # verify we now only have first and fourth article on screen and there numeration is intact
         my @ArticlesFilterOn = ( 'Article #1 – First Test Article', 'Article #4 – Fourth Test Article' );
         for my $ArticleFilterOn (@ArticlesFilterOn) {
             $Self->True(
                 index( $Selenium->get_page_source(), $ArticleFilterOn ) > -1,
-                "$ArticleFilterOn found on page with original numeration - article filter on",
+                "ZoomExpandSort: reverse - $ArticleFilterOn found on page with original numeration - article filter on",
+            );
+        }
+
+        # set ZoomExpandSort to normal
+        $SysConfigObject->ConfigItemUpdate(
+            Valid => 1,
+            Key   => 'Ticket::Frontend::ZoomExpandSort',
+            Value => 'normal',
+        );
+
+        # reset filter
+        $Selenium->find_element( "#ResetArticleFilter", 'css' )->click();
+
+        # click on first page
+        $Selenium->find_element("//a[contains(\@href, \'TicketID=$TicketID;ArticlePage=1')]")->VerifiedClick();
+        for my $Article (@SecondArticles) {
+            $Self->True(
+                index( $Selenium->get_page_source(), $Article ) > -1,
+                "ZoomExpandSort: normal - $Article found on first page - article filter off",
+            );
+        }
+
+        # click on second page
+        $Selenium->find_element("//a[contains(\@href, \'TicketID=$TicketID;ArticlePage=2')]")->VerifiedClick();
+        for my $Article (@FirstArticles) {
+            $Self->True(
+                index( $Selenium->get_page_source(), $Article ) > -1,
+                "ZoomExpandSort: normal - $Article found on second page - article filter off",
             );
         }
 


### PR DESCRIPTION
http://bugs.otrs.org/show_bug.cgi?id=11710

Hi Martin,

This is out proposal for fixing. As you can see in the comments of the bug reports, we were not sure is it necessary that there is numbering of ticket with filter the same as it is without filter. Maybe our solution is not the best one. Please let me know if we can improve it.
I think that we can slow down system in some case because there is loop through all article only to get numbers of the articles for filtered or paginated articles. 

What do you think about all of that?

Regards
Zoran