### PR TITLE
[ Rel-5_0 Bug 11826 ] - Split ignores CC

### DIFF
--- a/Kernel/Modules/AgentTicketPhone.pm
+++ b/Kernel/Modules/AgentTicketPhone.pm
@@ -319,6 +319,9 @@ sub Run {
                     $ArticleFrom = $Article{To};
                 }
             }
+            elsif ( IsStringWithData( $Article{Cc} ) ) {
+                $ArticleFrom = $Article{Cc};
+            }
 
             # body preparation for plain text processing
             $Article{Body} = $LayoutObject->ArticleQuote(

--- a/scripts/test/Selenium/Agent/AgentTicketSplitCc.t
+++ b/scripts/test/Selenium/Agent/AgentTicketSplitCc.t
@@ -1,0 +1,99 @@
+# --
+# Copyright (C) 2001-2016 OTRS AG, http://otrs.com/
+# --
+# This software comes with ABSOLUTELY NO WARRANTY. For details, see
+# the enclosed file COPYING for license information (AGPL). If you
+# did not receive this file, see http://www.gnu.org/licenses/agpl.txt.
+# --
+
+use strict;
+use warnings;
+use utf8;
+
+use vars (qw($Self));
+
+# get selenium object
+my $Selenium = $Kernel::OM->Get('Kernel::System::UnitTest::Selenium');
+
+$Selenium->RunTest(
+    sub {
+
+        # get needed objects
+        my $Helper       = $Kernel::OM->Get('Kernel::System::UnitTest::Helper');
+        my $TicketObject = $Kernel::OM->Get('Kernel::System::Ticket');
+
+        # create test ticket
+        my $TicketID = $TicketObject->TicketCreate(
+            Title        => 'Selenium test ticket',
+            Queue        => 'Raw',
+            Lock         => 'unlock',
+            Priority     => '3 normal',
+            State        => 'new',
+            CustomerID   => '123465',
+            CustomerUser => 'customer@example.com',
+            OwnerID      => 1,
+            UserID       => 1,
+        );
+        $Self->True(
+            $TicketID,
+            "TicketID $TicketID is created",
+        );
+
+        # create test article for test ticket
+        my $ArticleID = $TicketObject->ArticleCreate(
+            TicketID       => $TicketID,
+            ArticleType    => 'email-external',
+            SenderType     => 'customer',
+            Cc             => 'Cc@localhost.com',
+            Subject        => 'Selenium test',
+            Body           => 'Just a test body for selenium testing',
+            Charset        => 'ISO-8859-15',
+            MimeType       => 'text/plain',
+            HistoryType    => 'PhoneCallCustomer',
+            HistoryComment => 'Selenium testing',
+            UserID         => 1,
+        );
+        $Self->True(
+            $ArticleID,
+            "ArticleID $ArticleID is created",
+        );
+
+        # create test user and log in
+        my $TestUserLogin = $Helper->TestUserCreate(
+            Groups => [ 'admin', 'users' ],
+        ) || die "Did not get test user";
+
+        $Selenium->Login(
+            Type     => 'Agent',
+            User     => $TestUserLogin,
+            Password => $TestUserLogin,
+        );
+
+        # get script alias
+        my $ScriptAlias = $Kernel::OM->Get('Kernel::Config')->Get('ScriptAlias');
+
+        # navigate to split ticket screen of test ticket
+        $Selenium->VerifiedGet(
+            "${ScriptAlias}index.pl?Action=AgentTicketPhone;TicketID=$TicketID;ArticleID=$ArticleID;LinkTicketID=$TicketID"
+        );
+
+        # verify FromCustomer value after splitting ticket that have only Cc, see bug #11286
+        $Self->Is(
+            $Selenium->find_element("//input[\@type='text'][\@name='CustomerTicketText_1']")->get_value(),
+            'Cc@localhost.com',
+            'FromCustomer value on ticket split',
+        );
+
+        # delete test created ticket
+        my $Success = $TicketObject->TicketDelete(
+            TicketID => $TicketID,
+            UserID   => 1,
+        );
+        $Self->True(
+            $Success,
+            "TicketID $TicketID is deleted",
+        );
+    }
+);
+
+1;


### PR DESCRIPTION
http://bugs.otrs.org/show_bug.cgi?id=11826

Hello @mgruner ,

This is our proposal for fixing this reporters issues. Must admit that reproducing this kind of behaviour is more artificial then natural work flow. Current OTRS Split function IMO works as expected. Created Selenium test to simulate this type of behaviour.

Please if you could consider PR ( https://github.com/OTRS/otrs/pull/843 ) together when evaluating this proposal.

Kind regards,
Sanjin