### PR TITLE
[ Rel 5 0 Bug 11822 ] - S/MIME support is disabled in Kernel::Config::SMIME

### DIFF
--- a/Kernel/Modules/AdminSMIME.pm
+++ b/Kernel/Modules/AdminSMIME.pm
@@ -15,8 +15,6 @@ use Kernel::Language qw(Translatable);
 
 our $ObjectManagerDisabled = 1;
 
-use Kernel::Language qw(Translatable);
-
 sub new {
     my ( $Type, %Param ) = @_;
 
@@ -30,7 +28,7 @@ sub new {
 sub Run {
     my ( $Self, %Param ) = @_;
 
-    # get needed objects
+    # get objects
     my $ParamObject  = $Kernel::OM->Get('Kernel::System::Web::Request');
     my $LayoutObject = $Kernel::OM->Get('Kernel::Output::HTML::Layout');
 
@@ -43,6 +41,7 @@ sub Run {
         $Output .= $LayoutObject->NavigationBar();
 
         $LayoutObject->Block( Name => 'Overview' );
+        $LayoutObject->Block( Name => 'Notice' );
         $LayoutObject->Block( Name => 'Disabled' );
         $LayoutObject->Block( Name => 'OverviewResult' );
         $LayoutObject->Block(
@@ -71,6 +70,7 @@ sub Run {
         );
 
         $LayoutObject->Block( Name => 'Overview' );
+        $LayoutObject->Block( Name => 'Notice' );
         $LayoutObject->Block( Name => 'NotWorking' );
         $LayoutObject->Block( Name => 'OverviewResult' );
         $LayoutObject->Block(
@@ -103,7 +103,6 @@ sub Run {
         Key       => 'SMIMESearch',
         Value     => $Param{Search},
     );
-
 
     # ------------------------------------------------------------ #
     # delete cert

--- a/Kernel/Modules/AdminSMIME.pm
+++ b/Kernel/Modules/AdminSMIME.pm
@@ -11,6 +11,8 @@ package Kernel::Modules::AdminSMIME;
 use strict;
 use warnings;
 
+use Kernel::Language qw(Translatable);
+
 our $ObjectManagerDisabled = 1;
 
 use Kernel::Language qw(Translatable);
@@ -31,15 +33,57 @@ sub Run {
     # get needed objects
     my $ParamObject  = $Kernel::OM->Get('Kernel::System::Web::Request');
     my $LayoutObject = $Kernel::OM->Get('Kernel::Output::HTML::Layout');
-    my $ConfigObject = $Kernel::OM->Get('Kernel::Config');
 
     # ------------------------------------------------------------ #
     # check if feature is active
     # ------------------------------------------------------------ #
-    if ( !$ConfigObject->Get('SMIME') ) {
-        my $Output .= $LayoutObject->FatalError(
-            Message => Translatable('S/MIME support is disabled in Kernel::Config::SMIME.'),
+    if ( !$Kernel::OM->Get('Kernel::Config')->Get('SMIME') ) {
+
+        my $Output .= $LayoutObject->Header();
+        $Output .= $LayoutObject->NavigationBar();
+
+        $LayoutObject->Block( Name => 'Overview' );
+        $LayoutObject->Block( Name => 'Disabled' );
+        $LayoutObject->Block( Name => 'OverviewResult' );
+        $LayoutObject->Block(
+            Name => 'NoDataFoundMsg',
+            Data => {},
         );
+
+        $Output .= $LayoutObject->Output( TemplateFile => 'AdminSMIME' );
+        $Output .= $LayoutObject->Footer();
+
+        return $Output;
+    }
+
+    # get SMIME objects
+    my $SMIMEObject = $Kernel::OM->Get('Kernel::System::Crypt::SMIME');
+
+    if ( !$SMIMEObject ) {
+
+        my $Output = $LayoutObject->Header();
+        $Output .= $LayoutObject->NavigationBar();
+
+        $Output .= $LayoutObject->Notify(
+            Priority => 'Error',
+            Data     => Translatable("S/MIME environment is not working. Please check log for more info!"),
+            Link     => $LayoutObject->{Baselink} . 'Action=AdminLog',
+        );
+
+        $LayoutObject->Block( Name => 'Overview' );
+        $LayoutObject->Block( Name => 'NotWorking' );
+        $LayoutObject->Block( Name => 'OverviewResult' );
+        $LayoutObject->Block(
+            Name => 'NoDataFoundMsg',
+            Data => {},
+        );
+
+        $Output .= $LayoutObject->Output(
+            TemplateFile => 'AdminSMIME',
+        );
+
+        $Output .= $LayoutObject->Footer();
+
         return $Output;
     }
 
@@ -60,15 +104,6 @@ sub Run {
         Value     => $Param{Search},
     );
 
-    # get SMIME objects
-    my $SMIMEObject = $Kernel::OM->Get('Kernel::System::Crypt::SMIME');
-
-    if ( !$SMIMEObject ) {
-        my $Output .= $LayoutObject->FatalError(
-            Message => Translatable('S/MIME environment is not working. Please check log for more info!'),
-        );
-        return $Output;
-    }
 
     # ------------------------------------------------------------ #
     # delete cert
@@ -546,15 +581,10 @@ sub _MaskAdd {
 
     # get layout object
     my $LayoutObject = $Kernel::OM->Get('Kernel::Output::HTML::Layout');
-    $LayoutObject->Block(
-        Name => 'ActionList',
-    );
-    $LayoutObject->Block(
-        Name => 'ActionList',
-    );
-    $LayoutObject->Block(
-        Name => 'ActionOverview',
-    );
+
+    $LayoutObject->Block( Name => 'Overview' );
+    $LayoutObject->Block( Name => 'ActionList' );
+    $LayoutObject->Block( Name => 'ActionOverview' );
 
     # show the right tt block
     $LayoutObject->Block(
@@ -585,46 +615,8 @@ sub _Overview {
 
     # get needed objects
     my $LayoutObject = $Kernel::OM->Get('Kernel::Output::HTML::Layout');
-    my $ConfigObject = $Kernel::OM->Get('Kernel::Config');
+    my $SMIMEObject  = $Kernel::OM->Get('Kernel::System::Crypt::SMIME');
 
-    # check if SMIME is activated in the sysconfig first
-    if ( !$ConfigObject->Get('SMIME') ) {
-        $Output .= $LayoutObject->Notify(
-            Priority => 'Error',
-            Data     => $LayoutObject->{LanguageObject}->Translate( "Please activate %s first!", "SMIME" ),
-            Link =>
-                $LayoutObject->{Baselink}
-                . 'Action=AdminSysConfig;Subaction=Edit;SysConfigGroup=Framework;SysConfigSubGroup=Crypt::SMIME',
-        );
-    }
-
-    # check if SMIME Paths are writable
-    for my $PathKey (qw(SMIME::CertPath SMIME::PrivatePath)) {
-        if ( !-w $ConfigObject->Get($PathKey) ) {
-            $Output .= $LayoutObject->Notify(
-                Priority => 'Error',
-                Data     => $LayoutObject->{LanguageObject}->Translate(
-                    "%s is not writable!",
-                    "$PathKey " . $ConfigObject->Get($PathKey),
-                ),
-                Link =>
-                    $LayoutObject->{Baselink}
-                    . 'Action=AdminSysConfig;Subaction=Edit;SysConfigGroup=Framework;SysConfigSubGroup=Crypt::SMIME',
-            );
-        }
-    }
-
-    my $SMIMEObject = $Kernel::OM->Get('Kernel::System::Crypt::SMIME');
-
-    if ( !$SMIMEObject && $ConfigObject->Get('SMIME') ) {
-        $Output .= $LayoutObject->Notify(
-            Priority => 'Error',
-            Data     => $LayoutObject->{LanguageObject}->Translate( "Cannot create %s!", "CryptObject" ),
-            Link =>
-                $LayoutObject->{Baselink}
-                . 'Action=AdminSysConfig;Subaction=Edit;SysConfigGroup=Framework;SysConfigSubGroup=Crypt::SMIME',
-        );
-    }
     if ( $SMIMEObject && $SMIMEObject->Check() ) {
         $Output .= $LayoutObject->Notify(
             Priority => 'Error',
@@ -644,6 +636,7 @@ sub _Overview {
     if ($SMIMEObject) {
         @List = $SMIMEObject->Search();
     }
+    $LayoutObject->Block( Name => 'Overview' );
     $LayoutObject->Block(
         Name => 'OverviewResult',
     );
@@ -680,18 +673,11 @@ sub _Overview {
             Data => {},
         );
     }
-    $LayoutObject->Block(
-        Name => 'ActionList',
-    );
-    $LayoutObject->Block(
-        Name => 'ActionAdd',
-    );
-    $LayoutObject->Block(
-        Name => 'SMIMEFilter',
-    );
-    $LayoutObject->Block(
-        Name => 'OverviewHint',
-    );
+
+    $LayoutObject->Block( Name => 'ActionList' );
+    $LayoutObject->Block( Name => 'ActionAdd' );
+    $LayoutObject->Block( Name => 'SMIMEFilter' );
+    $LayoutObject->Block( Name => 'OverviewHint' );
 
     return $Output;
 }
@@ -740,15 +726,10 @@ sub _SignerCertificateOverview {
     @ShowCertList = grep ( !defined $RelatedCerts{ $_->{Fingerprint} }
             && $_->{Fingerprint} ne $Param{CertFingerprint}, @AvailableCerts );
 
-    $LayoutObject->Block(
-        Name => 'ActionList',
-    );
-    $LayoutObject->Block(
-        Name => 'ActionOverview',
-    );
-    $LayoutObject->Block(
-        Name => 'SignerCertHint',
-    );
+    $LayoutObject->Block( Name => 'Overview' );
+    $LayoutObject->Block( Name => 'ActionList' );
+    $LayoutObject->Block( Name => 'ActionOverview' );
+    $LayoutObject->Block( Name => 'SignerCertHint' );
 
     $LayoutObject->Block(
         Name => 'SignerCertificates',
@@ -799,52 +780,6 @@ sub _SignerCertificateOverview {
         $Output .= $LayoutObject->Notify(
             Priority => $Message{Type},
             Info     => $Message{Message},
-        );
-    }
-
-    # get config object
-    my $ConfigObject = $Kernel::OM->Get('Kernel::Config');
-
-    # check if SMIME is activated in the sysconfig first
-    if ( !$ConfigObject->Get('SMIME') ) {
-        $Output .= $LayoutObject->Notify(
-            Priority => 'Error',
-            Data     => $LayoutObject->{LanguageObject}->Translate( "Please activate %s first!", "SMIME" ),
-            Link =>
-                $LayoutObject->{Baselink}
-                . 'Action=AdminSysConfig;Subaction=Edit;SysConfigGroup=Framework;SysConfigSubGroup=Crypt::SMIME',
-        );
-    }
-
-    # check if SMIME Paths are writable
-    for my $PathKey (qw(SMIME::CertPath SMIME::PrivatePath)) {
-        if ( !-w $ConfigObject->Get($PathKey) ) {
-            $Output .= $LayoutObject->Notify(
-                Priority => 'Error',
-                Data     => $LayoutObject->{LanguageObject}->Translate(
-                    "%s is not writable!",
-                    "$PathKey " . $ConfigObject->Get($PathKey)
-                ),
-                ,
-                Link =>
-                    $LayoutObject->{Baselink}
-                    . 'Action=AdminSysConfig;Subaction=Edit;SysConfigGroup=Framework;SysConfigSubGroup=Crypt::SMIME',
-            );
-        }
-    }
-    if ( !$SMIMEObject && $ConfigObject->Get('SMIME') ) {
-        $Output .= $LayoutObject->Notify(
-            Priority => 'Error',
-            Data     => $LayoutObject->{LanguageObject}->Translate( "Cannot create %s!", "CryptObject" ),
-            Link =>
-                $LayoutObject->{Baselink}
-                . 'Action=AdminSysConfig;Subaction=Edit;SysConfigGroup=Framework;SysConfigSubGroup=Crypt::SMIME',
-        );
-    }
-    if ( $SMIMEObject && $SMIMEObject->Check() ) {
-        $Output .= $LayoutObject->Notify(
-            Priority => 'Error',
-            Data     => $LayoutObject->{LanguageObject}->Translate("' . $SMIMEObject->Check() . '"),
         );
     }
 

--- a/Kernel/Output/HTML/Templates/Standard/AdminSMIME.tt
+++ b/Kernel/Output/HTML/Templates/Standard/AdminSMIME.tt
@@ -21,7 +21,7 @@
                     <input type="hidden" name="Subaction" value="Edit"/>
                     <input type="hidden" name="SysConfigGroup" value="Framework"/>
                     <input type="hidden" name="SysConfigSubGroup" value="Crypt::SMIME"/>
-                    <h3>[% Translate("This feature is disabled!") | html %]</h3>
+                    <h3><span class="Warning">[% Translate("This feature is disabled!") | html %]<span></h3>
                     <fieldset>
                         <p class="FieldExplanation">
                             [% Translate("Use this feature if you want to work with SMIME keys.") | html %]
@@ -49,7 +49,7 @@
                     <input type="hidden" name="Subaction" value="Edit"/>
                     <input type="hidden" name="SysConfigGroup" value="Framework"/>
                     <input type="hidden" name="SysConfigSubGroup" value="Crypt::SMIME"/>
-                    <h3>[% Translate("This feature is not working!") | html %]</h3>
+                    <h3><span class="Error">[% Translate("This feature is not working!") | html %]<span></h3>
                     <fieldset>
                         <p class="FieldExplanation">
                             [% Translate("Use this feature if you want to work with SMIME keys.") | html %]

--- a/Kernel/Output/HTML/Templates/Standard/AdminSMIME.tt
+++ b/Kernel/Output/HTML/Templates/Standard/AdminSMIME.tt
@@ -10,6 +10,7 @@
 <div class="MainBox ARIARoleMain LayoutFixedSidebar SidebarFirst">
     <h1>[% Translate("S/MIME Management") | html %]: [% Translate(Data.Subtitle) | html %]</h1>
     <div class="SidebarColumn">
+[% RenderBlockStart("Notice") %]
         <div class="WidgetSimple">
             <div class="Header">
                 <h2>[% Translate("Notice") | html %]</h2>
@@ -49,7 +50,7 @@
                 </form>
             </div>
         </div>
-
+[% RenderBlockEnd("Notice") %]
 [% RenderBlockStart("ActionList") %]
         <div class="WidgetSimple">
             <div class="Header">

--- a/Kernel/Output/HTML/Templates/Standard/AdminSMIME.tt
+++ b/Kernel/Output/HTML/Templates/Standard/AdminSMIME.tt
@@ -6,9 +6,65 @@
 # did not receive this file, see http://www.gnu.org/licenses/agpl.txt.
 # --
 
+[% RenderBlockStart("Overview") %]
 <div class="MainBox ARIARoleMain LayoutFixedSidebar SidebarFirst">
     <h1>[% Translate("S/MIME Management") | html %]: [% Translate(Data.Subtitle) | html %]</h1>
     <div class="SidebarColumn">
+[% RenderBlockStart("Disabled") %]
+        <div class="WidgetSimple">
+            <div class="Header">
+                <h2>[% Translate("Notice") | html %]</h2>
+            </div>
+            <div class="Content ActionList">
+                <form action="[% Env("CGIHandle") %]" method="post">
+                    <input type="hidden" name="Action" value="AdminSysConfig"/>
+                    <input type="hidden" name="Subaction" value="Edit"/>
+                    <input type="hidden" name="SysConfigGroup" value="Framework"/>
+                    <input type="hidden" name="SysConfigSubGroup" value="Crypt::SMIME"/>
+                    <h3>[% Translate("This feature is disabled!") | html %]</h3>
+                    <fieldset>
+                        <p class="FieldExplanation">
+                            [% Translate("Use this feature if you want to work with SMIME keys.") | html %]
+                        </p>
+                        <div class="Field SpacingTop">
+                            <button class="CallForAction Fullsize Center" type="submit" value="[% Translate("Enable it here!") | html %]">
+                                <span><i class="fa fa-unlock-alt"></i> [% Translate("Enable it here!") | html %]</span>
+                            </button>
+                        </div>
+                        <div class="Clear"></div>
+                    </fieldset>
+                </form>
+            </div>
+        </div>
+[% RenderBlockEnd("Disabled") %]
+
+[% RenderBlockStart("NotWorking") %]
+        <div class="WidgetSimple">
+            <div class="Header">
+                <h2>[% Translate("Notice") | html %]</h2>
+            </div>
+            <div class="Content ActionList">
+                <form action="[% Env("CGIHandle") %]" method="post">
+                    <input type="hidden" name="Action" value="AdminSysConfig"/>
+                    <input type="hidden" name="Subaction" value="Edit"/>
+                    <input type="hidden" name="SysConfigGroup" value="Framework"/>
+                    <input type="hidden" name="SysConfigSubGroup" value="Crypt::SMIME"/>
+                    <h3>[% Translate("This feature is not working!") | html %]</h3>
+                    <fieldset>
+                        <p class="FieldExplanation">
+                            [% Translate("Use this feature if you want to work with SMIME keys.") | html %]
+                        </p>
+                        <div class="Field SpacingTop">
+                            <button class="CallForAction Fullsize Center" type="submit" value="[% Translate("Configure it here!") | html %]">
+                                <span><i class="fa fa-unlock-alt"></i> [% Translate("Configure it here!") | html %]</span>
+                            </button>
+                        </div>
+                        <div class="Clear"></div>
+                    </fieldset>
+                </form>
+            </div>
+        </div>
+[% RenderBlockEnd("NotWorking") %]
 
 [% RenderBlockStart("ActionList") %]
         <div class="WidgetSimple">
@@ -362,3 +418,4 @@
 [% RenderBlockEnd("SignerCertificates") %]
 </div>
 <div class="Clear"></div>
+[% RenderBlockEnd("Overview") %]

--- a/Kernel/Output/HTML/Templates/Standard/AdminSMIME.tt
+++ b/Kernel/Output/HTML/Templates/Standard/AdminSMIME.tt
@@ -10,7 +10,6 @@
 <div class="MainBox ARIARoleMain LayoutFixedSidebar SidebarFirst">
     <h1>[% Translate("S/MIME Management") | html %]: [% Translate(Data.Subtitle) | html %]</h1>
     <div class="SidebarColumn">
-[% RenderBlockStart("Disabled") %]
         <div class="WidgetSimple">
             <div class="Header">
                 <h2>[% Translate("Notice") | html %]</h2>
@@ -21,6 +20,7 @@
                     <input type="hidden" name="Subaction" value="Edit"/>
                     <input type="hidden" name="SysConfigGroup" value="Framework"/>
                     <input type="hidden" name="SysConfigSubGroup" value="Crypt::SMIME"/>
+[% RenderBlockStart("Disabled") %]
                     <h3><span class="Warning">[% Translate("This feature is disabled!") | html %]<span></h3>
                     <fieldset>
                         <p class="FieldExplanation">
@@ -31,24 +31,8 @@
                                 <span><i class="fa fa-unlock-alt"></i> [% Translate("Enable it here!") | html %]</span>
                             </button>
                         </div>
-                        <div class="Clear"></div>
-                    </fieldset>
-                </form>
-            </div>
-        </div>
 [% RenderBlockEnd("Disabled") %]
-
 [% RenderBlockStart("NotWorking") %]
-        <div class="WidgetSimple">
-            <div class="Header">
-                <h2>[% Translate("Notice") | html %]</h2>
-            </div>
-            <div class="Content ActionList">
-                <form action="[% Env("CGIHandle") %]" method="post">
-                    <input type="hidden" name="Action" value="AdminSysConfig"/>
-                    <input type="hidden" name="Subaction" value="Edit"/>
-                    <input type="hidden" name="SysConfigGroup" value="Framework"/>
-                    <input type="hidden" name="SysConfigSubGroup" value="Crypt::SMIME"/>
                     <h3><span class="Error">[% Translate("This feature is not working!") | html %]<span></h3>
                     <fieldset>
                         <p class="FieldExplanation">
@@ -59,12 +43,12 @@
                                 <span><i class="fa fa-unlock-alt"></i> [% Translate("Configure it here!") | html %]</span>
                             </button>
                         </div>
+[% RenderBlockEnd("NotWorking") %]
                         <div class="Clear"></div>
                     </fieldset>
                 </form>
             </div>
         </div>
-[% RenderBlockEnd("NotWorking") %]
 
 [% RenderBlockStart("ActionList") %]
         <div class="WidgetSimple">

--- a/scripts/test/Selenium/Agent/Admin/AdminSMIME.t
+++ b/scripts/test/Selenium/Agent/Admin/AdminSMIME.t
@@ -63,8 +63,12 @@ $Selenium->RunTest(
 
         # check widget sidebar when SMIME sysconfig is disabled
         $Self->True(
+            $Selenium->find_element('h3 span.Warning', 'css'),
+            "Widget sidebar with warning message is displayed.",
+        );
+        $Self->True(
             $Selenium->find_element("//button[\@value='Enable it here!']"),
-            "Widget sidebar with button 'Enable it here!' to the SMIME sysConfig is displayed.",
+            "Button 'Enable it here!' to the SMIME SysConfig is displayed.",
         );
 
         # enable SMIME in config
@@ -91,8 +95,12 @@ $Selenium->RunTest(
 
         # check widget sidebar when SMIME sysconfig does not work
         $Self->True(
+            $Selenium->find_element('h3 span.Error', 'css'),
+            "Widget sidebar with error message is displayed.",
+        );
+        $Self->True(
             $Selenium->find_element("//button[\@value='Configure it here!']"),
-            "Widget sidebar with button 'Configure it here!' to the SMIME sysConfig is displayed.",
+            "Button 'Configure it here!' to the SMIME SysConfig is displayed.",
         );
 
         # set SMIME paths in sysConfig

--- a/scripts/test/Selenium/Agent/Admin/AdminSMIME.t
+++ b/scripts/test/Selenium/Agent/Admin/AdminSMIME.t
@@ -63,7 +63,7 @@ $Selenium->RunTest(
 
         # check widget sidebar when SMIME sysconfig is disabled
         $Self->True(
-            $Selenium->find_element('h3 span.Warning', 'css'),
+            $Selenium->find_element( 'h3 span.Warning', 'css' ),
             "Widget sidebar with warning message is displayed.",
         );
         $Self->True(
@@ -90,12 +90,15 @@ $Selenium->RunTest(
             Value => '/SomePrivatePath',
         );
 
+        # let mod_perl / Apache2::Reload pick up the changed configuration
+        sleep 3;
+
         # refresh AdminSMIME screen
         $Selenium->VerifiedRefresh();
 
         # check widget sidebar when SMIME sysconfig does not work
         $Self->True(
-            $Selenium->find_element('h3 span.Error', 'css'),
+            $Selenium->find_element( 'h3 span.Error', 'css' ),
             "Widget sidebar with error message is displayed.",
         );
         $Self->True(
@@ -114,6 +117,9 @@ $Selenium->RunTest(
             Key   => 'SMIME::PrivatePath',
             Value => $PrivatePath,
         );
+
+        # let mod_perl / Apache2::Reload pick up the changed configuration
+        sleep 3;
 
         # refresh AdminSMIME screen
         $Selenium->VerifiedRefresh();


### PR DESCRIPTION
Hi @mgruner,

Hera is our proposal for fixing this bug and improving AdminSMIME screen in case SMIME is disabled.
You can see, I have made two different widget which displayed in cases SMIME sysconfig item is disabled or some other SMIME config item is not configured well.

I added result table with NoDataFoundMsg message in case SMIME  is not working or disabled, it is better layout for me, but I wanted to ask you what do you think about that.

I check if SMIME configured  well at the beginning, since I  removed if statement that had been before on other places in AdminSMIME.pm module.

If you like it I will be able to improve AdminPGP screen, I would do that in another PR. Now in AdminPGP you can go to Action=AdminPGP;Subaction=Add even CryptObject is not created. I suggest removing Action widget to avoid such cases. 

![screen shot 2016-01-28 at 12 11 11 pm](https://cloud.githubusercontent.com/assets/6348760/12642886/e9fc77c8-c5b8-11e5-8cdf-efe5c8c3aeab.png)

Please let me know what do you think about that.

Regards
Zoran