### PR TITLE
[Master - Bug 11862] - Ticket Notification Management - 'Send by default' has no impact

### DIFF
--- a/Kernel/Output/HTML/Templates/Standard/AdminNotificationEvent.tt
+++ b/Kernel/Output/HTML/Templates/Standard/AdminNotificationEvent.tt
@@ -471,11 +471,11 @@ $('.NotificationDelete').bind('click', function (Event) {
                         <div class="Clear"></div>
 
                         <label for="AgentEnabledByDefault[% Data.Transport | html %]" class="AgentEnabledByDefault">
-                            [% Translate("Send by default") | html %]:
+                            [% Translate("Enabled by default") | html %]:
                         </label>
                         <div class="Field AgentEnabledByDefault">
                             <input type="checkbox" name="AgentEnabledByDefault" id="AgentEnabledByDefault[% Data.Transport | html %]" value="[% Data.Transport | html %]"  title="" [% Data.AgentEnabledByDefaultChecked %] />
-                            <p class="FieldExplanation">[% Translate('Should the notification be sent to agents who have not yet made a choice in their preferences?') | html %]</p>
+                            <p class="FieldExplanation">[% Translate('Should the notification be enabled by default on agent create in AdminUser screen?') | html %]</p>
                         </div>
                         <div class="Clear"></div>
 


### PR DESCRIPTION
http://bugs.otrs.org/show_bug.cgi?id=11862

Hi @mgruner 

As you can see on the bug report, there was not so clear what meant "Send by default". I changed it a little bit, if you would like some other filed explanation, please let me know and I will be able to change it.

In any case this is not a bug. This field is used to activate by default ticket notification when new agent is created. It forks fine for me. There is not influence on created agents if you change this field, it will affected only on new ones.

Regards
Zoran