### PR TITLE
Rel-5_0 - OTRS - updated unit test - part 4

### DIFF
--- a/scripts/test/CustomerGroup.t
+++ b/scripts/test/CustomerGroup.t
@@ -273,7 +273,7 @@ my $ResetMembership = sub {
     }
 };
 
-# reset memberchip
+# reset membership
 $ResetMembership->(
     AlwaysGroups => $ConfigObject->Get('CustomerGroupAlwaysGroups'),
     GID          => $GID1,
@@ -285,7 +285,7 @@ $ConfigObject->Set(
     Value => [ $GroupObject->GroupLookup( GroupID => $GID1 ) ],
 );
 
-# reset memberchip with AlwaysGroups
+# reset membership with AlwaysGroups
 $ResetMembership->(
     AlwaysGroups => $ConfigObject->Get('CustomerGroupAlwaysGroups'),
     GID          => $GID1,
@@ -297,7 +297,7 @@ $ConfigObject->Set(
     Value => [],
 );
 
-# reset memberchip
+# reset membership
 $ResetMembership->(
     AlwaysGroups => $ConfigObject->Get('CustomerGroupAlwaysGroups'),
     GID          => $GID1,
@@ -347,7 +347,7 @@ $ResetMembership->(
         Config => {
             Type    => 'ro',
             Result  => 'Name',
-            UserID  => 'Notexistent' . $RandomID,
+            UserID  => 'Nonexistent' . $RandomID,
             GroupID => undef,
         },
         ExpectedResult => [],
@@ -358,7 +358,7 @@ $ResetMembership->(
         Config => {
             Type    => 'ro',
             Result  => 'HASH',
-            UserID  => 'Notexistent' . $RandomID,
+            UserID  => 'Nonexistent' . $RandomID,
             GroupID => undef,
         },
         ExpectedResult => {},
@@ -532,7 +532,7 @@ $ResetMembership->(
         ResetMembership => 1,
     },
     {
-        Name   => 'Mutiple With UserID - Result Name',
+        Name   => 'Multiple With UserID - Result Name',
         Config => {
             Type    => 'ro',
             Result  => 'Name',
@@ -814,7 +814,7 @@ for my $Test (@Tests) {
     {
         Name   => 'Wrong Group',
         Config => {
-            Group   => 'NonExistent' . $RandomID,
+            Group   => 'Nonexistent' . $RandomID,
             GroupID => undef,
         },
         ExpectedResults => '',

--- a/scripts/test/DynamicField.t
+++ b/scripts/test/DynamicField.t
@@ -13,11 +13,18 @@ use utf8;
 use vars (qw($Self));
 
 # get needed objects
-my $HelperObject       = $Kernel::OM->Get('Kernel::System::UnitTest::Helper');
 my $DBObject           = $Kernel::OM->Get('Kernel::System::DB');
 my $DynamicFieldObject = $Kernel::OM->Get('Kernel::System::DynamicField');
 
-my $RandomID = $HelperObject->GetRandomNumber();
+# get helper object
+$Kernel::OM->ObjectParamAdd(
+    'Kernel::System::UnitTest::Helper' => {
+        RestoreDatabase => 1,
+    },
+);
+my $Helper = $Kernel::OM->Get('Kernel::System::UnitTest::Helper');
+
+my $RandomID = $Helper->GetRandomNumber();
 my $UserID   = 1;
 
 my @Tests = (
@@ -39,7 +46,7 @@ my @Tests = (
         },
     },
     {
-        Name          => 'Test1', # add same field again - fail
+        Name          => 'Test1',    # add same field again - fail
         SuccessAdd    => 0,
         SuccessUpdate => 0,
         Add           => {
@@ -254,7 +261,7 @@ for my $Test (@Tests) {
         Name => $FieldName,
     );
 
-    if ( $FieldNames{ $FieldName } ) {
+    if ( $FieldNames{$FieldName} ) {
         $Self->IsNotDeeply(
             $GetResult,
             {},
@@ -1446,7 +1453,7 @@ for my $ObjectType (qw(Ticket Article)) {
 # tests with more than one object type
 {
 
-    # cobine list for comparisons
+    # combine list for comparisons
     my @ListFieldIDs = (
         @TicketFieldIDs,
         @ArticleFieldIDs,
@@ -1609,7 +1616,7 @@ $OrderCheckSuccess = $DynamicFieldObject->DynamicFieldOrderCheck();
 
 $Self->False(
     $OrderCheckSuccess,
-    'DynamicFieldOrderCheck() for duplicates, with Flase',
+    'DynamicFieldOrderCheck() for duplicates, with False',
 );
 
 # reset fields order
@@ -1617,7 +1624,7 @@ $OrderResetSuccess = $DynamicFieldObject->DynamicFieldOrderReset();
 
 $Self->True(
     $OrderResetSuccess,
-    'DynamicFieldOrderReset() remove dulicates, with True',
+    'DynamicFieldOrderReset() remove duplicates, with True',
 );
 
 $OrderCheckSuccess = $DynamicFieldObject->DynamicFieldOrderCheck();
@@ -1657,7 +1664,7 @@ $OrderCheckSuccess = $DynamicFieldObject->DynamicFieldOrderCheck();
 
 $Self->False(
     $OrderCheckSuccess,
-    'DynamicFieldOrderCheck() for gaps, with Flase',
+    'DynamicFieldOrderCheck() for gaps, with False',
 );
 
 # reset fields order
@@ -1688,5 +1695,7 @@ for my $DynamicFieldID (@AddedFieldIDs) {
         "DynamicFieldDelete() Field List() and ListGet() for Field ID $DynamicFieldID"
     );
 }
+
+# cleanup is done by RestoreDatabase
 
 1;

--- a/scripts/test/DynamicFieldValue.t
+++ b/scripts/test/DynamicFieldValue.t
@@ -13,12 +13,20 @@ use utf8;
 use vars (qw($Self));
 
 # get needed objects
-my $HelperObject            = $Kernel::OM->Get('Kernel::System::UnitTest::Helper');
 my $DynamicFieldObject      = $Kernel::OM->Get('Kernel::System::DynamicField');
 my $DynamicFieldValueObject = $Kernel::OM->Get('Kernel::System::DynamicFieldValue');
 my $TicketObject            = $Kernel::OM->Get('Kernel::System::Ticket');
 
-my $RandomID = int rand 1_000_000_000;
+# get helper object
+$Kernel::OM->ObjectParamAdd(
+    'Kernel::System::UnitTest::Helper' => {
+        RestoreSystemConfiguration => 1,
+        RestoreDatabase            => 1,
+    },
+);
+my $Helper = $Kernel::OM->Get('Kernel::System::UnitTest::Helper');
+
+my $RandomID = $Helper->GetRandomID();
 
 # create a ticket
 my $TicketID = $TicketObject->TicketCreate(
@@ -1012,20 +1020,6 @@ for my $TicketID (@CreatedTicketIds) {
     );
 }
 
-# delete created tickets
-for my $TicketID (@CreatedTicketIds) {
-
-    # delete the ticket
-    my $TicketDelete = $TicketObject->TicketDelete(
-        TicketID => $TicketID,
-        UserID   => 1,
-    );
-
-    # sanity check
-    $Self->True(
-        $TicketDelete,
-        "TicketDelete() successful for Ticket ID $TicketID - for HistoryValueGet()",
-    );
-}
+# cleanup is done by RestoreDatabase
 
 1;

--- a/scripts/test/Email.t
+++ b/scripts/test/Email.t
@@ -14,8 +14,17 @@ use vars (qw($Self));
 
 use Kernel::System::EmailParser;
 
-# get needed objects
+# get config object
 my $ConfigObject = $Kernel::OM->Get('Kernel::Config');
+
+# get helper object
+$Kernel::OM->ObjectParamAdd(
+    'Kernel::System::UnitTest::Helper' => {
+        RestoreSystemConfiguration => 1,
+        RestoreDatabase            => 1,
+    },
+);
+my $Helper = $Kernel::OM->Get('Kernel::System::UnitTest::Helper');
 
 # do not really send emails
 $ConfigObject->Set(
@@ -156,5 +165,7 @@ for my $Encoding ( '', qw(base64 quoted-printable 8bit) ) {
         }
     }
 }
+
+# cleanup is done by RestoreDatabase
 
 1;

--- a/scripts/test/EmailParser.t
+++ b/scripts/test/EmailParser.t
@@ -14,11 +14,10 @@ use vars (qw($Self));
 
 use Kernel::System::EmailParser;
 
-# get needed objects
-my $ConfigObject = $Kernel::OM->Get('Kernel::Config');
-my $MainObject   = $Kernel::OM->Get('Kernel::System::Main');
+# get main object
+my $MainObject = $Kernel::OM->Get('Kernel::System::Main');
 
-my $Home = $ConfigObject->Get('Home');
+my $Home = $Kernel::OM->Get('Kernel::Config')->Get('Home');
 
 # test #1
 my @Array = ();

--- a/scripts/test/Encode.t
+++ b/scripts/test/Encode.t
@@ -14,8 +14,7 @@ use vars (qw($Self));
 
 use Kernel::System::VariableCheck qw(:all);
 
-# get needed objects
-my $ConfigObject = $Kernel::OM->Get('Kernel::Config');
+# get encode object
 my $EncodeObject = $Kernel::OM->Get('Kernel::System::Encode');
 
 # convert tests

--- a/scripts/test/Environment.t
+++ b/scripts/test/Environment.t
@@ -12,9 +12,7 @@ use utf8;
 
 use vars (qw($Self));
 
-use Kernel::System::ObjectManager;
-
-# get needed objects
+# get environment object
 my $EnvironmentObject = $Kernel::OM->Get('Kernel::System::Environment');
 
 my %OSInfo = $EnvironmentObject->OSInfoGet();

--- a/scripts/test/Event.t
+++ b/scripts/test/Event.t
@@ -12,10 +12,16 @@ use utf8;
 
 use vars (qw($Self));
 
-use Kernel::System::ObjectManager;
-
-# get needed objects
+# get event object
 my $EventObject = $Kernel::OM->Get('Kernel::System::Event');
+
+# get helper object
+$Kernel::OM->ObjectParamAdd(
+    'Kernel::System::UnitTest::Helper' => {
+        RestoreDatabase => 1,
+    },
+);
+my $Helper = $Kernel::OM->Get('Kernel::System::UnitTest::Helper');
 
 my %EventList = $EventObject->EventList();
 
@@ -46,5 +52,7 @@ $Self->Is(
     undef,
     "EventListTicket() Article"
 );
+
+# cleanup is done by RestoreDatabase
 
 1;

--- a/scripts/test/FileTemp.t
+++ b/scripts/test/FileTemp.t
@@ -15,9 +15,7 @@ use vars (qw($Self));
 use File::Basename;
 use File::Copy;
 
-use Kernel::System::ObjectManager;
-
-# get needed objects
+# get config object
 my $ConfigObject = $Kernel::OM->Get('Kernel::Config');
 
 my ( $Filename, $FilenameSuffix, $TempDir, $FH, $FHSuffix );


### PR DESCRIPTION
Hi @mgruner 

This is the next part of the updated unit tests. You will see I also updated CustomerGroup, there were some spell mistakes.

In some test I made Helper object with RestoreDatabase, but actually I would like only to clean up cache. Maybe we can update Helper.pm and add RestoreCache for such cases (e.g Event.t - there were Valid and DynamicField in cache after running this test ). It is not big problem but maybe we can leave full clean system after any unit test.

Regards
Zoran