### PR TITLE
Enable asynchronous loading of AgentTicketZoom widgets

### DIFF
--- a/Kernel/Config/Files/Ticket.xml
+++ b/Kernel/Config/Files/Ticket.xml
@@ -10923,6 +10923,7 @@ Thanks for your help!
             <Hash>
                 <Item Key="Module">Kernel::Output::HTML::TicketZoom::CustomerInformation</Item>
                 <Item Key="Location">Sidebar</Item>
+                <Item Key="Async">1</Item>
             </Hash>
         </Setting>
     </ConfigItem>

--- a/Kernel/Modules/AgentTicketZoom.pm
+++ b/Kernel/Modules/AgentTicketZoom.pm
@@ -14,6 +14,7 @@ use warnings;
 our $ObjectManagerDisabled = 1;
 
 use POSIX qw/ceil/;
+use Digest::SHA1 ();
 use Kernel::System::EmailParser;
 use Kernel::System::VariableCheck qw(:all);
 use Kernel::Language qw(Translatable);
@@ -327,8 +328,73 @@ sub Run {
         );
     }
 
-    # get param object
+    # get required objects
     my $ParamObject = $Kernel::OM->Get('Kernel::System::Web::Request');
+    my $MainObject  = $Kernel::OM->Get('Kernel::System::Main');
+
+    if ( $Self->{Subaction} eq 'LoadWidget' ) {
+        my $ElementID = $ParamObject->GetParam( Param => 'ElementID' );
+        my $Config;
+        WIDGET:
+        for my $Key ( sort keys %{ $Self->{DisplaySettings}->{Widgets} // {} } ) {
+            if ( $ElementID eq 'Async_' . Digest::SHA1::sha1_hex( $Key ) ) {
+                $Config = $Self->{DisplaySettings}->{Widgets}->{$Key};
+                last WIDGET;
+            }
+        }
+        if ( $Config ) {
+            my $Success = eval { $MainObject->Require( $Config->{Module} ) };
+            if (!$Success) {
+                $Kernel::OM->Get('Kernel::System::Log')->Log(
+                    Priority => 'error',
+                    Message  => "Cannot load $Config->{Module}: $@",
+                );
+                return $LayoutObject->Attachment(
+                    ContentType => 'text/html',
+                    Content     => '',
+                    Type        => 'inline',
+                    NoCache     => 1,
+                );
+            }
+            my $Module = eval { $Config->{Module}->new(%$Self) };
+            if ( !$Module ) {
+                $Kernel::OM->Get('Kernel::System::Log')->Log(
+                    Priority => 'error',
+                    Message  => "new() of Widget module $Config->{Module} not successful!",
+
+                );
+                return $LayoutObject->Attachment(
+                    ContentType => 'text/html',
+                    Content     => '',
+                    Type        => 'inline',
+                    NoCache     => 1,
+                );
+            }
+            my $WidgetOutput = $Module->Run(
+                Ticket    => \%Ticket,
+                AclAction => \%AclAction,
+                Config    => $Config,
+            );
+            return $LayoutObject->Attachment(
+                ContentType => 'text/html',
+                Content     => $WidgetOutput->{Output},
+                Type        => 'inline',
+                NoCache     => 1,
+            );
+        }
+        else {
+            $Kernel::OM->Get('Kernel::System::Log')->Log(
+                Priority => 'error',
+                Message  => "Cannot locate module for ElementID $ElementID",
+            );
+            return $LayoutObject->Attachment(
+                ContentType => 'text/html',
+                Content     => '',
+                Type        => 'inline',
+                NoCache     => 1,
+            );
+        }
+    }
 
     # mark shown article as seen
     if ( $Self->{Subaction} eq 'MarkAsSeen' ) {
@@ -865,11 +931,29 @@ sub MaskAgentZoom {
         Space => ' '
     );
 
-    my %Widgets;
     my $MainObject = $Kernel::OM->Get('Kernel::System::Main');
+
+    my %Widgets;
     WIDGET:
     for my $Key ( sort keys %{ $Self->{DisplaySettings}->{Widgets} // {} } ) {
         my $Config = $Self->{DisplaySettings}->{Widgets}->{$Key};
+
+        if ( $Config->{Async} ) {
+            if ( ! $Config->{Location} ) {
+                $Kernel::OM->Get('Kernel::System::Log')->Log(
+                    Priority => 'error',
+                    Message  => "The configuration for $Config->{Module} must contain a Location, because it is marked as Async.",
+                );
+                next WIDGET;
+            }
+            push @{ $Widgets{ $Config->{Location} } }, {
+                Async => 1,
+                Rank  => $Config->{Rank} || $Key,
+                %Ticket,
+                ElementID => 'Async_' . Digest::SHA1::sha1_hex( $Key ),
+            };
+            next WIDGET;
+        }
         my $Success = eval { $MainObject->Require( $Config->{Module} ) };
         next WIDGET if !$Success;
         my $Module = eval { $Config->{Module}->new(%$Self) };
@@ -895,8 +979,7 @@ sub MaskAgentZoom {
     }
     for my $Location ( sort keys %Widgets ) {
         $Param{ $Location . 'Widgets' } = [
-            map      { $_->{Output} }
-                sort { $a->{Rank} cmp $b->{Rank} } @{ $Widgets{$Location} }
+            sort { $a->{Rank} cmp $b->{Rank} } @{ $Widgets{$Location} }
         ];
     }
 

--- a/Kernel/Output/HTML/Templates/Standard/AgentTicketZoom.tt
+++ b/Kernel/Output/HTML/Templates/Standard/AgentTicketZoom.tt
@@ -144,8 +144,20 @@
 
     <div class="LayoutFixedSidebar SidebarLast">
         <div class="SidebarColumn">
-            [% FOREACH widget IN Data.SidebarWidgets; %]
-                [% widget %]
+            [% FOREACH Widget IN Data.SidebarWidgets; %]
+                [% IF Widget.Async; %]
+                    <div id="[% Widget.ElementID %]"></div>
+                    [% WRAPPER JSOnDocumentComplete %]
+                    <script type="text/javascript">//<![CDATA[
+                        Core.AJAX.ContentUpdate($('#[% Widget.ElementID %]'),
+                            '[% Env("Baselink") %]Action=[% Env("Action") %];Subaction=LoadWidget;'
+                             + 'TicketID=[% Widget.TicketID %];ElementID=[% Widget.ElementID %]',
+                             null, true);
+                    //]]></script>
+                    [% END %]
+                [% ELSE; %]
+                    [% Widget.Output %]
+                [% END; %]
             [% END; %]
         </div>
         <div class="ContentColumn">
@@ -360,8 +372,8 @@ $('.ShowFieldInfoOverlay').bind('click', function() {
 [% Data.ArticleItems %]
             </div>
 
-            [% FOREACH widget IN Data.MainWidgets; %]
-                [% widget %]
+            [% FOREACH Widget IN Data.MainWidgets; %]
+                [% Widget.Output %]
             [% END; %]
 
         </div>

--- a/Kernel/Output/HTML/Templates/Standard/AgentTicketZoom.tt
+++ b/Kernel/Output/HTML/Templates/Standard/AgentTicketZoom.tt
@@ -373,7 +373,19 @@ $('.ShowFieldInfoOverlay').bind('click', function() {
             </div>
 
             [% FOREACH Widget IN Data.MainWidgets; %]
-                [% Widget.Output %]
+                [% IF Widget.Async; %]
+                    <div id="[% Widget.ElementID %]"></div>
+                    [% WRAPPER JSOnDocumentComplete %]
+                    <script type="text/javascript">//<![CDATA[
+                        Core.AJAX.ContentUpdate($('#[% Widget.ElementID %]'),
+                            '[% Env("Baselink") %]Action=[% Env("Action") %];Subaction=LoadWidget;'
+                             + 'TicketID=[% Widget.TicketID %];ElementID=[% Widget.ElementID %]',
+                             Core.Agent.Init, true);
+                    //]]></script>
+                    [% END %]
+                [% ELSE; %]
+                    [% Widget.Output %]
+                [% END; %]
             [% END; %]
 
         </div>

--- a/Kernel/Output/HTML/Templates/Standard/AgentTicketZoom.tt
+++ b/Kernel/Output/HTML/Templates/Standard/AgentTicketZoom.tt
@@ -152,7 +152,7 @@
                         Core.AJAX.ContentUpdate($('#[% Widget.ElementID %]'),
                             '[% Env("Baselink") %]Action=[% Env("Action") %];Subaction=LoadWidget;'
                              + 'TicketID=[% Widget.TicketID %];ElementID=[% Widget.ElementID %]',
-                             null, true);
+                             Core.Agent.Init, true);
                     //]]></script>
                     [% END %]
                 [% ELSE; %]

--- a/var/httpd/htdocs/js/Core.AJAX.js
+++ b/var/httpd/htdocs/js/Core.AJAX.js
@@ -481,10 +481,11 @@ Core.AJAX = (function (TargetNS) {
      * @param {jQueryObject} $ElementToUpdate - The jQuery object of the element(s) which should be updated
      * @param {String} URL - The URL which is called via Ajax
      * @param {Function} Callback - The additional callback function which is called after the request returned from the server
+     * @param {Bool} Replace - replace the DOM container with the response instead of updating the contents
      * @description
      *      Calls an URL via Ajax and updates a html element with the answer html of the server.
      */
-    TargetNS.ContentUpdate = function ($ElementToUpdate, URL, Callback) {
+    TargetNS.ContentUpdate = function ($ElementToUpdate, URL, Callback, Replace) {
         var QueryString, QueryIndex = URL.indexOf("?"), GlobalResponse;
 
         if (QueryIndex >= 0) {
@@ -509,7 +510,12 @@ Core.AJAX = (function (TargetNS) {
                 }
                 else if ($ElementToUpdate && isJQueryObject($ElementToUpdate) && $ElementToUpdate.length) {
                     GlobalResponse = Response;
-                    $ElementToUpdate.html(Response);
+                    if ( Replace ) {
+                        $ElementToUpdate.replaceWith(Response);
+                    }
+                    else {
+                        $ElementToUpdate.html(Response);
+                    }
                 }
                 else {
                     // We are out of the OTRS App scope, that's why an exception would not be caught. Therefore we handle the error manually.


### PR DESCRIPTION
This patch enables automatic asynchronous loading of the new AgentTicketZoom sidebar widgets.

This is not huge benefit for the Customer Information widget, for which I've enabled it now, but is very much appreciated for extensions that either have to talk to external APIs, or have to do potentially slow things (like list all the attachments in a ticket with several thousand articles).

It mostly works, just the triangles for toggling the visibility of the widget don't work. That's because the content of the widget is not available at the time the toggle functionality is attached. So we'd need a way to run the Core.UI init sequence on just the new DOM elements. And that's totally out of my depth, so feedback (or even a patch) from a frontend expert would be very much appreciated.
