### PR TITLE
Add new feature: define default headers for emails

### DIFF
--- a/Kernel/Config/Files/Framework.xml
+++ b/Kernel/Config/Files/Framework.xml
@@ -6877,7 +6877,7 @@ via the Preferences button after logging in.
     <ConfigItem Name="Email::DefaultHeaders" Required="0" Valid="0">
         <Description Translatable="1">Default headers for emails.</Description>
         <Group>Framework</Group>
-        <SubGroup>Core::Sendmai<l/SubGroup>
+        <SubGroup>Core::Sendmail</SubGroup>
         <Setting>
             <Hash>
                 <Item Key="Precedence">bulk</Item>

--- a/Kernel/Config/Files/Framework.xml
+++ b/Kernel/Config/Files/Framework.xml
@@ -772,6 +772,17 @@
             <String Regex="">base64</String>
         </Setting>
     </ConfigItem>
+    <ConfigItem Name="Email::DefaultHeaders" Required="0" Valid="0">
+        <Description Translatable="1">Default headers for emails.</Description>
+        <Group>Framework</Group>
+        <SubGroup>Core::Sendmail</SubGroup>
+        <Setting>
+            <Hash>
+                <Item Key="Precedence">bulk</Item>
+                <Item Key="Auto-Submitted">auto-generated</Item>
+            </Hash>
+        </Setting>
+    </ConfigItem>
     <ConfigItem Name="LoginURL" Required="0" Valid="0" ConfigLevel="200">
         <Description Translatable="1">Defines an alternate URL, where the login link refers to.</Description>
         <Group>Framework</Group>
@@ -6872,17 +6883,6 @@ via the Preferences button after logging in.
         <SubGroup>Core::Fetchmail</SubGroup>
         <Setting>
             <String Regex="[/|\w]+fetchmail$" Check="File">/usr/bin/fetchmail</String>
-        </Setting>
-    </ConfigItem>
-    <ConfigItem Name="Email::DefaultHeaders" Required="0" Valid="0">
-        <Description Translatable="1">Default headers for emails.</Description>
-        <Group>Framework</Group>
-        <SubGroup>Core::Sendmail</SubGroup>
-        <Setting>
-            <Hash>
-                <Item Key="Precedence">bulk</Item>
-                <Item Key="Auto-Submitted">auto-generated</Item>
-            </Hash>
         </Setting>
     </ConfigItem>
 </otrs_config>

--- a/Kernel/Config/Files/Framework.xml
+++ b/Kernel/Config/Files/Framework.xml
@@ -6874,5 +6874,15 @@ via the Preferences button after logging in.
             <String Regex="[/|\w]+fetchmail$" Check="File">/usr/bin/fetchmail</String>
         </Setting>
     </ConfigItem>
-
+    <ConfigItem Name="Email::DefaultHeaders" Required="0" Valid="0">
+        <Description Translatable="1">Default headers for emails.</Description>
+        <Group>Framework</Group>
+        <SubGroup>Core::Sendmai<l/SubGroup>
+        <Setting>
+            <Hash>
+                <Item Key="Precedence">bulk</Item>
+                <Item Key="Auto-Submitted">auto-generated</Item>
+            </Hash>
+        </Setting>
+    </ConfigItem>
 </otrs_config>

--- a/Kernel/Config/Files/Framework.xml
+++ b/Kernel/Config/Files/Framework.xml
@@ -778,8 +778,8 @@
         <SubGroup>Core::Sendmail</SubGroup>
         <Setting>
             <Hash>
-                <Item Key="Precedence">bulk</Item>
-                <Item Key="Auto-Submitted">auto-generated</Item>
+                <Item Key="Precedence:">bulk</Item>
+                <Item Key="Auto-Submitted:">auto-generated</Item>
             </Hash>
         </Setting>
     </ConfigItem>

--- a/Kernel/System/Email.pm
+++ b/Kernel/System/Email.pm
@@ -220,9 +220,18 @@ sub Send {
 
     # build header
     my %Header;
-    if ( IsHashRefWithData( $Param{CustomHeaders} ) ) {
-        %Header = %{ $Param{CustomHeaders} };
+    
+    my $DefaultHeaders = $ConfigObject->Get('Email::DefaultHeaders') || {};
+    if ( IsHashRefWithData($DefaultHeaders) ) {
+        %Header = %{$DefaultHeaders};
     }
+    
+    if ( IsHashRefWithData( $Param{CustomHeaders} ) ) {
+        for my $HeaderName ( keys %{ $Param{CustomHeaders} } ) {
+            $Header{$HeaderName} = $Param{CustomHeaders}->{$HeaderName};
+        }
+    }
+    
     ATTRIBUTE:
     for my $Attribute (qw(From To Cc Subject Charset Reply-To)) {
         next ATTRIBUTE if !$Param{$Attribute};

--- a/Kernel/System/Email.pm
+++ b/Kernel/System/Email.pm
@@ -220,18 +220,18 @@ sub Send {
 
     # build header
     my %Header;
-    
+
     my $DefaultHeaders = $ConfigObject->Get('Email::DefaultHeaders') || {};
     if ( IsHashRefWithData($DefaultHeaders) ) {
         %Header = %{$DefaultHeaders};
     }
-    
+
     if ( IsHashRefWithData( $Param{CustomHeaders} ) ) {
         for my $HeaderName ( keys %{ $Param{CustomHeaders} } ) {
             $Header{$HeaderName} = $Param{CustomHeaders}->{$HeaderName};
         }
     }
-    
+
     ATTRIBUTE:
     for my $Attribute (qw(From To Cc Subject Charset Reply-To)) {
         next ATTRIBUTE if !$Param{$Attribute};

--- a/scripts/test/Email/DefaultHeader.t
+++ b/scripts/test/Email/DefaultHeader.t
@@ -1,0 +1,108 @@
+# --
+# Copyright (C) 2001-2016 OTRS AG, http://otrs.com/
+# --
+# This software comes with ABSOLUTELY NO WARRANTY. For details, see
+# the enclosed file COPYING for license information (AGPL). If you
+# did not receive this file, see http://www.gnu.org/licenses/agpl.txt.
+# --
+
+use strict;
+use warnings;
+use utf8;
+
+use vars (qw($Self));
+
+use Kernel::System::EmailParser;
+
+# get config object
+my $ConfigObject = $Kernel::OM->Get('Kernel::Config');
+
+# get helper object
+$Kernel::OM->ObjectParamAdd(
+    'Kernel::System::UnitTest::Helper' => {
+        RestoreDatabase => 1,
+    },
+);
+my $Helper = $Kernel::OM->Get('Kernel::System::UnitTest::Helper');
+
+# do not really send emails
+$ConfigObject->Set(
+    Key   => 'SendmailModule',
+    Value => 'Kernel::System::Email::DoNotSendEmail',
+);
+
+# test scenarios
+my @Tests = (
+    {
+        Name => 'DefaultHeader',
+        Data => {
+            From    => 'john.smith@example.com',
+            To      => 'john.smith2@example.com',
+            Subject => 'some subject',
+            Body    => 'Some Body',
+            Type    => 'text/plain',
+            Charset => 'utf8',
+        },
+        Check => {
+            'Precedence:'     => 'bulk',
+            'Auto-Submitted:' => 'auto-generated',
+        },
+    },
+    {
+        Name => 'DefaultHeader - X-Header',
+        Data => {
+            From    => 'john.smith@example.com',
+            To      => 'john.smith2@example.com',
+            Subject => 'some subject',
+            Body    => 'Some Body',
+            Type    => 'text/plain',
+            Charset => 'utf8',
+        },
+        Check => {
+            'X-OTRS-Test'     => 'DefaultHeader',
+        },
+    },
+);
+
+my $Count = 1;
+for my $Test (@Tests) {
+
+    my $Name = "#$Count $Test->{Name}";
+
+    $Kernel::OM->ObjectsDiscard( Objects => ['Kernel::System::Email'] );
+    my $EmailObject = $Kernel::OM->Get('Kernel::System::Email');
+
+    # do not really send emails
+    $ConfigObject->Set(
+        Key   => 'Email::DefaultHeaders',
+        Value => $Test->{Check},
+    );
+
+    my ( $Header, $Body ) = $EmailObject->Send(
+        %{ $Test->{Data} },
+    );
+
+    # end MIME::Tools workaround
+    my $Email = ${$Header} . "\n" . ${$Body};
+    my @Array = split /\n/, $Email;
+
+    # parse email
+    my $ParserObject = Kernel::System::EmailParser->new(
+        Email => \@Array,
+    );
+
+    # check header
+    KEY:
+    for my $Key ( sort keys %{ $Test->{Check} || {} } ) {
+        next KEY if !$Test->{Check}->{$Key};
+        $Self->Is(
+            $ParserObject->GetParam( WHAT => $Key ),
+            $Test->{Check}->{$Key},
+            "$Name GetParam(WHAT => '$Key')",
+        );
+    }
+}
+
+# cleanup is done by RestoreDatabase
+
+1;


### PR DESCRIPTION
Sometimes someone might want to send some headers in each email sent via OTRS. Currently there is no way to define such headers. With this patch it would be possible...

Many mail servers do not send "out of office" replys for mails where those headers in the sample config are set. Some of my customers do not want any "out of office" replys at all, so they want to set the email headers.

Another use case is when OTRS "talks" to another system and you want to send a static X-Header to identify the system.