### PR TITLE
Removed GetTableDate from frontend modules - SystemAddressQueueList

### DIFF
--- a/Kernel/Modules/AgentTicketEmail.pm
+++ b/Kernel/Modules/AgentTicketEmail.pm
@@ -2051,12 +2051,7 @@ sub _GetTos {
             );
         }
         else {
-            %Tos = $Kernel::OM->Get('Kernel::System::DB')->GetTableData(
-                Table => 'system_address',
-                What  => 'queue_id, id',
-                Valid => 1,
-                Clamp => 1,
-            );
+            %Tos = $Kernel::OM->Get('Kernel::System::SystemAddress')->SystemAddressQueueList();
         }
 
         # get create permission queues

--- a/Kernel/Modules/AgentTicketPhone.pm
+++ b/Kernel/Modules/AgentTicketPhone.pm
@@ -2167,12 +2167,7 @@ sub _GetTos {
             );
         }
         else {
-            %Tos = $Kernel::OM->Get('Kernel::System::DB')->GetTableData(
-                Table => 'system_address',
-                What  => 'queue_id, id',
-                Valid => 1,
-                Clamp => 1,
-            );
+            %Tos = $Kernel::OM->Get('Kernel::System::SystemAddress')->SystemAddressQueueList();
         }
 
         # get create permission queues

--- a/Kernel/Modules/AgentTicketProcess.pm
+++ b/Kernel/Modules/AgentTicketProcess.pm
@@ -5791,12 +5791,7 @@ sub _GetQueues {
             );
         }
         else {
-            %Queues = $Kernel::OM->Get('Kernel::System::DB')->GetTableData(
-                Table => 'system_address',
-                What  => 'queue_id, id',
-                Valid => 1,
-                Clamp => 1,
-            );
+            %Queues = $Kernel::OM->Get('Kernel::System::SystemAddress')->SystemAddressQueueList();
         }
 
         # get permission queues

--- a/Kernel/Modules/CustomerTicketProcess.pm
+++ b/Kernel/Modules/CustomerTicketProcess.pm
@@ -4360,12 +4360,7 @@ sub _GetQueues {
             );
         }
         else {
-            %Queues = $Kernel::OM->Get('Kernel::System::DB')->GetTableData(
-                Table => 'system_address',
-                What  => 'queue_id, id',
-                Valid => 1,
-                Clamp => 1,
-            );
+            %Queues = $Kernel::OM->Get('Kernel::System::SystemAddress')->SystemAddressQueueList();
         }
 
         # get create permission queues

--- a/Kernel/Output/HTML/CustomerNewTicket/QueueSelectionGeneric.pm
+++ b/Kernel/Output/HTML/CustomerNewTicket/QueueSelectionGeneric.pm
@@ -86,12 +86,7 @@ sub Run {
                 Type           => 'create',
                 Action         => $Param{Env}->{Action},
             );
-            my %SystemTos = $Kernel::OM->Get('Kernel::System::DB')->GetTableData(
-                Table => 'system_address',
-                What  => 'queue_id, id',
-                Valid => 1,
-                Clamp => 1,
-            );
+            my %SystemTos = $Kernel::OM->Get('Kernel::System::SystemAddress')->SystemAddressQueueList();
             for my $QueueID ( sort keys %Queues ) {
                 if ( $SystemTos{$QueueID} ) {
                     $Tos{$QueueID} = $Queues{$QueueID};

--- a/Kernel/System/SystemAddress.pm
+++ b/Kernel/System/SystemAddress.pm
@@ -416,6 +416,59 @@ sub SystemAddressQueueID {
     return $QueueID;
 }
 
+=item SystemAddressQueueList()
+
+get a list of the queues and their system addresses IDs
+
+    my %List = $SystemAddressObject->SystemAddressQueueList(
+        Valid => 0,  # optional, defaults to 1
+    );
+
+returns:
+
+    %List = (
+        '5' => 3,
+        '7' => 1,
+        '9' => 2,
+    );
+
+=cut
+
+sub SystemAddressQueueList {
+    my ( $Self, %Param ) = @_;
+
+    # set default value
+    my $Valid = $Param{Valid} // 1;
+
+    # create the valid list
+    my $ValidIDs = join ', ', $Kernel::OM->Get('Kernel::System::Valid')->ValidIDsGet();
+
+    # build SQL
+    my $SQL = 'SELECT queue_id, id FROM system_address';
+
+    # add WHERE statement in case Valid param is set to '1', for valid system address
+    if ($Valid) {
+        $SQL .= ' WHERE valid_id IN (' . $ValidIDs . ')';
+    }
+
+    # get database object
+    my $DBObject = $Kernel::OM->Get('Kernel::System::DB');
+
+    # get data from database
+    return if !$DBObject->Prepare(
+        SQL => $SQL,
+    );
+
+    # fetch the result
+    my %SystemAddressQueueList;
+    while ( my @Row = $DBObject->FetchrowArray() ) {
+        $SystemAddressQueueList{ $Row[0] } = $Row[1];
+    }
+
+    return %SystemAddressQueueList;
+
+}
+
 1;
 
 =back


### PR DESCRIPTION
Hi @mgruner 

This is PR with removed GetTableData from frontend modules. 

Working on SystemAddress module I saw that there is maybe one problem. It is possible to add system addresses with the same Email address, Display name and Queue ( test@localhost, test, Junk - you can add such identical system addresses as many as you want  ). Is it OK, or we should add some protection in SystemAddress module.

There are not any more this deprecated method in frontend said.
There is only in the following modules in the backend:

<pre>
/opt/otrs/Kernel/System/Signature.pm:
  230  
  231      # sql
  232:     return $Kernel::OM->Get('Kernel::System::DB')->GetTableData(
  233          What  => 'id, name',
  234          Valid => $Valid,

/opt/otrs/Kernel/System/StdAttachment.pm:
  454  
  455      # return data
  456:     my %Relation = $DBObject->GetTableData(
  457          Table => 'standard_template_attachment',
  458          What  => 'standard_attachment_id, standard_template_id',
  ...
  493  
  494      # return data
  495:     return $DBObject->GetTableData(
  496          Table => 'standard_attachment',
  497          What  => 'id, name, filename',

/opt/otrs/Kernel/System/CustomerUser/DB.pm:
  378  
  379      # get data
  380:     my %Users = $Self->{DBObject}->GetTableData(
  381          What  => "$Self->{CustomerKey}, $Self->{CustomerKey}, $Self->{CustomerID}",
  382          Table => $Self->{CustomerTable},
</pre>
I am planning fix it on these places and we will be able to remove GetTeblaData function. I will do that in another PR.

Please let me know what do you think about all of that.

Regards
Zoran