### PR TITLE
[ Rel-5_0 Bug 11878 ] - Dashboard Widget Online removes menu bar if Italian language is set

### DIFF
--- a/Kernel/Output/HTML/Templates/Standard/AgentDashboardUserOnline.tt
+++ b/Kernel/Output/HTML/Templates/Standard/AgentDashboardUserOnline.tt
@@ -108,7 +108,7 @@ $('a.DashboardUserOnlineChatStart').off('click').on('click', function() {
         Data,
         function(Response) {
             if (Response < 1) {
-                window.alert('[% Translate("Selected agent is not available for chat") | html %]. ');
+                window.alert("[% Translate('Selected agent is not available for chat') | html %]. ");
 
                 // Reload page
                 document.location.reload(true);


### PR DESCRIPTION
http://bugs.otrs.org/show_bug.cgi?id=11878
Hello @mgruner ,

Hereby is our proposal for fixing this bug. There was problem when string 'Selected agent is not available for chat' is translated to Italian. This translated string when send to window.alert() function was looking like this 'L'operatore selezionato non è disponibile per la chat'. Apostrophe was escaped in original translation, but not when sent to java script function. 

Replaced single quotes with double quotes and translated string now looks like "L'operatore selezionato non è disponibile per la chat" and java script can execute it further on.

Kind Regards,
Sanjin