### PR TITLE
[ Rel-5_0 Bug 11816 ] - Ticket::Service::KeepChildren parameter - invalid Parent Service

### DIFF
--- a/Kernel/Modules/AdminGenericAgent.pm
+++ b/Kernel/Modules/AdminGenericAgent.pm
@@ -830,7 +830,7 @@ sub _MaskUpdate {
         # get list type
         my %Service = $Kernel::OM->Get('Kernel::System::Service')->ServiceList(
             Valid        => 1,
-            KeepChildren => 1,
+            KeepChildren => $ConfigObject->Get('Ticket::Service::KeepChildren'),
             UserID       => $Self->{UserID},
         );
         my %NewService = %Service;

--- a/Kernel/Modules/AdminNotificationEvent.pm
+++ b/Kernel/Modules/AdminNotificationEvent.pm
@@ -922,7 +922,7 @@ sub _Edit {
         # get list type
         my %Service = $Kernel::OM->Get('Kernel::System::Service')->ServiceList(
             Valid        => 1,
-            KeepChildren => 1,
+            KeepChildren => $ConfigObject->Get('Ticket::Service::KeepChildren'),
             UserID       => $Self->{UserID},
         );
         $Param{ServicesStrg} = $LayoutObject->BuildSelection(

--- a/Kernel/Modules/AdminSLA.pm
+++ b/Kernel/Modules/AdminSLA.pm
@@ -224,9 +224,8 @@ sub Run {
 
         # get service list
         my %ServiceList = $Kernel::OM->Get('Kernel::System::Service')->ServiceList(
-            Valid        => 0,
-            KeepChildren => 1,
-            UserID       => $Self->{UserID},
+            Valid  => 0,
+            UserID => $Self->{UserID},
         );
 
         # get valid list
@@ -335,7 +334,7 @@ sub _MaskNew {
     # get service list
     my %ServiceList = $Kernel::OM->Get('Kernel::System::Service')->ServiceList(
         Valid        => 1,
-        KeepChildren => 1,
+        KeepChildren => $ConfigObject->Get('Ticket::Service::KeepChildren'),
         UserID       => $Self->{UserID},
     );
 

--- a/Kernel/Modules/AgentTicketService.pm
+++ b/Kernel/Modules/AgentTicketService.pm
@@ -448,7 +448,7 @@ sub Run {
 
     # get all services
     my %AllServices = $ServiceObject->ServiceList(
-        Valid  => 1,
+        Valid  => 0,
         UserID => $Self->{UserID},
     );
 

--- a/Kernel/Output/HTML/Preferences/CustomService.pm
+++ b/Kernel/Output/HTML/Preferences/CustomService.pm
@@ -40,12 +40,15 @@ sub Param {
     my @Params;
     my @CustomServiceIDs;
 
+    # get config object
+    my $ConfigObject = $Kernel::OM->Get('Kernel::Config');
+
     # check needed param,
     # if no user id is given or Ticket::Service is disabled
     # do not show this box
     if (
         !$Param{UserData}->{UserID}
-        || !$Kernel::OM->Get('Kernel::Config')->Get('Ticket::Service')
+        || !$ConfigObject->Get('Ticket::Service')
         )
     {
         return ();
@@ -53,8 +56,9 @@ sub Param {
 
     # get all services
     my %ServiceList = $Kernel::OM->Get('Kernel::System::Service')->ServiceList(
-        Valid  => 1,
-        UserID => $Self->{UserID},
+        KeepChildren => $ConfigObject->Get('Ticket::Service::KeepChildren'),
+        Valid        => 1,
+        UserID       => $Self->{UserID},
     );
 
     # get param object

--- a/scripts/test/Selenium/Agent/AgentTicketService.t
+++ b/scripts/test/Selenium/Agent/AgentTicketService.t
@@ -51,17 +51,52 @@ $Selenium->RunTest(
             Password => $TestUserLogin,
         );
 
-        # create service for test
-        my $ServiceName = 'Service' . $Helper->GetRandomID();
-        my $ServiceID   = $Kernel::OM->Get('Kernel::System::Service')->ServiceAdd(
-            Name    => $ServiceName,
-            ValidID => 1,
-            Comment => 'Selenium Test',
-            UserID  => 1,
+        # get service object
+        my $ServiceObject = $Kernel::OM->Get('Kernel::System::Service');
+
+        # create two test services
+        my @ServiceIDs;
+        my @ServiceNames;
+        for my $Service (qw(Parent Child)) {
+            my $ServiceName = $Service . 'Service' . $Helper->GetRandomID();
+            my $ServiceID   = $ServiceObject->ServiceAdd(
+                Name    => $ServiceName,
+                ValidID => 1,
+                Comment => 'Selenium Test',
+                UserID  => 1,
+            );
+            $Self->True(
+                $ServiceID,
+                "Service ID $ServiceID is created",
+            );
+            push @ServiceIDs,   $ServiceID;
+            push @ServiceNames, $ServiceName;
+        }
+
+        # update second service to be child of first one
+        my $Success = $ServiceObject->ServiceUpdate(
+            ServiceID => $ServiceIDs[1],
+            Name      => $ServiceNames[1],
+            ParentID  => $ServiceIDs[0],
+            ValidID   => 1,
+            UserID    => 1,
         );
         $Self->True(
-            $ServiceID,
-            "Service is created - ID $ServiceID",
+            $Success,
+            "Service ID $ServiceIDs[1] is now child service"
+        );
+
+        # update parent service to invalid status, bug #11816
+        # test if child service are visible when parent is invalid
+        $Success = $ServiceObject->ServiceUpdate(
+            ServiceID => $ServiceIDs[0],
+            Name      => $ServiceNames[0],
+            ValidID   => 2,
+            UserID    => 1,
+        );
+        $Self->True(
+            $Success,
+            "Parent Service ID $ServiceIDs[0] is invalid"
         );
 
         # get ticket object
@@ -76,7 +111,7 @@ $Selenium->RunTest(
                 Lock          => $Lock,
                 Priority      => '3 normal',
                 State         => 'open',
-                ServiceID     => $ServiceID,
+                ServiceID     => $ServiceIDs[1],
                 CustomerID    => 'SeleniumCustomer',
                 CustomerUser  => 'SeleniumCustomer@localhost.com',
                 OwnerID       => 1,
@@ -85,11 +120,9 @@ $Selenium->RunTest(
             );
             $Self->True(
                 $TicketID,
-                "Ticket is created - ID $TicketID",
+                "Ticket ID $TicketID is created",
             );
-
             push @TicketIDs, $TicketID;
-
         }
 
         # get script alias
@@ -106,23 +139,29 @@ $Selenium->RunTest(
             "No tickets found with My Service filter",
         );
 
-        # check for test service filter button
+        # check for parent test service filter button and click on it
         my $Element = $Selenium->find_element(
-            "//a[contains(\@href, \'Action=AgentTicketService;ServiceID=$ServiceID;\' )]"
+            "//a[contains(\@href, \'Action=AgentTicketService;ServiceID=$ServiceIDs[0];\' )]"
         );
         $Element->is_enabled();
         $Element->is_displayed();
         $Element->VerifiedClick();
 
+        # click on child service
+        $Selenium->find_element("//a[contains(\@href, \'Action=AgentTicketService;ServiceID=$ServiceIDs[1];\' )]")
+            ->VerifiedClick();
+
         # check different views for filters
         for my $View (qw(Small Medium Preview)) {
 
             # go to default small view
-            $Selenium->VerifiedGet("${ScriptAlias}index.pl?Action=AgentTicketService;ServiceID=$ServiceID;View=Small");
+            $Selenium->VerifiedGet(
+                "${ScriptAlias}index.pl?Action=AgentTicketService;ServiceID=$ServiceIDs[1];View=Small"
+            );
 
             # click on viewer controller
             $Selenium->find_element(
-                "//a[contains(\@href, \'Filter=Unlocked;View=$View;ServiceID=$ServiceID;SortBy=Age;OrderBy=Up;View=Small;\' )]"
+                "//a[contains(\@href, \'Filter=Unlocked;View=$View;ServiceID=$ServiceIDs[1];SortBy=Age;OrderBy=Up;View=Small;\' )]"
             )->VerifiedClick();
 
             # verify that all expected tickets are present
@@ -138,7 +177,7 @@ $Selenium->RunTest(
 
                     # click on 'Available ticket' filter
                     $Selenium->find_element(
-                        "//a[contains(\@href, \'ServiceID=$ServiceID;SortBy=Age;OrderBy=Up;View=$View;Filter=Unlocked\' )]"
+                        "//a[contains(\@href, \'ServiceID=$ServiceIDs[1];SortBy=Age;OrderBy=Up;View=$View;Filter=Unlocked\' )]"
                     )->VerifiedClick();
 
                     # check for unlocked tickets with 'Available tickets' filter on
@@ -149,7 +188,7 @@ $Selenium->RunTest(
 
                     # click on 'All ticket' filter
                     $Selenium->find_element(
-                        "//a[contains(\@href, \'ServiceID=$ServiceID;SortBy=Age;OrderBy=Up;View=$View;Filter=All\' )]"
+                        "//a[contains(\@href, \'ServiceID=$ServiceIDs[1];SortBy=Age;OrderBy=Up;View=$View;Filter=All\' )]"
                     )->VerifiedClick();
 
                     # check for unlocked tickets with 'All tickets' filter on
@@ -162,7 +201,7 @@ $Selenium->RunTest(
 
                     # click on 'All ticket' filter
                     $Selenium->find_element(
-                        "//a[contains(\@href, \'ServiceID=$ServiceID;SortBy=Age;OrderBy=Up;View=$View;Filter=All\' )]"
+                        "//a[contains(\@href, \'ServiceID=$ServiceIDs[1];SortBy=Age;OrderBy=Up;View=$View;Filter=All\' )]"
                     )->VerifiedClick();
 
                     # check for locked tickets with  'All ticket' filter
@@ -173,7 +212,7 @@ $Selenium->RunTest(
 
                     # click on 'Available ticket' filter
                     $Selenium->find_element(
-                        "//a[contains(\@href, \'ServiceID=$ServiceID;SortBy=Age;OrderBy=Up;View=$View;Filter=Unlocked\' )]"
+                        "//a[contains(\@href, \'ServiceID=$ServiceIDs[1];SortBy=Age;OrderBy=Up;View=$View;Filter=Unlocked\' )]"
                     )->VerifiedClick();
 
                     # check for locked tickets with 'Available tickets' filter on
@@ -186,7 +225,6 @@ $Selenium->RunTest(
         }
 
         # delete created test tickets
-        my $Success;
         for my $TicketID (@TicketIDs) {
             $Success = $TicketObject->TicketDelete(
                 TicketID => $TicketID,
@@ -194,21 +232,20 @@ $Selenium->RunTest(
             );
             $Self->True(
                 $Success,
-                "Delete ticket - ID $TicketID"
+                "Ticket ID $TicketID is deleted"
             );
         }
 
-        # get DB object
-        my $DBObject = $Kernel::OM->Get('Kernel::System::DB');
-
         # delete created test service
-        $Success = $DBObject->Do(
-            SQL => "DELETE FROM service WHERE id = $ServiceID",
-        );
-        $Self->True(
-            $Success,
-            "Delete service - ID $ServiceID",
-        );
+        for my $ServiceDelete (@ServiceIDs) {
+            $Success = $Kernel::OM->Get('Kernel::System::DB')->Do(
+                SQL => "DELETE FROM service WHERE id = $ServiceDelete",
+            );
+            $Self->True(
+                $Success,
+                "Service ID $ServiceDelete is deleted",
+            );
+        }
 
         # make sure the cache is correct
         for my $Cache (


### PR DESCRIPTION
http://bugs.otrs.org/show_bug.cgi?id=118161

Hello @mgruner .

Hereby is proposal for fixing reporters issues.

In Preferences/CustomService.pm there was missing param KeepChildren.

In AgentTicketService.pm , even though there was no KeepChildren param, in order to reach sub level of service ( child ) we have to be able to click on parent to expand it. Edited Valid param to 0, now all service are visible even if they are valid or not. This is same fashion as how AgentTicketQueue works ATM.

Additionally i went through code and edited KeepChild param in AdminGenericAgent, AdminNotificationEvent and AdminSLA to get value from Config. In AdminSLA where we call in Overview screen for ServiceList, removed KeepChild param since we ask for all services not just valid ones, IMO there is no real point for it there, since it doesn't have an effect.

Modified Selenium test for AgentTicketService to now check tickets in child service, when parent service is set to invalid reproducing reporter issue.

Lastly, would like to ask you what do you think of proposal for future task to implement some notice for invalid ticket parameters for Queue, Service, ect. , like how it is done for Customer. 
![screen shot 2016-01-27 at 1 22 46 pm](https://cloud.githubusercontent.com/assets/6348760/12615511/68e086e6-c506-11e5-8e54-c91859a042a3.png)

Please review this proposal and let me know if there are any issues or questions regarding this PR.

Regards,
Sanjin