### PR TITLE
Rel-5_0 selenium update Output/NavBar

### DIFF
--- a/scripts/test/Selenium/Output/NavBar/AgentTicketProcess.t
+++ b/scripts/test/Selenium/Output/NavBar/AgentTicketProcess.t
@@ -202,6 +202,9 @@ $Selenium->RunTest(
         $Selenium->VerifiedGet("${ScriptAlias}index.pl?Action=AdminProcessManagement");
         $Selenium->find_element("//a[contains(\@href, \'Subaction=ProcessSync' )]")->VerifiedClick();
 
+        # sleep a little bit to allow mod_perl to pick up the changed config files
+        sleep 3;
+
         # check if NavBarAgentTicketProcess button is not available when no process is available
         $Selenium->refresh();
         $Self->True(
@@ -220,6 +223,9 @@ $Selenium->RunTest(
             Key   => 'Frontend::NavBarModule###1-TicketProcesses',
             Value => \%NavBarAgentTicketProcess,
         );
+
+        # sleep a little bit to allow mod_perl to pick up the changed config files
+        sleep 3;
 
         $Selenium->refresh();
         $Self->True(

--- a/scripts/test/Selenium/Output/NavBar/AgentTicketProcess.t
+++ b/scripts/test/Selenium/Output/NavBar/AgentTicketProcess.t
@@ -52,8 +52,6 @@ $Selenium->RunTest(
         # get config object
         my $ConfigObject = $Kernel::OM->Get('Kernel::Config');
 
-        my $ScriptAlias = $ConfigObject->Get('ScriptAlias');
-
         # get all processes
         my $ProcessList = $ProcessObject->ProcessListGet(
             UserID => $TestUserID,
@@ -78,21 +76,18 @@ $Selenium->RunTest(
             }
         }
 
+        my $ScriptAlias = $ConfigObject->Get('ScriptAlias');
+
         # import test selenium process
         $Selenium->get("${ScriptAlias}index.pl?Action=AdminProcessManagement");
         my $Location = $ConfigObject->Get('Home')
             . "/scripts/test/sample/ProcessManagement/TestProcess.yml";
         $Selenium->find_element( "#FileUpload",                      'css' )->send_keys($Location);
-        $Selenium->find_element( "#OverwriteExistingEntitiesImport", 'css' )->click();
-        $Selenium->find_element("//button[\@value='Upload process configuration'][\@type='submit']")->click();
+        $Selenium->find_element( "#OverwriteExistingEntitiesImport", 'css' )->VerifiedClick();
+        $Selenium->find_element("//button[\@value='Upload process configuration'][\@type='submit']")->VerifiedClick();
 
-        # wait until page has loaded, if neccessary
-        $Selenium->WaitFor( JavaScript => 'return typeof($) === "function" && $("body").length' );
-
-        $Selenium->find_element("//a[contains(\@href, \'Subaction=ProcessSync' )]")->click();
-
-        # wait until page has loaded, if neccessary
-        $Selenium->WaitFor( JavaScript => 'return typeof($) === "function" && $("body").length' );
+        # synchronize process
+        $Selenium->find_element("//a[contains(\@href, \'Subaction=ProcessSync' )]")->VerifiedClick();
 
         # get process list
         my $List = $ProcessObject->ProcessList(
@@ -108,9 +103,6 @@ $Selenium->RunTest(
             EntityID => $ListReverse{$ProcessName},
             UserID   => $TestUserID,
         );
-
-        # Sleep a little bit to allow mod_perl to pick up the changed config files.
-        sleep 3;
 
         # check if NavBarAgentTicketProcess button is available when process is available
         $Selenium->refresh();
@@ -207,11 +199,8 @@ $Selenium->RunTest(
             "Process deleted - $Process->{Name},",
         );
 
-        $Selenium->get("${ScriptAlias}index.pl?Action=AdminProcessManagement");
-        $Selenium->find_element("//a[contains(\@href, \'Subaction=ProcessSync' )]")->click();
-
-        # Sleep a little bit to allow mod_perl to pick up the changed config files.
-        sleep 3;
+        $Selenium->VerifiedGet("${ScriptAlias}index.pl?Action=AdminProcessManagement");
+        $Selenium->find_element("//a[contains(\@href, \'Subaction=ProcessSync' )]")->VerifiedClick();
 
         # check if NavBarAgentTicketProcess button is not available when no process is available
         $Selenium->refresh();
@@ -231,9 +220,6 @@ $Selenium->RunTest(
             Key   => 'Frontend::NavBarModule###1-TicketProcesses',
             Value => \%NavBarAgentTicketProcess,
         );
-
-        # Sleep a little bit to allow mod_perl to pick up the changed config files.
-        sleep 3;
 
         $Selenium->refresh();
         $Self->True(
@@ -255,8 +241,8 @@ $Selenium->RunTest(
         }
 
         # synchronize process after deleting test process
-        $Selenium->get("${ScriptAlias}index.pl?Action=AdminProcessManagement");
-        $Selenium->find_element("//a[contains(\@href, \'Subaction=ProcessSync' )]")->click();
+        $Selenium->VerifiedGet("${ScriptAlias}index.pl?Action=AdminProcessManagement");
+        $Selenium->find_element("//a[contains(\@href, \'Subaction=ProcessSync' )]")->VerifiedClick();
 
         # make sure the cache is correct.
         for my $Cache (

--- a/scripts/test/Selenium/Output/NavBar/AgentTicketService.t
+++ b/scripts/test/Selenium/Output/NavBar/AgentTicketService.t
@@ -50,6 +50,9 @@ $Selenium->RunTest(
             Value => \%FrontendAgentTicketService,
         );
 
+        # sleep a little bit to allow mod_perl to pick up the changed config files
+        sleep 1;
+
         # check for NavBarAgentTicketService button when frontend service module is disabled
         my $ScriptAlias = $Kernel::OM->Get('Kernel::Config')->Get('ScriptAlias');
         $Selenium->VerifiedGet("${ScriptAlias}index.pl?Action=AgentDashboard");
@@ -68,6 +71,9 @@ $Selenium->RunTest(
             Name => 'Ticket::Service',
         );
 
+        # sleep a little bit to allow mod_perl to pick up the changed config files
+        sleep 1;
+
         # check for NavBarAgentTicketService button
         # when frontend service module is enabled but service feature is disabled
         $Selenium->refresh();
@@ -82,6 +88,9 @@ $Selenium->RunTest(
             Key   => 'Ticket::Service',
             Value => 1,
         );
+
+        # sleep a little bit to allow mod_perl to pick up the changed config files
+        sleep 1;
 
         # check for NavBarAgentTicketService button when frontend service module and service feature are enabled
         $Selenium->refresh();
@@ -103,6 +112,9 @@ $Selenium->RunTest(
         $SysConfigObject->ConfigItemReset(
             Name => 'Ticket::Service',
         );
+
+        # sleep a little bit to allow mod_perl to pick up the changed config files
+        sleep 1;
 
         $Selenium->refresh();
         $Self->True(

--- a/scripts/test/Selenium/Output/NavBar/AgentTicketService.t
+++ b/scripts/test/Selenium/Output/NavBar/AgentTicketService.t
@@ -50,12 +50,9 @@ $Selenium->RunTest(
             Value => \%FrontendAgentTicketService,
         );
 
-        # Sleep a bit to allow mod_perl to pick up the changed config files.
-        sleep 1;
-
         # check for NavBarAgentTicketService button when frontend service module is disabled
         my $ScriptAlias = $Kernel::OM->Get('Kernel::Config')->Get('ScriptAlias');
-        $Selenium->get("${ScriptAlias}index.pl?Action=AgentDashboard");
+        $Selenium->VerifiedGet("${ScriptAlias}index.pl?Action=AgentDashboard");
         $Self->True(
             index( $Selenium->get_page_source(), 'Action=AgentTicketService' ) == -1,
             "NavBar 'Service view' button NOT available when frontend service module is disabled",
@@ -71,9 +68,6 @@ $Selenium->RunTest(
             Name => 'Ticket::Service',
         );
 
-        # Sleep a bit to allow mod_perl to pick up the changed config files.
-        sleep 1;
-
         # check for NavBarAgentTicketService button
         # when frontend service module is enabled but service feature is disabled
         $Selenium->refresh();
@@ -88,9 +82,6 @@ $Selenium->RunTest(
             Key   => 'Ticket::Service',
             Value => 1,
         );
-
-        # Sleep a bit to allow mod_perl to pick up the changed config files.
-        sleep 1;
 
         # check for NavBarAgentTicketService button when frontend service module and service feature are enabled
         $Selenium->refresh();
@@ -112,9 +103,6 @@ $Selenium->RunTest(
         $SysConfigObject->ConfigItemReset(
             Name => 'Ticket::Service',
         );
-
-        # Sleep a bit to allow mod_perl to pick up the changed config files.
-        sleep 1;
 
         $Selenium->refresh();
         $Self->True(

--- a/scripts/test/Selenium/Output/NavBar/CustomerCompany.t
+++ b/scripts/test/Selenium/Output/NavBar/CustomerCompany.t
@@ -58,6 +58,9 @@ $Selenium->RunTest(
             "NavBar 'Customer Administration' button NOT available when frontend AdminCustomerCompany module is disabled",
         );
 
+        # sleep a little bit to allow mod_perl to pick up the changed config files
+        sleep 1;
+
         # enable frontend AdminCustomerCompany module
         $SysConfigObject->ConfigItemReset(
             Name => 'Frontend::Module###AdminCustomerCompany',

--- a/scripts/test/Selenium/Output/NavBar/CustomerCompany.t
+++ b/scripts/test/Selenium/Output/NavBar/CustomerCompany.t
@@ -52,14 +52,11 @@ $Selenium->RunTest(
 
         # check for NavBarCustomerCompany button when frontend AdminCustomerCompany module is disabled
         my $ScriptAlias = $Kernel::OM->Get('Kernel::Config')->Get('ScriptAlias');
-        $Selenium->get("${ScriptAlias}index.pl?Action=AgentDashboard");
+        $Selenium->VerifiedGet("${ScriptAlias}index.pl?Action=AgentDashboard");
         $Self->True(
             index( $Selenium->get_page_source(), 'AdminCustomerCompany;Nav=Agent' ) == -1,
             "NavBar 'Customer Administration' button NOT available when frontend AdminCustomerCompany module is disabled",
         );
-
-        # Sleep a little bit so that mod_perl can detect that the system configuration changed and reload it.
-        sleep 1;
 
         # enable frontend AdminCustomerCompany module
         $SysConfigObject->ConfigItemReset(

--- a/scripts/test/Selenium/Output/NavBar/CustomerTicketProcess.t
+++ b/scripts/test/Selenium/Output/NavBar/CustomerTicketProcess.t
@@ -52,8 +52,6 @@ $Selenium->RunTest(
         # get config object
         my $ConfigObject = $Kernel::OM->Get('Kernel::Config');
 
-        my $ScriptAlias = $ConfigObject->Get('ScriptAlias');
-
         # get all processes
         my $ProcessList = $ProcessObject->ProcessListGet(
             UserID => $TestUserID,
@@ -78,24 +76,18 @@ $Selenium->RunTest(
             }
         }
 
+        my $ScriptAlias = $ConfigObject->Get('ScriptAlias');
+
         # import test selenium process
-        $Selenium->get("${ScriptAlias}index.pl?Action=AdminProcessManagement");
+        $Selenium->VerifiedGet("${ScriptAlias}index.pl?Action=AdminProcessManagement");
         my $Location = $ConfigObject->Get('Home')
             . "/scripts/test/sample/ProcessManagement/TestProcess.yml";
         $Selenium->find_element( "#FileUpload",                      'css' )->send_keys($Location);
-        $Selenium->find_element( "#OverwriteExistingEntitiesImport", 'css' )->click();
-        $Selenium->find_element("//button[\@value='Upload process configuration'][\@type='submit']")->click();
+        $Selenium->find_element( "#OverwriteExistingEntitiesImport", 'css' )->VerifiedClick();
+        $Selenium->find_element("//button[\@value='Upload process configuration'][\@type='submit']")->VerifiedClick();
 
-        # wait until page has loaded, if neccessary
-        $Selenium->WaitFor( JavaScript => 'return typeof($) === "function" && $("body").length' );
-
-        $Selenium->find_element("//a[contains(\@href, \'Subaction=ProcessSync' )]")->click();
-
-        # wait until page has loaded, if neccessary
-        $Selenium->WaitFor( JavaScript => 'return typeof($) === "function" && $("body").length' );
-
-        # Sleep a little bit to allow mod_perl to pick up the changed config files.
-        sleep 3;
+        # synchronize process
+        $Selenium->find_element("//a[contains(\@href, \'Subaction=ProcessSync' )]")->VerifiedClick();
 
         # get process list
         my $List = $ProcessObject->ProcessList(
@@ -124,7 +116,7 @@ $Selenium->RunTest(
         );
 
         # check if NavBarCustomerTicketProcess button is available when process is available
-        $Selenium->get("${ScriptAlias}customer.pl?Action=CustomerTicketOverview;Subaction=MyTickets");
+        $Selenium->VerifiedGet("${ScriptAlias}customer.pl?Action=CustomerTicketOverview;Subaction=MyTickets");
         $Self->True(
             index( $Selenium->get_page_source(), 'Action=CustomerTicketProcess' ) > -1,
             "NavBar 'New process ticket' button available",
@@ -225,11 +217,8 @@ $Selenium->RunTest(
             Password => $TestUserLogin,
         );
 
-        $Selenium->get("${ScriptAlias}index.pl?Action=AdminProcessManagement");
-        $Selenium->find_element("//a[contains(\@href, \'Subaction=ProcessSync' )]")->click();
-
-        # Sleep a little bit to allow mod_perl to pick up the changed config files.
-        sleep 3;
+        $Selenium->VerifiedGet("${ScriptAlias}index.pl?Action=AdminProcessManagement");
+        $Selenium->find_element("//a[contains(\@href, \'Subaction=ProcessSync' )]")->VerifiedClick();
 
         # log in customer
         $Selenium->Login(
@@ -239,7 +228,7 @@ $Selenium->RunTest(
         );
 
         # check if NavBarCustomerTicketProcess button is not available when no process is available
-        $Selenium->get("${ScriptAlias}customer.pl?Action=CustomerTicketOverview;Subaction=MyTickets");
+        $Selenium->VerifiedGet("${ScriptAlias}customer.pl?Action=CustomerTicketOverview;Subaction=MyTickets");
         $Self->True(
             index( $Selenium->get_page_source(), 'Action=AgentTicketProcess' ) == -1,
             "'New process ticket' button NOT available when no process is available",
@@ -256,9 +245,6 @@ $Selenium->RunTest(
             Key   => 'CustomerFrontend::NavBarModule###10-CustomerTicketProcesses',
             Value => \%NavBarCustomerTicketProcess,
         );
-
-        # Sleep a little bit to allow mod_perl to pick up the changed config files.
-        sleep 3;
 
         $Selenium->refresh();
         $Self->True(
@@ -287,8 +273,8 @@ $Selenium->RunTest(
         );
 
         # synchronize process after deleting test process
-        $Selenium->get("${ScriptAlias}index.pl?Action=AdminProcessManagement");
-        $Selenium->find_element("//a[contains(\@href, \'Subaction=ProcessSync' )]")->click();
+        $Selenium->VerifiedGet("${ScriptAlias}index.pl?Action=AdminProcessManagement");
+        $Selenium->find_element("//a[contains(\@href, \'Subaction=ProcessSync' )]")->VerifiedClick();
 
         # make sure the cache is correct.
         for my $Cache (

--- a/scripts/test/Selenium/Output/NavBar/CustomerTicketProcess.t
+++ b/scripts/test/Selenium/Output/NavBar/CustomerTicketProcess.t
@@ -89,6 +89,9 @@ $Selenium->RunTest(
         # synchronize process
         $Selenium->find_element("//a[contains(\@href, \'Subaction=ProcessSync' )]")->VerifiedClick();
 
+        # sleep a little bit to allow mod_perl to pick up the changed config files
+        sleep 3;
+
         # get process list
         my $List = $ProcessObject->ProcessList(
             UseEntities => 1,
@@ -220,6 +223,9 @@ $Selenium->RunTest(
         $Selenium->VerifiedGet("${ScriptAlias}index.pl?Action=AdminProcessManagement");
         $Selenium->find_element("//a[contains(\@href, \'Subaction=ProcessSync' )]")->VerifiedClick();
 
+        # sleep a little bit to allow mod_perl to pick up the changed config files
+        sleep 3;
+
         # log in customer
         $Selenium->Login(
             Type     => 'Customer',
@@ -245,6 +251,9 @@ $Selenium->RunTest(
             Key   => 'CustomerFrontend::NavBarModule###10-CustomerTicketProcesses',
             Value => \%NavBarCustomerTicketProcess,
         );
+
+        # sleep a little bit to allow mod_perl to pick up the changed config files
+        sleep 3;
 
         $Selenium->refresh();
         $Self->True(


### PR DESCRIPTION
Hi Martin,

You can see that I removed "sleeping to allow mod_perl to pick up the changed config files". There were some such sleeping in the test which are updated in this PR. I know that you mentioned that it is necessary in your system and I suppose the main OTRS test server, however it is not needed on my system. Please let me know if you see some problem testing on your system these Selenium tests. I tested it with FF and PhantomJS as well. All tests work fine for me without these "sleeps".

I will be able to rollback on previous state if it is necessary.

Regards
Zoran
