### PR TITLE
Removed deprecated method GetTableDate

### DIFF
--- a/Kernel/System/CustomerUser.pm
+++ b/Kernel/System/CustomerUser.pm
@@ -180,32 +180,6 @@ sub CustomerSearch {
     return %Data;
 }
 
-=item CustomerUserList()
-
-return a hash with all users (depreciated)
-
-    my %List = $CustomerUserObject->CustomerUserList(
-        Valid => 1, # not required
-    );
-
-=cut
-
-sub CustomerUserList {
-    my ( $Self, %Param ) = @_;
-
-    my %Data;
-    SOURCE:
-    for my $Count ( '', 1 .. 10 ) {
-
-        next SOURCE if !$Self->{"CustomerUser$Count"};
-
-        # get customer list result of backend and merge it
-        my %SubData = $Self->{"CustomerUser$Count"}->CustomerUserList(%Param);
-        %Data = ( %Data, %SubData );
-    }
-    return %Data;
-}
-
 =item CustomerIDList()
 
 return a list of with all known unique CustomerIDs of the registered customers users (no SearchTerm),

--- a/Kernel/System/CustomerUser/DB.pm
+++ b/Kernel/System/CustomerUser/DB.pm
@@ -357,45 +357,6 @@ sub CustomerSearch {
     return %Users;
 }
 
-sub CustomerUserList {
-    my ( $Self, %Param ) = @_;
-
-    my $Valid = defined $Param{Valid} ? $Param{Valid} : 1;
-
-    # check cache
-    if ( $Self->{CacheObject} ) {
-        my $Users = $Self->{CacheObject}->Get(
-            Type => $Self->{CacheType},
-            Key  => "CustomerUserList::$Valid",
-        );
-        return %{$Users} if ref $Users eq 'HASH';
-    }
-
-    # do not use valid option if no valid option is used
-    if ( !$Self->{CustomerUserMap}->{CustomerValid} ) {
-        $Valid = 0;
-    }
-
-    # get data
-    my %Users = $Self->{DBObject}->GetTableData(
-        What  => "$Self->{CustomerKey}, $Self->{CustomerKey}, $Self->{CustomerID}",
-        Table => $Self->{CustomerTable},
-        Clamp => 1,
-        Valid => $Valid,
-    );
-
-    # cache request
-    if ( $Self->{CacheObject} ) {
-        $Self->{CacheObject}->Set(
-            Type  => $Self->{CacheType},
-            Key   => "CustomerUserList::$Valid",
-            Value => \%Users,
-            TTL   => $Self->{CustomerUserMap}->{CacheTTL},
-        );
-    }
-    return %Users;
-}
-
 sub CustomerIDList {
     my ( $Self, %Param ) = @_;
 

--- a/Kernel/System/DB.pm
+++ b/Kernel/System/DB.pm
@@ -1056,66 +1056,6 @@ sub SQLProcessorPost {
     return ();
 }
 
-# GetTableData()
-#
-# !! DONT USE THIS FUNCTION !!
-#
-# Due to compatibility reason this function is still available and it will be removed
-# in upcoming releases.
-
-sub GetTableData {
-    my ( $Self, %Param ) = @_;
-
-    my $Table = $Param{Table};
-    my $What  = $Param{What};
-    my $Where = $Param{Where} || '';
-    my $Valid = $Param{Valid} || '';
-    my $Clamp = $Param{Clamp} || '';
-    my %Data;
-
-    my $SQL = "SELECT $What FROM $Table ";
-    if ($Where) {
-        $SQL .= ' WHERE ' . $Where;
-    }
-
-    if ( !$Where && $Valid ) {
-        my @ValidIDs;
-
-        return if !$Self->Prepare( SQL => 'SELECT id FROM valid WHERE name = \'valid\'' );
-        while ( my @Row = $Self->FetchrowArray() ) {
-            push @ValidIDs, $Row[0];
-        }
-
-        $SQL .= " WHERE valid_id IN ( ${\(join ', ', @ValidIDs)} )";
-    }
-
-    $Self->Prepare( SQL => $SQL );
-
-    while ( my @Row = $Self->FetchrowArray() ) {
-        if ( $Row[3] ) {
-            if ($Clamp) {
-                $Data{ $Row[0] } = "$Row[1] $Row[2] ($Row[3])";
-            }
-            else {
-                $Data{ $Row[0] } = "$Row[1] $Row[2] $Row[3]";
-            }
-        }
-        elsif ( $Row[2] ) {
-            if ($Clamp) {
-                $Data{ $Row[0] } = "$Row[1] ( $Row[2] )";
-            }
-            else {
-                $Data{ $Row[0] } = "$Row[1] $Row[2]";
-            }
-        }
-        else {
-            $Data{ $Row[0] } = $Row[1];
-        }
-    }
-
-    return %Data;
-}
-
 =item QueryCondition()
 
 generate SQL condition query based on a search expression

--- a/scripts/test/Group/Group.t
+++ b/scripts/test/Group/Group.t
@@ -192,7 +192,7 @@ for my $GroupName ( sort keys %GroupIDByGroupName ) {
 
     $Self->False(
         exists $Groups{$GroupID},
-        'GroupList() does not contains group ' . $GroupName . ' with ID ' . $GroupID,
+        'GroupList() does not contain group ' . $GroupName . ' with ID ' . $GroupID,
     );
 }
 

--- a/scripts/test/Group/Group.t
+++ b/scripts/test/Group/Group.t
@@ -104,7 +104,7 @@ for my $GroupName ( sort keys %GroupIDByGroupName ) {
 
     $Self->True(
         exists $Groups{$GroupID} && $Groups{$GroupID} eq $GroupName,
-        'GroupList() contains group ' . $GroupName . ' with ID ' . $GroupID,
+        'GroupList() contains the group ' . $GroupName . ' with ID ' . $GroupID,
     );
 }
 
@@ -115,7 +115,7 @@ for my $GroupName ( sort keys %GroupIDByGroupName ) {
 
     $Self->True(
         exists $GroupDataList{$GroupID} && $GroupDataList{$GroupID}->{Name} eq $GroupName,
-        'GroupDataList() contains group ' . $GroupName . ' with ID ' . $GroupID,
+        'GroupDataList() contains the group ' . $GroupName . ' with ID ' . $GroupID,
     );
 }
 
@@ -192,7 +192,7 @@ for my $GroupName ( sort keys %GroupIDByGroupName ) {
 
     $Self->False(
         exists $Groups{$GroupID},
-        'GroupList() does not contain group ' . $GroupName . ' with ID ' . $GroupID,
+        'GroupList() does not contain the group ' . $GroupName . ' with ID ' . $GroupID,
     );
 }
 
@@ -203,7 +203,7 @@ for my $GroupName ( sort keys %GroupIDByGroupName ) {
 
     $Self->True(
         exists $Groups{$GroupID} && $Groups{$GroupID} eq $GroupName,
-        'GroupList() contains group ' . $GroupName . ' with ID ' . $GroupID,
+        'GroupList() contains the group ' . $GroupName . ' with ID ' . $GroupID,
     );
 }
 

--- a/scripts/test/Signature.t
+++ b/scripts/test/Signature.t
@@ -15,7 +15,6 @@ use vars (qw($Self));
 # get helper object
 $Kernel::OM->ObjectParamAdd(
     'Kernel::System::UnitTest::Helper' => {
-        RestoreSystemConfiguration => 1,
         RestoreDatabase            => 1,
     },
 );

--- a/scripts/test/Signature.t
+++ b/scripts/test/Signature.t
@@ -12,14 +12,21 @@ use utf8;
 
 use vars (qw($Self));
 
-use Kernel::System::ObjectManager;
+# get helper object
+$Kernel::OM->ObjectParamAdd(
+    'Kernel::System::UnitTest::Helper' => {
+        RestoreSystemConfiguration => 1,
+        RestoreDatabase            => 1,
+    },
+);
+my $Helper = $Kernel::OM->Get('Kernel::System::UnitTest::Helper');
 
-# get needed objects
+# get signature object
 my $SignatureObject = $Kernel::OM->Get('Kernel::System::Signature');
 
 # add signature
-my $SignatureNameRand0 = 'example-signature' . int( rand(1000000) );
-my $Signature          = "Your OTRS-Team
+my $SignatureName = 'signature' . $Helper->GetRandomID();
+my $SignatureText = "Your OTRS-Team
 
 <OTRS_CURRENT_UserFirstname> <OTRS_CURRENT_UserLastname>
 
@@ -30,8 +37,8 @@ Email: hot\@florida.com - Web: http://hot.florida.com/
 --";
 
 my $SignatureID = $SignatureObject->SignatureAdd(
-    Name        => $SignatureNameRand0,
-    Text        => $Signature,
+    Name        => $SignatureName,
+    Text        => $SignatureText,
     ContentType => 'text/plain; charset=iso-8859-1',
     Comment     => 'some comment',
     ValidID     => 1,
@@ -47,12 +54,12 @@ my %Signature = $SignatureObject->SignatureGet( ID => $SignatureID );
 
 $Self->Is(
     $Signature{Name} || '',
-    $SignatureNameRand0,
+    $SignatureName,
     'SignatureGet() - Name',
 );
 $Self->True(
-    $Signature{Text} eq $Signature,
-    'SignatureGet() - Signature',
+    $Signature{Text} eq $SignatureText,
+    'SignatureGet() - Signature text',
 );
 $Self->Is(
     $Signature{ContentType} || '',
@@ -71,21 +78,17 @@ $Self->Is(
 );
 
 my %SignatureList = $SignatureObject->SignatureList( Valid => 0 );
-my $Hit = 0;
-for ( sort keys %SignatureList ) {
-    if ( $_ eq $SignatureID ) {
-        $Hit = 1;
-    }
-}
 $Self->True(
-    $Hit eq 1,
-    'SignatureList()',
+    exists $SignatureList{$SignatureID} && $SignatureList{$SignatureID} eq $SignatureName,
+    "SignatureList() contains the signature $SignatureName",
 );
 
-my $SignatureUpdate = $SignatureObject->SignatureUpdate(
+my $SignatureNameUpdate = $SignatureName . ' - Update';
+my $SignatureTextUpdate = $SignatureText . ' - Update';
+my $SignatureUpdate     = $SignatureObject->SignatureUpdate(
     ID          => $SignatureID,
-    Name        => $SignatureNameRand0 . '1',
-    Text        => $Signature . '1',
+    Name        => $SignatureNameUpdate,
+    Text        => $SignatureTextUpdate,
     ContentType => 'text/plain; charset=utf-8',
     Comment     => 'some comment 1',
     ValidID     => 2,
@@ -101,11 +104,11 @@ $Self->True(
 
 $Self->Is(
     $Signature{Name} || '',
-    $SignatureNameRand0 . '1',
+    $SignatureNameUpdate,
     'SignatureGet() - Name',
 );
 $Self->True(
-    $Signature{Text} eq $Signature . '1',
+    $Signature{Text} eq $SignatureTextUpdate,
     'SignatureGet() - Signature',
 );
 $Self->Is(
@@ -123,5 +126,13 @@ $Self->Is(
     2,
     'SignatureGet() - ValidID',
 );
+
+%SignatureList = $SignatureObject->SignatureList( Valid => 1 );
+$Self->False(
+    exists $SignatureList{$SignatureID},
+    "SignatureList() does not contain invalid signature $SignatureNameUpdate",
+);
+
+# cleanup is done by RestoreDatabase
 
 1;

--- a/scripts/test/SystemAddress.t
+++ b/scripts/test/SystemAddress.t
@@ -222,8 +222,8 @@ $Self->True(
 %SystemQueues = $Kernel::OM->Get('Kernel::System::SystemAddress')->SystemAddressQueueList( Valid => 1 );
 
 $Self->False(
-    exists $SystemQueues{'1'} && $SystemQueues{'1'} == $SystemAddressID,
-    "SystemAddressQueueList() does not contains the queue 1 of the SystemAddress $SystemAddressID",
+    exists $SystemQueues{'1'},
+    "SystemAddressQueueList() does not contain the queue 1 of the SystemAddress $SystemAddressID",
 );
 $Self->True(
     exists $SystemQueues{'3'} && $SystemQueues{'3'} == $SystemAddressID1,


### PR DESCRIPTION
Hi @mgruner 

In this PR I removed GetTableDate method. There have been done the following steps:

* There are redefined two methods: SignatureList and StdAttachmentList
* added unit tests for this methods
* removed deprecated methods: StdAttachmentSetResponses, CustomerUser/DB/CustomerUserList() and CustomerUser/CustomerUserList() and of course GetTableData itself. 
* fixed some spelling mistake in the tests on which I had done recently ( 'does not contains' instead 'does not contain') and 
* fixed illogicality such checking if nonexistent item is equal with something
<pre>
$Self->False(
    exists $SystemQueues{'1'} && $SystemQueues{'1'} == $SystemAddressID,
    "SystemAddressQueueList() does not contains the queue 1 of the SystemAddress $SystemAddressID",
);
</pre> 

Please let me know, what do you think about all of that.

Regards
Zoran

