### PR TITLE
[ Rel-5_0 Bug 9241 ] - Ticket searching in GenericAgent not working as expected - ver2

### DIFF
--- a/Kernel/Config/Files/Ticket.xml
+++ b/Kernel/Config/Files/Ticket.xml
@@ -9288,6 +9288,17 @@
             </Hash>
         </Setting>
     </ConfigItem>
+    <ConfigItem Name="Ticket::GenericAgentTicketSearch###ExtendedSearchCondition" Required="1" Valid="1">
+        <Description Translatable="1">Allows extended search conditions in ticket search of the generic agent interface. With this feature you can search e. g. ticket title with this kind of conditions like "(*key1*&amp;&amp;*key2*)" or "(*key1*||*key2*)".</Description>
+        <Group>Ticket</Group>
+        <SubGroup>Core::Ticket</SubGroup>
+        <Setting>
+            <Option SelectedID="1">
+                <Item Key="0" Translatable="1">No</Item>
+                <Item Key="1" Translatable="1">Yes</Item>
+            </Option>
+        </Setting>
+    </ConfigItem>
     <ConfigItem Name="Ticket::GenericAgentRunLimit" Required="0" Valid="1">
         <Description Translatable="1">Set the limit of tickets that will be executed on a single genericagent job execution.</Description>
         <Group>Ticket</Group>

--- a/Kernel/Modules/AdminGenericAgent.pm
+++ b/Kernel/Modules/AdminGenericAgent.pm
@@ -1253,17 +1253,19 @@ sub _MaskRun {
         }
     }
 
-    # get ticket object
+    # get needed objects
     my $TicketObject = $Kernel::OM->Get('Kernel::System::Ticket');
+    my $ConfigObject = $Kernel::OM->Get('Kernel::Config');
 
     # perform ticket search
-    my $Counter = $TicketObject->TicketSearch(
+    my $GenericAgentTicketSearch = $ConfigObject->Get("Ticket::GenericAgentTicketSearch");
+    my $Counter                  = $TicketObject->TicketSearch(
         Result          => 'COUNT',
         SortBy          => 'Age',
         OrderBy         => 'Down',
         UserID          => 1,
         Limit           => 60_000,
-        ConditionInline => 1,
+        ConditionInline => $GenericAgentTicketSearch->{ExtendedSearchCondition},
         %JobData,
         %DynamicFieldSearchParameters,
     ) || 0;
@@ -1274,7 +1276,7 @@ sub _MaskRun {
         OrderBy         => 'Down',
         UserID          => 1,
         Limit           => 30,
-        ConditionInline => 1,
+        ConditionInline => $GenericAgentTicketSearch->{ExtendedSearchCondition},
         %JobData,
         %DynamicFieldSearchParameters,
     );
@@ -1294,7 +1296,7 @@ sub _MaskRun {
         },
     );
 
-    my $RunLimit = $Kernel::OM->Get('Kernel::Config')->Get('Ticket::GenericAgentRunLimit');
+    my $RunLimit = $ConfigObject->Get('Ticket::GenericAgentRunLimit');
     if ( $Counter > $RunLimit ) {
         $LayoutObject->Block(
             Name => 'RunLimit',

--- a/Kernel/System/GenericAgent.pm
+++ b/Kernel/System/GenericAgent.pm
@@ -315,14 +315,15 @@ sub JobRun {
         $Job{TicketID} = $Param{OnlyTicketID};
     }
 
-    # get ticket object
+    # get needed objects
     my $TicketObject = $Kernel::OM->Get('Kernel::System::Ticket');
+    my $ConfigObject = $Kernel::OM->Get('Kernel::Config');
 
     # escalation tickets
     my %Tickets;
 
     # get ticket limit on job run
-    my $RunLimit = $Kernel::OM->Get('Kernel::Config')->Get('Ticket::GenericAgentRunLimit');
+    my $RunLimit = $ConfigObject->Get('Ticket::GenericAgentRunLimit');
     if ( $Job{Escalation} ) {
 
         # Find all tickets which will escalate within the next five days.
@@ -453,7 +454,7 @@ sub JobRun {
             %Tickets = $TicketObject->TicketSearch(
                 %Job,
                 %DynamicFieldSearchParameters,
-                ConditionInline => 1,
+                ConditionInline => $ConfigObject->Get("Ticket::GenericAgentTicketSearch")->{ExtendedSearchCondition},
                 Limit           => $Param{Limit} || $RunLimit,
                 UserID          => $Param{UserID},
             );

--- a/scripts/test/Selenium/Agent/Admin/AdminGenericAgent.t
+++ b/scripts/test/Selenium/Agent/Admin/AdminGenericAgent.t
@@ -18,19 +18,27 @@ my $Selenium = $Kernel::OM->Get('Kernel::System::UnitTest::Selenium');
 $Selenium->RunTest(
     sub {
 
-        # get helper object
+        # get needed objects
         $Kernel::OM->ObjectParamAdd(
             'Kernel::System::UnitTest::Helper' => {
                 RestoreSystemConfiguration => 1,
             },
         );
-        my $Helper = $Kernel::OM->Get('Kernel::System::UnitTest::Helper');
+        my $Helper          = $Kernel::OM->Get('Kernel::System::UnitTest::Helper');
+        my $SysConfigObject = $Kernel::OM->Get('Kernel::System::SysConfig');
 
         # set generic agent run limit
-        $Kernel::OM->Get('Kernel::System::SysConfig')->ConfigItemUpdate(
+        $SysConfigObject->ConfigItemUpdate(
             Valid => 1,
             Key   => 'Ticket::GenericAgentRunLimit',
             Value => 10
+        );
+
+        # enable extended condition search for generic agent ticket search
+        $SysConfigObject->ConfigItemUpdate(
+            Valid => 1,
+            Key   => 'Ticket::GenericAgentTicketSearch###ExtendedSearchCondition',
+            Value => 1,
         );
 
         # create test user and login
@@ -53,7 +61,8 @@ $Selenium->RunTest(
         my $TicketObject = $Kernel::OM->Get('Kernel::System::Ticket');
 
         # create test tickets
-        my $TestTicketTitle = 'TicketGenericAgent' . $Helper->GetRandomID();
+        my $TestTicketRandomID = $Helper->GetRandomID();
+        my $TestTicketTitle    = "Test Ticket $TestTicketRandomID Generic Agent";
         my @TicketNumbers;
         for ( 1 .. 20 ) {
 
@@ -105,9 +114,10 @@ $Selenium->RunTest(
         $Selenium->execute_script('$(".WidgetSimple.Collapsed .WidgetAction.Toggle a").click();');
 
         # create test job
-        my $RandomID = "GenericAgent" . $Helper->GetRandomID();
+        my $GenericTicketSearch = "*Ticket $TestTicketRandomID Generic*";
+        my $RandomID            = "GenericAgent" . $Helper->GetRandomID();
         $Selenium->find_element( "#Profile", 'css' )->send_keys($RandomID);
-        $Selenium->find_element( "#Title",   'css' )->send_keys($TestTicketTitle);
+        $Selenium->find_element( "#Title",   'css' )->send_keys($GenericTicketSearch);
         $Selenium->find_element( "#Profile", 'css' )->VerifiedSubmit();
 
         # check if test job show on AdminGenericAgent
@@ -123,6 +133,25 @@ $Selenium->RunTest(
         $Selenium->execute_script('$(".WidgetSimple.Collapsed .WidgetAction.Toggle a").click();');
         $Selenium->execute_script("\$('#NewDelete').val('1').trigger('redraw.InputField').trigger('change');");
         $Selenium->find_element( "#Profile", 'css' )->VerifiedSubmit();
+
+        # run test job
+        $Selenium->find_element("//a[contains(\@href, \'Subaction=Run;Profile=$RandomID' )]")->VerifiedClick();
+
+        # verify there are no tickets found with enabled ExtendedSearchCondition
+        $Self->True(
+            index( $Selenium->get_page_source(), '0 Tickets affected! What do you want to do?' ) > -1,
+            "No tickets found on page with ExtendedSearchCondition enabled",
+        );
+
+        # disable extended condition search for generic agent ticket search
+        $SysConfigObject->ConfigItemUpdate(
+            Valid => 1,
+            Key   => 'Ticket::GenericAgentTicketSearch###ExtendedSearchCondition',
+            Value => 0,
+        );
+
+        # navigate to AgentGenericAgent screen again
+        $Selenium->VerifiedGet("${ScriptAlias}index.pl?Action=AdminGenericAgent");
 
         # run test job
         $Selenium->find_element("//a[contains(\@href, \'Subaction=Run;Profile=$RandomID' )]")->VerifiedClick();


### PR DESCRIPTION
Hello @mgruner ,

Thank you for your feedback on previous PR regarding this issue. You are right regarding ConditionInline param. Although without 'ContentSearchPrefix' and 'ContentSearchSuffix' params in TicketSearch() for GenericAgent, if user want to search by only 2-3 words extracted from ticket title he must then add * before and after each word. This behaviour is not present in AgentTicketSearch where those params are sent to TicketSearch() function. 
On the end i think it's better to go forward with this approach ( without prefix and suffix params ) so there is clear option left for user if and how they want to use ticket search function in AdminGenericAgent. Additionally it can prevent some unexpected tickets to show in search result causing further unwanted ticket actions on those tickets.

Added new sysconfig 'Ticket::GenericAgentTicketSearch###ExtendedSearchCondition' to control ConditionInline param. In description of a config added how to use appropriately if user wants to search by multiple words that are not next to each-other e.g. (*key1*||*key2*)

Update Selenium tests to search first tickets when this sysconfig is enabled, expecting no results found, since search input is "*Ticket $TestTicketRandomID Generic*". After disabling sysconfig, test find expected tickets and continue with module testing.

Please review this updated proposal and let me know if there are any issues or remarks.

Kind regards,
Sanjin