### PR TITLE
Bugfix: Load missing Customer Company names (CustomerID search).

### DIFF
--- a/Kernel/Modules/AgentCustomerInformationCenterSearch.pm
+++ b/Kernel/Modules/AgentCustomerInformationCenterSearch.pm
@@ -46,6 +46,7 @@ sub Run {
 
         my %CustomerCompanyList = $Kernel::OM->Get('Kernel::System::CustomerCompany')->CustomerCompanyList(
             Search => $ParamObject->GetParam( Param => 'Term' ) || '',
+            Limit => 0,
         );
 
         # add CustomerIDs for which no CustomerCompany are registered


### PR DESCRIPTION
Please, take a look at [http://bugs.otrs.org/show_bug.cgi?id=11808](http://bugs.otrs.org/show_bug.cgi?id=11808).

We got 600+ registered customers in our system. 

System loads only 250 Customers, so it might happen that some Customer information is not included. This patch allows to load all Customers available in the system.

This fix could be applied on the "master" branch also.

If you have any questions, please don't hesitate to ask.

BR,
Jaroslav

