### PR TITLE
Master - update Selenium tests - TicketZoom

### DIFF
--- a/scripts/test/Selenium/Output/TicketZoom/CustomerInformation.t
+++ b/scripts/test/Selenium/Output/TicketZoom/CustomerInformation.t
@@ -75,11 +75,10 @@ $Selenium->RunTest(
             UserFirstname  => $CustomerData{CustomerFirstName},
             UserLastname   => $CustomerData{CustomerLastName},
             UserCustomerID => $CompanyNameID,
-            ,
-            UserLogin => $CustomerData{CustomerLogin},
-            UserEmail => $CustomerData{CustomerEmail},
-            ValidID   => 1,
-            UserID    => 1,
+            UserLogin      => $CustomerData{CustomerLogin},
+            UserEmail      => $CustomerData{CustomerEmail},
+            ValidID        => 1,
+            UserID         => 1,
         );
         $Self->True(
             $CustomerUserID,
@@ -97,8 +96,8 @@ $Selenium->RunTest(
             Lock         => 'unlock',
             Priority     => '3 normal',
             State        => 'open',
-            CustomerID   => $CustomerUserID,
-            CustomerUser => $CustomerData{CustomerLogin},
+            CustomerID   => $CompanyNameID,
+            CustomerUser => $CustomerUserID,
             OwnerID      => 1,
             UserID       => 1,
         );

--- a/scripts/test/Selenium/Output/TicketZoom/TicketInformation.t
+++ b/scripts/test/Selenium/Output/TicketZoom/TicketInformation.t
@@ -9,6 +9,7 @@
 use strict;
 use warnings;
 use utf8;
+use POSIX qw( floor );
 
 use vars (qw($Self));
 
@@ -380,9 +381,16 @@ $Selenium->RunTest(
         # refresh screen to be sure escalation time will get latest times
         $Selenium->VerifiedRefresh();
 
+        # get ticket data for escalation time values
+        my %Ticket = $TicketObject->TicketGet(
+            TicketID => $TicketID,
+            Extended => 1,
+            UserID   => 1,
+        );
+
         # verify escalation times, warning should be active
-        for my $EscalationTime ( values %EscalationTimes ) {
-            $EscalationTime--;
+        for my $EscalationTime ( sort keys %EscalationTimes ) {
+            $EscalationTime = floor( $Ticket{$EscalationTime} / 60 );
             $Self->True(
                 $Selenium->find_element("//p[\@class='Warning'][\@title='Service Time: $EscalationTime m']"),
                 "Escalation Time $EscalationTime m , found in Ticket Information Widget",


### PR DESCRIPTION
Hi @mgruner 

As we discussed by mail about it, there is very strange case. I am not sure what is real problem here. I could not reproduce the problem on my local system. We analyzed it and maybe there is problem in Customer Information because we saw that there was wrong data for CustomerUserAdd(). However it is so strange, why it works on our local system :) 

In TicketInformation we change way how the escalation times are tested. I believe it is better to get Ticket data before checking these values. In previous version there could be problem if escalation time is changed in meantime for example instead 29m there could be 30m for fast system or 28m for slow system. I am not sure about that i just suppose.

Regards
Zoram