### PR TITLE
Bug 11810 - <OTRS_TICKET_State> not translated

### DIFF
--- a/Kernel/System/TemplateGenerator.pm
+++ b/Kernel/System/TemplateGenerator.pm
@@ -412,6 +412,25 @@ sub Template {
         );
     }
 
+    # get user language
+    my $Language;
+    if ( defined $Param{TicketID} ) {
+
+        # get ticket data
+        my %Ticket = $Kernel::OM->Get('Kernel::System::Ticket')->TicketGet(
+            TicketID => $Param{TicketID},
+        );
+
+        # get recipient
+        my %User = $Kernel::OM->Get('Kernel::System::CustomerUser')->CustomerUserDataGet(
+            User => $Ticket{CustomerUserID},
+        );
+        $Language = $User{UserLanguage};
+    }
+
+    # if customer language is not defined, set default language
+    $Language //= $Kernel::OM->Get('Kernel::Config')->Get('DefaultLanguage') || 'en';
+
     # replace place holder stuff
     my $TemplateText = $Self->_Replace(
         RichText => $Self->{RichText},
@@ -419,6 +438,7 @@ sub Template {
         TicketID => $Param{TicketID} || '',
         Data     => $Param{Data} || {},
         UserID   => $Param{UserID},
+        Language => $Language,
     );
 
     return $TemplateText;
@@ -1127,7 +1147,7 @@ sub _Replace {
             NoOutOfOffice => 1,
         );
 
-        # html quoting of content
+        # HTML quoting of content
         if ( $Param{RichText} ) {
 
             ATTRIBUTE:
@@ -1153,7 +1173,7 @@ sub _Replace {
         NoOutOfOffice => 1,
     );
 
-    # html quoting of content
+    # HTML quoting of content
     if ( $Param{RichText} ) {
 
         ATTRIBUTE:
@@ -1290,7 +1310,7 @@ sub _Replace {
     for my $DataType (qw(OTRS_CUSTOMER_ OTRS_AGENT_)) {
         my %Data = %{ $ArticleData{$DataType} };
 
-        # html quoting of content
+        # HTML quoting of content
         if (
             $Param{RichText}
             && ( !$Data{ContentType} || $Data{ContentType} !~ /application\/json/ )
@@ -1322,7 +1342,7 @@ sub _Replace {
                         Data => $Data{Body},
                     );
 
-                    # replace body with html text
+                    # replace body with HTML text
                     $Data{Body} = $Kernel::OM->Get('Kernel::Output::HTML::Layout')->Output(
                         TemplateFile => "ChatDisplay",
                         Data         => {

--- a/scripts/test/Selenium/Agent/AgentTicketCompose.t
+++ b/scripts/test/Selenium/Agent/AgentTicketCompose.t
@@ -53,24 +53,102 @@ $Selenium->RunTest(
             Value => 0
         );
 
+        # disable RequiredLock for AgentTicketCompose
+        $SysConfigObject->ConfigItemUpdate(
+            Valid => 1,
+            Key   => 'Ticket::Frontend::AgentTicketCompose###RequiredLock',
+            Value => 0
+        );
+
+        # get standard template object
+        my $StandardTemplateObject = $Kernel::OM->Get('Kernel::System::StandardTemplate');
+
+        # create a new template
+        my $TemplateID = $StandardTemplateObject->StandardTemplateAdd(
+            Name     => 'New Standard Template' . $Helper->GetRandomID(),
+            Template => "Thank you for your email.
+                             Ticket state: <OTRS_TICKET_State>.\n
+                             Ticket lock: <OTRS_TICKET_Lock>.\n
+                             Ticket priority: <OTRS_TICKET_Priority>.\n
+                            ",
+            ContentType  => 'text/plain; charset=utf-8',
+            TemplateType => 'Answer',
+            ValidID      => 1,
+            UserID       => 1,
+        );
+        $Self->True(
+            $TemplateID,
+            "Standard template is created - ID $TemplateID",
+        );
+
+        # assign template to the queue
+        my $Success = $Kernel::OM->Get('Kernel::System::Queue')->QueueStandardTemplateMemberAdd(
+            QueueID            => 1,
+            StandardTemplateID => $TemplateID,
+            Active             => 1,
+            UserID             => 1,
+        );
+        $Self->True(
+            $Success,
+            "$TemplateID is assigned to the queue.",
+        );
+
+        # get customer user object
+        my $CustomerUserObject = $Kernel::OM->Get('Kernel::System::CustomerUser');
+
+        # add test customer for testing
+        my $TestCustomer       = 'Customer' . $Helper->GetRandomID();
+        my $CustomerEmail      = "$TestCustomer\@localhost.com";
+        my $TestCustomerUserID = $CustomerUserObject->CustomerUserAdd(
+            Source         => 'CustomerUser',
+            UserFirstname  => $TestCustomer,
+            UserLastname   => $TestCustomer,
+            UserCustomerID => $TestCustomer,
+            UserLogin      => $TestCustomer,
+            UserEmail      => $CustomerEmail,
+            ValidID        => 1,
+            UserID         => 1
+        );
+        $Self->True(
+            $TestCustomerUserID,
+            "CustomerUserAdd - ID $TestCustomerUserID",
+        );
+
+        # set customer user language
+        my $Language = 'es';
+        $Success = $CustomerUserObject->SetPreferences(
+            Key    => 'UserLanguage',
+            Value  => $Language,
+            UserID => $TestCustomer,
+        );
+        $Self->True(
+            $Success,
+            "Customer user language is set.",
+        );
+
         # get ticket object
         my $TicketObject = $Kernel::OM->Get('Kernel::System::Ticket');
 
         # create test ticket
+        my %TicketData = (
+            State    => 'new',
+            Priority => '4 high',
+            Lock     => 'unlock',
+        );
         my $TicketID = $TicketObject->TicketCreate(
-            Title        => 'Selenium ticket',
-            Queue        => 'Raw',
-            Lock         => 'unlock',
-            Priority     => '3 normal',
-            State        => 'new',
+            Title    => 'Selenium ticket',
+            QueueID  => 1,
+            Lock     => $TicketData{Lock},
+            Priority => $TicketData{Priority},
+            State    => $TicketData{State},
             CustomerID   => 'SeleniumCustomer',
-            CustomerUser => 'customer@example.com',
+            CustomerUser => $TestCustomer,
             OwnerID      => 1,
             UserID       => 1,
         );
         $Self->True(
             $TicketID,
-            "TicketCreate - ID $TicketID",
+            "Ticket is created - ID $TicketID",
         );
 
         # create test email article
@@ -88,25 +166,7 @@ $Selenium->RunTest(
         );
         $Self->True(
             $ArticleID,
-            "ArticleCreate - ID $ArticleID",
-        );
-
-        # add test customer for testing
-        my $TestCustomer       = 'Customer' . $Helper->GetRandomID();
-        my $CustomerEmail      = "$TestCustomer\@localhost.com";
-        my $TestCustomerUserID = $Kernel::OM->Get('Kernel::System::CustomerUser')->CustomerUserAdd(
-            Source         => 'CustomerUser',
-            UserFirstname  => $TestCustomer,
-            UserLastname   => $TestCustomer,
-            UserCustomerID => $TestCustomer,
-            UserLogin      => $TestCustomer,
-            UserEmail      => $CustomerEmail,
-            ValidID        => 1,
-            UserID         => 1
-        );
-        $Self->True(
-            $TestCustomerUserID,
-            "CustomerUserAdd - ID $TestCustomerUserID",
+            "Article is created - ID $ArticleID",
         );
 
         # create test user and login
@@ -127,7 +187,9 @@ $Selenium->RunTest(
         $Selenium->VerifiedGet("${ScriptAlias}index.pl?Action=AgentTicketZoom;TicketID=$TicketID");
 
         # click on reply
-        $Selenium->execute_script("\$('#ResponseID').val('1').trigger('redraw.InputField').trigger('change');");
+        $Selenium->execute_script(
+            "\$('#ResponseID').val('$TemplateID').trigger('redraw.InputField').trigger('change');"
+        );
 
         # switch to compose window
         $Selenium->WaitFor( WindowCount => 2 );
@@ -147,6 +209,21 @@ $Selenium->RunTest(
             $Element->is_enabled();
         }
 
+        # test bug #11810 - http://bugs.otrs.org/show_bug.cgi?id=11810
+        # translate ticket data tags (e.g. <OTRS_TICKET_State> ) in standard template
+        my $LanguageObject = Kernel::Language->new(
+            UserLanguage => $Language,
+        );
+        for my $Item ( sort keys %TicketData ) {
+            my $TransletedStateValue = $LanguageObject->Translate( $TicketData{$Item} );
+
+            # check translated value
+            $Self->True(
+                index( $Selenium->get_page_source(), $TransletedStateValue ) > -1,
+                "Translated \'$Item\' value is found - $TicketData{$Item} .",
+            );
+        }
+
         # input required fields and submit compose
         my $AutoCompleteString = "\"$TestCustomer $TestCustomer\" <$TestCustomer\@localhost.com> ($TestCustomer)";
         $Selenium->find_element( "#ToCustomer", 'css' )->send_keys($TestCustomer);
@@ -160,8 +237,17 @@ $Selenium->RunTest(
         $Selenium->WaitFor( WindowCount => 1 );
         $Selenium->switch_to_window( $Handles->[0] );
 
-        # navigate to AgentTicketHistory screen of created test ticket
-        $Selenium->VerifiedGet("${ScriptAlias}index.pl?Action=AgentTicketHistory;TicketID=$TicketID");
+        # force sub menus to be visible in order to be able to click one of the links
+        $Selenium->execute_script("\$('.Cluster ul ul').addClass('ForceVisible');");
+
+        $Selenium->find_element("//*[text()='History']")->click();
+
+        $Selenium->WaitFor( WindowCount => 2 );
+        $Handles = $Selenium->get_window_handles();
+        $Selenium->switch_to_window( $Handles->[1] );
+
+        # wait until page has loaded, if necessary
+        $Selenium->WaitFor( JavaScript => 'return typeof($) === "function" && $(".CancelClosePopup").length' );
 
         # verify that compose worked as expected
         my $HistoryText = "Email sent to \"\"$TestCustomer $TestCustomer\"";
@@ -172,13 +258,22 @@ $Selenium->RunTest(
         );
 
         # delete created test ticket
-        my $Success = $TicketObject->TicketDelete(
+        $Success = $TicketObject->TicketDelete(
             TicketID => $TicketID,
             UserID   => 1,
         );
         $Self->True(
             $Success,
             "Ticket with ticket ID $TicketID is deleted"
+        );
+
+        # delete standard template
+        $Success = $StandardTemplateObject->StandardTemplateDelete(
+            ID => $TemplateID,
+        );
+        $Self->True(
+            $Success,
+            "Standard template is deleted - ID $TemplateID"
         );
 
         # delete created test customer user


### PR DESCRIPTION
http://bugs.otrs.org/show_bug.cgi?id=11810

Hi Martin,

This is our proposal for fixing. There was a problem because in the Standard Template was not the language selected in TemplateGenerator module.

I extended Selenium test with this test case as well. In my opinion we can add Language parameter also for Signature and Salutation.
In hint for these two entities there is possibility to add:

<code>
...

<OTRS_TICKET_*>
    Options of the ticket data (e. g. OTRS_TICKET_TicketNumber, OTRS_TICKET_TicketID> OTRS_TICKET_Queue, OTRS_TICKET_State). 

...
</code> 

Please let me know what do you think about all of that.

Regards
Zoran
