### PR TITLE
[ Rel-5_0 Bug 11834 ] - Ticket Title is not correct in a csv/excel output

### DIFF
--- a/Kernel/Config/Files/Ticket.xml
+++ b/Kernel/Config/Files/Ticket.xml
@@ -2408,7 +2408,7 @@
                 <Item Translatable="1">CustomerID</Item>
                 <Item Translatable="1">CustomerName</Item>
                 <Item Translatable="1">From</Item>
-                <Item Translatable="1">Subject</Item>
+                <Item Translatable="1">Title</Item>
                 <Item Translatable="1">AccountedTime</Item>
                 <Item Translatable="1">ArticleTree</Item>
                 <Item Translatable="1">SolutionInMin</Item>
@@ -8102,17 +8102,17 @@
         <SubGroup>Frontend::Customer::Ticket::ViewSearch</SubGroup>
         <Setting>
             <Array>
-                <Item>TicketNumber</Item>
-                <Item>Age</Item>
-                <Item>Created</Item>
-                <Item>Closed</Item>
-                <Item>State</Item>
-                <Item>Priority</Item>
-                <Item>Lock</Item>
-                <Item>CustomerID</Item>
-                <Item>CustomerName</Item>
-                <Item>From</Item>
-                <Item>Subject</Item>
+                <Item Translatable="1">TicketNumber</Item>
+                <Item Translatable="1">Age</Item>
+                <Item Translatable="1">Created</Item>
+                <Item Translatable="1">Closed</Item>
+                <Item Translatable="1">State</Item>
+                <Item Translatable="1">Priority</Item>
+                <Item Translatable="1">Lock</Item>
+                <Item Translatable="1">CustomerID</Item>
+                <Item Translatable="1">CustomerName</Item>
+                <Item Translatable="1">From</Item>
+                <Item Translatable="1">Title</Item>
             </Array>
         </Setting>
     </ConfigItem>

--- a/Kernel/Modules/AgentTicketSearch.pm
+++ b/Kernel/Modules/AgentTicketSearch.pm
@@ -885,7 +885,7 @@ sub Run {
                 push @PDFRow,  $Data{TicketNumber};
                 push @PDFRow,  $Created;
                 push @PDFRow,  $Data{From};
-                push @PDFRow,  $Data{Subject};
+                push @PDFRow,  $Data{Title};
                 push @PDFRow,  $Data{State};
                 push @PDFRow,  $Data{Queue};
                 push @PDFRow,  $Owner;
@@ -918,7 +918,7 @@ sub Run {
                 $CellData->[0]->[1]->{Font}    = 'ProportionalBold';
                 $CellData->[0]->[2]->{Content} = $LayoutObject->{LanguageObject}->Translate('From');
                 $CellData->[0]->[2]->{Font}    = 'ProportionalBold';
-                $CellData->[0]->[3]->{Content} = $LayoutObject->{LanguageObject}->Translate('Subject');
+                $CellData->[0]->[3]->{Content} = $LayoutObject->{LanguageObject}->Translate('Title');
                 $CellData->[0]->[3]->{Font}    = 'ProportionalBold';
                 $CellData->[0]->[4]->{Content} = $LayoutObject->{LanguageObject}->Translate('State');
                 $CellData->[0]->[4]->{Font}    = 'ProportionalBold';

--- a/Kernel/Modules/CustomerTicketSearch.pm
+++ b/Kernel/Modules/CustomerTicketSearch.pm
@@ -784,7 +784,7 @@ sub Run {
                 push @PDFRow,  $Data{TicketNumber};
                 push @PDFRow,  $Created;
                 push @PDFRow,  $Data{From};
-                push @PDFRow,  $Data{Subject};
+                push @PDFRow,  $Data{Title};
                 push @PDFRow,  $Data{State};
                 push @PDFRow,  $Data{Queue};
                 push @PDFRow,  $Customer;
@@ -816,7 +816,7 @@ sub Run {
                 $CellData->[0]->[1]->{Font}    = 'ProportionalBold';
                 $CellData->[0]->[2]->{Content} = $LayoutObject->{LanguageObject}->Translate('From');
                 $CellData->[0]->[2]->{Font}    = 'ProportionalBold';
-                $CellData->[0]->[3]->{Content} = $LayoutObject->{LanguageObject}->Translate('Subject');
+                $CellData->[0]->[3]->{Content} = $LayoutObject->{LanguageObject}->Translate('Title');
                 $CellData->[0]->[3]->{Font}    = 'ProportionalBold';
                 $CellData->[0]->[4]->{Content} = $LayoutObject->{LanguageObject}->Translate('State');
                 $CellData->[0]->[4]->{Font}    = 'ProportionalBold';
@@ -1103,7 +1103,7 @@ sub Run {
                     # Condense down the subject
                     my $Subject = $TicketObject->TicketSubjectClean(
                         TicketNumber => $Article{TicketNumber},
-                        Subject      => $Article{Subject} || '',
+                        Subject      => $Article{Title} || '',
                     );
                     $Article{CustomerAge} = $LayoutObject->CustomerAge(
                         Age   => $Article{Age},

--- a/Kernel/Output/HTML/Templates/Standard/AdminGenericAgent.tt
+++ b/Kernel/Output/HTML/Templates/Standard/AdminGenericAgent.tt
@@ -935,7 +935,7 @@ Core.Agent.Admin.GenericAgent.Init({
                         <tr>
                             <th>[% Config("Ticket::Hook") %]</th>
                             <th>[% Translate("Age") | html %]</th>
-                            <th>[% Translate("From") | html %] / [% Translate("Subject") | html %]</th>
+                            <th>[% Translate("From") | html %] / [% Translate("Title") | html %]</th>
                             <th>[% Translate("State") | html %]</th>
                             <th>[% Translate("Queue") | html %]</th>
                             <th>[% Translate("Owner") | html %]</th>
@@ -951,7 +951,7 @@ Core.Agent.Admin.GenericAgent.Init({
                                 </a>
                             </td>
                             <td>[% Data.Age | html %]</td>
-                            <td>[% Data.From | truncate(30) | html %][% Data.Subject | truncate(30) | html %]</td>
+                            <td>[% Data.From | truncate(30) | html %][% Data.Title | truncate(30) | html %]</td>
                             <td>[% Translate(Data.State) | html %]</td>
                             <td>[% Data.Queue | truncate(30) | html %]</td>
                             <td>[% Data.Owner | truncate(30) | html %] ([% Data.UserFirstname | html %] [% Data.UserLastname | html %])</td>

--- a/Kernel/Output/HTML/Templates/Standard/CustomerTicketSearchResultShort.tt
+++ b/Kernel/Output/HTML/Templates/Standard/CustomerTicketSearchResultShort.tt
@@ -47,7 +47,7 @@
                         </a>
                     </th>
                     <th class="Title">
-                        <span>[% Translate("Subject") | html %]</span>
+                        <span>[% Translate("Title") | html %]</span>
                     </th>
                     <th class="Age [% Data.AgeSort %]">
                         <a href="[% Env("Baselink") %]Action=[% Env("Action") %];Subaction=Search;SortBy=Age;Order=[% Data.Order | uri %];Filter=[% Data.Filter | uri %];Limit=[% Data.Limit | uri %];ShowClosedTickets=[% Data.ShowClosed | uri %];Type=[% Data.Type | uri %];Profile=[% Data.Profile | uri %];TakeLastSearch=1">
@@ -80,7 +80,7 @@
                 <tr class="MasterAction">
                     <td class="Ticket"><a href="[% Env("Baselink") %]Action=CustomerTicketZoom;TicketNumber=[% Data.TicketNumber | uri %]" class="MasterActionLink">[% Data.TicketNumber | html %]</a></td>
                     <td class="Status">[% Translate(Data.State) | html %]</td>
-                    <td class="Title"><div><h2>[% Data.Subject | truncate(60) | html %]</h2>&nbsp;-&nbsp; [% Data.Body | truncate(200) | html %]</div></td>
+                    <td class="Title"><div><h2>[% Data.Subject | truncate(60) | html %]</h2></div></td>
                     <td class="Age" title="[% Data.Created | Localize("TimeShort") | html %]">[% Data.CustomerAge | truncate(20) | html %]</td>
 [% RenderBlockStart("RecordDynamicField") %]
                     <td class="DynamicField" title="[% Data.Title | html %]">[% Data.Value %]</td>


### PR DESCRIPTION
http://bugs.otrs.org/show_bug.cgi?id=11834

Hello @mgruner ,

Hereby is proposal for fixing this bug and additional unification of the system output on search ticket. 

In config replaced Subject with Title for CSV/Excel output for agent and customer search. Added Translatable for customer headers in table.

There is similar issue in PDF output, changed that. 

CustomerTicketSearch normal output, changed to show Title as well and removed 'Body' from output, since IMO if we show ticket title there is no need to show body of first article.

In AdminGenericAgent, changed in ticket result table to show ticket title instead of article subject.

I am aware that these changes are not critical to the system, but i believe that they will provide nice user experience when outputting ticket search and reading data. 
Please let me know if you disagree with these changes or if there are any questions regarding this PR.

Regards,
Sanjin