### PR TITLE
Bug 8298: Use of "Submit" and "Save" buttons

### DIFF
--- a/Kernel/Output/HTML/Templates/Standard/AdminAttachment.tt
+++ b/Kernel/Output/HTML/Templates/Standard/AdminAttachment.tt
@@ -155,7 +155,7 @@
                         <div class="Clear"></div>
 
                         <div class="Field SpacingTop">
-                            <button class="Primary CallForAction" type="submit" value="[% Translate("Submit") | html %]"><span>[% Translate("Submit") | html %]</span></button>
+                            <button class="Primary CallForAction" type="submit" value="[% Translate("Save") | html %]"><span>[% Translate("Save") | html %]</span></button>
                             [% Translate("or") | html %]
                             <a href="[% Env("Baselink") %]Action=[% Env("Action") %]">[% Translate("Cancel") | html %]</a>
                         </div>

--- a/Kernel/Output/HTML/Templates/Standard/AdminAutoResponse.tt
+++ b/Kernel/Output/HTML/Templates/Standard/AdminAutoResponse.tt
@@ -173,7 +173,7 @@
                         <div class="Clear"></div>
 
                         <div class="Field">
-                            <button class="Primary CallForAction" type="submit" value="[% Translate("Submit") | html %]"><span>[% Translate("Submit") | html %]</span></button>
+                            <button class="Primary CallForAction" type="submit" value="[% Translate("Save") | html %]"><span>[% Translate("Save") | html %]</span></button>
                             [% Translate("or") | html %]
                             <a href="[% Env("Baselink") %]Action=[% Env("Action") %]">[% Translate("Cancel") | html %]</a>
                         </div>

--- a/Kernel/Output/HTML/Templates/Standard/AdminCustomerCompany.tt
+++ b/Kernel/Output/HTML/Templates/Standard/AdminCustomerCompany.tt
@@ -200,7 +200,7 @@ Core.Form.DisableForm($('form#edit'));
 [% RenderBlockEnd("PreferencesGeneric") %]
                             [% IF  Config(Data.Source).ReadOnly != 1 %]
                             <div class="Field SpacingTop">
-                                <button class="Primary CallForAction" type="submit" value="[% Translate("Submit") | html %]"><span>[% Translate("Submit") | html %]</span></button>
+                                <button class="Primary CallForAction" type="submit" value="[% Translate("Save") | html %]"><span>[% Translate("Save") | html %]</span></button>
                                     [% Translate("or") | html %]
                                 <a href="[% Env("Baselink") %]Action=[% Env("Action") %];Nav=[% Data.Nav | uri %]">[% Translate("Cancel") | html %]</a>
                             </div>

--- a/Kernel/Output/HTML/Templates/Standard/AdminCustomerUser.tt
+++ b/Kernel/Output/HTML/Templates/Standard/AdminCustomerUser.tt
@@ -264,7 +264,7 @@ Core.Form.DisableForm($('form[name=compose]'));
 [% RenderBlockEnd("Item") %]
                         [% IF Config(Data.Source).ReadOnly != 1 && Config(Data.Source).Module.match('DB') %]
                         <div class="Field SpacingTop">
-                            <button class="Primary CallForAction" type="submit" value="[% Translate("Submit") | html %]"><span>[% Translate("Submit") | html %]</span></button>
+                            <button class="Primary CallForAction" type="submit" value="[% Translate("Save") | html %]"><span>[% Translate("Save") | html %]</span></button>
                                 [% Translate("or") | html %]
                             <a href="[% Env("Baselink") %]Action=[% Env("Action") %];Nav=[% Data.Nav | uri %]">[% Translate("Cancel") | html %]</a>
                         </div>

--- a/Kernel/Output/HTML/Templates/Standard/AdminCustomerUserGroup.tt
+++ b/Kernel/Output/HTML/Templates/Standard/AdminCustomerUserGroup.tt
@@ -234,7 +234,7 @@
                         </tbody>
                     </table>
                     <div class="Field SpacingTop">
-                        <button class="Primary CallForAction" type="submit" value="[% Translate("Submit") | html %]"><span>[% Translate("Submit") | html %]</span></button>
+                        <button class="Primary CallForAction" type="submit" value="[% Translate("Save") | html %]"><span>[% Translate("Save") | html %]</span></button>
                         [% Translate("or") | html %]
                         <a href="[% Env("Baselink") %]Action=[% Env("Action") %]">[% Translate("Cancel") | html %]</a>
                     </div>

--- a/Kernel/Output/HTML/Templates/Standard/AdminCustomerUserService.tt
+++ b/Kernel/Output/HTML/Templates/Standard/AdminCustomerUserService.tt
@@ -182,7 +182,7 @@ $('input[type="checkbox"][name=ItemsSelected]').bind('click', function () {
                         </tbody>
                     </table>
                     <div class="Field SpacingTop">
-                        <button class="Primary CallForAction" type="submit" value="[% Translate("Submit") | html %]"><span>[% Translate("Submit") | html %]</span></button>
+                        <button class="Primary CallForAction" type="submit" value="[% Translate("Save") | html %]"><span>[% Translate("Save") | html %]</span></button>
                         [% Translate("or") | html %]
                         <a href="[% Env("Baselink") %]Action=[% Env("Action") %]">[% Translate("Cancel") | html %]</a>
                     </div>

--- a/Kernel/Output/HTML/Templates/Standard/AdminDynamicField.tt
+++ b/Kernel/Output/HTML/Templates/Standard/AdminDynamicField.tt
@@ -104,7 +104,7 @@ $('#ShowContextSettingsDialog').bind('click', function (Event) {
     Core.UI.Dialog.ShowContentDialog($('#ContextSettingsDialogContainer'), [% Translate("Settings") | JSON %], '20%', 'Center', true,
         [
             {
-                Label: [% Translate("Submit") | JSON %],
+                Label: [% Translate("Save") | JSON %],
                 Type: 'Submit',
                 Class: 'Primary'}
         ]);

--- a/Kernel/Output/HTML/Templates/Standard/AdminDynamicFieldCheckbox.tt
+++ b/Kernel/Output/HTML/Templates/Standard/AdminDynamicFieldCheckbox.tt
@@ -125,7 +125,7 @@
             </div>
             <fieldset class="TableLike">
                 <div class="Field SpacingTop">
-                    <button type="submit" class="Primary CallForAction" value="[% Translate("Submit") | html %]"><span>[% Translate("Submit") | html %]</span></button>
+                    <button type="submit" class="Primary CallForAction" value="[% Translate("Save") | html %]"><span>[% Translate("Save") | html %]</span></button>
                     [% Translate("or") | html %]
                     <a href="[% Env("Baselink") %]Action=AdminDynamicField">[% Translate("Cancel") | html %]</a>
                 </div>

--- a/Kernel/Output/HTML/Templates/Standard/AdminDynamicFieldDateTime.tt
+++ b/Kernel/Output/HTML/Templates/Standard/AdminDynamicFieldDateTime.tt
@@ -174,7 +174,7 @@
             </div>
             <fieldset class="TableLike">
                 <div class="Field SpacingTop">
-                    <button type="submit" class="Primary CallForAction" value="[% Translate("Submit") | html %]"><span>[% Translate("Submit") | html %]</span></button>
+                    <button type="submit" class="Primary CallForAction" value="[% Translate("Save") | html %]"><span>[% Translate("Save") | html %]</span></button>
                     [% Translate("or") | html %]
                     <a href="[% Env("Baselink") %]Action=AdminDynamicField">[% Translate("Cancel") | html %]</a>
                 </div>

--- a/Kernel/Output/HTML/Templates/Standard/AdminDynamicFieldDropdown.tt
+++ b/Kernel/Output/HTML/Templates/Standard/AdminDynamicFieldDropdown.tt
@@ -205,7 +205,7 @@
             </div>
             <fieldset class="TableLike">
                 <div class="Field SpacingTop">
-                    <button type="submit" class="Primary CallForAction" value="[% Translate("Submit") | html %]"><span>[% Translate("Submit") | html %]</span></button>
+                    <button type="submit" class="Primary CallForAction" value="[% Translate("Save") | html %]"><span>[% Translate("Save") | html %]</span></button>
                     [% Translate("or") | html %]
                     <a href="[% Env("Baselink") %]Action=AdminDynamicField">[% Translate("Cancel") | html %]</a>
                 </div>

--- a/Kernel/Output/HTML/Templates/Standard/AdminDynamicFieldMultiselect.tt
+++ b/Kernel/Output/HTML/Templates/Standard/AdminDynamicFieldMultiselect.tt
@@ -196,7 +196,7 @@
             </div>
             <fieldset class="TableLike">
                 <div class="Field SpacingTop">
-                    <button type="submit" class="Primary CallForAction" value="[% Translate("Submit") | html %]"><span>[% Translate("Submit") | html %]</span></button>
+                    <button type="submit" class="Primary CallForAction" value="[% Translate("Save") | html %]"><span>[% Translate("Save") | html %]</span></button>
                     [% Translate("or") | html %]
                     <a href="[% Env("Baselink") %]Action=AdminDynamicField">[% Translate("Cancel") | html %]</a>
                 </div>

--- a/Kernel/Output/HTML/Templates/Standard/AdminDynamicFieldText.tt
+++ b/Kernel/Output/HTML/Templates/Standard/AdminDynamicFieldText.tt
@@ -225,7 +225,7 @@
             </div>
             <fieldset class="TableLike">
                 <div class="Field SpacingTop">
-                    <button type="submit" class="Primary CallForAction" value="[% Translate("Submit") | html %]"><span>[% Translate("Submit") | html %]</span></button>
+                    <button type="submit" class="Primary CallForAction" value="[% Translate("Save") | html %]"><span>[% Translate("Save") | html %]</span></button>
                     [% Translate("or") | html %]
                     <a href="[% Env("Baselink") %]Action=AdminDynamicField">[% Translate("Cancel") | html %]</a>
                 </div>

--- a/Kernel/Output/HTML/Templates/Standard/AdminGenericAgent.tt
+++ b/Kernel/Output/HTML/Templates/Standard/AdminGenericAgent.tt
@@ -878,7 +878,7 @@ Core.Agent.Admin.GenericAgent.Init({
                 <div class="Content">
                     <fieldset class="TableLike">
                         <div class="Field SpacingTop">
-                            <button class="Primary CallForAction" type="submit" value="[% Translate("Submit") | html %]"><span>[% Translate("Submit") |  html %]</span></button>
+                            <button class="Primary CallForAction" type="submit" value="[% Translate("Save") | html %]"><span>[% Translate("Save") |  html %]</span></button>
                             [% Translate("or") | html %]
                             <a href="[% Env("Baselink") %]Action=[% Env("Action") %]">[% Translate("Cancel") | html %]</a>
                         </div>

--- a/Kernel/Output/HTML/Templates/Standard/AdminGroup.tt
+++ b/Kernel/Output/HTML/Templates/Standard/AdminGroup.tt
@@ -178,7 +178,7 @@ Core.Agent.Admin.Group = (function (TargetNS) {
 
 
                         <div class="Field SpacingTop">
-                            <button class="Primary CallForAction" type="submit" id="Submit" value="[% Translate("Submit") | html %]"><span>[% Translate("Submit") | html %]</span></button>
+                            <button class="Primary CallForAction" type="submit" id="Submit" value="[% Translate("Save") | html %]"><span>[% Translate("Save") | html %]</span></button>
                             [% Translate("or") | html %]
                             <a href="[% Env("Baselink") %]Action=[% Env("Action") %]">[% Translate("Cancel") | html %]</a>
                         </div>

--- a/Kernel/Output/HTML/Templates/Standard/AdminMailAccount.tt
+++ b/Kernel/Output/HTML/Templates/Standard/AdminMailAccount.tt
@@ -204,7 +204,7 @@
                         <div class="Clear"></div>
 
                         <div class="Field SpacingTop">
-                            <button class="Primary CallForAction" type="submit" value="[% Translate("Submit") | html %]"><span>[% Translate("Submit") | html %]</span></button>
+                            <button class="Primary CallForAction" type="submit" value="[% Translate("Save") | html %]"><span>[% Translate("Save") | html %]</span></button>
                             [% Translate("or") | html %]
                             <a href="[% Env("Baselink") %]Action=[% Env("Action") %]">[% Translate("Cancel") | html %]</a>
                         </div>
@@ -339,7 +339,7 @@
                         <div class="Clear"></div>
 
                         <div class="Field SpacingTop">
-                            <button class="Primary CallForAction" type="submit" value="[% Translate("Submit") | html %]"><span>[% Translate("Submit") | html %]</span></button>
+                            <button class="Primary CallForAction" type="submit" value="[% Translate("Save") | html %]"><span>[% Translate("Save") | html %]</span></button>
                             [% Translate("or") | html %]
                             <a href="[% Env("Baselink") %]Action=[% Env("Action") %]">[% Translate("Cancel") | html %]</a>
                         </div>

--- a/Kernel/Output/HTML/Templates/Standard/AdminNotificationEvent.tt
+++ b/Kernel/Output/HTML/Templates/Standard/AdminNotificationEvent.tt
@@ -676,7 +676,7 @@ Core.Agent.Admin.NotificationEvent.Init({
                     <fieldset class="TableLike">
 
                         <div class="Field SpacingTop">
-                            <button class="Primary CallForAction" type="submit" value="[% Translate("Save") | html %]"><span>[% Translate("Submit") | html %]</span></button>
+                            <button class="Primary CallForAction" type="submit" value="[% Translate("Save") | html %]"><span>[% Translate("Save") | html %]</span></button>
                             [% Translate("or") | html %]
                             <a href="[% Env("Baselink") %]Action=[% Env("Action") %]">[% Translate("Cancel") | html %]</a>
                         </div>

--- a/Kernel/Output/HTML/Templates/Standard/AdminPostMasterFilter.tt
+++ b/Kernel/Output/HTML/Templates/Standard/AdminPostMasterFilter.tt
@@ -193,7 +193,7 @@
                 <div class="Content">
                     <fieldset class="TableLike">
                         <div class="Field SpacingTop">
-                            <button class="CallForAction Primary" type="submit" value="[% Translate("Submit") | html %]"><span>[% Translate("Submit") | html %]</span></button>
+                            <button class="CallForAction Primary" type="submit" value="[% Translate("Save") | html %]"><span>[% Translate("Save") | html %]</span></button>
                             [% Translate("or") | html %]
                             <a href="[% Env("Baselink") %]Action=[% Env("Action") %]">[% Translate("Cancel") | html %]</a>
                         </div>

--- a/Kernel/Output/HTML/Templates/Standard/AdminPriority.tt
+++ b/Kernel/Output/HTML/Templates/Standard/AdminPriority.tt
@@ -124,7 +124,7 @@
                         <div class="Clear"></div>
 
                         <div class="Field SpacingTop">
-                            <button class="Primary CallForAction" type="submit" value="[% Translate("Submit") | html %]"><span>[% Translate("Submit") | html %]</span></button>
+                            <button class="Primary CallForAction" type="submit" value="[% Translate("Save") | html %]"><span>[% Translate("Save") | html %]</span></button>
                             [% Translate("or") | html %]
                             <a href="[% Env("Baselink") %]Action=[% Env("Action") %]">[% Translate("Cancel") | html %]</a>
                         </div>

--- a/Kernel/Output/HTML/Templates/Standard/AdminProcessManagementActivity.tt
+++ b/Kernel/Output/HTML/Templates/Standard/AdminProcessManagementActivity.tt
@@ -134,7 +134,7 @@
         </div>
     </div>
     <div class="Footer">
-        <button class="Primary CallForAction" id="Submit" title="[% Translate("Submit") | html %]" type="submit" value="[% Translate("Submit") | html %]"><span>[% Translate("Submit") | html %]</span></button>
+        <button class="Primary CallForAction" id="Submit" title="[% Translate("Save") | html %]" type="submit" value="[% Translate("Save") | html %]"><span>[% Translate("Save") | html %]</span></button>
     </div>
 </div>
 [% WRAPPER JSOnDocumentComplete %]

--- a/Kernel/Output/HTML/Templates/Standard/AdminProcessManagementActivityDialog.tt
+++ b/Kernel/Output/HTML/Templates/Standard/AdminProcessManagementActivityDialog.tt
@@ -188,7 +188,7 @@
         </div>
     </div>
     <div class="Footer">
-        <button class="Primary CallForAction" id="Submit" title="[% Translate("Submit") | html %]" type="submit" value="[% Translate("Submit") | html %]"><span>[% Translate("Submit") | html %]</span></button>
+        <button class="Primary CallForAction" id="Submit" title="[% Translate("Save") | html %]" type="submit" value="[% Translate("Save") | html %]"><span>[% Translate("Save") | html %]</span></button>
     </div>
 </div>
 

--- a/Kernel/Output/HTML/Templates/Standard/AdminProcessManagementPath.tt
+++ b/Kernel/Output/HTML/Templates/Standard/AdminProcessManagementPath.tt
@@ -111,7 +111,7 @@
         </div>
     </div>
     <div class="Footer">
-        <button class="Primary CallForAction" id="Submit" title="[% Translate("Submit") | html %]" type="submit" value="[% Translate("Submit") | html %]"><span>[% Translate("Submit") | html %]</span></button>
+        <button class="Primary CallForAction" id="Submit" title="[% Translate("Save") | html %]" type="submit" value="[% Translate("Save") | html %]"><span>[% Translate("Save") | html %]</span></button>
     </div>
 </div>
 [% WRAPPER JSOnDocumentComplete %]

--- a/Kernel/Output/HTML/Templates/Standard/AdminProcessManagementTransition.tt
+++ b/Kernel/Output/HTML/Templates/Standard/AdminProcessManagementTransition.tt
@@ -280,7 +280,7 @@
         </div>
     </div>
     <div class="Footer">
-        <button class="Primary CallForAction" id="Submit" title="[% Translate("Submit") | html %]" type="submit" value="[% Translate("Submit") | html %]"><span>[% Translate("Submit") | html %]</span></button>
+        <button class="Primary CallForAction" id="Submit" title="[% Translate("Save") | html %]" type="submit" value="[% Translate("Save") | html %]"><span>[% Translate("Save") | html %]</span></button>
     </div>
 </div>
 [% WRAPPER JSOnDocumentComplete %]

--- a/Kernel/Output/HTML/Templates/Standard/AdminProcessManagementTransitionAction.tt
+++ b/Kernel/Output/HTML/Templates/Standard/AdminProcessManagementTransitionAction.tt
@@ -123,7 +123,7 @@
         </div>
     </div>
     <div class="Footer">
-        <button class="Primary CallForAction" id="Submit" title="[% Translate("Submit") | html %]" type="submit" value="[% Translate("Submit") | html %]"><span>[% Translate("Submit") | html %]</span></button>
+        <button class="Primary CallForAction" id="Submit" title="[% Translate("Save") | html %]" type="submit" value="[% Translate("Save") | html %]"><span>[% Translate("Save") | html %]</span></button>
     </div>
 </div>
 [% WRAPPER JSOnDocumentComplete %]

--- a/Kernel/Output/HTML/Templates/Standard/AdminQueue.tt
+++ b/Kernel/Output/HTML/Templates/Standard/AdminQueue.tt
@@ -357,7 +357,7 @@
 [% RenderBlockEnd("Password") %]
 [% RenderBlockEnd("Item") %]
                         <div class="Field SpacingTop">
-                            <button class="Primary CallForAction" id="Submit" type="submit" value="[% Translate("Submit") | html %]"><span>[% Translate("Submit") | html %]</span></button>
+                            <button class="Primary CallForAction" id="Submit" type="submit" value="[% Translate("Save") | html %]"><span>[% Translate("Save") | html %]</span></button>
                             [% Translate("or") | html %]
                             <a href="[% Env("Baselink") %]Action=[% Env("Action") %]"><span>[% Translate("Cancel") | html %]</span></a>
                         </div>

--- a/Kernel/Output/HTML/Templates/Standard/AdminQueueAutoResponse.tt
+++ b/Kernel/Output/HTML/Templates/Standard/AdminQueueAutoResponse.tt
@@ -127,7 +127,7 @@
                         <div class="Clear"></div>
 [% RenderBlockEnd("ChangeItemList") %]
                         <div class="Field SpacingTop">
-                            <button class="Primary CallForAction" type="submit" value="[% Translate("Submit") | html %]"><span>[% Translate("Submit") | html %]</span></button>
+                            <button class="Primary CallForAction" type="submit" value="[% Translate("Save") | html %]"><span>[% Translate("Save") | html %]</span></button>
                             [% Translate("or") | html %]
                             <a href="[% Env("Baselink") %]Action=[% Data.Action | uri %]">[% Translate("Cancel") | html %]</a>
                         </div>

--- a/Kernel/Output/HTML/Templates/Standard/AdminQueueTemplates.tt
+++ b/Kernel/Output/HTML/Templates/Standard/AdminQueueTemplates.tt
@@ -158,7 +158,7 @@
                         </tbody>
                     </table>
                     <div class="Field SpacingTop">
-                        <button class="Primary CallForAction" type="submit" value="[% Translate("Submit") | html %]"><span>[% Translate("Submit") | html %]</span></button>
+                        <button class="Primary CallForAction" type="submit" value="[% Translate("Save") | html %]"><span>[% Translate("Save") | html %]</span></button>
                         [% Translate("or") | html %]
                         <a href="[% Env("Baselink") %]Action=[% Env("Action") %]">[% Translate("Cancel") | html %]</a>
                     </div>

--- a/Kernel/Output/HTML/Templates/Standard/AdminRole.tt
+++ b/Kernel/Output/HTML/Templates/Standard/AdminRole.tt
@@ -123,7 +123,7 @@
                         <div class="Clear"></div>
 
                         <div class="Field SpacingTop">
-                            <button class="Primary CallForAction" type="submit" value="[% Translate("Submit") | html %]"><span>[% Translate("Submit") | html %]</span></button>
+                            <button class="Primary CallForAction" type="submit" value="[% Translate("Save") | html %]"><span>[% Translate("Save") | html %]</span></button>
                             [% Translate("or") | html %]
                             <a href="[% Env("Baselink") %]Action=[% Env("Action") %]">[% Translate("Cancel") | html %]</a>
                         </div>

--- a/Kernel/Output/HTML/Templates/Standard/AdminRoleGroup.tt
+++ b/Kernel/Output/HTML/Templates/Standard/AdminRoleGroup.tt
@@ -177,7 +177,7 @@
                         </tbody>
                     </table>
                     <div class="Field SpacingTop">
-                        <button class="Primary CallForAction" type="submit" value="[% Translate("Submit") | html %]"><span>[% Translate("Submit") | html %]</span></button>
+                        <button class="Primary CallForAction" type="submit" value="[% Translate("Save") | html %]"><span>[% Translate("Save") | html %]</span></button>
                         [% Translate("or") | html %]
                         <a href="[% Env("Baselink") %]Action=[% Env("Action") %]">[% Translate("Cancel") | html %]</a>
                     </div>

--- a/Kernel/Output/HTML/Templates/Standard/AdminRoleUser.tt
+++ b/Kernel/Output/HTML/Templates/Standard/AdminRoleUser.tt
@@ -174,7 +174,7 @@
                         </tbody>
                     </table>
                     <div class="Field SpacingTop">
-                        <button class="Primary CallForAction" type="submit" value="[% Translate("Submit") | html %]"><span>[% Translate("Submit") | html %]</span></button>
+                        <button class="Primary CallForAction" type="submit" value="[% Translate("Save") | html %]"><span>[% Translate("Save") | html %]</span></button>
                         [% Translate("or") | html %]
                         <a href="[% Env("Baselink") %]Action=[% Env("Action") %]">[% Translate("Cancel") | html %]</a>
                     </div>

--- a/Kernel/Output/HTML/Templates/Standard/AdminSLA.tt
+++ b/Kernel/Output/HTML/Templates/Standard/AdminSLA.tt
@@ -220,7 +220,7 @@
 [% RenderBlockEnd("Password") %]
 [% RenderBlockEnd("SLAItem") %]
                         <div class="Field SpacingTop">
-                            <button class="Primary CallForAction" type="submit" value="[% Translate("Submit") | html %]"><span>[% Translate("Submit") | html %]</span></button>
+                            <button class="Primary CallForAction" type="submit" value="[% Translate("Save") | html %]"><span>[% Translate("Save") | html %]</span></button>
                             [% Translate("or") | html %]
                             <a href="[% Env("Baselink") %]Action=[% Env("Action") %]">[% Translate("Cancel") | html %]</a>
                         </div>

--- a/Kernel/Output/HTML/Templates/Standard/AdminSMIME.tt
+++ b/Kernel/Output/HTML/Templates/Standard/AdminSMIME.tt
@@ -205,7 +205,7 @@
                     <div class="Clear"></div>
 
                     <div class="Field SpacingTop">
-                        <button class="Primary CallForAction" type="submit"><span>[% Translate("Submit") | html %]</span></button>
+                        <button class="Primary CallForAction" type="submit" value="[% Translate("Add")%]"><span>[% Translate("Add") | html %]</span></button>
                         [% Translate("or") | html %]
                         <a href="[% Env("Baselink") %]Action=[% Env("Action") %]">[% Translate("Cancel") | html %]</a>
                     </div>

--- a/Kernel/Output/HTML/Templates/Standard/AdminSalutation.tt
+++ b/Kernel/Output/HTML/Templates/Standard/AdminSalutation.tt
@@ -136,7 +136,7 @@
                         <div class="Clear"></div>
 
                         <div class="Field">
-                            <button class="Primary CallForAction" type="submit" value="[% Translate("Submit") | html %]"><span>[% Translate("Submit") | html %]</span></button>
+                            <button class="Primary CallForAction" type="submit" value="[% Translate("Save") | html %]"><span>[% Translate("Save") | html %]</span></button>
                             [% Translate("or") | html %]
                             <a href="[% Env("Baselink") %]Action=[% Env("Action") %]">[% Translate("Cancel") | html %]</a>
                         </div>

--- a/Kernel/Output/HTML/Templates/Standard/AdminService.tt
+++ b/Kernel/Output/HTML/Templates/Standard/AdminService.tt
@@ -167,7 +167,7 @@
 [% RenderBlockEnd("Password") %]
 [% RenderBlockEnd("Item") %]
                         <div class="Field SpacingTop">
-                            <button class="Primary CallForAction" type="submit" value="[% Translate("Submit") | html %]"><span>[% Translate("Submit") | html %]</span></button>
+                            <button class="Primary CallForAction" type="submit" value="[% Translate("Save") | html %]"><span>[% Translate("Save") | html %]</span></button>
                             [% Translate("or") | html %]
                             <a href="[% Env("Baselink") %]Action=[% Env("Action") %]">[% Translate("Cancel") | html %]</a>
                         </div>

--- a/Kernel/Output/HTML/Templates/Standard/AdminSignature.tt
+++ b/Kernel/Output/HTML/Templates/Standard/AdminSignature.tt
@@ -133,7 +133,7 @@
                         <div class="Clear"></div>
 
                         <div class="Field">
-                            <button class="Primary CallForAction" type="submit" value="[% Translate("Submit") | html %]"><span>[% Translate("Submit") | html %]</span></button>
+                            <button class="Primary CallForAction" type="submit" value="[% Translate("Save") | html %]"><span>[% Translate("Save") | html %]</span></button>
                             [% Translate("or") | html %]
                             <a href="[% Env("Baselink") %]Action=[% Env("Action") %]">[% Translate("Cancel") | html %]</a>
                         </div>

--- a/Kernel/Output/HTML/Templates/Standard/AdminState.tt
+++ b/Kernel/Output/HTML/Templates/Standard/AdminState.tt
@@ -151,7 +151,7 @@
                         <div class="Clear"></div>
 
                         <div class="Field SpacingTop">
-                            <button class="Primary CallForAction" type="submit" id="Submit" value="[% Translate("Submit") | html %]"><span>[% Translate("Submit") | html %]</span></button>
+                            <button class="Primary CallForAction" type="submit" id="Submit" value="[% Translate("Save") | html %]"><span>[% Translate("Save") | html %]</span></button>
                             [% Translate("or") | html %]
                             <a href="[% Env("Baselink") %]Action=[% Env("Action") %]">[% Translate("Cancel") | html %]</a>
                         </div>

--- a/Kernel/Output/HTML/Templates/Standard/AdminSysConfig.tt
+++ b/Kernel/Output/HTML/Templates/Standard/AdminSysConfig.tt
@@ -110,7 +110,7 @@ $('#SysConfigGroup').bind('change', function(){
                         </div>
                         <div class="Field">
                             <button title="[% Translate("Load SysConfig settings from file") | html %]" class="Primary" type="submit" value="[% Translate("Import") | html %]">
-                                [% Translate("Submit") | html %]
+                                [% Translate("Import") | html %]
                             </button>
                             [% Translate("or") | html %]
                             <a href="[% Env("Baselink") %]Action=[% Env("Action") %]">[% Translate("Cancel") | html %]</a>

--- a/Kernel/Output/HTML/Templates/Standard/AdminSystemAddress.tt
+++ b/Kernel/Output/HTML/Templates/Standard/AdminSystemAddress.tt
@@ -188,7 +188,7 @@ $('.MasterAction').bind('click', function (Event) {
                         <div class="Clear"></div>
 
                         <div class="Field SpacingTop">
-                            <button class="Primary CallForAction" type="submit" value="[% Translate("Submit") | html %]"><span>[% Translate("Submit") | html %]</span></button>
+                            <button class="Primary CallForAction" type="submit" value="[% Translate("Save") | html %]"><span>[% Translate("Save") | html %]</span></button>
                             [% Translate("or") | html %]
                             <a href="[% Env("Baselink") %]Action=[% Env("Action") %]">[% Translate("Cancel") | html %]</a>
                         </div>

--- a/Kernel/Output/HTML/Templates/Standard/AdminTemplate.tt
+++ b/Kernel/Output/HTML/Templates/Standard/AdminTemplate.tt
@@ -197,7 +197,7 @@
                         <div class="Clear"></div>
 
                         <div class="Field">
-                            <button class="Primary CallForAction" type="submit" value="[% Translate("Submit") | html %]"><span>[% Translate("Submit") | html %]</span></button>
+                            <button class="Primary CallForAction" type="submit" value="[% Translate("Save") | html %]"><span>[% Translate("Save") | html %]</span></button>
                             [% Translate("or") | html %]
                             <a href="[% Env("Baselink") %]Action=AdminTemplate">[% Translate("Cancel") | html %]</a>
                         </div>

--- a/Kernel/Output/HTML/Templates/Standard/AdminTemplateAttachment.tt
+++ b/Kernel/Output/HTML/Templates/Standard/AdminTemplateAttachment.tt
@@ -177,7 +177,7 @@ Core.UI.Table.InitTableFilter($('#Filter'), $('#TemplateAttachment'));
                         </tbody>
                     </table>
                     <div class="Field SpacingTop">
-                        <button class="Primary CallForAction" type="submit" value="[% Translate("Submit") | html %]"><span>[% Translate("Submit") | html %]</span></button>
+                        <button class="Primary CallForAction" type="submit" value="[% Translate("Save") | html %]"><span>[% Translate("Save") | html %]</span></button>
                         [% Translate("or") | html %]
                         <a href="[% Env("Baselink") %]Action=[% Env("Action") %]">[% Translate("Cancel") | html %]</a>
                     </div>

--- a/Kernel/Output/HTML/Templates/Standard/AdminType.tt
+++ b/Kernel/Output/HTML/Templates/Standard/AdminType.tt
@@ -122,7 +122,7 @@
                         <div class="Clear"></div>
 
                         <div class="Field">
-                            <button class="Primary CallForAction" type="submit" value="[% Translate("Submit") | html %]"><span>[% Translate("Submit") | html %]</span></button>
+                            <button class="Primary CallForAction" type="submit" value="[% Translate("Save") | html %]"><span>[% Translate("Save") | html %]</span></button>
                             [% Translate("or") | html %]
                             <a href="[% Env("Baselink") %]Action=[% Env("Action") %]">[% Translate("Cancel") | html %]</a>
                         </div>

--- a/Kernel/Output/HTML/Templates/Standard/AdminUser.tt
+++ b/Kernel/Output/HTML/Templates/Standard/AdminUser.tt
@@ -308,7 +308,7 @@
 [% RenderBlockEnd("RawHTML") %]
 [% RenderBlockEnd("Item") %]
                         <div class="Field SpacingTop">
-                            <button class="Primary CallForAction" type="submit" value="[% Translate("Submit") | html %]"><span>[% Translate("Submit") | html %]</span></button>
+                            <button class="Primary CallForAction" type="submit" value="[% Translate("Save") | html %]"><span>[% Translate("Save") | html %]</span></button>
                             [% Translate("or") | html %]
                             <a href="[% Env("Baselink") %]Action=[% Env("Action") %]">[% Translate("Cancel") | html %]</a>
                         </div>

--- a/Kernel/Output/HTML/Templates/Standard/AdminUserGroup.tt
+++ b/Kernel/Output/HTML/Templates/Standard/AdminUserGroup.tt
@@ -190,7 +190,7 @@
                                     </tbody>
                                 </table>
                                 <div class="Field SpacingTop">
-                                    <button class="Primary CallForAction" type="submit" value="[% Translate("Submit") | html %]"><span>[% Translate("Submit") | html %]</span></button>
+                                    <button class="Primary CallForAction" type="submit" value="[% Translate("Save") | html %]"><span>[% Translate("Save") | html %]</span></button>
                         [% Translate("or") | html %]
                                     <a href="[% Env("Baselink") %]Action=[% Env("Action") %]">[% Translate("Cancel") | html %]</a>
                                 </div>

--- a/Kernel/Output/HTML/Templates/Standard/AgentDashboardCommon.tt
+++ b/Kernel/Output/HTML/Templates/Standard/AgentDashboardCommon.tt
@@ -114,7 +114,7 @@ $('#Dashboard[% Data.Name | html %]_toggle').on('click', function() {
 [% RenderBlockEnd("ContentSmallPreferencesItemTextArea") %]
 [% RenderBlockEnd("ContentSmallPreferencesItem") %]
                         <div class="SpacingTop Center">
-                            <button id="Dashboard[% Data.Name | html %]_submit" class="button DontPrint CallForAction Primary" type="submit" value="[% Translate("Submit") | html %]"><span>[% Translate("Submit") | html %]</span></button>
+                            <button id="Dashboard[% Data.Name | html %]_submit" class="button DontPrint CallForAction Primary" type="submit" value="[% Translate("Save") | html %]"><span>[% Translate("Save Changes") | html %]</span></button>
                             <button id="Dashboard[% Data.Name | html %]_cancel" class="button DontPrint CallForAction" type="submit" value="[% Translate("Cancel") | html %]"><span>[% Translate("Cancel") | html %]</span></button>
                         </div>
 [% WRAPPER JSOnDocumentComplete %]

--- a/Kernel/Output/HTML/Templates/Standard/AgentTicketBulk.tt
+++ b/Kernel/Output/HTML/Templates/Standard/AgentTicketBulk.tt
@@ -254,7 +254,7 @@ $('#MergeTo').bind('blur', function() {
             </div>
         </div>
         <div class="Footer">
-            <button class="Primary" id="submitRichText" accesskey="g" title="[% Translate("Submit") | html %] (g)" type="submit" value="[% Translate("Submit") | html %]">[% Translate("Submit") | html %]</button>
+            <button class="Primary" id="submitRichText" accesskey="g" title="[% Translate("Submit") | html %] (g)" type="submit" value="[% Translate("Execute Bulk Action") | html %]">[% Translate("Execute Bulk Action") | html %]</button>
         </div>
     </div>
 </form>

--- a/Kernel/Output/HTML/Templates/Standard/AgentTicketMove.tt
+++ b/Kernel/Output/HTML/Templates/Standard/AgentTicketMove.tt
@@ -328,7 +328,7 @@
 
         </div>
         <div class="Footer">
-            <button class="CallForAction Primary" id="submitRichText" accesskey="g" title="[% Translate("Submit") | html %] (g)" type="submit" value="[% Translate("Submit") | html %]"><span>[% Translate("Submit") | html %]</span></button>
+            <button class="CallForAction Primary" id="submitRichText" accesskey="g" title="[% Translate("Move") | html %] (g)" type="submit" value="[% Translate("Move") | html %]"><span>[% Translate("Move") | html %]</span></button>
         </div>
     </div>
 </form>

--- a/Kernel/Output/HTML/Templates/Standard/AgentTicketOverviewNavBar.tt
+++ b/Kernel/Output/HTML/Templates/Standard/AgentTicketOverviewNavBar.tt
@@ -120,7 +120,7 @@ $('#ShowContextSettingsDialog').bind('click', function (Event) {
     Core.UI.Dialog.ShowContentDialog($('#ContextSettingsDialogContainer'), [% Translate("Settings") | JSON %], '15%', 'Center', true,
         [
             {
-                Label: [% Translate("Submit") | JSON %],
+                Label: [% Translate("Save") | JSON %],
                 Type: 'Submit',
                 Class: 'Primary',
                 Function: function () {


### PR DESCRIPTION
This pull request contains the following changes (All are textual, no functionality has been changed):

In general, settings are saved, so on almost every admin screen, the “Sumbit” button has been changed to “Save”, with a few exceptions:
- otrs/index.pl?Action=AdminSMIME;Subaction=ShowAddCertificate - I changed the “Submit” button to “Add”, because the user is adding a certificate here
- otrs/index.pl?Action=AdminSysConfig;Subaction=Import - I changed the “Submit” button to “Import”, since the user is importing settings here

Mostly, agent actions are “submitted”, so the submit button can stay whenever there’s a creation of a ticket, adding of an article or sending of a message. Everywhere where there are settings involved (like the settings on the dashboard or in the ticket overview screen) I changed “submit” to “Save” or to “Save Changes” if the last one was more in line with similar situations. There are two exceptions:
- otrs/index.pl?Action=AgentTicketBulk - I changed the “Submit” button to “Excecute Bulk Action”, because the user wants to execute the bulk action
- otrs/index.pl?Action=AgentTicketMove - I changed the “Submit” button to “Move”, since the ticket is moved to a different queue