### PR TITLE
[ Rel-5_0 ] - menu moduls update

### DIFF
--- a/Kernel/Config/Files/Ticket.xml
+++ b/Kernel/Config/Files/Ticket.xml
@@ -6697,8 +6697,8 @@
             </Hash>
         </Setting>
     </ConfigItem>
-    <ConfigItem Name="Ticket::Frontend::PreMenuModule###460-Spam" Required="0" Valid="0">
-        <Description Translatable="1">Shows a link in the menu to set a ticket as spam in every ticket overview of the agent interface. Additional access control to show or not show this link can be done by using Key "Group" and Content like "rw:group1;move_into:group2".</Description>
+    <ConfigItem Name="Ticket::Frontend::PreMenuModule###460-Junk" Required="0" Valid="0">
+        <Description Translatable="1">Shows a link in the menu to set a ticket as junk in every ticket overview of the agent interface. Additional access control to show or not show this link can be done by using Key "Group" and Content like "rw:group1;move_into:group2".</Description>
         <Group>Ticket</Group>
         <SubGroup>Frontend::Agent::Ticket::MenuModulePre</SubGroup>
         <Setting>
@@ -6707,7 +6707,7 @@
                 <Item Key="Name">Spam</Item>
                 <Item Key="Action">AgentTicketMove</Item>
                 <Item Key="Description" Translatable="1">Mark as Spam!</Item>
-                <Item Key="Link">Action=AgentTicketMove;TicketID=[% Data.TicketID %];DestQueue=Delete</Item>
+                <Item Key="Link">Action=AgentTicketMove;TicketID=[% Data.TicketID %];DestQueue=Junk</Item>
                 <Item Key="Target"></Item>
                 <Item Key="PopupType"></Item>
             </Hash>

--- a/Kernel/Modules/AgentTicketZoom.pm
+++ b/Kernel/Modules/AgentTicketZoom.pm
@@ -1002,7 +1002,7 @@ sub MaskAgentZoom {
             }
 
             $Item->{NameForID} = $Item->{Name};
-            $Item->{NameForID} =~ s/ /-/g if( $Item->{NameForID} =~ m/ / );
+            $Item->{NameForID} =~ s/ /-/g if ( $Item->{NameForID} =~ m/ / );
 
             if ( !$Menus{$Menu}->{ClusterName} ) {
 
@@ -1024,15 +1024,15 @@ sub MaskAgentZoom {
         for my $Cluster ( sort keys %MenuClusters ) {
 
             my $NameForID = $Cluster;
-            $NameForID =~ s/ /-/g if( $NameForID =~ m/ / );
+            $NameForID =~ s/ /-/g if ( $NameForID =~ m/ / );
 
             $ZoomMenuItems{ $MenuClusters{$Cluster}->{Priority} . $Cluster } = {
-                Name  => $Cluster,
+                Name      => $Cluster,
                 NameForID => $NameForID,
-                Type  => 'Cluster',
-                Link  => '#',
-                Class => 'ClusterLink',
-                Items => $MenuClusters{$Cluster}->{Items},
+                Type      => 'Cluster',
+                Link      => '#',
+                Class     => 'ClusterLink',
+                Items     => $MenuClusters{$Cluster}->{Items},
                 }
         }
 
@@ -1050,7 +1050,7 @@ sub MaskAgentZoom {
                     Name => 'TicketMenuSubContainer',
                     Data => {
                         NameForID => $ZoomMenuItems{$Item}->{NameForID},
-                    }
+                        }
                 );
 
                 for my $SubItem ( sort keys %{ $ZoomMenuItems{$Item}->{Items} } ) {
@@ -2428,8 +2428,9 @@ sub _ArticleTree {
                         Data => $Item->{ArticleData}->{Body},
                     );
 
-                    for my $ChatMessage (@{ $ChatMessages // [] }) {
-                        $ChatMessage->{CreateTime} = $LayoutObject->{LanguageObject}->FormatTimeString( $ChatMessage->{CreateTime}, 'DateFormat' );
+                    for my $ChatMessage ( @{ $ChatMessages // [] } ) {
+                        $ChatMessage->{CreateTime} = $LayoutObject->{LanguageObject}
+                            ->FormatTimeString( $ChatMessage->{CreateTime}, 'DateFormat' );
                     }
                     $Item->{ArticleData}->{ChatMessages} = $ChatMessages;
 

--- a/Kernel/Modules/AgentTicketZoom.pm
+++ b/Kernel/Modules/AgentTicketZoom.pm
@@ -1001,9 +1001,6 @@ sub MaskAgentZoom {
                 $Item->{Class} = "AsPopup PopupType_$Menus{$Menu}->{PopupType}";
             }
 
-            $Item->{NameForID} = $Item->{Name};
-            $Item->{NameForID} =~ s/ /-/g if ( $Item->{NameForID} =~ m/ / );
-
             if ( !$Menus{$Menu}->{ClusterName} ) {
 
                 $ZoomMenuItems{$Menu} = $Item;
@@ -1022,17 +1019,12 @@ sub MaskAgentZoom {
         }
 
         for my $Cluster ( sort keys %MenuClusters ) {
-
-            my $NameForID = $Cluster;
-            $NameForID =~ s/ /-/g if ( $NameForID =~ m/ / );
-
             $ZoomMenuItems{ $MenuClusters{$Cluster}->{Priority} . $Cluster } = {
-                Name      => $Cluster,
-                NameForID => $NameForID,
-                Type      => 'Cluster',
-                Link      => '#',
-                Class     => 'ClusterLink',
-                Items     => $MenuClusters{$Cluster}->{Items},
+                Name  => $Cluster,
+                Type  => 'Cluster',
+                Link  => '#',
+                Class => 'ClusterLink',
+                Items => $MenuClusters{$Cluster}->{Items},
                 }
         }
 
@@ -1049,8 +1041,8 @@ sub MaskAgentZoom {
                 $LayoutObject->Block(
                     Name => 'TicketMenuSubContainer',
                     Data => {
-                        NameForID => $ZoomMenuItems{$Item}->{NameForID},
-                        }
+                        Name => $ZoomMenuItems{$Item}->{Name},
+                    },
                 );
 
                 for my $SubItem ( sort keys %{ $ZoomMenuItems{$Item}->{Items} } ) {

--- a/Kernel/Modules/AgentTicketZoom.pm
+++ b/Kernel/Modules/AgentTicketZoom.pm
@@ -1001,6 +1001,9 @@ sub MaskAgentZoom {
                 $Item->{Class} = "AsPopup PopupType_$Menus{$Menu}->{PopupType}";
             }
 
+            $Item->{NameForID} = $Item->{Name};
+            $Item->{NameForID} =~ s/ /-/g if( $Item->{NameForID} =~ m/ / );
+
             if ( !$Menus{$Menu}->{ClusterName} ) {
 
                 $ZoomMenuItems{$Menu} = $Item;
@@ -1019,8 +1022,13 @@ sub MaskAgentZoom {
         }
 
         for my $Cluster ( sort keys %MenuClusters ) {
+
+            my $NameForID = $Cluster;
+            $NameForID =~ s/ /-/g if( $NameForID =~ m/ / );
+
             $ZoomMenuItems{ $MenuClusters{$Cluster}->{Priority} . $Cluster } = {
                 Name  => $Cluster,
+                NameForID => $NameForID,
                 Type  => 'Cluster',
                 Link  => '#',
                 Class => 'ClusterLink',
@@ -1039,7 +1047,10 @@ sub MaskAgentZoom {
             if ( $ZoomMenuItems{$Item}->{Type} eq 'Cluster' ) {
 
                 $LayoutObject->Block(
-                    Name => 'TicketMenuSubContainer'
+                    Name => 'TicketMenuSubContainer',
+                    Data => {
+                        NameForID => $ZoomMenuItems{$Item}->{NameForID},
+                    }
                 );
 
                 for my $SubItem ( sort keys %{ $ZoomMenuItems{$Item}->{Items} } ) {

--- a/Kernel/Output/HTML/Templates/Standard/AgentTicketZoom.tt
+++ b/Kernel/Output/HTML/Templates/Standard/AgentTicketZoom.tt
@@ -373,16 +373,16 @@
                     <div class="ActionRow Cluster">
                         <ul class="Actions">
 [% RenderBlockStart("TicketMenu") %]
-                            <li id="nav-[% Data.Name %]">
+                            <li id="nav-[% Data.NameForID %]">
                             [% IF Data.Type == 'Cluster' %]
-                                <span class="[% Data.Class %]" title="[% Translate(Data.Description) | html %]">[% Translate(Data.Name) | html %] <i class="fa fa-caret-down"></i></span>
+                                <span class="[% Data.Class %]" >[% Translate(Data.Name) | html %] <i class="fa fa-caret-down"></i></span>
                             [% ELSE %]
                                 <a href="[% Env("Baselink") %][% Data.Link | Interpolate %]" class="[% Data.Class %]" [% Data.LinkParam %] title="[% Translate(Data.Description) | html %]">[% Translate(Data.Name) | html %]</a>
                             [% END %]
 [% RenderBlockStart("TicketMenuSubContainer") %]
-                                <ul id="nav-[% Data.Name %]-container" class="[% Data.Class | html %]">
+                                <ul id="nav-[% Data.NameForID %]-container">
 [% RenderBlockStart("TicketMenuSubContainerItem") %]
-                                    <li id="nav-[% Data.Name %]">
+                                    <li id="nav-[% Data.NameForID %]">
                                         <a href="[% Env("Baselink") %][% Data.Link | Interpolate %]" class="[% Data.Class | html %]" [% Data.LinkParam %] title="[% Translate(Data.Description) | html %]">[% Translate(Data.Name) | html %]</a>
                                     </li>
 [% RenderBlockEnd("TicketMenuSubContainerItem") %]

--- a/Kernel/Output/HTML/Templates/Standard/AgentTicketZoom.tt
+++ b/Kernel/Output/HTML/Templates/Standard/AgentTicketZoom.tt
@@ -379,7 +379,7 @@
                             [% ELSE %]
                                 <a href="[% Env("Baselink") %][% Data.Link | Interpolate %]" class="[% Data.Class %]" [% Data.LinkParam %] title="[% Translate(Data.Description) | html %]">[% Translate(Data.Name) | html %]</a>
                             [% END %]
-[% RenderBlockStart("TicketMenuSubContainer") %]
+            [% RenderBlockStart("TicketMenuSubContainer") %]
                                 <ul id="nav-[% Data.NameForID %]-container">
 [% RenderBlockStart("TicketMenuSubContainerItem") %]
                                     <li id="nav-[% Data.NameForID %]">

--- a/Kernel/Output/HTML/Templates/Standard/AgentTicketZoom.tt
+++ b/Kernel/Output/HTML/Templates/Standard/AgentTicketZoom.tt
@@ -373,16 +373,16 @@
                     <div class="ActionRow Cluster">
                         <ul class="Actions">
 [% RenderBlockStart("TicketMenu") %]
-                            <li id="nav-[% Data.NameForID %]">
+                            <li id="nav-[% Data.Name | replace(' ', '-') | html %]">
                             [% IF Data.Type == 'Cluster' %]
                                 <span class="[% Data.Class %]" >[% Translate(Data.Name) | html %] <i class="fa fa-caret-down"></i></span>
                             [% ELSE %]
                                 <a href="[% Env("Baselink") %][% Data.Link | Interpolate %]" class="[% Data.Class %]" [% Data.LinkParam %] title="[% Translate(Data.Description) | html %]">[% Translate(Data.Name) | html %]</a>
                             [% END %]
-            [% RenderBlockStart("TicketMenuSubContainer") %]
-                                <ul id="nav-[% Data.NameForID %]-container">
+[% RenderBlockStart("TicketMenuSubContainer") %]
+                                <ul id="nav-[% Data.Name | replace(' ', '-') | html %]-container">
 [% RenderBlockStart("TicketMenuSubContainerItem") %]
-                                    <li id="nav-[% Data.NameForID %]">
+                                    <li id="nav-[% Data.Name | replace(' ', '-') | html %]">
                                         <a href="[% Env("Baselink") %][% Data.Link | Interpolate %]" class="[% Data.Class | html %]" [% Data.LinkParam %] title="[% Translate(Data.Description) | html %]">[% Translate(Data.Name) | html %]</a>
                                     </li>
 [% RenderBlockEnd("TicketMenuSubContainerItem") %]

--- a/Kernel/Output/HTML/TicketMenu/Generic.pm
+++ b/Kernel/Output/HTML/TicketMenu/Generic.pm
@@ -1,5 +1,5 @@
 # --
-# Copyright (C) 2001-2015 OTRS AG, http://otrs.com/
+# Copyright (C) 2001-2016 OTRS AG, http://otrs.com/
 # --
 # This software comes with ABSOLUTELY NO WARRANTY. For details, see
 # the enclosed file COPYING for license information (AGPL). If you

--- a/Kernel/Output/HTML/TicketMenu/Generic.pm
+++ b/Kernel/Output/HTML/TicketMenu/Generic.pm
@@ -1,5 +1,5 @@
 # --
-# Copyright (C) 2001-2016 OTRS AG, http://otrs.com/
+# Copyright (C) 2001-2015 OTRS AG, http://otrs.com/
 # --
 # This software comes with ABSOLUTELY NO WARRANTY. For details, see
 # the enclosed file COPYING for license information (AGPL). If you
@@ -53,14 +53,13 @@ sub Run {
     if ( $Param{Config}->{Action} ) {
         my $Module = $ConfigObject->Get('Frontend::Module')->{ $Param{Config}->{Action} };
         return if !$Module;
-    }
 
-    # get ticket object
-    my $TicketObject = $Kernel::OM->Get('Kernel::System::Ticket');
+        # get ticket object
+        my $TicketObject = $Kernel::OM->Get('Kernel::System::Ticket');
 
-    # check permission
-    my $Config = $ConfigObject->Get("Ticket::Frontend::$Param{Config}->{Action}");
-    if ($Config) {
+        # check permission
+        my $Config = $ConfigObject->Get("Ticket::Frontend::$Param{Config}->{Action}");
+
         if ( $Config->{Permission} ) {
             my $AccessOk = $TicketObject->TicketPermission(
                 Type     => $Config->{Permission},

--- a/scripts/test/Selenium/Output/Ticket/Menu.t
+++ b/scripts/test/Selenium/Output/Ticket/Menu.t
@@ -80,7 +80,7 @@ $Selenium->RunTest(
                 SysConfigItem => {
                     Active      => "AgentTicketMove",
                     Description => "Mark as Spam!",
-                    Link        => "Action=AgentTicketMove;TicketID=[% Data.TicketID %];DestQueue=Delete",
+                    Link        => "Action=AgentTicketMove;TicketID=[% Data.TicketID %];DestQueue=Junk",
                     Module      => "Kernel::Output::HTML::TicketMenu::Generic",
                     Name        => "Spam",
                     PopupType   => "",
@@ -150,49 +150,50 @@ $Selenium->RunTest(
         # create pre menu module test params
         my @PreMenuModule = (
             {
-                Name      => "Lock",
-                NameForID => "Lock",
-                Action    => "AgentTicket"
+                Name   => "Lock",
+                Action => "AgentTicket"
             },
             {
-                Name      => "Zoom",
-                NameForID => "Zoom",
-                Action    => "AgentTicketZoom",
+                Name   => "Zoom",
+                Action => "AgentTicketZoom",
             },
             {
-                Name      => "History",
-                NameForID => "History",
-                Action    => "AgentTicketHistory",
+                Name   => "History",
+                Action => "AgentTicketHistory",
             },
             {
-                Name      => "Priority",
-                NameForID => "Priority",
-                Action    => "AgentTicketPriority",
+                Name   => "Priority",
+                Action => "AgentTicketPriority",
             },
             {
-                Name      => "Note",
-                NameForID => "Note",
-                Action    => "AgentTicketNote",
+                Name   => "Note",
+                Action => "AgentTicketNote",
             },
             {
-                Name      => "Move",
-                NameForID => "DestQueueID",
-                Action    => "AgentTicketMove",
+                Name   => "Move",
+                Action => "AgentTicketMove",
             },
             {
-                Name      => "Delete",
-                NameForID => "Delete",
-                Action    => "AgentTicketMove;TicketID=$TicketID;DestQueue=Delete",
+                Name   => "Delete",
+                Action => "AgentTicketMove;TicketID=$TicketID;DestQueue=Delete",
             },
             {
-                Name      => "Spam",
-                NameForID => "Spam",
-                Action    => "AgentTicketMove;TicketID=$TicketID;DestQueue=Junk",
+                Name   => "Spam",
+                Action => "AgentTicketMove;TicketID=$TicketID;DestQueue=Junk",
             },
         );
 
         # check ticket pre menu modules
         for my $MenuModulePre (@PreMenuModule) {
+
+            my $NameForID;
+            if ( $MenuModulePre->{Name} eq 'Move' ) {
+                $NameForID = 'DestQueueID';
+            }
+            else {
+                $NameForID = $MenuModulePre->{Name};
+                $NameForID =~ s/ /-/g if ( $NameForID =~ m/ / );
+            }
 
             # check pre menu module link
             $Self->True(
@@ -202,7 +203,7 @@ $Selenium->RunTest(
 
             # check pre menu module name
             $Self->True(
-                $Selenium->find_element( "#$MenuModulePre->{NameForID}$TicketID", 'css' ),
+                $Selenium->find_element( "#$NameForID$TicketID", 'css' ),
                 "Ticket menu name $MenuModulePre->{Name} is found"
             );
         }
@@ -213,130 +214,110 @@ $Selenium->RunTest(
         # create menu module test params
         my @MenuModule = (
             {
-                Name      => "Back",
-                NameForID => "Back",
-                Action    => "AgentDashboard",
+                Name   => "Back",
+                Action => "AgentDashboard",
             },
             {
-                Name      => "Lock",
-                NameForID => "Lock",
-                Action    => "AgentTicket"
+                Name   => "Lock",
+                Action => "AgentTicket"
             },
             {
-                Name      => "History",
-                NameForID => "History",
-                Action    => "AgentTicketHistory",
+                Name   => "History",
+                Action => "AgentTicketHistory",
             },
             {
-                Name      => "Print",
-                NameForID => "Print",
-                Action    => "AgentTicketPrint",
+                Name   => "Print",
+                Action => "AgentTicketPrint",
             },
             {
-                Name      => "Priority",
-                NameForID => "Print",
-                Action    => "AgentTicketPriority",
+                Name   => "Priority",
+                Action => "AgentTicketPriority",
             },
             {
-                Name      => "Free Fields",
-                NameForID => "Free-Fields",
-                Action    => "AgentTicketFreeText",
+                Name   => "Free Fields",
+                Action => "AgentTicketFreeText",
             },
             {
-                Name      => "Link",
-                NameForID => "Link",
-                Action    => "AgentLinkObject",
+                Name   => "Link",
+                Action => "AgentLinkObject",
             },
             {
-                Name      => "Owner",
-                NameForID => "Owner",
-                Action    => "AgentTicketOwner",
+                Name   => "Owner",
+                Action => "AgentTicketOwner",
             },
             {
-                Name      => "Responsible",
-                NameForID => "Responsible",
-                Action    => "AgentTicketResponsible",
+                Name   => "Responsible",
+                Action => "AgentTicketResponsible",
             },
             {
-                Name      => "Customer",
-                NameForID => "Customer",
-                Action    => "AgentTicketCustomer",
+                Name   => "Customer",
+                Action => "AgentTicketCustomer",
             },
             {
-                Name      => "Note",
-                NameForID => "Note",
-                Action    => "AgentTicketNote",
+                Name   => "Note",
+                Action => "AgentTicketNote",
             },
             {
-                Name      => "Phone Call Outbound",
-                NameForID => "Phone-Call-Outbound",
-                Action    => "AgentTicketPhoneOutbound",
+                Name   => "Phone Call Outbound",
+                Action => "AgentTicketPhoneOutbound",
             },
             {
-                Name      => "Phone Call Inbound",
-                NameForID => "Phone-Call-Inbound",
-                Action    => "AgentTicketPhoneInbound",
+                Name   => "Phone Call Inbound",
+                Action => "AgentTicketPhoneInbound",
             },
             {
-                Name      => "E-Mail Outbound",
-                NameForID => "E-Mail-Outbound",
-                Action    => "AgentTicketEmailOutbound",
+                Name   => "E-Mail Outbound",
+                Action => "AgentTicketEmailOutbound",
             },
             {
-                Name      => "Merge",
-                NameForID => "Merge",
-                Action    => "AgentTicketMerge",
+                Name   => "Merge",
+                Action => "AgentTicketMerge",
             },
             {
-                Name      => "Pending",
-                NameForID => "Pending",
-                Action    => "AgentTicketPending",
+                Name   => "Pending",
+                Action => "AgentTicketPending",
             },
             {
-                Name      => "Watch",
-                NameForID => "Watch",
-                Action    => "AgentTicketWatcher",
+                Name   => "Watch",
+                Action => "AgentTicketWatcher",
             },
             {
-                Name      => "Close",
-                NameForID => "Close",
-                Action    => "AgentTicketClose",
+                Name   => "Close",
+                Action => "AgentTicketClose",
             },
             {
-                Name      => "Delete",
-                NameForID => "Delete",
-                Action    => "AgentTicketMove;TicketID=$TicketID;DestQueue=Delete",
+                Name   => "Delete",
+                Action => "AgentTicketMove;TicketID=$TicketID;DestQueue=Delete",
             },
             {
-                Name      => "Spam",
-                NameForID => "Spam",
-                Action    => "AgentTicketMove;TicketID=$TicketID;DestQueue=Junk",
+                Name   => "Spam",
+                Action => "AgentTicketMove;TicketID=$TicketID;DestQueue=Junk",
             },
             {
-                Name      => "People",
-                NameForID => "People",
-                Type      => "Cluster",
+                Name => "People",
+                Type => "Cluster",
             },
             {
-                Name      => "Communication",
-                NameForID => "Communication",
-                Type      => "Cluster",
+                Name => "Communication",
+                Type => "Cluster",
             },
             {
-                Name      => "Miscellaneous",
-                NameForID => "Miscellaneous",
-                Type      => "Cluster",
+                Name => "Miscellaneous",
+                Type => "Cluster",
             },
         );
 
         # check ticket menu modules
         for my $ZoomMenuModule (@MenuModule) {
 
+            my $NameForID = $ZoomMenuModule->{Name};
+            $NameForID =~ s/ /-/g if ( $NameForID =~ m/ / );
+
             if ( defined $ZoomMenuModule->{Type} && $ZoomMenuModule->{Type} eq 'Cluster' ) {
 
                 # check menu module link
                 $Self->True(
-                    $Selenium->find_element( "li ul#nav-$ZoomMenuModule->{NameForID}-container", 'css' ),
+                    $Selenium->find_element( "li ul#nav-$NameForID-container", 'css' ),
                     "Ticket menu link $ZoomMenuModule->{Name} is found"
                 );
             }
@@ -351,7 +332,7 @@ $Selenium->RunTest(
 
             # check menu module name
             $Self->True(
-                $Selenium->find_element( "li#nav-$ZoomMenuModule->{NameForID}", 'css' ),
+                $Selenium->find_element( "li#nav-$NameForID", 'css' ),
                 "Ticket menu name $ZoomMenuModule->{Name} is found"
             );
         }

--- a/scripts/test/Selenium/Output/Ticket/Menu.t
+++ b/scripts/test/Selenium/Output/Ticket/Menu.t
@@ -55,14 +55,14 @@ $Selenium->RunTest(
             {
                 SysConfigItem => {
                     Active      => "AgentTicketMove",
-                    Description => "Mark as Spam!",
-                    Link        => "Action=AgentTicketMove;TicketID=[% Data.TicketID %];DestQueue=Delete",
+                    Description => "Mark this ticket as junk!",
+                    Link        => "Action=AgentTicketMove;TicketID=[% Data.TicketID %];DestQueue=Junk",
                     Module      => "Kernel::Output::HTML::TicketMenu::Generic",
                     Name        => "Spam",
                     PopupType   => "",
                     Target      => "",
                 },
-                Key => "Ticket::Frontend::MenuModule###470-Spam",
+                Key => "Ticket::Frontend::MenuModule###470-Junk",
             },
             {
                 SysConfigItem => {
@@ -170,7 +170,7 @@ $Selenium->RunTest(
                 Action => "AgentTicketNote",
             },
             {
-                Name   => "Move",
+                Name   => "DestQueueID",
                 Action => "AgentTicketMove",
             },
             {
@@ -185,9 +185,17 @@ $Selenium->RunTest(
 
         # check ticket pre menu modules
         for my $MenuModulePre (@PreMenuModule) {
+
+            # check pre menu module link
             $Self->True(
                 $Selenium->find_element("//a[contains(\@href, \'Action=$MenuModulePre->{Action}' )]"),
-                "Ticket pre menu $MenuModulePre->{Name} - found"
+                "Ticket pre menu $MenuModulePre->{Name} is found"
+            );
+
+            # check pre menu module name
+            $Self->True(
+                $Selenium->find_element("#$MenuModulePre->{Name}$TicketID",'css'),
+                "Ticket menu name $MenuModulePre->{Name} is found"
             );
         }
 
@@ -217,7 +225,7 @@ $Selenium->RunTest(
                 Action => "AgentTicketPriority",
             },
             {
-                Name   => "Free Fields",
+                Name   => "Free-Fields",
                 Action => "AgentTicketFreeText",
             },
             {
@@ -241,15 +249,15 @@ $Selenium->RunTest(
                 Action => "AgentTicketNote",
             },
             {
-                Name   => "Phone Call Outbound",
+                Name   => "Phone-Call-Outbound",
                 Action => "AgentTicketPhoneOutbound",
             },
             {
-                Name   => "Phone Call Inbound",
+                Name   => "Phone-Call-Inbound",
                 Action => "AgentTicketPhoneInbound",
             },
             {
-                Name   => "E-Mail Outbound",
+                Name   => "E-Mail-Outbound",
                 Action => "AgentTicketEmailOutbound",
             },
             {
@@ -274,15 +282,49 @@ $Selenium->RunTest(
             },
             {
                 Name   => "Spam",
-                Action => "AgentTicketMove;TicketID=$TicketID;DestQueue=Delete",
+                Action => "AgentTicketMove;TicketID=$TicketID;DestQueue=Junk",
+            },
+            {
+                Name   => "People",
+                Action => "AgentTicketMove;TicketID=$TicketID;DestQueue=Junk",
+                Type   => "Cluster",
+            },
+            {
+                Name   => "Communication",
+                Action => "AgentTicketMove;TicketID=$TicketID;DestQueue=Junk",
+                Type   => "Cluster",
+            },
+            {
+                Name   => "Miscellaneous",
+                Action => "AgentTicketMove;TicketID=$TicketID;DestQueue=Junk",
+                Type   => "Cluster",
             },
         );
 
         # check ticket menu modules
         for my $ZoomMenuModule (@MenuModule) {
+
+            if ( $ZoomMenuModule->{Type} eq 'Cluster' ) {
+
+                # check menu module link
+                $Self->True(
+                    $Selenium->find_element("li ul#nav-$ZoomMenuModule->{Name}-container", 'css'),
+                    "Ticket menu link $ZoomMenuModule->{Name} is found"
+                );
+            }
+            else{
+
+                # check menu module link
+                $Self->True(
+                    $Selenium->find_element("//a[contains(\@href, \'Action=$ZoomMenuModule->{Action}' )]"),
+                    "Ticket menu link $ZoomMenuModule->{Name} is found"
+                );
+            }
+
+            # check menu module name
             $Self->True(
-                $Selenium->find_element("//a[contains(\@href, \'Action=$ZoomMenuModule->{Action}' )]"),
-                "Ticket menu $ZoomMenuModule->{Name} - found"
+                $Selenium->find_element("li#nav-$ZoomMenuModule->{Name}",'css'),
+                "Ticket menu name $ZoomMenuModule->{Name} is found"
             );
         }
 

--- a/scripts/test/Selenium/Output/Ticket/Menu.t
+++ b/scripts/test/Selenium/Output/Ticket/Menu.t
@@ -187,7 +187,7 @@ $Selenium->RunTest(
             {
                 Name      => "Spam",
                 NameForID => "Spam",
-                Action    => "AgentTicketMove;TicketID=$TicketID;DestQueue=Delete",
+                Action    => "AgentTicketMove;TicketID=$TicketID;DestQueue=Junk",
             },
         );
 
@@ -315,19 +315,16 @@ $Selenium->RunTest(
             {
                 Name      => "People",
                 NameForID => "People",
-                Action    => "AgentTicketMove;TicketID=$TicketID;DestQueue=Junk",
                 Type      => "Cluster",
             },
             {
                 Name      => "Communication",
                 NameForID => "Communication",
-                Action    => "AgentTicketMove;TicketID=$TicketID;DestQueue=Junk",
                 Type      => "Cluster",
             },
             {
                 Name      => "Miscellaneous",
                 NameForID => "Miscellaneous",
-                Action    => "AgentTicketMove;TicketID=$TicketID;DestQueue=Junk",
                 Type      => "Cluster",
             },
         );

--- a/scripts/test/Selenium/Output/Ticket/Menu.t
+++ b/scripts/test/Selenium/Output/Ticket/Menu.t
@@ -194,7 +194,7 @@ $Selenium->RunTest(
 
             # check pre menu module name
             $Self->True(
-                $Selenium->find_element("#$MenuModulePre->{Name}$TicketID",'css'),
+                $Selenium->find_element( "#$MenuModulePre->{Name}$TicketID", 'css' ),
                 "Ticket menu name $MenuModulePre->{Name} is found"
             );
         }
@@ -308,11 +308,11 @@ $Selenium->RunTest(
 
                 # check menu module link
                 $Self->True(
-                    $Selenium->find_element("li ul#nav-$ZoomMenuModule->{Name}-container", 'css'),
+                    $Selenium->find_element( "li ul#nav-$ZoomMenuModule->{Name}-container", 'css' ),
                     "Ticket menu link $ZoomMenuModule->{Name} is found"
                 );
             }
-            else{
+            else {
 
                 # check menu module link
                 $Self->True(
@@ -323,7 +323,7 @@ $Selenium->RunTest(
 
             # check menu module name
             $Self->True(
-                $Selenium->find_element("li#nav-$ZoomMenuModule->{Name}",'css'),
+                $Selenium->find_element( "li#nav-$ZoomMenuModule->{Name}", 'css' ),
                 "Ticket menu name $ZoomMenuModule->{Name} is found"
             );
         }

--- a/scripts/test/Selenium/Output/Ticket/Menu.t
+++ b/scripts/test/Selenium/Output/Ticket/Menu.t
@@ -150,36 +150,44 @@ $Selenium->RunTest(
         # create pre menu module test params
         my @PreMenuModule = (
             {
-                Name   => "Lock",
-                Action => "AgentTicket"
+                Name      => "Lock",
+                NameForID => "Lock",
+                Action    => "AgentTicket"
             },
             {
-                Name   => "Zoom",
-                Action => "AgentTicketZoom",
+                Name      => "Zoom",
+                NameForID => "Zoom",
+                Action    => "AgentTicketZoom",
             },
             {
-                Name   => "History",
-                Action => "AgentTicketHistory",
+                Name      => "History",
+                NameForID => "History",
+                Action    => "AgentTicketHistory",
             },
             {
-                Name   => "Priority",
-                Action => "AgentTicketPriority",
+                Name      => "Priority",
+                NameForID => "Priority",
+                Action    => "AgentTicketPriority",
             },
             {
-                Name   => "Note",
-                Action => "AgentTicketNote",
+                Name      => "Note",
+                NameForID => "Note",
+                Action    => "AgentTicketNote",
             },
             {
-                Name   => "DestQueueID",
-                Action => "AgentTicketMove",
+                Name      => "Move",
+                NameForID => "DestQueueID",
+                Action    => "AgentTicketMove",
             },
             {
-                Name   => "Delete",
-                Action => "AgentTicketMove;TicketID=$TicketID;DestQueue=Delete",
+                Name      => "Delete",
+                NameForID => "Delete",
+                Action    => "AgentTicketMove;TicketID=$TicketID;DestQueue=Delete",
             },
             {
-                Name   => "Spam",
-                Action => "AgentTicketMove;TicketID=$TicketID;DestQueue=Delete",
+                Name      => "Spam",
+                NameForID => "Spam",
+                Action    => "AgentTicketMove;TicketID=$TicketID;DestQueue=Delete",
             },
         );
 
@@ -194,7 +202,7 @@ $Selenium->RunTest(
 
             # check pre menu module name
             $Self->True(
-                $Selenium->find_element( "#$MenuModulePre->{Name}$TicketID", 'css' ),
+                $Selenium->find_element( "#$MenuModulePre->{NameForID}$TicketID", 'css' ),
                 "Ticket menu name $MenuModulePre->{Name} is found"
             );
         }
@@ -205,110 +213,133 @@ $Selenium->RunTest(
         # create menu module test params
         my @MenuModule = (
             {
-                Name   => "Back",
-                Action => "AgentDashboard",
+                Name      => "Back",
+                NameForID => "Back",
+                Action    => "AgentDashboard",
             },
             {
-                Name   => "Lock",
-                Action => "AgentTicket"
+                Name      => "Lock",
+                NameForID => "Lock",
+                Action    => "AgentTicket"
             },
             {
-                Name   => "History",
-                Action => "AgentTicketHistory",
+                Name      => "History",
+                NameForID => "History",
+                Action    => "AgentTicketHistory",
             },
             {
-                Name   => "Print",
-                Action => "AgentTicketPrint",
+                Name      => "Print",
+                NameForID => "Print",
+                Action    => "AgentTicketPrint",
             },
             {
-                Name   => "Priority",
-                Action => "AgentTicketPriority",
+                Name      => "Priority",
+                NameForID => "Print",
+                Action    => "AgentTicketPriority",
             },
             {
-                Name   => "Free-Fields",
-                Action => "AgentTicketFreeText",
+                Name      => "Free Fields",
+                NameForID => "Free-Fields",
+                Action    => "AgentTicketFreeText",
             },
             {
-                Name   => "Link",
-                Action => "AgentLinkObject",
+                Name      => "Link",
+                NameForID => "Link",
+                Action    => "AgentLinkObject",
             },
             {
-                Name   => "Owner",
-                Action => "AgentTicketOwner",
+                Name      => "Owner",
+                NameForID => "Owner",
+                Action    => "AgentTicketOwner",
             },
             {
-                Name   => "Responsible",
-                Action => "AgentTicketResponsible",
+                Name      => "Responsible",
+                NameForID => "Responsible",
+                Action    => "AgentTicketResponsible",
             },
             {
-                Name   => "Customer",
-                Action => "AgentTicketCustomer",
+                Name      => "Customer",
+                NameForID => "Customer",
+                Action    => "AgentTicketCustomer",
             },
             {
-                Name   => "Note",
-                Action => "AgentTicketNote",
+                Name      => "Note",
+                NameForID => "Note",
+                Action    => "AgentTicketNote",
             },
             {
-                Name   => "Phone-Call-Outbound",
-                Action => "AgentTicketPhoneOutbound",
+                Name      => "Phone Call Outbound",
+                NameForID => "Phone-Call-Outbound",
+                Action    => "AgentTicketPhoneOutbound",
             },
             {
-                Name   => "Phone-Call-Inbound",
-                Action => "AgentTicketPhoneInbound",
+                Name      => "Phone Call Inbound",
+                NameForID => "Phone-Call-Inbound",
+                Action    => "AgentTicketPhoneInbound",
             },
             {
-                Name   => "E-Mail-Outbound",
-                Action => "AgentTicketEmailOutbound",
+                Name      => "E-Mail Outbound",
+                NameForID => "E-Mail-Outbound",
+                Action    => "AgentTicketEmailOutbound",
             },
             {
-                Name   => "Merge",
-                Action => "AgentTicketMerge",
+                Name      => "Merge",
+                NameForID => "Merge",
+                Action    => "AgentTicketMerge",
             },
             {
-                Name   => "Pending",
-                Action => "AgentTicketPending",
+                Name      => "Pending",
+                NameForID => "Pending",
+                Action    => "AgentTicketPending",
             },
             {
-                Name   => "Watch",
-                Action => "AgentTicketWatcher",
+                Name      => "Watch",
+                NameForID => "Watch",
+                Action    => "AgentTicketWatcher",
             },
             {
-                Name   => "Close",
-                Action => "AgentTicketClose",
+                Name      => "Close",
+                NameForID => "Close",
+                Action    => "AgentTicketClose",
             },
             {
-                Name   => "Delete",
-                Action => "AgentTicketMove;TicketID=$TicketID;DestQueue=Delete",
+                Name      => "Delete",
+                NameForID => "Delete",
+                Action    => "AgentTicketMove;TicketID=$TicketID;DestQueue=Delete",
             },
             {
-                Name   => "Spam",
-                Action => "AgentTicketMove;TicketID=$TicketID;DestQueue=Junk",
+                Name      => "Spam",
+                NameForID => "Spam",
+                Action    => "AgentTicketMove;TicketID=$TicketID;DestQueue=Junk",
             },
             {
-                Name   => "People",
-                Action => "AgentTicketMove;TicketID=$TicketID;DestQueue=Junk",
-                Type   => "Cluster",
+                Name      => "People",
+                NameForID => "People",
+                Action    => "AgentTicketMove;TicketID=$TicketID;DestQueue=Junk",
+                Type      => "Cluster",
             },
             {
-                Name   => "Communication",
-                Action => "AgentTicketMove;TicketID=$TicketID;DestQueue=Junk",
-                Type   => "Cluster",
+                Name      => "Communication",
+                NameForID => "Communication",
+                Action    => "AgentTicketMove;TicketID=$TicketID;DestQueue=Junk",
+                Type      => "Cluster",
             },
             {
-                Name   => "Miscellaneous",
-                Action => "AgentTicketMove;TicketID=$TicketID;DestQueue=Junk",
-                Type   => "Cluster",
+                Name      => "Miscellaneous",
+                NameForID => "Miscellaneous",
+                Action    => "AgentTicketMove;TicketID=$TicketID;DestQueue=Junk",
+                Type      => "Cluster",
             },
         );
 
         # check ticket menu modules
         for my $ZoomMenuModule (@MenuModule) {
 
-            if ( $ZoomMenuModule->{Type} eq 'Cluster' ) {
+            if ( defined $ZoomMenuModule->{Type} && $ZoomMenuModule->{Type} eq 'Cluster' ) {
 
                 # check menu module link
                 $Self->True(
-                    $Selenium->find_element( "li ul#nav-$ZoomMenuModule->{Name}-container", 'css' ),
+                    $Selenium->find_element( "li ul#nav-$ZoomMenuModule->{NameForID}-container", 'css' ),
                     "Ticket menu link $ZoomMenuModule->{Name} is found"
                 );
             }
@@ -323,7 +354,7 @@ $Selenium->RunTest(
 
             # check menu module name
             $Self->True(
-                $Selenium->find_element( "li#nav-$ZoomMenuModule->{Name}", 'css' ),
+                $Selenium->find_element( "li#nav-$ZoomMenuModule->{NameForID}", 'css' ),
                 "Ticket menu name $ZoomMenuModule->{Name} is found"
             );
         }


### PR DESCRIPTION
Hi @mgruner 

Working on some bug I saw that Spam menu item changed and now it moves Ticket to Junk queue. It have been done in this commit https://github.com/OTRS/otrs/commit/8ce6b493b63456fc1e3d71a97d708ecb06cbba6d

I saw that it was not changed in the TicketMenu/Menu.t Selenium test. I wanted to update this test and then I saw there are some error in Fred, and because of that I also fix code in /TicketMenu/Generic.pm. There was a problem if there is not $Param{Config}->{Action} and then $Config will be empty.
`
        my $Config = $ConfigObject->Get("Ticket::Frontend::$Param{Config}->{Action}");`

There was also a problem with  <li id="nav-[% Data.Name %]"> in AgentTicketZoom.tt In some case id was with space for example "nav-Phone Call Outbound".

Title attribute  for cluster menu item is not neccecccary, acctually it was empty ( titlt="") 
It is not needed because on hover the submenu is expanded. Simmilar to empty title, the class for ul of cluster container is not needed, because there is not value, it was also empty.
I used idea from AgentNavigationBar.tt to make this two screen consistent, since I add NameForID.

And the last thing that I changed Ticket::Frontend::PreMenuModule###460-Spam, I think it could be confusing that Spam action in Zoom and Overview screens  have different behavior one move ticket in Junk and the other in Delete queue.

I did not open a bug for that, but if you would like I will be able to do that. If you think this changes is necessary you can marge it. Please let me now what do you think about all of that.

Regards
Zoran





