### PR TITLE
[ Rel-5_0 - Bug 11805 ] - Cancel the Bulk Action always unlocks tickets

### DIFF
--- a/Kernel/Modules/AgentTicketBulk.pm
+++ b/Kernel/Modules/AgentTicketBulk.pm
@@ -425,8 +425,9 @@ sub Run {
         # check if it's already locked by somebody else
         if ( !$Config->{RequiredLock} ) {
             $Output .= $LayoutObject->Notify(
-                Data => "$Ticket{TicketNumber}: "
-                    . $LayoutObject->{LanguageObject}->Translate("Ticket selected."),
+                Priority => 'Info',
+                Data     => "$Ticket{TicketNumber}: "
+                    . $LayoutObject->{LanguageObject}->Translate("Ticket is selected."),
             );
         }
         else {
@@ -440,28 +441,36 @@ sub Run {
                 );
                 next TICKET_ID;
             }
-            else {
+            elsif ( $Ticket{Lock} eq 'unlock' ) {
                 $LockedTickets .= "LockedTicketID=" . $TicketID . ';';
                 $Param{TicketsWereLocked} = 1;
+
+                # set lock
+                $TicketObject->TicketLockSet(
+                    TicketID => $TicketID,
+                    Lock     => 'lock',
+                    UserID   => $Self->{UserID},
+                );
+
+                # set user id
+                $TicketObject->TicketOwnerSet(
+                    TicketID  => $TicketID,
+                    UserID    => $Self->{UserID},
+                    NewUserID => $Self->{UserID},
+                );
+                $Output .= $LayoutObject->Notify(
+                    Data => "$Ticket{TicketNumber}: "
+                        . $LayoutObject->{LanguageObject}->Translate("Ticket is locked."),
+                );
+            }
+            else {
+                $Output .= $LayoutObject->Notify(
+                    Priority => 'Info',
+                    Data     => "$Ticket{TicketNumber}: "
+                        . $LayoutObject->{LanguageObject}->Translate("Ticket is selected."),
+                );
             }
 
-            # set lock
-            $TicketObject->TicketLockSet(
-                TicketID => $TicketID,
-                Lock     => 'lock',
-                UserID   => $Self->{UserID},
-            );
-
-            # set user id
-            $TicketObject->TicketOwnerSet(
-                TicketID  => $TicketID,
-                UserID    => $Self->{UserID},
-                NewUserID => $Self->{UserID},
-            );
-            $Output .= $LayoutObject->Notify(
-                Data => "$Ticket{TicketNumber}: "
-                    . $LayoutObject->{LanguageObject}->Translate("Ticket locked."),
-            );
         }
 
         # remember selected ticket ids

--- a/scripts/test/Selenium/Agent/AgentTicketBulk.t
+++ b/scripts/test/Selenium/Agent/AgentTicketBulk.t
@@ -18,8 +18,28 @@ my $Selenium = $Kernel::OM->Get('Kernel::System::UnitTest::Selenium');
 $Selenium->RunTest(
     sub {
 
-        # get helper object
-        my $Helper = $Kernel::OM->Get('Kernel::System::UnitTest::Helper');
+        # get needed objects
+        $Kernel::OM->ObjectParamAdd(
+            'Kernel::System::UnitTest::Helper' => {
+                RestoreSystemConfiguration => 1,
+            },
+        );
+        my $Helper          = $Kernel::OM->Get('Kernel::System::UnitTest::Helper');
+        my $SysConfigObject = $Kernel::OM->Get('Kernel::System::SysConfig');
+
+        # enable bulk feature
+        $SysConfigObject->ConfigItemUpdate(
+            Valid => 1,
+            Key   => 'Ticket::Frontend::BulkFeature',
+            Value => 1,
+        );
+
+        # enable required lock feature in bulk
+        $SysConfigObject->ConfigItemUpdate(
+            Valid => 1,
+            Key   => 'Ticket::Frontend::AgentTicketBulk###RequiredLock',
+            Value => 1,
+        );
 
         # create test user and login
         my $TestUserLogin = $Helper->TestUserCreate(
@@ -32,37 +52,60 @@ $Selenium->RunTest(
             Password => $TestUserLogin,
         );
 
+        # get test user ID
+        my $TestUserID = $Kernel::OM->Get('Kernel::System::User')->UserLookup(
+            UserLogin => $TestUserLogin,
+        );
+
         # get ticket object
         my $TicketObject = $Kernel::OM->Get('Kernel::System::Ticket');
 
-        # create two test tickets
+        my @Tests = (
+            {
+                TicketTitle => 'TestTicket-One',
+                Lock        => 'lock',
+                OwnerID     => $TestUserID,
+                UserID      => $TestUserID,
+            },
+            {
+                TicketTitle => 'TestTicket-Two',
+                Lock        => 'unlock',
+                OwnerID     => $TestUserID,
+                UserID      => $TestUserID,
+            },
+            {
+                # ticket locked by another agent
+                TicketTitle => 'TestTicket-Three',
+                Lock        => 'lock',
+                OwnerID     => 1,
+                UserID      => 1,
+            },
+        );
+
+        # create three test tickets
         my @Tickets;
-        for my $TicketCreate (qw(One Two)) {
-            my $TicketTitle = "TestTicket" . $TicketCreate;
-            my $TicketID    = $TicketObject->TicketCreate(
-                Title      => $TicketTitle,
+        for my $Test (@Tests) {
+            my $TicketNumber = $TicketObject->TicketCreateNumber();
+            my $TicketID     = $TicketObject->TicketCreate(
+                TN         => $TicketNumber,
+                Title      => $Test->{TicketTitle},
                 Queue      => 'Raw',
-                Lock       => 'unlock',
+                Lock       => $Test->{Lock},
                 Priority   => '3 normal',
                 State      => 'open',
                 CustomerID => 'TestCustomer',
-                OwnerID    => 1,
-                UserID     => 1,
+                OwnerID    => $Test->{OwnerID},
+                UserID     => $Test->{UserID},
             );
-
-            # get tickets number
-            my %TicketData = $TicketObject->TicketGet(
-                TicketID => $TicketID,
-            );
-
             $Self->True(
                 $TicketID,
-                "Ticket created -  $TicketTitle, $TicketData{TicketNumber} ",
+                "Ticket is created -  $Test->{TicketTitle}, $TicketNumber ",
             );
 
             my %Ticket = (
                 TicketID     => $TicketID,
-                TicketNumber => $TicketData{TicketNumber},
+                TicketNumber => $TicketNumber,
+                OwnerID      => $Test->{OwnerID}
             );
 
             push @Tickets, \%Ticket;
@@ -74,19 +117,19 @@ $Selenium->RunTest(
         # navigate to AgentTicketStatusView
         $Selenium->VerifiedGet("${ScriptAlias}index.pl?Action=AgentTicketStatusView");
 
-        # verify that both tickets are in open state
-        $Self->True(
-            index( $Selenium->get_page_source(), $Tickets[0]->{TicketNumber} ) > -1,
-            "Open ticket $Tickets[0]->{TicketNumber} found on page",
-        );
-        $Self->True(
-            index( $Selenium->get_page_source(), $Tickets[1]->{TicketNumber} ) > -1,
-            "Open ticket $Tickets[1]->{TicketNumber} found on page",
-        );
+        # verify that test tickets are in open state
+        for my $Ticket (@Tickets) {
+            $Self->True(
+                index( $Selenium->get_page_source(), $Ticket->{TicketNumber} ) > -1,
+                "Open ticket $Ticket->{TicketNumber} is found on page",
+            );
+        }
 
         # select both tickets and click on "bulk"
-        $Selenium->find_element("//input[\@value='$Tickets[0]->{TicketID}']")->VerifiedClick();
-        $Selenium->find_element("//input[\@value='$Tickets[1]->{TicketID}']")->VerifiedClick();
+        # test case for the bug #11805 - http://bugs.otrs.org/show_bug.cgi?id=11805
+        $Selenium->find_element("//input[\@value='$Tickets[0]->{TicketID}']")->click();
+        $Selenium->find_element("//input[\@value='$Tickets[1]->{TicketID}']")->click();
+        $Selenium->find_element("//input[\@value='$Tickets[2]->{TicketID}']")->click();
         $Selenium->find_element( "Bulk", 'link_text' )->VerifiedClick();
 
         # switch to bulk window
@@ -108,7 +151,50 @@ $Selenium->RunTest(
             $Element->is_displayed();
         }
 
-        # close state and change priority in bulk action for test tickets
+        # click on 'Undo & close' link
+        $Selenium->find_element( ".UndoClosePopup", 'css' )->click();
+
+        # return to status view
+        $Selenium->WaitFor( WindowCount => 1 );
+        $Selenium->switch_to_window( $Handles->[0] );
+
+        # check ticket lock
+        $Self->Is(
+            $TicketObject->TicketLockGet(
+                TicketID => $Tickets[0]->{TicketID},
+            ),
+            1,
+            "Ticket remind locked after undo in bulk feature - $Tickets[0]->{TicketNumber}"
+        );
+
+        # select test tickets and click on "bulk"
+        $Selenium->find_element("//input[\@value='$Tickets[0]->{TicketID}']")->click();
+        $Selenium->find_element("//input[\@value='$Tickets[1]->{TicketID}']")->click();
+        $Selenium->find_element("//input[\@value='$Tickets[2]->{TicketID}']")->click();
+        $Selenium->find_element( "Bulk", 'link_text' )->click();
+
+        # switch to bulk window
+        $Selenium->WaitFor( WindowCount => 2 );
+        $Handles = $Selenium->get_window_handles();
+        $Selenium->switch_to_window( $Handles->[1] );
+
+        # wait until page has loaded, if necessary
+        $Selenium->WaitFor( JavaScript => 'return typeof($) === "function" && $("#StateID").length' );
+
+        # check data
+        my @ExpectedMessages = (
+            $Tickets[0]->{TicketNumber} . ': Ticket is selected.',
+            $Tickets[1]->{TicketNumber} . ': Ticket is locked.',
+            $Tickets[2]->{TicketNumber} . ': Ticket is locked by another agent and will be ignored!',
+        );
+        for my $ExpectedMessage (@ExpectedMessages) {
+            $Self->True(
+                index( $Selenium->get_page_source(), $ExpectedMessage ) > -1,
+                $ExpectedMessage,
+            );
+        }
+
+        # change state and priority in bulk action for test tickets
         $Selenium->execute_script("\$('#PriorityID').val('4').trigger('redraw.InputField').trigger('change');");
         $Selenium->execute_script("\$('#StateID').val('2').trigger('redraw.InputField').trigger('change');");
         $Selenium->find_element( "#submitRichText", 'css' )->click();
@@ -123,15 +209,24 @@ $Selenium->RunTest(
         # select closed view to verify ticket bulk functionality
         $Selenium->find_element("//a[contains(\@href, \'Filter=Closed' )]")->VerifiedClick();
 
-        # verify that both tickets are shown in ticket closed view
-        $Self->True(
-            index( $Selenium->get_page_source(), $Tickets[0]->{TicketNumber} ) > -1,
-            "Closed ticket $Tickets[0]->{TicketNumber} found on page",
-        ) || die "Could not find closed ticket $Tickets[0]->{TicketNumber} on page";
-        $Self->True(
-            index( $Selenium->get_page_source(), $Tickets[1]->{TicketNumber} ) > -1,
-            "Closed ticket $Tickets[1]->{TicketNumber} found on page",
-        ) || die "Could not find closed ticket $Tickets[1]->{TicketNumber} on page";
+        # verify which tickets are shown in ticket closed view
+        for my $Ticket (@Tickets) {
+            if ( $Ticket->{OwnerID} != 1 ) {
+                $Self->True(
+                    index( $Selenium->get_page_source(), $Ticket->{TicketNumber} ) > -1,
+                    "Closed ticket $Ticket->{TicketNumber} is found on page",
+                );
+            }
+            else {
+
+                # ticket is locked by another agent and it was ignored in bulk feature
+                $Self->True(
+                    index( $Selenium->get_page_source(), $Ticket->{TicketNumber} ) == -1,
+                    "Ticket $Ticket->{TicketNumber} is not found on page",
+                );
+            }
+
+        }
 
         # clean up test data from the DB
         for my $Ticket (@Tickets) {


### PR DESCRIPTION
Hi Martin,

There is our proposal for fixing this bug. We are improved this feature. I added message for the tickets that was locked before a bulk features. I changed selenium test for AgentTIcketBulk as well.

Please let me know what do you think about that.

Regards
Zoran