### PR TITLE
Rel-5_0 - OTRS - updated unit test - part 3

### DIFF
--- a/scripts/test/Auth.t
+++ b/scripts/test/Auth.t
@@ -17,7 +17,7 @@ $Kernel::OM->ObjectParamAdd(
     'Kernel::System::UnitTest::Helper' => {
         RestoreSystemConfiguration => 1,
         RestoreDatabase            => 1,
-        }
+    },
 );
 my $Helper = $Kernel::OM->Get('Kernel::System::UnitTest::Helper');
 

--- a/scripts/test/AuthSession.t
+++ b/scripts/test/AuthSession.t
@@ -25,7 +25,7 @@ $Kernel::OM->ObjectParamAdd(
     'Kernel::System::UnitTest::Helper' => {
         RestoreSystemConfiguration => 1,
         RestoreDatabase            => 1,
-        }
+    },
 );
 my $Helper = $Kernel::OM->Get('Kernel::System::UnitTest::Helper');
 

--- a/scripts/test/AutoResponse.t
+++ b/scripts/test/AutoResponse.t
@@ -20,7 +20,7 @@ my $SystemAddressObject = $Kernel::OM->Get('Kernel::System::SystemAddress');
 $Kernel::OM->ObjectParamAdd(
     'Kernel::System::UnitTest::Helper' => {
         RestoreDatabase => 1,
-        }
+    },
 );
 my $Helper = $Kernel::OM->Get('Kernel::System::UnitTest::Helper');
 

--- a/scripts/test/AutoResponseSent.t
+++ b/scripts/test/AutoResponseSent.t
@@ -24,7 +24,7 @@ $Kernel::OM->ObjectParamAdd(
     'Kernel::System::UnitTest::Helper' => {
         RestoreSystemConfiguration => 1,
         RestoreDatabase            => 1,
-        }
+    },
 );
 my $Helper = $Kernel::OM->Get('Kernel::System::UnitTest::Helper');
 

--- a/scripts/test/CustomerCompany.t
+++ b/scripts/test/CustomerCompany.t
@@ -17,6 +17,15 @@ my $ConfigObject = $Kernel::OM->Get('Kernel::Config');
 my $DBObject     = $Kernel::OM->Get('Kernel::System::DB');
 my $XMLObject    = $Kernel::OM->Get('Kernel::System::XML');
 
+# get helper object
+$Kernel::OM->ObjectParamAdd(
+    'Kernel::System::UnitTest::Helper' => {
+        RestoreSystemConfiguration => 1,
+        RestoreDatabase            => 1,
+    },
+);
+my $Helper = $Kernel::OM->Get('Kernel::System::UnitTest::Helper');
+
 my $Data         = $ConfigObject->Get('CustomerCompany');
 my $DefaultValue = $Data->{Params}->{Table};
 
@@ -79,7 +88,7 @@ my $CustomerCompanyObject = $Kernel::OM->Get('Kernel::System::CustomerCompany');
 
 for my $Key ( 1 .. 3, 'ä', 'カス' ) {
 
-    my $CompanyRand = 'Example-Customer-Company' . $Key . int( rand(1000000) );
+    my $CompanyRand = 'Example-Customer-Company' . $Key . $Helper->GetRandomID();
 
     my $CustomerID = $CustomerCompanyObject->CustomerCompanyAdd(
         CustomerID             => $CompanyRand,
@@ -276,7 +285,7 @@ $CustomerCompanyObject = $Kernel::OM->Get('Kernel::System::CustomerCompany');
 
 for my $Key ( 1 .. 3, 'ä', 'カス' ) {
 
-    my $CompanyRand = 'Example-Customer-Company' . $Key . int( rand(1000000) );
+    my $CompanyRand = 'Example-Customer-Company' . $Key . $Helper->GetRandomID();
 
     my $CustomerID = $CustomerCompanyObject->CustomerCompanyAdd(
         CustomerID             => $CompanyRand,
@@ -432,5 +441,7 @@ $Self->False(
     scalar keys %CustomerCompanyList,
     "CustomerCompanyList() with Search",
 );
+
+# cleanup is done by RestoreDatabase
 
 1;

--- a/scripts/test/CustomerGroup.t
+++ b/scripts/test/CustomerGroup.t
@@ -14,9 +14,17 @@ use vars (qw($Self));
 
 use Kernel::System::VariableCheck qw(:all);
 
-# get needed objects
+# get config object
 my $ConfigObject = $Kernel::OM->Get('Kernel::Config');
-my $HelperObject = $Kernel::OM->Get('Kernel::System::UnitTest::Helper');
+
+# get helper object
+$Kernel::OM->ObjectParamAdd(
+    'Kernel::System::UnitTest::Helper' => {
+        RestoreSystemConfiguration => 1,
+        RestoreDatabase            => 1,
+    },
+);
+my $Helper = $Kernel::OM->Get('Kernel::System::UnitTest::Helper');
 
 $ConfigObject->Set(
     Key   => 'CustomerGroupAlwaysGroups',
@@ -32,7 +40,7 @@ my $CustomerGroupObject = $Kernel::OM->Get('Kernel::System::CustomerGroup');
 my $CustomerUserObject  = $Kernel::OM->Get('Kernel::System::CustomerUser');
 my $GroupObject         = $Kernel::OM->Get('Kernel::System::Group');
 
-my $RandomID = $HelperObject->GetRandomID();
+my $RandomID = $Helper->GetRandomID();
 my $UserID   = 1;
 my $UID      = $RandomID;
 my $GID1     = 1;
@@ -861,5 +869,7 @@ for my $Test (@Tests) {
         );
     }
 }
+
+# cleanup is done by RestoreDatabase
 
 1;

--- a/scripts/test/CustomerUser.t
+++ b/scripts/test/CustomerUser.t
@@ -20,8 +20,14 @@ my $CacheObject        = $Kernel::OM->Get('Kernel::System::Cache');
 my $CustomerUserObject = $Kernel::OM->Get('Kernel::System::CustomerUser');
 my $DBObject           = $Kernel::OM->Get('Kernel::System::DB');
 
-use Kernel::System::CustomerUser;
-use Kernel::System::CustomerAuth;
+# get helper object
+$Kernel::OM->ObjectParamAdd(
+    'Kernel::System::UnitTest::Helper' => {
+        RestoreSystemConfiguration => 1,
+        RestoreDatabase            => 1,
+    },
+);
+my $Helper = $Kernel::OM->Get('Kernel::System::UnitTest::Helper');
 
 # add three users
 $ConfigObject->Set(
@@ -35,7 +41,7 @@ my $CustomerDatabaseCaseSensitiveDefault = $ConfigObject->{CustomerUser}->{Param
 my $UserID = '';
 for my $Key ( 1 .. 3, 'ä', 'カス', '_', '&' ) {
 
-    my $UserRand = 'Example-Customer-User' . $Key . int( rand(1000000) );
+    my $UserRand = 'Example-Customer-User' . $Key . $Helper->GetRandomID();
 
     $UserID = $UserRand;
     my $UserID = $CustomerUserObject->CustomerUserAdd(
@@ -824,5 +830,7 @@ $Self->Is(
     1,
     "CustomerSourceList - found 1 writable sources",
 );
+
+# cleanup is done by RestoreDatabase
 
 1;


### PR DESCRIPTION
Hi @mgruner 

Here is one more PR with updated unit tests. I updated the previus ones where omitted come in list of the helper param. 
You can see CustomerUserService.t, I think that clean-up code which was at the end of the test is not necessary any more because clean-up is done by RestoreDatabase.

Regards
Zoran
