### PR TITLE
Rel-5_0 - OTRS - updated unit test - part 12

### DIFF
--- a/scripts/test/ACL/DB/ACL.t
+++ b/scripts/test/ACL/DB/ACL.t
@@ -18,13 +18,13 @@ use Kernel::System::VariableCheck qw(:all);
 my $ConfigObject = $Kernel::OM->Get('Kernel::Config');
 my $ACLObject    = $Kernel::OM->Get('Kernel::System::ACL::DB::ACL');
 my $CacheObject  = $Kernel::OM->Get('Kernel::System::Cache');
-my $HelperObject = $Kernel::OM->Get('Kernel::System::UnitTest::Helper');
+my $Helper       = $Kernel::OM->Get('Kernel::System::UnitTest::Helper');
 
 # set fixed time
-$HelperObject->FixedTimeSet();
+$Helper->FixedTimeSet();
 
 # define needed variables
-my $RandomID = $HelperObject->GetRandomID();
+my $RandomID = $Helper->GetRandomID();
 my $UserID   = 1;
 
 # get original ACL list
@@ -382,7 +382,7 @@ for my $Test (@Tests) {
 
 # try to update the ACL
 print "Force a gap between create and update ACL, Sleeping 2s\n";
-$HelperObject->FixedTimeAddSeconds(2);
+$Helper->FixedTimeAddSeconds(2);
 
 TEST:
 for my $Test (@Tests) {
@@ -730,7 +730,7 @@ for my $ACLID ( sort keys %AddedACL ) {
     # sanity check
     $Self->True(
         $Success,
-        "ACLDelete() ACLID:$ACLID | Deleted sucessfully",
+        "ACLDelete() ACLID:$ACLID | Deleted successfully",
     );
 
     $Self->True(

--- a/scripts/test/Cache/Configure.t
+++ b/scripts/test/Cache/Configure.t
@@ -12,8 +12,6 @@ use utf8;
 
 use vars (qw($Self));
 
-use Kernel::System::Cache;
-
 # get needed objects
 my $ConfigObject = $Kernel::OM->Get('Kernel::Config');
 
@@ -42,7 +40,7 @@ for my $ModuleFile (@BackendModuleFiles) {
     );
 
     # create a local cache object
-    my $CacheObject = Kernel::System::Cache->new();
+    my $CacheObject = $Kernel::OM->Get('Kernel::System::Cache');
     $CacheObject->Configure(
         CacheInMemory  => 1,
         CacheInBackend => 1,
@@ -50,7 +48,7 @@ for my $ModuleFile (@BackendModuleFiles) {
 
     die "Could not setup $Module" if !$CacheObject;
 
-    # flush the cache to have a clear test enviroment
+    # flush the cache to have a clear test environment
     $CacheObject->CleanUp();
 
     # set value in memory and in backend

--- a/scripts/test/Cache/KeepTypes.t
+++ b/scripts/test/Cache/KeepTypes.t
@@ -12,8 +12,6 @@ use utf8;
 
 use vars (qw($Self));
 
-use Kernel::System::Cache;
-
 # get needed objects
 my $ConfigObject = $Kernel::OM->Get('Kernel::Config');
 
@@ -40,11 +38,11 @@ for my $ModuleFile (@BackendModuleFiles) {
     );
 
     # create a local cache object
-    my $CacheObject = Kernel::System::Cache->new();
+    my $CacheObject = $Kernel::OM->Get('Kernel::System::Cache');
 
     die "Could not setup $Module" if !$CacheObject;
 
-    # flush the cache to have a clear test enviroment
+    # flush the cache to have a clear test environment
     $CacheObject->CleanUp();
 
     my $SetCaches = sub {

--- a/scripts/test/CloudService/Backend/Configuration.t
+++ b/scripts/test/CloudService/Backend/Configuration.t
@@ -12,10 +12,13 @@ use utf8;
 
 use vars (qw($Self));
 
-my $HelperObject       = $Kernel::OM->Get('Kernel::System::UnitTest::Helper');
+# get cloud service object
 my $CloudServiceObject = $Kernel::OM->Get('Kernel::System::CloudService::Backend::Configuration');
 
-my $RandomID = $HelperObject->GetRandomID();
+# get helper object
+my $Helper = $Kernel::OM->Get('Kernel::System::UnitTest::Helper');
+
+my $RandomID = $Helper->GetRandomID();
 
 my @Tests = (
     {
@@ -368,5 +371,10 @@ for my $CloudServiceID (@CloudServiceIDs) {
         "CloudServiceList() from cache did not find cloud service $CloudServiceID",
     );
 }
+
+# make sure the cache is corrects
+$Kernel::OM->Get('Kernel::System::Cache')->CleanUp(
+    Type => 'CloudService',
+);
 
 1;

--- a/scripts/test/CloudService/OperationResultGet.t
+++ b/scripts/test/CloudService/OperationResultGet.t
@@ -16,6 +16,14 @@ use vars (qw($Self));
 my $ConfigObject       = $Kernel::OM->Get('Kernel::Config');
 my $CloudServiceObject = $Kernel::OM->Get('Kernel::System::CloudService::Backend::Run');
 
+# get helper object
+$Kernel::OM->ObjectParamAdd(
+    'Kernel::System::UnitTest::Helper' => {
+        RestoreDatabase => 1,
+    },
+);
+my $Helper = $Kernel::OM->Get('Kernel::System::UnitTest::Helper');
+
 my %RequestResult = (
     CloudServiceTest => [
         {
@@ -77,7 +85,7 @@ my @Tests = (
         Success => 0,
     },
     {
-        Name   => 'Mising RequestResult',
+        Name   => 'Missing RequestResult',
         Config => {
             CloudService  => 'Test',
             Operation     => 'Test',
@@ -86,7 +94,7 @@ my @Tests = (
         Success => 0,
     },
     {
-        Name   => 'Mising CloudService',
+        Name   => 'Missing CloudService',
         Config => {
             CloudService  => undef,
             Operation     => 'Test',
@@ -95,7 +103,7 @@ my @Tests = (
         Success => 0,
     },
     {
-        Name   => 'Mising Operation',
+        Name   => 'Missing Operation',
         Config => {
             CloudService  => 'Test',
             Operation     => undef,
@@ -249,5 +257,7 @@ for my $Test (@Tests) {
         );
     }
 }
+
+# cleanup cache is done by RestoreDatabase
 
 1;

--- a/scripts/test/Config/AccessKeys.t
+++ b/scripts/test/Config/AccessKeys.t
@@ -12,9 +12,8 @@ use utf8;
 
 use vars (qw($Self));
 
-# get needed objects
+# get config object
 my $ConfigObject = $Kernel::OM->Get('Kernel::Config');
-my $HelperObject = $Kernel::OM->Get('Kernel::System::UnitTest::Helper');
 
 # check used accesskeys in agent frontend
 my %UsedAccessKeysAgent;

--- a/scripts/test/Config/Defaults.t
+++ b/scripts/test/Config/Defaults.t
@@ -14,10 +14,6 @@ use vars (qw($Self));
 
 use Kernel::Config::Files::ZZZAAuto;
 
-# get needed objects
-my $ConfigObject = $Kernel::OM->Get('Kernel::Config');
-my $MainObject   = $Kernel::OM->Get('Kernel::System::Main');
-
 =head1 SYNOPSIS
 
 This test verifies that the settings defined in Defaults.pm
@@ -30,8 +26,8 @@ and cause wrong test failures.
 =cut
 
 # Get list of installed config XML files
-my $Directory   = $ConfigObject->Get('Home') . "/Kernel/Config/Files/";
-my @ConfigFiles = $MainObject->DirectoryRead(
+my $Directory   = $Kernel::OM->Get('Kernel::Config')->Get('Home') . "/Kernel/Config/Files/";
+my @ConfigFiles = $Kernel::OM->Get('Kernel::System::Main')->DirectoryRead(
     Directory => $Directory,
     Filter    => "*.xml",
 );


### PR DESCRIPTION
Hi @mgruner 

There is one more PR with updated unit tests. 
I had a problem with using Helper object with RestoreDataBase for test ACL/DB/ACL.t and CloudService/Backend/Configuration.t. There were error in test results with RestoreDataBase  param I used simple CleanUp for cache, I checked in DB state is cleaned after running these tests.

Regards
Zoran