### PR TITLE
[ Rel-5_0 Bug 11854 ] - Error with the Spam

### DIFF
--- a/Kernel/Modules/AgentTicketMove.pm
+++ b/Kernel/Modules/AgentTicketMove.pm
@@ -239,6 +239,15 @@ sub Run {
         $Error{DestQueue} = 1;
     }
 
+    # check if destination queue is restricted by ACL
+    my %QueueList = $TicketObject->TicketMoveList(
+        TicketID => $Self->{TicketID},
+        UserID   => $Self->{UserID},
+    );
+    if ( $GetParam{DestQueueID} && !exists $QueueList{ $GetParam{DestQueueID} } ) {
+        return $LayoutObject->NoPermission( WithHeader => 'yes' );
+    }
+
     # do not submit
     if ( $GetParam{NoSubmit} ) {
         $Error{NoSubmit} = 1;

--- a/scripts/test/Selenium/Agent/AgentTicketMove.t
+++ b/scripts/test/Selenium/Agent/AgentTicketMove.t
@@ -24,13 +24,98 @@ $Selenium->RunTest(
                 RestoreSystemConfiguration => 1,
             },
         );
-        my $Helper = $Kernel::OM->Get('Kernel::System::UnitTest::Helper');
+        my $Helper          = $Kernel::OM->Get('Kernel::System::UnitTest::Helper');
+        my $SysConfigObject = $Kernel::OM->Get('Kernel::System::SysConfig');
 
         # set to change queue for ticket in a new window
-        $Kernel::OM->Get('Kernel::System::SysConfig')->ConfigItemUpdate(
+        $SysConfigObject->ConfigItemUpdate(
             Valid => 1,
             Key   => 'Ticket::Frontend::MoveType',
             Value => 'link'
+        );
+
+        # create two test queues to use as 'Junk' and 'Delete' queue
+        my @QueueNames;
+        my @QueueIDs;
+        for my $QueueCreate (qw(Delete Junk)) {
+            my $QueueName = $QueueCreate . $Helper->GetRandomID();
+            my $QueueID   = $Kernel::OM->Get('Kernel::System::Queue')->QueueAdd(
+                Name            => $QueueName,
+                ValidID         => 1,
+                GroupID         => 1,
+                SystemAddressID => 1,
+                SalutationID    => 1,
+                SignatureID     => 1,
+                Comment         => 'Selenium Test Queue',
+                UserID          => 1,
+            );
+            $Self->True(
+                $QueueID,
+                "QueueID $QueueID is created",
+            );
+            push @QueueIDs,   $QueueID;
+            push @QueueNames, $QueueName;
+        }
+
+        # get sysconfig data
+        my @SysConfigData = (
+            {
+                MenuModule    => 'Ticket::Frontend::MenuModule###460-Delete',
+                OrgQueueLink  => 'Delete',
+                TestQueueLink => $QueueNames[0],
+            },
+            {
+                MenuModule    => 'Ticket::Frontend::MenuModule###470-Junk',
+                OrgQueueLink  => 'Junk',
+                TestQueueLink => $QueueNames[1],
+            },
+        );
+
+        for my $SysConfigUpdate (@SysConfigData) {
+
+            # enable menu module and modify destination link
+            my %MenuModuleConfig = $SysConfigObject->ConfigItemGet(
+                Name    => $SysConfigUpdate->{MenuModule},
+                Default => 1,
+            );
+            my %MenuModuleConfigUpdate = map { $_->{Key} => $_->{Content} }
+                grep { defined $_->{Key} } @{ $MenuModuleConfig{Setting}->[1]->{Hash}->[1]->{Item} };
+
+            $MenuModuleConfigUpdate{Link} =~ s/$SysConfigUpdate->{OrgQueueLink}/$SysConfigUpdate->{TestQueueLink}/g;
+
+            $SysConfigObject->ConfigItemUpdate(
+                Valid => 1,
+                Key   => $SysConfigUpdate->{MenuModule},
+                Value => \%MenuModuleConfigUpdate,
+            );
+        }
+
+        # get ACL object
+        my $ACLObject = $Kernel::OM->Get('Kernel::System::ACL::DB::ACL');
+
+        # create test ACL with possible not selection of test queues
+        my $ACLID = $ACLObject->ACLAdd(
+            Name           => 'ACL' . $Helper->GetRandomID(),
+            Comment        => 'Selenium ACL',
+            Description    => 'Description',
+            StopAfterMatch => 1,
+            ConfigMatch    => '',
+            ConfigChange   => {
+                Possible    => {},
+                PossibleNot => {
+                    Ticket => {
+                        Queue => [
+                            $QueueNames[0], $QueueNames[1]
+                        ],
+                    },
+                },
+            },
+            ValidID => 1,
+            UserID  => 1,
+        );
+        $Self->True(
+            $ACLID,
+            "ACLID $ACLID is created",
         );
 
         # create test user and login
@@ -67,11 +152,17 @@ $Selenium->RunTest(
         # get script alias
         my $ScriptAlias = $Kernel::OM->Get('Kernel::Config')->Get('ScriptAlias');
 
+        # navigate to AdminACL and synchronize ACL's
+        $Selenium->VerifiedGet("${ScriptAlias}index.pl?Action=AdminACL");
+
+        # click 'Deploy ACLs'
+        $Selenium->find_element("//a[contains(\@href, 'Action=AdminACL;Subaction=ACLDeploy')]")->VerifiedClick();
+
         # navigate to zoom view of created test ticket
         $Selenium->VerifiedGet("${ScriptAlias}index.pl?Action=AgentTicketZoom;TicketID=$TicketID");
 
         # click on 'Move' and switch window
-        $Selenium->find_element("//a[contains(\@href, \'Action=AgentTicketMove;TicketID=$TicketID' )]")->click();
+        $Selenium->find_element("//a[contains(\@title, \'Change Queue' )]")->click();
 
         $Selenium->WaitFor( WindowCount => 2 );
         my $Handles = $Selenium->get_window_handles();
@@ -116,8 +207,65 @@ $Selenium->RunTest(
             "Ticket move action completed",
         );
 
+        # click on close window and switch back screen
+        $Selenium->find_element( ".CancelClosePopup", 'css' )->click();
+
+        $Selenium->WaitFor( WindowCount => 1 );
+        $Selenium->switch_to_window( $Handles->[0] );
+
+        # test bug #11854 ( http://bugs.otrs.org/show_bug.cgi?id=11854 )
+        # ACL restriction on queue which is destination queue for 'Spam' menu in AgentTicketZoom
+        # get error message
+        my $ErrorMessage
+            = 'We are sorry, you do not have permissions anymore to access this ticket in its current state';
+
+        # click on 'Delete' and check for ACL error message
+        $Selenium->find_element("//a[contains(\@title, 'Delete this ticket')]")->VerifiedClick();
+        $Self->True(
+            index( $Selenium->get_page_source(), $ErrorMessage ) > -1,
+            "ACL restriction error message found for 'Delete' menu",
+        );
+
+        # click to return back to AgentTicketZoom screen
+        $Selenium->find_element( "#GoBack", 'css' )->VerifiedClick();
+
+        # click on 'Spam' and check for ACL error message
+        $Selenium->find_element("//a[contains(\@title, 'Mark this ticket as junk!')]")->VerifiedClick();
+        $Self->True(
+            index( $Selenium->get_page_source(), $ErrorMessage ) > -1,
+            "ACL restriction error message found for 'Spam' menu",
+        );
+
+        # delete test ACL
+        my $Success = $ACLObject->ACLDelete(
+            ID     => $ACLID,
+            UserID => 1,
+        );
+        $Self->True(
+            $Success,
+            "ACLID $ACLID is deleted",
+        );
+
+        # navigate to AdminACL to synchronize after test ACL cleanup
+        $Selenium->VerifiedGet("${ScriptAlias}index.pl?Action=AdminACL");
+
+        # click 'Deploy ACLs'
+        $Selenium->find_element("//a[contains(\@href, 'Action=AdminACL;Subaction=ACLDeploy')]")->VerifiedClick();
+
+        # delete created test queues
+        for my $QueueDelete (@QueueIDs) {
+
+            $Success = $Kernel::OM->Get('Kernel::System::DB')->Do(
+                SQL => "DELETE FROM queue WHERE id = $QueueDelete",
+            );
+            $Self->True(
+                $Success,
+                "DeleteID $QueueDelete is deleted",
+            );
+        }
+
         # delete created test tickets
-        my $Success = $TicketObject->TicketDelete(
+        $Success = $TicketObject->TicketDelete(
             TicketID => $TicketID,
             UserID   => 1,
         );
@@ -127,9 +275,11 @@ $Selenium->RunTest(
         );
 
         # make sure the cache is correct
-        $Kernel::OM->Get('Kernel::System::Cache')->CleanUp(
-            Type => 'Ticket',
-        );
+        for my $Cache (qw( Ticket Queue )) {
+            $Kernel::OM->Get('Kernel::System::Cache')->CleanUp(
+                Type => $Cache,
+            );
+        }
 
     }
 );


### PR DESCRIPTION
http://bugs.otrs.org/show_bug.cgi?id=11854

Hello @mgruner ,

Here's our proposal for fixing this bug. Added so that ACL restriction on 'Spam' and 'Delete' menu module in AgentTicketZoom show error that is used for ACL restrictions. 

If you think it's needed i can change it so that ACL remove also menu modules button in AgentTicketZoom if match is satisfied and leave this type of error to show when restricted queue added directly in URL.

Modified AgentTicketMove.t Selenium tests to simulate this type of behaviour.

Please let me know what do you think about this proposal.

Kind Regards,
Sanjin