### PR TITLE
Rel 5-0 ut restore database part19

### DIFF
--- a/scripts/test/Console/Command/Maint/Ticket/ArchiveCleanup.t
+++ b/scripts/test/Console/Command/Maint/Ticket/ArchiveCleanup.t
@@ -12,6 +12,14 @@ use utf8;
 
 use vars (qw($Self));
 
+# get helper object
+$Kernel::OM->ObjectParamAdd(
+    'Kernel::System::UnitTest::Helper' => {
+        RestoreDatabase => 1,
+    },
+);
+my $Helper = $Kernel::OM->Get('Kernel::System::UnitTest::Helper');
+
 my $CommandObject = $Kernel::OM->Get('Kernel::System::Console::Command::Maint::Ticket::ArchiveCleanup');
 
 my $ExitCode = $CommandObject->Execute();
@@ -22,5 +30,7 @@ $Self->Is(
     $Kernel::OM->Get('Kernel::Config')->Get('Ticket::ArchiveSystem') ? 0 : 1,
     "Maint::Ticket::ArchiveCleanup exit code",
 );
+
+# cleanup is done by RestoreDatabase
 
 1;

--- a/scripts/test/Console/Command/Maint/Ticket/Delete.t
+++ b/scripts/test/Console/Command/Maint/Ticket/Delete.t
@@ -12,160 +12,120 @@ use utf8;
 
 use vars (qw($Self));
 
-my $CommandObject = $Kernel::OM->Get('Kernel::System::Console::Command::Maint::Ticket::Delete');
+# get helper object
+$Kernel::OM->ObjectParamAdd(
+    'Kernel::System::UnitTest::Helper' => {
+        RestoreDatabase => 1,
+    },
+);
+my $Helper = $Kernel::OM->Get('Kernel::System::UnitTest::Helper');
 
-my $CacheObject = $Kernel::OM->Get('Kernel::System::Cache');
-$CacheObject->Configure(
+# get needed object
+my $CommandObject = $Kernel::OM->Get('Kernel::System::Console::Command::Maint::Ticket::Delete');
+my $TicketObject  = $Kernel::OM->Get('Kernel::System::Ticket');
+
+$Kernel::OM->Get('Kernel::System::Cache')->Configure(
     CacheInMemory => 0,
 );
 
-# create a new ticket
-my $TicketID = $Kernel::OM->Get('Kernel::System::Ticket')->TicketCreate(
-    Title        => 'My ticket created by Agent A',
-    Queue        => 'Raw',
-    Lock         => 'unlock',
-    Priority     => '3 normal',
-    State        => 'open',
-    CustomerNo   => '123465',
-    CustomerUser => 'customer@example.com',
-    OwnerID      => 1,
-    UserID       => 1,
-);
+my $CustomerUser = $Helper->GetRandomID() . '@example.com';
 
-$Self->True(
-    $TicketID,
-    "Ticket created",
-);
+# create a new tickets
+my @Tickets;
+for ( 1 .. 4 ) {
+    my $TicketNumber = $TicketObject->TicketCreateNumber();
+    my $TicketID     = $Kernel::OM->Get('Kernel::System::Ticket')->TicketCreate(
+        TN           => $TicketNumber,
+        Title        => 'Test ticket',
+        Queue        => 'Raw',
+        Lock         => 'unlock',
+        Priority     => '3 normal',
+        State        => 'open',
+        CustomerNo   => '123465',
+        CustomerUser => $CustomerUser,
+        OwnerID      => 1,
+        UserID       => 1,
+    );
 
-my $TicketID2 = $Kernel::OM->Get('Kernel::System::Ticket')->TicketCreate(
-    Title        => 'My ticket created by Agent A',
-    Queue        => 'Raw',
-    Lock         => 'unlock',
-    Priority     => '3 normal',
-    State        => 'open',
-    CustomerNo   => '123465',
-    CustomerUser => 'customer@example.com',
-    OwnerID      => 1,
-    UserID       => 1,
-);
+    $Self->True(
+        $TicketID,
+        "Ticket is created - $TicketID",
+    );
 
-$Self->True(
-    $TicketID2,
-    "Ticket2 created",
-);
+    my %TicketHash = (
+        TicketID => $TicketID,
+        TN       => $TicketNumber,
+    );
+    push @Tickets, \%TicketHash;
+}
+
 my $ExitCode = $CommandObject->Execute();
 
 $Self->Is(
     $ExitCode,
     1,
-    "Maint::Ticket::Delete exit code without arguments",
+    "Maint::Ticket::Delete exit code without arguments.",
 );
 
-$ExitCode = $CommandObject->Execute( '--ticket-id', $TicketID, '--ticket-id', $TicketID2 );
+$ExitCode = $CommandObject->Execute( '--ticket-id', $Tickets[0]->{TicketID}, '--ticket-id', $Tickets[1]->{TicketID} );
 
 $Self->Is(
     $ExitCode,
     0,
-    "Maint::Ticket::Delete exit code",
+    "Maint::Ticket::Delete exit code - delete by --ticket-id options.",
 );
 
-my %Ticket = $Kernel::OM->Get('Kernel::System::Ticket')->TicketGet(
-    TicketID => $TicketID,
-);
-
-$Self->False(
-    $Ticket{TicketID},
-    "Ticket deleted by ticket id",
-);
-
-my %Ticket2 = $Kernel::OM->Get('Kernel::System::Ticket')->TicketGet(
-    TicketID => $TicketID,
+my %TicketIDs = $TicketObject->TicketSearch(
+    Result            => 'HASH',
+    CustomerUserLogin => $CustomerUser,
+    UserID            => 1,
 );
 
 $Self->False(
-    $Ticket2{TicketID},
-    "Ticket2 deleted by ticket id",
+    $TicketIDs{ $Tickets[0]->{TicketID} },
+    "Ticket is deleted - $Tickets[0]->{TicketID}",
 );
 
-# create a new ticket
-$TicketID = $Kernel::OM->Get('Kernel::System::Ticket')->TicketCreate(
-    Title        => 'My ticket created by Agent A',
-    Queue        => 'Raw',
-    Lock         => 'unlock',
-    Priority     => '3 normal',
-    State        => 'open',
-    CustomerNo   => '123465',
-    CustomerUser => 'customer@example.com',
-    OwnerID      => 1,
-    UserID       => 1,
+$Self->False(
+    $TicketIDs{ $Tickets[1]->{TicketID} },
+    "Ticket is deleted - $Tickets[1]->{TicketID}",
 );
 
-$Self->True(
-    $TicketID,
-    "Ticket created",
-);
-
-# create a new ticket
-$TicketID2 = $Kernel::OM->Get('Kernel::System::Ticket')->TicketCreate(
-    Title        => 'My ticket created by Agent A',
-    Queue        => 'Raw',
-    Lock         => 'unlock',
-    Priority     => '3 normal',
-    State        => 'open',
-    CustomerNo   => '123465',
-    CustomerUser => 'customer@example.com',
-    OwnerID      => 1,
-    UserID       => 1,
-);
-
-$Self->True(
-    $TicketID2,
-    "Ticket2 created",
-);
-
-%Ticket = $Kernel::OM->Get('Kernel::System::Ticket')->TicketGet(
-    TicketID => $TicketID,
-);
-
-$Self->True(
-    $Ticket{TicketID},
-    "Ticket created",
-);
-
-%Ticket2 = $Kernel::OM->Get('Kernel::System::Ticket')->TicketGet(
-    TicketID => $TicketID2,
-);
-
-$Self->True(
-    $Ticket2{TicketID},
-    "Ticket2 created",
-);
-
-$ExitCode
-    = $CommandObject->Execute( '--ticket-number', $Ticket{TicketNumber}, '--ticket-number', $Ticket2{TicketNumber} );
+$ExitCode = $CommandObject->Execute( '--ticket-number', $Tickets[2]->{TN}, '--ticket-number', $Tickets[3]->{TN} );
 
 $Self->Is(
     $ExitCode,
     0,
-    "Maint::Ticket::Delete exit code",
+    "Maint::Ticket::Delete exit code - delete by --ticket-number options.",
 );
 
-%Ticket = $Kernel::OM->Get('Kernel::System::Ticket')->TicketGet(
-    TicketID => $TicketID,
-);
-
-$Self->False(
-    $Ticket{TicketID},
-    "Ticket deleted by ticket number",
-);
-
-%Ticket2 = $Kernel::OM->Get('Kernel::System::Ticket')->TicketGet(
-    TicketID => $TicketID2,
+%TicketIDs = $TicketObject->TicketSearch(
+    Result            => 'HASH',
+    CustomerUserLogin => $CustomerUser,
+    UserID            => 1,
 );
 
 $Self->False(
-    $Ticket2{TicketID},
-    "Ticket2 deleted by ticket number",
+    $TicketIDs{ $Tickets[2]->{TicketID} },
+    "Ticket is deleted - $Tickets[2]->{TicketID}",
 );
+
+$Self->False(
+    $TicketIDs{ $Tickets[3]->{TicketID} },
+    "Ticket is deleted - $Tickets[3]->{TicketID}",
+);
+
+$ExitCode = $CommandObject->Execute(
+    '--ticket-id',     $Tickets[0]->{TicketID}, '--ticket-id',     $Tickets[1]->{TicketID},
+    '--ticket-number', $Tickets[2]->{TN},       '--ticket-number', $Tickets[3]->{TN}
+);
+
+$Self->Is(
+    $ExitCode,
+    1,
+    "Maint::Ticket::Delete exit code - try to delete with wrong ticket numbers and ticket IDs.",
+);
+
+# cleanup is done by RestoreDatabase
 
 1;

--- a/scripts/test/Console/Command/Maint/Ticket/Dump.t
+++ b/scripts/test/Console/Command/Maint/Ticket/Dump.t
@@ -12,6 +12,15 @@ use utf8;
 
 use vars (qw($Self));
 
+# get helper object
+$Kernel::OM->ObjectParamAdd(
+    'Kernel::System::UnitTest::Helper' => {
+        RestoreDatabase => 1,
+    },
+);
+my $Helper = $Kernel::OM->Get('Kernel::System::UnitTest::Helper');
+
+# get command object
 my $CommandObject = $Kernel::OM->Get('Kernel::System::Console::Command::Maint::Ticket::Dump');
 
 my $ExitCode = $CommandObject->Execute();
@@ -62,14 +71,6 @@ $Self->True(
     "Title found",
 );
 
-my $Deleted = $Kernel::OM->Get('Kernel::System::Ticket')->TicketDelete(
-    TicketID => $TicketID,
-    UserID   => 1,
-);
-
-$Self->True(
-    $Deleted,
-    "Ticket deleted",
-);
+# cleanup is done by RestoreDatabase
 
 1;

--- a/scripts/test/Console/Command/Maint/Ticket/EscalationCheck.t
+++ b/scripts/test/Console/Command/Maint/Ticket/EscalationCheck.t
@@ -12,6 +12,15 @@ use utf8;
 
 use vars (qw($Self));
 
+# get helper object
+$Kernel::OM->ObjectParamAdd(
+    'Kernel::System::UnitTest::Helper' => {
+        RestoreDatabase => 1,
+    },
+);
+my $Helper = $Kernel::OM->Get('Kernel::System::UnitTest::Helper');
+
+# get command object
 my $CommandObject = $Kernel::OM->Get('Kernel::System::Console::Command::Maint::Ticket::EscalationCheck');
 
 my $ExitCode = $CommandObject->Execute();
@@ -21,6 +30,8 @@ $Self->Is(
     0,
     "Maint::Ticket::EscalationCheck exit code",
 );
+
+# cleanup cache is done by RestoreDatabase
 
 # It is also possible to capture the command output, see test/Console/Command/Maint/Config/Dump.t for an example.
 

--- a/scripts/test/Console/Command/Maint/Ticket/EscalationIndexRebuild.t
+++ b/scripts/test/Console/Command/Maint/Ticket/EscalationIndexRebuild.t
@@ -12,6 +12,15 @@ use utf8;
 
 use vars (qw($Self));
 
+# get helper object
+$Kernel::OM->ObjectParamAdd(
+    'Kernel::System::UnitTest::Helper' => {
+        RestoreDatabase => 1,
+    },
+);
+my $Helper = $Kernel::OM->Get('Kernel::System::UnitTest::Helper');
+
+# get command object
 my $CommandObject = $Kernel::OM->Get('Kernel::System::Console::Command::Maint::Ticket::EscalationIndexRebuild');
 
 my $ExitCode = $CommandObject->Execute();
@@ -23,5 +32,7 @@ $Self->Is(
     0,
     "Maint::Ticket::EscalationIndexRebuild exit code",
 );
+
+# cleanup cache is done by RestoreDatabase
 
 1;

--- a/scripts/test/Console/Command/Maint/Ticket/FulltextIndexRebuild.t
+++ b/scripts/test/Console/Command/Maint/Ticket/FulltextIndexRebuild.t
@@ -12,6 +12,15 @@ use utf8;
 
 use vars (qw($Self));
 
+# get helper object
+$Kernel::OM->ObjectParamAdd(
+    'Kernel::System::UnitTest::Helper' => {
+        RestoreDatabase => 1,
+    },
+);
+my $Helper = $Kernel::OM->Get('Kernel::System::UnitTest::Helper');
+
+# get command object
 my $CommandObject = $Kernel::OM->Get('Kernel::System::Console::Command::Maint::Ticket::FulltextIndexRebuild');
 
 my $ExitCode = $CommandObject->Execute();
@@ -22,5 +31,7 @@ $Self->Is(
     0,
     "Maint::Ticket::FulltextIndexRebuild exit code",
 );
+
+# cleanup cache is done by RestoreDatabase
 
 1;

--- a/scripts/test/Console/Command/Maint/Ticket/InvalidUserCleanup.t
+++ b/scripts/test/Console/Command/Maint/Ticket/InvalidUserCleanup.t
@@ -12,6 +12,15 @@ use utf8;
 
 use vars (qw($Self));
 
+# get helper object
+$Kernel::OM->ObjectParamAdd(
+    'Kernel::System::UnitTest::Helper' => {
+        RestoreDatabase => 1,
+    },
+);
+my $Helper = $Kernel::OM->Get('Kernel::System::UnitTest::Helper');
+
+# get command object
 my $CommandObject = $Kernel::OM->Get('Kernel::System::Console::Command::Maint::Ticket::InvalidUserCleanup');
 
 my $ExitCode = $CommandObject->Execute();
@@ -22,5 +31,7 @@ $Self->Is(
     0,
     "Maint::Ticket::InvalidUserCleanup exit code",
 );
+
+# cleanup cache is done by RestoreDatabase
 
 1;

--- a/scripts/test/Console/Command/Maint/Ticket/PendingCheck.t
+++ b/scripts/test/Console/Command/Maint/Ticket/PendingCheck.t
@@ -12,11 +12,18 @@ use utf8;
 
 use vars (qw($Self));
 
-my $CommandObject = $Kernel::OM->Get('Kernel::System::Console::Command::Maint::Ticket::PendingCheck');
+# get helper object
+$Kernel::OM->ObjectParamAdd(
+    'Kernel::System::UnitTest::Helper' => {
+        RestoreDatabase => 1,
+    },
+);
+my $Helper = $Kernel::OM->Get('Kernel::System::UnitTest::Helper');
 
-my $TimeObject   = $Kernel::OM->Get('Kernel::System::Time');
-my $TicketObject = $Kernel::OM->Get('Kernel::System::Ticket');
-my $HelperObject = $Kernel::OM->Get('Kernel::System::UnitTest::Helper');
+# get needed objects
+my $CommandObject = $Kernel::OM->Get('Kernel::System::Console::Command::Maint::Ticket::PendingCheck');
+my $TimeObject    = $Kernel::OM->Get('Kernel::System::Time');
+my $TicketObject  = $Kernel::OM->Get('Kernel::System::Ticket');
 
 my $TicketID = $TicketObject->TicketCreate(
     Title        => 'My ticket created by Agent A',
@@ -52,7 +59,7 @@ my $SystemTime = $TimeObject->TimeStamp2SystemTime(
 );
 
 # set the fixed time
-$HelperObject->FixedTimeSet($SystemTime);
+$Helper->FixedTimeSet($SystemTime);
 
 my $ExitCode = $CommandObject->Execute();
 
@@ -78,7 +85,7 @@ $SystemTime = $TimeObject->TimeStamp2SystemTime(
 );
 
 # set the fixed time
-$HelperObject->FixedTimeSet($SystemTime);
+$Helper->FixedTimeSet($SystemTime);
 
 $ExitCode = $CommandObject->Execute();
 
@@ -98,14 +105,6 @@ $Self->Is(
     "Ticket pending auto closed time reached",
 );
 
-my $Deleted = $TicketObject->TicketDelete(
-    TicketID => $TicketID,
-    UserID   => 1,
-);
-
-$Self->True(
-    $Deleted,
-    "Ticket deleted",
-);
+# cleanup is done by RestoreDatabase
 
 1;

--- a/scripts/test/Console/Command/Maint/Ticket/QueueIndexCleanup.t
+++ b/scripts/test/Console/Command/Maint/Ticket/QueueIndexCleanup.t
@@ -12,6 +12,15 @@ use utf8;
 
 use vars (qw($Self));
 
+# get helper object
+$Kernel::OM->ObjectParamAdd(
+    'Kernel::System::UnitTest::Helper' => {
+        RestoreDatabase => 1,
+    },
+);
+my $Helper = $Kernel::OM->Get('Kernel::System::UnitTest::Helper');
+
+# get command object
 my $CommandObject = $Kernel::OM->Get('Kernel::System::Console::Command::Maint::Ticket::QueueIndexCleanup');
 
 my $ExitCode = $CommandObject->Execute();
@@ -22,5 +31,7 @@ $Self->Is(
     0,
     "Maint::Ticket::QueueIndexCleanup exit code",
 );
+
+# cleanup cache is done by RestoreDatabase
 
 1;

--- a/scripts/test/Console/Command/Maint/Ticket/QueueIndexRebuild.t
+++ b/scripts/test/Console/Command/Maint/Ticket/QueueIndexRebuild.t
@@ -12,6 +12,15 @@ use utf8;
 
 use vars (qw($Self));
 
+# get helper object
+$Kernel::OM->ObjectParamAdd(
+    'Kernel::System::UnitTest::Helper' => {
+        RestoreDatabase => 1,
+    },
+);
+my $Helper = $Kernel::OM->Get('Kernel::System::UnitTest::Helper');
+
+# get command object
 my $CommandObject = $Kernel::OM->Get('Kernel::System::Console::Command::Maint::Ticket::QueueIndexRebuild');
 
 my $ExitCode = $CommandObject->Execute();
@@ -22,5 +31,7 @@ $Self->Is(
     0,
     "Maint::Ticket::QueueIndexRebuild exit code",
 );
+
+# cleanup cache is done by RestoreDatabase
 
 1;

--- a/scripts/test/Console/Command/Maint/Ticket/RestoreFromArchive.t
+++ b/scripts/test/Console/Command/Maint/Ticket/RestoreFromArchive.t
@@ -12,6 +12,15 @@ use utf8;
 
 use vars (qw($Self));
 
+# get helper object
+$Kernel::OM->ObjectParamAdd(
+    'Kernel::System::UnitTest::Helper' => {
+        RestoreDatabase => 1,
+    },
+);
+my $Helper = $Kernel::OM->Get('Kernel::System::UnitTest::Helper');
+
+# get command object
 my $CommandObject = $Kernel::OM->Get('Kernel::System::Console::Command::Maint::Ticket::RestoreFromArchive');
 
 my $ExitCode = $CommandObject->Execute();
@@ -22,5 +31,7 @@ $Self->Is(
     0,
     "Maint::Ticket::RestoreFromArchive exit code",
 );
+
+# cleanup cache is done by RestoreDatabase
 
 1;

--- a/scripts/test/Console/Command/Maint/Ticket/UnlockTicket.t
+++ b/scripts/test/Console/Command/Maint/Ticket/UnlockTicket.t
@@ -12,6 +12,15 @@ use utf8;
 
 use vars (qw($Self));
 
+# get helper object
+$Kernel::OM->ObjectParamAdd(
+    'Kernel::System::UnitTest::Helper' => {
+        RestoreDatabase => 1,
+    },
+);
+my $Helper = $Kernel::OM->Get('Kernel::System::UnitTest::Helper');
+
+# get command object
 my $CommandObject = $Kernel::OM->Get('Kernel::System::Console::Command::Maint::Ticket::UnlockTicket');
 
 my $TicketID = $Kernel::OM->Get('Kernel::System::Ticket')->TicketCreate(
@@ -49,14 +58,6 @@ $Self->Is(
     "Ticket unlocked",
 );
 
-my $Deleted = $Kernel::OM->Get('Kernel::System::Ticket')->TicketDelete(
-    TicketID => $TicketID,
-    UserID   => 1,
-);
-
-$Self->True(
-    $Deleted,
-    "Ticket deleted",
-);
+# cleanup cache is done by RestoreDatabase
 
 1;

--- a/scripts/test/Console/Command/Maint/Ticket/UnlockTimeout.t
+++ b/scripts/test/Console/Command/Maint/Ticket/UnlockTimeout.t
@@ -12,6 +12,15 @@ use utf8;
 
 use vars (qw($Self));
 
+# get helper object
+$Kernel::OM->ObjectParamAdd(
+    'Kernel::System::UnitTest::Helper' => {
+        RestoreDatabase => 1,
+    },
+);
+my $Helper = $Kernel::OM->Get('Kernel::System::UnitTest::Helper');
+
+# get command object
 my $CommandObject = $Kernel::OM->Get('Kernel::System::Console::Command::Maint::Ticket::UnlockTimeout');
 
 my $ExitCode = $CommandObject->Execute();
@@ -22,5 +31,7 @@ $Self->Is(
     0,
     "Maint::Ticket::UnlockTimeout exit code",
 );
+
+# cleanup cache is done by RestoreDatabase
 
 1;


### PR DESCRIPTION
Hi @mgruner 

- updated Console/Command selenium tests

You can see that I add in many tests RestoreDatabase even though there is only check exit code because in all of these Ticket Console commands there is changes in DB ( or could be - ArchiveCleanup, EscalationIndexRebuild ... etc ).

Regards
Zoran