### PR TITLE
Fixed output for Age data in Ticket Information sidebar widget

### DIFF
--- a/Kernel/Modules/AgentTicketZoom.pm
+++ b/Kernel/Modules/AgentTicketZoom.pm
@@ -856,6 +856,15 @@ sub MaskAgentZoom {
         @ArticleBoxShown = @ArticleBox;
     }
 
+    # get layout object
+    my $LayoutObject = $Kernel::OM->Get('Kernel::Output::HTML::Layout');
+
+    # age design
+    $Ticket{Age} = $LayoutObject->CustomerAge(
+        Age   => $Ticket{Age},
+        Space => ' '
+    );
+
     my %Widgets;
     my $MainObject = $Kernel::OM->Get('Kernel::System::Main');
     WIDGET:
@@ -925,9 +934,6 @@ sub MaskAgentZoom {
         );
     }
 
-    # get layout object
-    my $LayoutObject = $Kernel::OM->Get('Kernel::Output::HTML::Layout');
-
     # show articles items
     if ( !$Self->{ZoomTimeline} ) {
 
@@ -959,12 +965,6 @@ sub MaskAgentZoom {
             Data => { TicketID => $Ticket{TicketID} },
         );
     }
-
-    # age design
-    $Ticket{Age} = $LayoutObject->CustomerAge(
-        Age   => $Ticket{Age},
-        Space => ' '
-    );
 
     # number of articles
     $Param{ArticleCount} = scalar @ArticleBox;
@@ -1273,7 +1273,7 @@ sub MaskAgentZoom {
     my $DynamicFieldBeckendObject = $Kernel::OM->Get('Kernel::System::DynamicField::Backend');
 
     # to store dynamic fields to be displayed in the process widget and in the sidebar
-    my ( @FieldsWidget );
+    my (@FieldsWidget);
 
     # cycle trough the activated Dynamic Fields for ticket object
     DYNAMICFIELD:


### PR DESCRIPTION
Hi @mgruner 

Working on the Selenium tests for new sidebar widgets we saw that there is small mistake with output Age data in Ticket Information widget.

You can see in the picture:

![screen shot 2016-02-08 at 11 43 15 am](https://cloud.githubusercontent.com/assets/6348760/12883784/4920e08c-ce5a-11e5-971d-b799df93930a.png)

Here, it is fixed and now output for Age data is again human readable from CustomerAge method.

P.S. If you would like you could marge it and we will be able to include it in the selenium tests as well. 

Regards
Zoran
