### PR TITLE
Improved rendering for custom development

### DIFF
--- a/var/httpd/htdocs/js/Core.UI.InputFields.js
+++ b/var/httpd/htdocs/js/Core.UI.InputFields.js
@@ -2122,7 +2122,7 @@ Core.UI.InputFields = (function (TargetNS) {
                     // redraw event is critical on hidden elements because
                     // e.g. chrome can't calculate the width of hidden elements correctly
                     // so we skip it for hidden elements
-                    if ( !$(this).is(':visible') ) return;
+                    if (!$SearchObj.is(':visible')) return;
 
                     CloseOpenSelections();
                     if (Filterable) {

--- a/var/httpd/htdocs/js/Core.UI.InputFields.js
+++ b/var/httpd/htdocs/js/Core.UI.InputFields.js
@@ -507,7 +507,7 @@ Core.UI.InputFields = (function (TargetNS) {
 
                     // If first selection, we must shorten it in order to display it
                     if (i === 0) {
-                        while (OffsetLeft + $SelectionObj.outerWidth() >= MaxWidth) {
+                        while (MadWidth > 0 && OffsetLeft + $SelectionObj.outerWidth() >= MaxWidth) {
                             $TextObj.text(
                                 $TextObj.text().substring(0, $TextObj.text().length - 4)
                                 + '...'

--- a/var/httpd/htdocs/js/Core.UI.InputFields.js
+++ b/var/httpd/htdocs/js/Core.UI.InputFields.js
@@ -507,7 +507,7 @@ Core.UI.InputFields = (function (TargetNS) {
 
                     // If first selection, we must shorten it in order to display it
                     if (i === 0) {
-                        while (MadWidth > 0 && OffsetLeft + $SelectionObj.outerWidth() >= MaxWidth) {
+                        while (MaxWidth > 0 && OffsetLeft + $SelectionObj.outerWidth() >= MaxWidth) {
                             $TextObj.text(
                                 $TextObj.text().substring(0, $TextObj.text().length - 4)
                                 + '...'
@@ -2118,6 +2118,12 @@ Core.UI.InputFields = (function (TargetNS) {
                 // Handle custom redraw event on original select field
                 // to update values when changed via AJAX calls
                 $SelectObj.off('redraw.InputField').on('redraw.InputField', function () {
+
+                    // redraw event is critical on hidden elements because
+                    // e.g. chrome can't calculate the width of hidden elements correctly
+                    // so we skip it for hidden elements
+                    if ( !$(this).is(':visible') ) return;
+
                     CloseOpenSelections();
                     if (Filterable) {
                         $SelectObj.data('original', $SelectObj.children());


### PR DESCRIPTION
Hi OTRS,
if you are doing some custom development to hide dynamic fields for AgentTicketClose for example and it will get rerendered in Chrome browser then the chrome will be not able to calculate the width of the hidden field and crash very hard, because of this endless loop. I added this small improvement to prevent the crash.

Big thanks also to @thorsteneckel !

Best regards,
Rolf