### PR TITLE
Upload cache performance fix

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,4 +1,5 @@
 #6.0.0.beta1 2016-??-??
+ - 2016-05-27 Upload cache cleanup command name changed, unit test added.
  - 2016-02-18 Upload cache performance fix.
  - 2016-02-01 Upload cache performance fix.
  - 2015-12-16 Fixed bug#[6333](http://bugs.otrs.org/show_bug.cgi?id=6333) - Ticket merging does not work with customized state name.

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,4 +1,5 @@
 #6.0.0.beta1 2016-??-??
+ - 2016-02-18 Upload cache performance fix.
  - 2016-02-01 Upload cache performance fix.
  - 2015-12-16 Fixed bug#[6333](http://bugs.otrs.org/show_bug.cgi?id=6333) - Ticket merging does not work with customized state name.
  - 2015-12-15 Fixed bug#[8653](http://bugs.otrs.org/show_bug.cgi?id=8653) - Sysconfig option ComposeExcludeCCRecipients for AgentTicketCompose is obsolete.

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,4 +1,5 @@
 #6.0.0.beta1 2016-??-??
+ - 2016-02-01 Upload cache performance fix.
  - 2015-12-16 Fixed bug#[6333](http://bugs.otrs.org/show_bug.cgi?id=6333) - Ticket merging does not work with customized state name.
  - 2015-12-15 Fixed bug#[8653](http://bugs.otrs.org/show_bug.cgi?id=8653) - Sysconfig option ComposeExcludeCCRecipients for AgentTicketCompose is obsolete.
  - 2015-11-27 Added possibility to restrict Zoom and Print screens in the customer interface by using ACLs. Thanks to Sanjin Vik @ s7design.

--- a/Kernel/Config/Files/Daemon.xml
+++ b/Kernel/Config/Files/Daemon.xml
@@ -175,6 +175,24 @@
             </Hash>
         </Setting>
     </ConfigItem>
+    <ConfigItem Name="Daemon::SchedulerCronTaskManager::Task###WebUploadCacheCleanup" Required="0" Valid="1" ConfigLevel="100">
+        <Description Translatable="1">Delete expired upload cache hourly.</Description>
+        <Group>Daemon</Group>
+        <SubGroup>Daemon::SchedulerCronTaskManager::Task</SubGroup>
+        <Setting>
+            <Hash>
+                <Item Key="TaskName">WebUploadCacheCleanup</Item>
+                <Item Key="Schedule">46 * * * *</Item> <!-- default every hour -->
+                <Item Key="Module">Kernel::System::Web::UploadCache</Item>
+                <Item Key="Function">FormIDCleanUp</Item>
+                <Item Key="MaximumParallelInstances">1</Item>
+                <Item Key="Params">
+                    <Array>
+                    </Array>
+                </Item>
+            </Hash>
+        </Setting>
+    </ConfigItem>
     <ConfigItem Name="Daemon::SchedulerCronTaskManager::Task###LoaderCacheDelete" Required="0" Valid="1" ConfigLevel="100">
         <Description Translatable="1">Delete expired loader cache weekly (Sunday mornings).</Description>
         <Group>Daemon</Group>

--- a/Kernel/System/Console/Command/Maint/Web/UploadCache/Cleanup.pm
+++ b/Kernel/System/Console/Command/Maint/Web/UploadCache/Cleanup.pm
@@ -1,0 +1,51 @@
+# --
+# Copyright (C) 2016 Informatyka Boguslawski sp. z o.o. sp.k., http://www.ib.pl/
+# --
+# This software comes with ABSOLUTELY NO WARRANTY. For details, see
+# the enclosed file COPYING for license information (AGPL). If you
+# did not receive this file, see http://www.gnu.org/licenses/agpl.txt.
+# --
+
+package Kernel::System::Console::Command::Maint::Web::UploadCache::Cleanup;
+
+use strict;
+use warnings;
+
+use base qw(Kernel::System::Console::BaseCommand);
+
+our @ObjectDependencies = (
+    'Kernel::System::Web::UploadCache',
+);
+
+sub Configure {
+    my ( $Self, %Param ) = @_;
+
+    $Self->Description('Cleanup the upload cache.');
+
+    return;
+}
+
+sub Run {
+    my ( $Self, %Param ) = @_;
+
+    $Self->Print("<yellow>Cleaning up the upload cache files...</yellow>\n");
+
+    my @DeletedFiles = $Kernel::OM->Get('Kernel::System::Web::UploadCache')->FormIDCleanUp();
+    $Self->Print("<green>Done.</green>\n");
+
+    return $Self->ExitCodeOk();
+}
+
+1;
+
+=back
+
+=head1 TERMS AND CONDITIONS
+
+This software is part of the OTRS project (L<http://otrs.org/>).
+
+This software comes with ABSOLUTELY NO WARRANTY. For details, see
+the enclosed file COPYING for license information (AGPL). If you
+did not receive this file, see L<http://www.gnu.org/licenses/agpl.txt>.
+
+=cut

--- a/Kernel/System/Console/Command/Maint/WebUploadCache/Cleanup.pm
+++ b/Kernel/System/Console/Command/Maint/WebUploadCache/Cleanup.pm
@@ -6,7 +6,7 @@
 # did not receive this file, see http://www.gnu.org/licenses/agpl.txt.
 # --
 
-package Kernel::System::Console::Command::Maint::Web::UploadCache::Cleanup;
+package Kernel::System::Console::Command::Maint::WebUploadCache::Cleanup;
 
 use strict;
 use warnings;

--- a/Kernel/System/Web/UploadCache/DB.pm
+++ b/Kernel/System/Web/UploadCache/DB.pm
@@ -33,9 +33,6 @@ sub new {
 sub FormIDCreate {
     my ( $Self, %Param ) = @_;
 
-    # cleanup temp form ids
-    $Self->FormIDCleanUp();
-
     # return requested form id
     return time() . '.' . rand(12341241);
 }

--- a/Kernel/System/Web/UploadCache/FS.pm
+++ b/Kernel/System/Web/UploadCache/FS.pm
@@ -53,6 +53,10 @@ sub FormIDRemove {
 
     my $Directory = $Self->_GetCacheDirectory(%Param);
 
+    if ( !-d $Directory ) {
+        return 1;
+    }
+
     # get main object
     my $MainObject = $Kernel::OM->Get('Kernel::System::Main');
 
@@ -97,13 +101,13 @@ sub FormIDAddFile {
 
     # create cache subdirectory if not exist
     my $Directory = $Self->_GetCacheDirectory(%Param);
-    if ( !-e $Directory ) {
+    if ( !-d $Directory ) {
 
         # Create directory. This could fail if another process creates the
         #   same directory, so don't use the return value.
         File::Path::mkpath( $Directory, 0, 0770 );    ## no critic
 
-        if ( !-e $Directory ) {
+        if ( !-d $Directory ) {
             $Kernel::OM->Get('Kernel::System::Log')->Log(
                 Priority => 'error',
                 Message  => "Can't create directory '$Directory': $!",
@@ -165,6 +169,10 @@ sub FormIDRemoveFile {
     my %File  = %{ $Index[$ID] };
 
     my $Directory = $Self->_GetCacheDirectory(%Param);
+
+    if ( !-d $Directory ) {
+        return 1;
+    }
 
     # get main object
     my $MainObject = $Kernel::OM->Get('Kernel::System::Main');

--- a/scripts/test/Console/Command/Maint/WebUploadCache/Cleanup.t
+++ b/scripts/test/Console/Command/Maint/WebUploadCache/Cleanup.t
@@ -1,0 +1,140 @@
+# --
+# Copyright (C) 2016 Informatyka Boguslawski sp. z o.o. sp.k., http://www.ib.pl/
+# Based on WebUploadCache.t by OTRS AG, http://otrs.com/
+# --
+# This software comes with ABSOLUTELY NO WARRANTY. For details, see
+# the enclosed file COPYING for license information (AGPL). If you
+# did not receive this file, see http://www.gnu.org/licenses/agpl.txt.
+# --
+
+use strict;
+use warnings;
+use utf8;
+
+use vars (qw($Self));
+
+use Digest::MD5 qw(md5_hex);
+
+# get needed objects
+my $ConfigObject = $Kernel::OM->Get('Kernel::Config');
+my $EncodeObject = $Kernel::OM->Get('Kernel::System::Encode');
+my $MainObject   = $Kernel::OM->Get('Kernel::System::Main');
+
+# get command object
+my $CommandObject = $Kernel::OM->Get('Kernel::System::Console::Command::Maint::WebUploadCache::Cleanup');
+
+my ( $Result, $ExitCode );
+
+my $Helper = $Kernel::OM->Get('Kernel::System::UnitTest::Helper');
+
+
+for my $Module (qw(DB FS)) {
+
+    # make sure that the $UploadCacheObject gets recreated for each loop.
+    $Kernel::OM->ObjectsDiscard( Objects => ['Kernel::System::Web::UploadCache'] );
+
+    $ConfigObject->Set(
+        Key   => 'WebUploadCacheModule',
+        Value => "Kernel::System::Web::UploadCache::$Module",
+    );
+
+    # get a new upload cache object
+    my $UploadCacheObject = $Kernel::OM->Get('Kernel::System::Web::UploadCache');
+
+    my $FormID = $UploadCacheObject->FormIDCreate();
+
+    $Self->True(
+        $FormID,
+        "#$Module - FormIDCreate()",
+    );
+
+    my $Location = $ConfigObject->Get('Home')
+        . "/scripts/test/sample/WebUploadCache/WebUploadCache-Test1.txt";
+
+    my $ContentRef = $MainObject->FileRead(
+        Location => $Location,
+        Mode     => 'binmode',
+    );
+    my $Content = ${$ContentRef};
+    $EncodeObject->EncodeOutput( \$Content );
+
+    my $MD5         = md5_hex($Content);
+    my $ContentID   = undef;
+    my $Disposition = 'attachment';
+
+    my $Add = $UploadCacheObject->FormIDAddFile(
+        FormID      => $FormID,
+        Filename    => 'UploadCache Test1äöüß.txt',
+        Content     => $Content,
+        ContentType => 'text/html',
+        ContentID   => $ContentID,
+        Disposition => $Disposition,
+    );
+
+    $Self->True(
+        $Add || '',
+        "#$Module - FormIDAddFile()",
+    );
+
+    # delete upload cache - should not remove cached form
+    $ExitCode = $CommandObject->Execute();
+    $Self->Is(
+        $ExitCode,
+        0,
+        "#$Module - delete upload cache",
+    );
+
+    my @Data = $UploadCacheObject->FormIDGetAllFilesData(
+        FormID => $FormID,
+    );
+
+    $Self->True(
+        scalar @Data,
+        "#$Module - FormIDGetAllFilesData() check if formid is present",
+    );
+
+    @Data = $UploadCacheObject->FormIDGetAllFilesMeta( FormID => $FormID );
+
+    $Self->True(
+        scalar @Data,
+        "#$Module - FormIDGetAllFilesMeta() check if formid is present",
+    );
+
+    # set fixed time
+    $Helper->FixedTimeSet();
+
+    # wait 24h+1s to expire upload cache
+    $Helper->FixedTimeAddSeconds(86401);
+
+    # delete upload cache - should remove cached form
+    $ExitCode = $CommandObject->Execute();
+    $Self->Is(
+        $ExitCode,
+        0,
+        "#$Module - delete upload cache",
+    );
+
+    @Data = $UploadCacheObject->FormIDGetAllFilesData(
+        FormID => $FormID,
+    );
+
+    $Self->False(
+         scalar @Data,
+        "#$Module - FormIDGetAllFilesData() check if formid is absent",
+    );
+
+    @Data = $UploadCacheObject->FormIDGetAllFilesMeta(
+        FormID => $FormID,
+    );
+
+    $Self->False(
+         scalar @Data,
+        "#$Module - FormIDGetAllFilesMeta() check if formid is absent",
+    );
+
+    # unset fixed time
+    $Helper->FixedTimeUnset();
+
+}
+
+1;


### PR DESCRIPTION
OTRS upload cache cleaning up is done on every FormID creation which may
hurt performance, especially if there are many cached files on slower
storage (i.e. shared NFS directory).

This mod moves cleaning upload cache to separate scheduler task fired
every hour.

When WebUploadCacheModule=FS is used, files are also spread between
different subdirectories to avoid many files in one directory (for
better performance and easier cleaning up).

Related: https://dev.ib.pl/ib/otrs/issues/20
Author-Change-Id: IB#1048779