### PR TITLE
Fix Bug#11786 - Reference of undefined variable in AgentTicketSearch

### DIFF
--- a/Kernel/Modules/AgentTicketSearch.pm
+++ b/Kernel/Modules/AgentTicketSearch.pm
@@ -344,7 +344,7 @@ sub Run {
                         Result => 'ID',
                     );
                 }
-                elsif ( $Param{StateType} eq 'Closed' ) {
+                elsif ( $GetParam{StateType} eq 'Closed' ) {
                     @StateIDs = $Kernel::OM->Get('Kernel::System::State')->StateGetStatesByType(
                         Type   => 'Viewable',
                         Result => 'ID',


### PR DESCRIPTION
This PR is fix for bug#11786.
See http://bugs.otrs.org/show_bug.cgi?id=11786 .
