### PR TITLE
[ Rel-5_0 Bug 11866 ] - Customerhistory destroyies the cutsomerinformation

### DIFF
--- a/Kernel/Output/HTML/Templates/Standard/AgentTicketEmail.tt
+++ b/Kernel/Output/HTML/Templates/Standard/AgentTicketEmail.tt
@@ -652,6 +652,7 @@ $('#FileUpload').bind('change', function () {
                 </fieldset>
             </form>
         </div>
+        <div class="Clear"></div>
     </div>
     <div id="CustomerTickets"></div>
 </div>

--- a/Kernel/Output/HTML/Templates/Standard/AgentTicketPhone.tt
+++ b/Kernel/Output/HTML/Templates/Standard/AgentTicketPhone.tt
@@ -512,6 +512,7 @@
                     </fieldset>
                 </form>
             </div>
+            <div class="Clear"></div>
         </div>
         <div id="CustomerTickets"></div>
     </div>


### PR DESCRIPTION
http://bugs.otrs.org/show_bug.cgi?id=11866

Hello @mgruner ,

Hereby is proposal for fixing reporter issue. In AgentTicketEmail and AgentTicketPhone there was no break line before CustomerTickets <div>, which was resulting in mixing CustomerInformation with CustomerTickets, when CustomerInformation is longer then default.

Regards,
Sanjin