### PR TITLE
[ Rel-5_0 Bug 11791 ] - Can't use FullTextSearch with Russian words

### DIFF
--- a/Kernel/Config/Files/Ticket.xml
+++ b/Kernel/Config/Files/Ticket.xml
@@ -526,7 +526,7 @@
             <Array>
                 <Item><![CDATA[[,\&\<\>\?"\!\*\|;\[\]\(\)\+\$\^=]]]></Item>
                 <Item><![CDATA[^[':.]|[':.]$]]></Item>
-                <Item><![CDATA[^[^a-zA-Z0-9]+$]]></Item>
+                <Item><![CDATA[^[^\w]+$]]></Item>
             </Array>
         </Setting>
     </ConfigItem>

--- a/Kernel/System/Ticket/ArticleSearchIndex/StaticDB.pm
+++ b/Kernel/System/Ticket/ArticleSearchIndex/StaticDB.pm
@@ -367,7 +367,9 @@ sub _ArticleIndexStringToWord {
     for my $Word ( split /\s+/, ${ $Param{String} } ) {
 
         # apply filters
+        FILTER:
         for my $Filter (@Filters) {
+            next FILTER if !$Word;
             $Word =~ s/$Filter//g;
         }
 

--- a/scripts/test/Ticket/ArticleSearchIndex.t
+++ b/scripts/test/Ticket/ArticleSearchIndex.t
@@ -142,6 +142,53 @@ Perl modules provide a range of features to help you avoid reinventing the wheel
         'TicketSearch() (HASH:Body)',
     );
 
+    # use full text search on ticket with Cyrillic characters
+    # see bug #11791 ( http://bugs.otrs.org/show_bug.cgi?id=11791 )
+    $ArticleID = $TicketObject->ArticleCreate(
+        TicketID       => $TicketID,
+        ArticleType    => 'note-internal',
+        SenderType     => 'agent',
+        From           => 'Some Agent <email@example.com>',
+        To             => 'Some Customer <customer@example.com>',
+        Subject        => 'Испытуемый',
+        Body           => 'Это полный приговор',
+        ContentType    => 'text/plain; charset=ISO-8859-15',
+        HistoryType    => 'OwnerUpdate',
+        HistoryComment => 'Some free text!',
+        UserID         => 1,
+        NoAgentNotify  => 1,
+    );
+    $Self->True(
+        $ArticleID,
+        'ArticleCreate()',
+    );
+
+    # search
+    %TicketIDs = $TicketObject->TicketSearch(
+        Subject    => '%испытуемый%',
+        Result     => 'HASH',
+        Limit      => 100,
+        UserID     => 1,
+        Permission => 'rw',
+    );
+    $Self->True(
+        $TicketIDs{$TicketID},
+        'TicketSearch() (HASH:Subject)',
+    );
+
+    # search
+    %TicketIDs = $TicketObject->TicketSearch(
+        Body       => '%полный%',
+        Result     => 'HASH',
+        Limit      => 100,
+        UserID     => 1,
+        Permission => 'rw',
+    );
+    $Self->True(
+        $TicketIDs{$TicketID},
+        'TicketSearch() (HASH:Body)',
+    );
+
     my $Delete = $TicketObject->TicketDelete(
         TicketID => $TicketID,
         UserID   => 1,
@@ -187,8 +234,38 @@ my @Tests = (
         ],
     },
     {
-        Name   => "Stop words",
-        String => 'is a the of for and und der',
+        Name   => "English - Stop words",
+        String => 'is a the of for and',
+        Result => [
+        ],
+    },
+    {
+        Name   => "German - Stop words",
+        String => 'ist eine der von für und',
+        Result => [
+        ],
+    },
+    {
+        Name   => "Dutch - Stop words",
+        String => 'goed tijd hebben voor gaan',
+        Result => [
+        ],
+    },
+    {
+        Name   => "Spanish - Stop words",
+        String => 'también algún siendo arriba',
+        Result => [
+        ],
+    },
+    {
+        Name   => "French - Stop words",
+        String => 'là pièce étaient où',
+        Result => [
+        ],
+    },
+    {
+        Name   => "Italian - Stop words",
+        String => 'avevano consecutivo meglio nuovo',
         Result => [
         ],
     },
@@ -204,6 +281,56 @@ my @Tests = (
         String => 'Word ' . 'x' x 50,
         Result => [
             'word',
+        ],
+    },
+    {
+        Name   => '# @ Characters alone',
+        String => "# Word @ Something",
+        Result => [
+            'word',
+            'something',
+        ],
+    },
+    {
+        Name   => '# @ Characters with other words',
+        String => '#Word @Something',
+        Result => [
+            '#word',
+            '@something',
+        ],
+    },
+    {
+        Name   => "Cyrillic Serbian string",
+        String => "Чудесна жута шума",
+        Result => [
+            "чудесна",
+            "жута",
+            "шума"
+        ],
+    },
+    {
+        Name   => "Latin Croatian string",
+        String => "Čudesna žuta šuma",
+        Result => [
+            "čudesna",
+            "žuta",
+            "šuma"
+        ],
+    },
+    {
+        Name   => "Cyrillic Russian string",
+        String => "Это полный приговор",
+        Result => [
+            "это",
+            "полный",
+            "приговор",
+        ],
+    },
+    {
+        Name   => "Chinese string",
+        String => "这是一个完整的句子",
+        Result => [
+            "这是一个完整的句子",
         ],
     },
 );

--- a/scripts/test/Ticket/ArticleSearchIndex.t
+++ b/scripts/test/Ticket/ArticleSearchIndex.t
@@ -12,13 +12,21 @@ use utf8;
 
 use vars (qw($Self));
 
+# get helper object
+$Kernel::OM->ObjectParamAdd(
+    'Kernel::System::UnitTest::Helper' => {
+        RestoreDatabase => 1,
+    },
+);
+my $Helper = $Kernel::OM->Get('Kernel::System::UnitTest::Helper');
+
 # get needed objects
 my $ConfigObject = $Kernel::OM->Get('Kernel::Config');
 
 # tests for article search index modules
 for my $Module (qw(StaticDB RuntimeDB)) {
 
-    # Make sure that the TicketObject gets recreated for each loop.
+    # make sure that the TicketObject gets recreated for each loop.
     $Kernel::OM->ObjectsDiscard( Objects => ['Kernel::System::Ticket'] );
 
     $ConfigObject->Set(
@@ -63,7 +71,7 @@ Perl modules provide a range of features to help you avoid reinventing the wheel
         HistoryType    => 'OwnerUpdate',
         HistoryComment => 'Some free text!',
         UserID         => 1,
-        NoAgentNotify  => 1,                                   # if you don't want to send agent notifications
+        NoAgentNotify  => 1,
     );
     $Self->True(
         $ArticleID,
@@ -96,7 +104,7 @@ Perl modules provide a range of features to help you avoid reinventing the wheel
         HistoryType    => 'OwnerUpdate',
         HistoryComment => 'Some free text!',
         UserID         => 1,
-        NoAgentNotify  => 1,                                   # if you don't want to send agent notifications
+        NoAgentNotify  => 1,
     );
     $Self->True(
         $ArticleID,
@@ -359,5 +367,7 @@ for my $Module (qw(StaticDB)) {
         );
     }
 }
+
+# cleanup is done by RestoreDatabase
 
 1;


### PR DESCRIPTION
http://bugs.otrs.org/show_bug.cgi?id=11791

Hello @mgruner ,

Hereby is our proposal for fixing this issue. Changed 'Ticket::SearchIndex::Filters' to look for WorldCharacters instead of a-z A-Z 0-9. Now Cyrillic characters that are 2 bytes and Chinese characters that are 3 bytes, when encoded, are not removed by filter. They are added in the article_search DB on ArticleCreate/ArticleUpdate events and can be used by FullText TicketSearch.

Added also small improvement in apply filter 'for loop;. Where we escape it if string is empty as a result of previous filter action.

Modified ArticleSearchIndex.t unit test to simulate reporter issue and created some additional cases that can help in future testings. 

Please let me know if there are any issues or questions regarding this PR.

Kind Regards,
Sanjin