### PR TITLE
[ Rel-5_0 Bug 11875 ] - Printed timestamp is shown with GMT

### DIFF
--- a/Kernel/Modules/AgentTicketPrint.pm
+++ b/Kernel/Modules/AgentTicketPrint.pm
@@ -176,11 +176,16 @@ sub Run {
         );
     }
 
-    # get PDF object
-    my $PDFObject = $Kernel::OM->Get('Kernel::System::PDF');
+    # get needed objects
+    my $PDFObject  = $Kernel::OM->Get('Kernel::System::PDF');
+    my $TimeObject = $Kernel::OM->Get('Kernel::System::Time');
 
     my $PrintedBy = $LayoutObject->{LanguageObject}->Translate('printed by');
-    my $Time      = $LayoutObject->{Time};
+    my $Time      = $LayoutObject->{LanguageObject}->FormatTimeString(
+        $TimeObject->CurrentTimestamp(),
+        'DateFormat',
+    );
+
     my %Page;
 
     # get maximum number of pages
@@ -299,7 +304,6 @@ sub Run {
 
     # get time object and use the UserTimeObject, if the system use UTC as
     # system time and the TimeZoneUser feature is active
-    my $TimeObject = $Kernel::OM->Get('Kernel::System::Time');
     if (
         !$Kernel::OM->Get('Kernel::System::Time')->ServerLocalTimeOffsetSeconds()
         && $Kernel::OM->Get('Kernel::Config')->Get('TimeZoneUser')
@@ -1134,7 +1138,8 @@ sub _PDFOutputArticles {
             my $Lines;
             if ( IsArrayRefWithData( $Article{Body} ) ) {
                 for my $Line ( @{ $Article{Body} } ) {
-                    my $CreateTime = $LayoutObject->{LanguageObject}->FormatTimeString( $Line->{CreateTime}, 'DateFormat' );
+                    my $CreateTime
+                        = $LayoutObject->{LanguageObject}->FormatTimeString( $Line->{CreateTime}, 'DateFormat' );
                     if ( $Line->{SystemGenerated} ) {
                         $Lines .= '[' . $CreateTime . '] ' . $Line->{MessageText} . "\n";
                     }

--- a/Kernel/Modules/AgentTicketSearch.pm
+++ b/Kernel/Modules/AgentTicketSearch.pm
@@ -898,7 +898,10 @@ sub Run {
                 . $LayoutObject->{LanguageObject}->Translate('Search');
             my $PrintedBy = $LayoutObject->{LanguageObject}->Translate('printed by');
             my $Page      = $LayoutObject->{LanguageObject}->Translate('Page');
-            my $Time      = $LayoutObject->{Time};
+            my $Time      = $LayoutObject->{LanguageObject}->FormatTimeString(
+                $TimeObject->CurrentTimestamp(),
+                'DateFormat',
+            );
 
             # get maximum number of pages
             my $MaxPages = $ConfigObject->Get('PDF::MaxPages');

--- a/Kernel/Modules/CustomerTicketPrint.pm
+++ b/Kernel/Modules/CustomerTicketPrint.pm
@@ -101,10 +101,15 @@ sub Run {
         $Ticket{PendingUntil} = '-';
     }
 
-    my $PDFObject = $Kernel::OM->Get('Kernel::System::PDF');
+    # get needed objects
+    my $TimeObject = $Kernel::OM->Get('Kernel::System::Time');
+    my $PDFObject  = $Kernel::OM->Get('Kernel::System::PDF');
 
     my $PrintedBy = $LayoutObject->{LanguageObject}->Translate('printed by');
-    my $Time      = $LayoutObject->{Time};
+    my $Time      = $LayoutObject->{LanguageObject}->FormatTimeString(
+        $TimeObject->CurrentTimestamp(),
+        'DateFormat',
+    );
     my %Page;
     my $ConfigObject = $Kernel::OM->Get('Kernel::Config');
 
@@ -213,8 +218,7 @@ sub Run {
     );
 
     # return the pdf document
-    my $TimeObject = $Kernel::OM->Get('Kernel::System::Time');
-    my $Filename   = 'Ticket_' . $Ticket{TicketNumber};
+    my $Filename = 'Ticket_' . $Ticket{TicketNumber};
     my ( $s, $m, $h, $D, $M, $Y ) = $TimeObject->SystemTime2Date(
         SystemTime => $TimeObject->SystemTime(),
     );
@@ -819,7 +823,8 @@ sub _PDFOutputArticles {
             my $Lines;
             if ( IsArrayRefWithData( $Article{Body} ) ) {
                 for my $Line ( @{ $Article{Body} } ) {
-                    my $CreateTime = $LayoutObject->{LanguageObject}->FormatTimeString( $Line->{CreateTime}, 'DateFormat' );
+                    my $CreateTime
+                        = $LayoutObject->{LanguageObject}->FormatTimeString( $Line->{CreateTime}, 'DateFormat' );
                     if ( $Line->{SystemGenerated} ) {
                         $Lines .= '[' . $CreateTime . '] ' . $Line->{MessageText} . "\n";
                     }

--- a/Kernel/Modules/CustomerTicketSearch.pm
+++ b/Kernel/Modules/CustomerTicketSearch.pm
@@ -796,7 +796,10 @@ sub Run {
                 . $LayoutObject->{LanguageObject}->Translate('Search');
             my $PrintedBy = $LayoutObject->{LanguageObject}->Translate('printed by');
             my $Page      = $LayoutObject->{LanguageObject}->Translate('Page');
-            my $Time      = $LayoutObject->{Time};
+            my $Time      = $LayoutObject->{LanguageObject}->FormatTimeString(
+                $TimeObject->CurrentTimestamp(),
+                'DateFormat',
+            );
 
             # get maximum number of pages
             my $MaxPages = $ConfigObject->Get('PDF::MaxPages');


### PR DESCRIPTION
http://bugs.otrs.org/show_bug.cgi?id=11875

Hello @mgruner ,

Hereby is our proposal for fixing reporters issues. Changed variable $Time in PDF print output for 'printed by' time, to call FormatTimeString() function which includes 'UserTimeZome' preference and modify time by it.

Bug is reported for AgentTicketPrint and CustomerTicketPrint, but changed AgentTicketSearch and CustomerTicketSearch as well for PDF output.

Please let me know if there are any questions or issues regarding this proposal.

Kind Regards,
Sanjin