### PR TITLE
Fix LDAP group sync at every second agent login

### DIFF
--- a/Kernel/System/Auth/Sync/LDAP.pm
+++ b/Kernel/System/Auth/Sync/LDAP.pm
@@ -522,54 +522,28 @@ sub Sync {
         }
     }
 
-    # compare group permissions from ldap with current user group permissions
-    my %GroupPermissionsChanged;
+    # Set group permissions from ldap for current user
     if (%GroupPermissionsFromLDAP) {
         PERMISSIONTYPE:
         for my $PermissionType ( @{ $ConfigObject->Get('System::Permission') } ) {
 
-            # get current permission for type
-            my %GroupPermissions = $GroupObject->PermissionUserGroupGet(
-                UserID => $UserID,
-                Type   => $PermissionType,
-            );
-
-            GROUPID:
+            # Update all available group permissions for system groups
+	    GROUPID:
             for my $GroupID ( sort keys %SystemGroups ) {
 
-                my $OldPermission = $GroupPermissions{$GroupID};
-                my $NewPermission = $GroupPermissionsFromLDAP{$GroupID}->{$PermissionType};
-
-                # if old and new permission for group/type match, do nothing
-                if (
-                    ( $OldPermission && $NewPermission )
-                    ||
-                    ( !$OldPermission && !$NewPermission )
-                    )
-                {
-                    next GROUPID;
-                }
-
-                # permission for group/type differs - remember
-                $GroupPermissionsChanged{$GroupID}->{$PermissionType} = $NewPermission;
+		# Update group permissions for user from ldap or default to empty permission
+                $Kernel::OM->Get('Kernel::System::Log')->Log(
+                    Priority => 'notice',
+                    Message  => "User: '$Param{User}' sync ldap group '$SystemGroups{$GroupID}' "
+		                . "permission '$PermissionType'!",
+                );
+                $GroupObject->PermissionGroupUserAdd(
+                    GID        => $GroupID,
+                    UID        => $UserID,
+                    Permission => $GroupPermissionsFromLDAP{$GroupID} || \%PermissionsEmpty,
+                    UserID     => 1,
+                );
             }
-        }
-    }
-
-    # update changed group permissions
-    if (%GroupPermissionsChanged) {
-        for my $GroupID ( sort keys %GroupPermissionsChanged ) {
-
-            $Kernel::OM->Get('Kernel::System::Log')->Log(
-                Priority => 'notice',
-                Message  => "User: '$Param{User}' sync ldap group $SystemGroups{$GroupID}!",
-            );
-            $GroupObject->PermissionGroupUserAdd(
-                GID        => $GroupID,
-                UID        => $UserID,
-                Permission => $GroupPermissionsChanged{$GroupID} || \%PermissionsEmpty,
-                UserID     => 1,
-            );
         }
     }
 

--- a/Kernel/System/Auth/Sync/LDAP.pm
+++ b/Kernel/System/Auth/Sync/LDAP.pm
@@ -528,14 +528,14 @@ sub Sync {
         for my $PermissionType ( @{ $ConfigObject->Get('System::Permission') } ) {
 
             # Update all available group permissions for system groups
-	    GROUPID:
+            GROUPID:
             for my $GroupID ( sort keys %SystemGroups ) {
 
-		# Update group permissions for user from ldap or default to empty permission
+                # Update group permissions for user from ldap or default to empty permission
                 $Kernel::OM->Get('Kernel::System::Log')->Log(
                     Priority => 'notice',
                     Message  => "User: '$Param{User}' sync ldap group '$SystemGroups{$GroupID}' "
-		                . "permission '$PermissionType'!",
+                        . "permission '$PermissionType'!",
                 );
                 $GroupObject->PermissionGroupUserAdd(
                     GID        => $GroupID,


### PR DESCRIPTION
The module AuthSyncModule::LDAP::UserSyncGroupsDefinition tried to
reduce database interaction when checking ldap vs. db group grants.
Group check was not implemented correctly. Groups were only granted to
agents at every second login.
It's may more easy and secure to update all group permissons on every
agent login.

##### LDAP Sync configuration
```
    # Synchronize LDAP user data to OTRS agent database
    $Self->{'AuthModule::UseSyncBackend'} = 'AuthSyncBackend';
    $Self->{'AuthSyncModule'} = 'Kernel::System::Auth::Sync::LDAP';
    $Self->{'AuthSyncModule::LDAP::Host'} = 'ldap://myldap:389/';
    $Self->{'AuthSyncModule::LDAP::SearchUserDN'} = "$Self->{'AuthModule::LDAP::SearchUserDN'}";
    $Self->{'AuthSyncModule::LDAP::SearchUserPw'} = "$Self->{'AuthModule::LDAP::SearchUserPw'}";
    # Search settings for agents in LDAP
    $Self->{'AuthSyncModule::LDAP::BaseDN'} = "$Self->{'AuthModule::LDAP::BaseDN'}";
    $Self->{'AuthSyncModule::LDAP::UID'} = "$Self->{'AuthModule::LDAP::UID'}";
    $Self->{'AuthSyncModule::LDAP::AccessAttr'} = "$Self->{'AuthModule::LDAP::AccessAttr'}";
    $Self->{'AuthSyncModule::LDAP::UserAttr'} = "Self->{'AuthModule::LDAP::UserAttr'}";

    # Map OTRS agent database fields to LDAP attributes
    $Self->{'AuthSyncModule::LDAP::UserSyncMap'} = {
        UserFirstname => 'givenname',
        UserLastname  => 'sn',
        UserEmail     => 'mail',
    };

    # Add OTRS agents to groups by LDAP group settings
    $Self->{'AuthSyncModule::LDAP::UserSyncGroupsDefinition'} = {
        # your ldap entry (user/group)
        # Admin users
        'cn=otrsadmin, ou=groups, dc=otrs, dc=com' => {
            # otrs group(s)
            'admin' => {
                # OTRS group permission
                rw => 1,
                ro => 1,
            },
            'users' => {
                rw => 1,
                ro => 1,
            },
        },
        # Normal users
        'cn=otrs, ou=groups, dc=otrs, dc=com' => {
            'users' => {
                rw => 1,
            },
        },
    };
```

##### Groups in database
```
> use otrs;
> select id, name, valid_id from groups;
+----+------------+----------+
| id | name       | valid_id |
+----+------------+----------+
|  1 | users      |        1 |
|  2 | admin      |        1 |
|  3 | stats      |        1 |
+----+------------+----------+
```

##### Tracing of login attempts
```
[Notice][Kernel::System::Auth::LDAP::Auth] User: myagent (cn=Agent Name,ou=people,dc=otrs,dc=com) authentication ok

Query     SELECT id, login,  title, first_name, last_name, pw, valid_id,  create_time, change_time FROM users WHERE  (login) = 'myagent' LIMIT 1

[Notice][Kernel::System::Auth::Sync::LDAP::Sync] User: 'myagent' sync ldap group users!

Query     DELETE FROM group_user WHERE user_id = '3' AND group_id = '1'
Query     INSERT INTO group_user (user_id, group_id, permission_key, permission_value, create_time, create_by, change_time, change_by) VALUES ('3', '1', 'rw', '1', '2016-02-16 13:00:47' , '1', '2016-02-16 13:00:47' , '1')

===================

[Notice][Kernel::System::Auth::LDAP::Auth] User: myagent (cn=Agent Name,ou=people,dc=otrs,dc=com) authentication ok

Query     SELECT id, login,  title, first_name, last_name, pw, valid_id,  create_time, change_time FROM users WHERE  (login) = 'myagent' LIMIT 1

[Notice][Kernel::System::Auth::Sync::LDAP::Sync] User: 'myagent' sync ldap group users!

Query     DELETE FROM group_user WHERE user_id = '3' AND group_id = '1'

===================
```