### PR TITLE
Give some classes a common base class

### DIFF
--- a/Kernel/Output/HTML/ArticleAttachment/HTMLViewer.pm
+++ b/Kernel/Output/HTML/ArticleAttachment/HTMLViewer.pm
@@ -8,6 +8,8 @@
 
 package Kernel::Output::HTML::ArticleAttachment::HTMLViewer;
 
+use base 'Kernel::Output::HTML::Base';
+
 use strict;
 use warnings;
 
@@ -16,16 +18,6 @@ our @ObjectDependencies = (
     'Kernel::Config',
     'Kernel::Output::HTML::Layout',
 );
-
-sub new {
-    my ( $Type, %Param ) = @_;
-
-    # allocate new hash for object
-    my $Self = {};
-    bless( $Self, $Type );
-
-    return $Self;
-}
 
 sub Run {
     my ( $Self, %Param ) = @_;

--- a/Kernel/Output/HTML/ArticleCompose/Crypt.pm
+++ b/Kernel/Output/HTML/ArticleCompose/Crypt.pm
@@ -8,6 +8,8 @@
 
 package Kernel::Output::HTML::ArticleCompose::Crypt;
 
+use base 'Kernel::Output::HTML::Base';
+
 use strict;
 use warnings;
 
@@ -20,16 +22,6 @@ our @ObjectDependencies = (
     'Kernel::System::Crypt::SMIME',
     'Kernel::Output::HTML::Layout',
 );
-
-sub new {
-    my ( $Type, %Param ) = @_;
-
-    # allocate new hash for object
-    my $Self = {};
-    bless( $Self, $Type );
-
-    return $Self;
-}
 
 sub Option {
     my ( $Self, %Param ) = @_;

--- a/Kernel/Output/HTML/ArticleCompose/Sign.pm
+++ b/Kernel/Output/HTML/ArticleCompose/Sign.pm
@@ -8,6 +8,8 @@
 
 package Kernel::Output::HTML::ArticleCompose::Sign;
 
+use base 'Kernel::Output::HTML::Base';
+
 use strict;
 use warnings;
 
@@ -21,16 +23,6 @@ our @ObjectDependencies = (
     'Kernel::Output::HTML::Layout',
     'Kernel::System::Queue',
 );
-
-sub new {
-    my ( $Type, %Param ) = @_;
-
-    # allocate new hash for object
-    my $Self = {};
-    bless( $Self, $Type );
-
-    return $Self;
-}
 
 sub Option {
     my ( $Self, %Param ) = @_;

--- a/Kernel/Output/HTML/Base.pm
+++ b/Kernel/Output/HTML/Base.pm
@@ -1,0 +1,63 @@
+# --
+# Copyright (C) 2001-2016 OTRS AG, http://otrs.com/
+# --
+# This software comes with ABSOLUTELY NO WARRANTY. For details, see
+# the enclosed file COPYING for license information (AGPL). If you
+# did not receive this file, see http://www.gnu.org/licenses/agpl.txt.
+# --
+
+package Kernel::Output::HTML::Base;
+
+use strict;
+use warnings;
+
+use utf8;
+
+sub new {
+    my ( $Type, %Param ) = @_;
+
+    # allocate new hash for object
+    my $Self = {};
+    bless( $Self, $Type );
+
+    # get UserID param
+    $Self->{UserID} = $Param{UserID} || die "Got no UserID!";
+
+    return $Self;
+}
+
+=head1 NAME
+
+Kernel::Output::HTML::Base - Base class for Output classes
+
+=head1 SYNOPSIS
+
+    package Kernel::Output::HTML::ToolBar::MyToolBar;
+    use base 'Kernel::Output::HTML::Base';
+
+    # methods go here
+
+=head1 PUBLIC INTERFACE
+
+=item new()
+
+Creates an object. Call it not on this class, but on a subclass.
+
+    use Kernel::Output::HTML::ToolBar::MyToolBar;
+    my $Object = Kernel::Output::HTML::ToolBar::MyToolBar->new(
+        UserID  => 123,
+    );
+
+=back
+
+=head1 TERMS AND CONDITIONS
+
+This software is part of the OTRS project (L<http://otrs.org/>).
+
+This software comes with ABSOLUTELY NO WARRANTY. For details, see
+the enclosed file COPYING for license information (AGPL). If you
+did not receive this file, see L<http://www.gnu.org/licenses/agpl.txt>.
+
+=cut
+
+1;

--- a/Kernel/Output/HTML/CustomerUser/Generic.pm
+++ b/Kernel/Output/HTML/CustomerUser/Generic.pm
@@ -8,23 +8,12 @@
 
 package Kernel::Output::HTML::CustomerUser::Generic;
 
+use base 'Kernel::Output::HTML::Base';
+
 use strict;
 use warnings;
 
 our $ObjectManagerDisabled = 1;
-
-sub new {
-    my ( $Type, %Param ) = @_;
-
-    # allocate new hash for object
-    my $Self = {};
-    bless( $Self, $Type );
-
-    # get UserID param
-    $Self->{UserID} = $Param{UserID} || die "Got no UserID!";
-
-    return $Self;
-}
 
 sub Run {
     my ( $Self, %Param ) = @_;

--- a/Kernel/Output/HTML/CustomerUser/GenericTicket.pm
+++ b/Kernel/Output/HTML/CustomerUser/GenericTicket.pm
@@ -8,23 +8,12 @@
 
 package Kernel::Output::HTML::CustomerUser::GenericTicket;
 
+use base 'Kernel::Output::HTML::Base';
+
 use strict;
 use warnings;
 
 our $ObjectManagerDisabled = 1;
-
-sub new {
-    my ( $Type, %Param ) = @_;
-
-    # allocate new hash for object
-    my $Self = {};
-    bless( $Self, $Type );
-
-    # get UserID param
-    $Self->{UserID} = $Param{UserID} || die "Got no UserID!";
-
-    return $Self;
-}
 
 sub Run {
     my ( $Self, %Param ) = @_;

--- a/Kernel/Output/HTML/NavBar/AgentTicketProcess.pm
+++ b/Kernel/Output/HTML/NavBar/AgentTicketProcess.pm
@@ -8,6 +8,8 @@
 
 package Kernel::Output::HTML::NavBar::AgentTicketProcess;
 
+use base 'Kernel::Output::HTML::Base';
+
 use strict;
 use warnings;
 
@@ -19,19 +21,6 @@ our @ObjectDependencies = (
     'Kernel::System::Ticket',
     'Kernel::System::ProcessManagement::Process',
 );
-
-sub new {
-    my ( $Type, %Param ) = @_;
-
-    # allocate new hash for object
-    my $Self = {};
-    bless( $Self, $Type );
-
-    # get UserID param
-    $Self->{UserID} = $Param{UserID} || die "Got no UserID!";
-
-    return $Self;
-}
 
 sub Run {
     my ( $Self, %Param ) = @_;

--- a/Kernel/Output/HTML/NavBar/AgentTicketService.pm
+++ b/Kernel/Output/HTML/NavBar/AgentTicketService.pm
@@ -8,25 +8,14 @@
 
 package Kernel::Output::HTML::NavBar::AgentTicketService;
 
+use base 'Kernel::Output::HTML::Base';
+
 use strict;
 use warnings;
 
 our @ObjectDependencies = (
     'Kernel::Config',
 );
-
-sub new {
-    my ( $Type, %Param ) = @_;
-
-    # allocate new hash for object
-    my $Self = {};
-    bless( $Self, $Type );
-
-    # get UserID param
-    $Self->{UserID} = $Param{UserID} || die "Got no UserID!";
-
-    return $Self;
-}
 
 sub Run {
     my ( $Self, %Param ) = @_;

--- a/Kernel/Output/HTML/NavBar/CustomerCompany.pm
+++ b/Kernel/Output/HTML/NavBar/CustomerCompany.pm
@@ -8,25 +8,14 @@
 
 package Kernel::Output::HTML::NavBar::CustomerCompany;
 
+use base 'Kernel::Output::HTML::Base';
+
 use strict;
 use warnings;
 
 our @ObjectDependencies = (
     'Kernel::Config',
 );
-
-sub new {
-    my ( $Type, %Param ) = @_;
-
-    # allocate new hash for object
-    my $Self = {};
-    bless( $Self, $Type );
-
-    # get UserID param
-    $Self->{UserID} = $Param{UserID} || die "Got no UserID!";
-
-    return $Self;
-}
 
 sub Run {
     my ( $Self, %Param ) = @_;

--- a/Kernel/Output/HTML/NavBar/CustomerTicketProcess.pm
+++ b/Kernel/Output/HTML/NavBar/CustomerTicketProcess.pm
@@ -8,6 +8,8 @@
 
 package Kernel::Output::HTML::NavBar::CustomerTicketProcess;
 
+use base 'Kernel::Output::HTML::Base';
+
 use strict;
 use warnings;
 
@@ -19,19 +21,6 @@ our @ObjectDependencies = (
     'Kernel::System::Ticket',
     'Kernel::System::ProcessManagement::Process',
 );
-
-sub new {
-    my ( $Type, %Param ) = @_;
-
-    # allocate new hash for object
-    my $Self = {};
-    bless( $Self, $Type );
-
-    # get UserID param
-    $Self->{UserID} = $Param{UserID} || die "Got no UserID!";
-
-    return $Self;
-}
 
 sub Run {
     my ( $Self, %Param ) = @_;

--- a/Kernel/Output/HTML/NavBar/ModuleAdmin.pm
+++ b/Kernel/Output/HTML/NavBar/ModuleAdmin.pm
@@ -8,6 +8,8 @@
 
 package Kernel::Output::HTML::NavBar::ModuleAdmin;
 
+use base 'Kernel::Output::HTML::Base';
+
 use strict;
 use warnings;
 
@@ -15,19 +17,6 @@ our @ObjectDependencies = (
     'Kernel::Config',
     'Kernel::Output::HTML::Layout',
 );
-
-sub new {
-    my ( $Type, %Param ) = @_;
-
-    # allocate new hash for object
-    my $Self = {};
-    bless( $Self, $Type );
-
-    # get UserID param
-    $Self->{UserID} = $Param{UserID} || die "Got no UserID!";
-
-    return $Self;
-}
 
 sub Run {
     my ( $Self, %Param ) = @_;

--- a/Kernel/Output/HTML/Notification/AgentOTRSBusiness.pm
+++ b/Kernel/Output/HTML/Notification/AgentOTRSBusiness.pm
@@ -8,6 +8,8 @@
 
 package Kernel::Output::HTML::Notification::AgentOTRSBusiness;
 
+use base 'Kernel::Output::HTML::Base';
+
 use strict;
 use warnings;
 use utf8;
@@ -16,16 +18,6 @@ our @ObjectDependencies = (
     'Kernel::System::OTRSBusiness',
     'Kernel::Output::HTML::Layout',
 );
-
-sub new {
-    my ( $Type, %Param ) = @_;
-
-    # allocate new hash for object
-    my $Self = {};
-    bless( $Self, $Type );
-
-    return $Self;
-}
 
 sub Run {
     my ( $Self, %Param ) = @_;

--- a/Kernel/Output/HTML/Notification/AgentOnline.pm
+++ b/Kernel/Output/HTML/Notification/AgentOnline.pm
@@ -8,6 +8,8 @@
 
 package Kernel::Output::HTML::Notification::AgentOnline;
 
+use base 'Kernel::Output::HTML::Base';
+
 use strict;
 use warnings;
 
@@ -16,19 +18,6 @@ our @ObjectDependencies = (
     'Kernel::System::Time',
     'Kernel::Output::HTML::Layout',
 );
-
-sub new {
-    my ( $Type, %Param ) = @_;
-
-    # allocate new hash for object
-    my $Self = {};
-    bless( $Self, $Type );
-
-    # get UserID param
-    $Self->{UserID} = $Param{UserID} || die "Got no UserID!";
-
-    return $Self;
-}
 
 sub Run {
     my ( $Self, %Param ) = @_;

--- a/Kernel/Output/HTML/Notification/AgentTicketEscalation.pm
+++ b/Kernel/Output/HTML/Notification/AgentTicketEscalation.pm
@@ -8,6 +8,8 @@
 
 package Kernel::Output::HTML::Notification::AgentTicketEscalation;
 
+use base 'Kernel::Output::HTML::Base';
+
 use strict;
 use warnings;
 
@@ -18,19 +20,6 @@ our @ObjectDependencies = (
     'Kernel::System::Cache',
     'Kernel::System::Ticket',
 );
-
-sub new {
-    my ( $Type, %Param ) = @_;
-
-    # allocate new hash for object
-    my $Self = {};
-    bless( $Self, $Type );
-
-    # get UserID param
-    $Self->{UserID} = $Param{UserID} || die "Got no UserID!";
-
-    return $Self;
-}
 
 sub Run {
     my ( $Self, %Param ) = @_;

--- a/Kernel/Output/HTML/Notification/CustomerOTRSBusiness.pm
+++ b/Kernel/Output/HTML/Notification/CustomerOTRSBusiness.pm
@@ -8,6 +8,8 @@
 
 package Kernel::Output::HTML::Notification::CustomerOTRSBusiness;
 
+use base 'Kernel::Output::HTML::Base';
+
 use strict;
 use warnings;
 use utf8;
@@ -16,16 +18,6 @@ our @ObjectDependencies = (
     'Kernel::System::OTRSBusiness',
     'Kernel::Output::HTML::Layout',
 );
-
-sub new {
-    my ( $Type, %Param ) = @_;
-
-    # allocate new hash for object
-    my $Self = {};
-    bless( $Self, $Type );
-
-    return $Self;
-}
 
 sub Run {
     my ( $Self, %Param ) = @_;

--- a/Kernel/Output/HTML/Notification/CustomerOnline.pm
+++ b/Kernel/Output/HTML/Notification/CustomerOnline.pm
@@ -8,6 +8,8 @@
 
 package Kernel::Output::HTML::Notification::CustomerOnline;
 
+use base 'Kernel::Output::HTML::Base';
+
 use strict;
 use warnings;
 
@@ -16,16 +18,6 @@ our @ObjectDependencies = (
     'Kernel::System::Time',
     'Kernel::Output::HTML::Layout',
 );
-
-sub new {
-    my ( $Type, %Param ) = @_;
-
-    # allocate new hash for object
-    my $Self = {};
-    bless( $Self, $Type );
-
-    return $Self;
-}
 
 sub Run {
     my ( $Self, %Param ) = @_;

--- a/Kernel/Output/HTML/Notification/CustomerSystemMaintenanceCheck.pm
+++ b/Kernel/Output/HTML/Notification/CustomerSystemMaintenanceCheck.pm
@@ -8,6 +8,8 @@
 
 package Kernel::Output::HTML::Notification::CustomerSystemMaintenanceCheck;
 
+use base 'Kernel::Output::HTML::Base';
+
 use strict;
 use warnings;
 
@@ -17,19 +19,6 @@ our @ObjectDependencies = (
     'Kernel::Config',
     'Kernel::System::Time',
 );
-
-sub new {
-    my ( $Type, %Param ) = @_;
-
-    # allocate new hash for object
-    my $Self = {};
-    bless( $Self, $Type );
-
-    # get UserID param
-    $Self->{UserID} = $Param{UserID} || die "Got no UserID!";
-
-    return $Self;
-}
 
 sub Run {
     my ( $Self, %Param ) = @_;

--- a/Kernel/Output/HTML/Notification/DaemonCheck.pm
+++ b/Kernel/Output/HTML/Notification/DaemonCheck.pm
@@ -8,6 +8,8 @@
 
 package Kernel::Output::HTML::Notification::DaemonCheck;
 
+use base 'Kernel::Output::HTML::Base';
+
 use strict;
 use warnings;
 
@@ -19,18 +21,6 @@ our @ObjectDependencies = (
     'Kernel::System::Cache',
     'Kernel::System::Group',
 );
-
-sub new {
-    my ( $Type, %Param ) = @_;
-
-    # allocate new hash for object
-    my $Self = {};
-    bless( $Self, $Type );
-
-    $Self->{UserID} = $Param{UserID};
-
-    return $Self;
-}
 
 sub Run {
     my ( $Self, %Param ) = @_;

--- a/Kernel/Output/HTML/Notification/Generic.pm
+++ b/Kernel/Output/HTML/Notification/Generic.pm
@@ -8,6 +8,8 @@
 
 package Kernel::Output::HTML::Notification::Generic;
 
+use base 'Kernel::Output::HTML::Base';
+
 use strict;
 use warnings;
 
@@ -16,16 +18,6 @@ our @ObjectDependencies = (
     'Kernel::Output::HTML::Layout',
     'Kernel::Config',
 );
-
-sub new {
-    my ( $Type, %Param ) = @_;
-
-    # allocate new hash for object
-    my $Self = {};
-    bless( $Self, $Type );
-
-    return $Self;
-}
 
 sub Run {
     my ( $Self, %Param ) = @_;

--- a/Kernel/Output/HTML/Notification/OutofOfficeCheck.pm
+++ b/Kernel/Output/HTML/Notification/OutofOfficeCheck.pm
@@ -8,6 +8,8 @@
 
 package Kernel::Output::HTML::Notification::OutofOfficeCheck;
 
+use base 'Kernel::Output::HTML::Base';
+
 use strict;
 use warnings;
 
@@ -16,19 +18,6 @@ our @ObjectDependencies = (
     'Kernel::System::Time',
     'Kernel::Output::HTML::Layout',
 );
-
-sub new {
-    my ( $Type, %Param ) = @_;
-
-    # allocate new hash for object
-    my $Self = {};
-    bless( $Self, $Type );
-
-    # get UserID param
-    $Self->{UserID} = $Param{UserID} || die "Got no UserID!";
-
-    return $Self;
-}
 
 sub Run {
     my ( $Self, %Param ) = @_;

--- a/Kernel/Output/HTML/Notification/SystemMaintenanceCheck.pm
+++ b/Kernel/Output/HTML/Notification/SystemMaintenanceCheck.pm
@@ -8,6 +8,8 @@
 
 package Kernel::Output::HTML::Notification::SystemMaintenanceCheck;
 
+use base 'Kernel::Output::HTML::Base';
+
 use strict;
 use warnings;
 
@@ -17,19 +19,6 @@ our @ObjectDependencies = (
     'Kernel::Config',
     'Kernel::System::Time',
 );
-
-sub new {
-    my ( $Type, %Param ) = @_;
-
-    # allocate new hash for object
-    my $Self = {};
-    bless( $Self, $Type );
-
-    # get UserID param
-    $Self->{UserID} = $Param{UserID} || die "Got no UserID!";
-
-    return $Self;
-}
 
 sub Run {
     my ( $Self, %Param ) = @_;

--- a/Kernel/Output/HTML/Notification/UIDCheck.pm
+++ b/Kernel/Output/HTML/Notification/UIDCheck.pm
@@ -8,6 +8,8 @@
 
 package Kernel::Output::HTML::Notification::UIDCheck;
 
+use base 'Kernel::Output::HTML::Base';
+
 use strict;
 use warnings;
 
@@ -16,19 +18,6 @@ use Kernel::Language qw(Translatable);
 our @ObjectDependencies = (
     'Kernel::Output::HTML::Layout'
 );
-
-sub new {
-    my ( $Type, %Param ) = @_;
-
-    # allocate new hash for object
-    my $Self = {};
-    bless( $Self, $Type );
-
-    # get UserID param
-    $Self->{UserID} = $Param{UserID} || die "Got no UserID!";
-
-    return $Self;
-}
 
 sub Run {
     my ( $Self, %Param ) = @_;

--- a/Kernel/Output/HTML/Preferences/OutOfOffice.pm
+++ b/Kernel/Output/HTML/Preferences/OutOfOffice.pm
@@ -8,6 +8,8 @@
 
 package Kernel::Output::HTML::Preferences::OutOfOffice;
 
+use base 'Kernel::Output::HTML::Base';
+
 use strict;
 use warnings;
 
@@ -21,20 +23,6 @@ our @ObjectDependencies = (
     'Kernel::System::AuthSession',
     'Kernel::System::Time',
 );
-
-sub new {
-    my ( $Type, %Param ) = @_;
-
-    # allocate new hash for object
-    my $Self = {%Param};
-    bless( $Self, $Type );
-
-    if ( !$Self->{UserID} ) {
-        die "Got no UserID!";
-    }
-
-    return $Self;
-}
 
 sub Param {
     my ( $Self, %Param ) = @_;

--- a/Kernel/Output/HTML/TicketMenu/Generic.pm
+++ b/Kernel/Output/HTML/TicketMenu/Generic.pm
@@ -8,6 +8,8 @@
 
 package Kernel::Output::HTML::TicketMenu::Generic;
 
+use base 'Kernel::Output::HTML::Base';
+
 use strict;
 use warnings;
 
@@ -17,19 +19,6 @@ our @ObjectDependencies = (
     'Kernel::System::Ticket',
     'Kernel::System::Group',
 );
-
-sub new {
-    my ( $Type, %Param ) = @_;
-
-    # allocate new hash for object
-    my $Self = {};
-    bless( $Self, $Type );
-
-    # get UserID param
-    $Self->{UserID} = $Param{UserID} || die "Got no UserID!";
-
-    return $Self;
-}
 
 sub Run {
     my ( $Self, %Param ) = @_;

--- a/Kernel/Output/HTML/TicketMenu/Lock.pm
+++ b/Kernel/Output/HTML/TicketMenu/Lock.pm
@@ -8,6 +8,8 @@
 
 package Kernel::Output::HTML::TicketMenu::Lock;
 
+use base 'Kernel::Output::HTML::Base';
+
 use strict;
 use warnings;
 
@@ -19,19 +21,6 @@ our @ObjectDependencies = (
     'Kernel::System::Ticket',
     'Kernel::System::Group',
 );
-
-sub new {
-    my ( $Type, %Param ) = @_;
-
-    # allocate new hash for object
-    my $Self = {};
-    bless( $Self, $Type );
-
-    # get UserID param
-    $Self->{UserID} = $Param{UserID} || die "Got no UserID!";
-
-    return $Self;
-}
 
 sub Run {
     my ( $Self, %Param ) = @_;

--- a/Kernel/Output/HTML/TicketMenu/Move.pm
+++ b/Kernel/Output/HTML/TicketMenu/Move.pm
@@ -8,6 +8,8 @@
 
 package Kernel::Output::HTML::TicketMenu::Move;
 
+use base 'Kernel::Output::HTML::Base';
+
 use strict;
 use warnings;
 
@@ -18,19 +20,6 @@ our @ObjectDependencies = (
     'Kernel::System::Group',
     'Kernel::Output::HTML::Layout',
 );
-
-sub new {
-    my ( $Type, %Param ) = @_;
-
-    # allocate new hash for object
-    my $Self = {};
-    bless( $Self, $Type );
-
-    # get UserID param
-    $Self->{UserID} = $Param{UserID} || die "Got no UserID!";
-
-    return $Self;
-}
 
 sub Run {
     my ( $Self, %Param ) = @_;

--- a/Kernel/Output/HTML/TicketMenu/Process.pm
+++ b/Kernel/Output/HTML/TicketMenu/Process.pm
@@ -8,6 +8,8 @@
 
 package Kernel::Output::HTML::TicketMenu::Process;
 
+use base 'Kernel::Output::HTML::Base';
+
 use strict;
 use warnings;
 
@@ -18,19 +20,6 @@ our @ObjectDependencies = (
     'Kernel::System::Ticket',
     'Kernel::System::Group',
 );
-
-sub new {
-    my ( $Type, %Param ) = @_;
-
-    # allocate new hash for object
-    my $Self = {};
-    bless( $Self, $Type );
-
-    # get UserID param
-    $Self->{UserID} = $Param{UserID} || die "Got no UserID!";
-
-    return $Self;
-}
 
 sub Run {
     my ( $Self, %Param ) = @_;

--- a/Kernel/Output/HTML/TicketMenu/Responsible.pm
+++ b/Kernel/Output/HTML/TicketMenu/Responsible.pm
@@ -8,8 +8,11 @@
 
 package Kernel::Output::HTML::TicketMenu::Responsible;
 
+use base 'Kernel::Output::HTML::Base';
+
 use strict;
 use warnings;
+
 
 our @ObjectDependencies = (
     'Kernel::System::Log',
@@ -17,19 +20,6 @@ our @ObjectDependencies = (
     'Kernel::System::Ticket',
     'Kernel::System::Group',
 );
-
-sub new {
-    my ( $Type, %Param ) = @_;
-
-    # allocate new hash for object
-    my $Self = {};
-    bless( $Self, $Type );
-
-    # get UserID param
-    $Self->{UserID} = $Param{UserID} || die "Got no UserID!";
-
-    return $Self;
-}
 
 sub Run {
     my ( $Self, %Param ) = @_;

--- a/Kernel/Output/HTML/TicketMenu/TicketWatcher.pm
+++ b/Kernel/Output/HTML/TicketMenu/TicketWatcher.pm
@@ -8,6 +8,8 @@
 
 package Kernel::Output::HTML::TicketMenu::TicketWatcher;
 
+use base 'Kernel::Output::HTML::Base';
+
 use strict;
 use warnings;
 
@@ -19,19 +21,6 @@ our @ObjectDependencies = (
     'Kernel::System::Ticket',
     'Kernel::Output::HTML::Layout',
 );
-
-sub new {
-    my ( $Type, %Param ) = @_;
-
-    # allocate new hash for object
-    my $Self = {};
-    bless( $Self, $Type );
-
-    # get UserID param
-    $Self->{UserID} = $Param{UserID} || die "Got no UserID!";
-
-    return $Self;
-}
 
 sub Run {
     my ( $Self, %Param ) = @_;

--- a/Kernel/Output/HTML/TicketOverview/Medium.pm
+++ b/Kernel/Output/HTML/TicketOverview/Medium.pm
@@ -8,6 +8,8 @@
 
 package Kernel::Output::HTML::TicketOverview::Medium;
 
+use base 'Kernel::Output::HTML::Base';
+
 use strict;
 use warnings;
 
@@ -26,19 +28,6 @@ our @ObjectDependencies = (
     'Kernel::System::Main',
     'Kernel::System::Queue'
 );
-
-sub new {
-    my ( $Type, %Param ) = @_;
-
-    # allocate new hash for object
-    my $Self = \%Param;
-    bless( $Self, $Type );
-
-    # get UserID param
-    $Self->{UserID} = $Param{UserID} || die "Got no UserID!";
-
-    return $Self;
-}
 
 sub ActionRow {
     my ( $Self, %Param ) = @_;

--- a/Kernel/Output/HTML/TicketOverview/Medium.pm
+++ b/Kernel/Output/HTML/TicketOverview/Medium.pm
@@ -8,8 +8,6 @@
 
 package Kernel::Output::HTML::TicketOverview::Medium;
 
-use base 'Kernel::Output::HTML::Base';
-
 use strict;
 use warnings;
 
@@ -28,6 +26,19 @@ our @ObjectDependencies = (
     'Kernel::System::Main',
     'Kernel::System::Queue'
 );
+
+sub new {
+    my ( $Type, %Param ) = @_;
+
+    # allocate new hash for object
+    my $Self = \%Param;
+    bless( $Self, $Type );
+
+    # get UserID param
+    $Self->{UserID} = $Param{UserID} || die "Got no UserID!";
+
+    return $Self;
+}
 
 sub ActionRow {
     my ( $Self, %Param ) = @_;

--- a/Kernel/Output/HTML/TicketOverview/Preview.pm
+++ b/Kernel/Output/HTML/TicketOverview/Preview.pm
@@ -8,6 +8,8 @@
 
 package Kernel::Output::HTML::TicketOverview::Preview;
 
+use base 'Kernel::Output::HTML::Base';
+
 use strict;
 use warnings;
 
@@ -27,19 +29,6 @@ our @ObjectDependencies = (
     'Kernel::System::Main',
     'Kernel::System::Queue',
 );
-
-sub new {
-    my ( $Type, %Param ) = @_;
-
-    # allocate new hash for object
-    my $Self = \%Param;
-    bless( $Self, $Type );
-
-    # get UserID param
-    $Self->{UserID} = $Param{UserID} || die "Got no UserID!";
-
-    return $Self;
-}
 
 sub ActionRow {
     my ( $Self, %Param ) = @_;

--- a/Kernel/Output/HTML/TicketOverview/Preview.pm
+++ b/Kernel/Output/HTML/TicketOverview/Preview.pm
@@ -8,8 +8,6 @@
 
 package Kernel::Output::HTML::TicketOverview::Preview;
 
-use base 'Kernel::Output::HTML::Base';
-
 use strict;
 use warnings;
 
@@ -29,6 +27,19 @@ our @ObjectDependencies = (
     'Kernel::System::Main',
     'Kernel::System::Queue',
 );
+
+sub new {
+    my ( $Type, %Param ) = @_;
+
+    # allocate new hash for object
+    my $Self = \%Param;
+    bless( $Self, $Type );
+
+    # get UserID param
+    $Self->{UserID} = $Param{UserID} || die "Got no UserID!";
+
+    return $Self;
+}
 
 sub ActionRow {
     my ( $Self, %Param ) = @_;

--- a/Kernel/Output/HTML/TicketZoom/CustomerInformation.pm
+++ b/Kernel/Output/HTML/TicketZoom/CustomerInformation.pm
@@ -8,19 +8,12 @@
 
 package Kernel::Output::HTML::TicketZoom::CustomerInformation;
 
+use base 'Kernel::Output::HTML::Base';
+
 use strict;
 use warnings;
 
 our $ObjectManagerDisabled = 1;
-
-sub new {
-    my ( $Type, %Param ) = @_;
-
-    my $Self = \%Param;
-    bless( $Self, $Type );
-
-    return $Self;
-}
 
 sub Run {
     my ( $Self, %Param ) = @_;

--- a/Kernel/Output/HTML/TicketZoom/LinkTable.pm
+++ b/Kernel/Output/HTML/TicketZoom/LinkTable.pm
@@ -8,19 +8,12 @@
 
 package Kernel::Output::HTML::TicketZoom::LinkTable;
 
+use base 'Kernel::Output::HTML::Base';
+
 use strict;
 use warnings;
 
 our $ObjectManagerDisabled = 1;
-
-sub new {
-    my ( $Type, %Param ) = @_;
-
-    my $Self = \%Param;
-    bless( $Self, $Type );
-
-    return $Self;
-}
 
 sub Run {
     my ( $Self, %Param ) = @_;

--- a/Kernel/Output/HTML/TicketZoom/TicketInformation.pm
+++ b/Kernel/Output/HTML/TicketZoom/TicketInformation.pm
@@ -8,6 +8,8 @@
 
 package Kernel::Output::HTML::TicketZoom::TicketInformation;
 
+use base 'Kernel::Output::HTML::Base';
+
 use strict;
 use warnings;
 
@@ -15,15 +17,6 @@ use Kernel::Language qw(Translatable);
 use Kernel::System::VariableCheck qw(IsHashRefWithData);
 
 our $ObjectManagerDisabled = 1;
-
-sub new {
-    my ( $Type, %Param ) = @_;
-
-    my $Self = \%Param;
-    bless( $Self, $Type );
-
-    return $Self;
-}
 
 sub Run {
     my ( $Self, %Param ) = @_;

--- a/Kernel/Output/HTML/ToolBar/Generic.pm
+++ b/Kernel/Output/HTML/ToolBar/Generic.pm
@@ -8,18 +8,10 @@
 
 package Kernel::Output::HTML::ToolBar::Generic;
 
+use base 'Kernel::Output::HTML::Base';
+
 use strict;
 use warnings;
-
-sub new {
-    my ( $Type, %Param ) = @_;
-
-    # allocate new hash for object
-    my $Self = {};
-    bless( $Self, $Type );
-
-    return $Self;
-}
 
 sub Run {
     my ( $Self, %Param ) = @_;

--- a/Kernel/Output/HTML/ToolBar/Link.pm
+++ b/Kernel/Output/HTML/ToolBar/Link.pm
@@ -8,6 +8,8 @@
 
 package Kernel::Output::HTML::ToolBar::Link;
 
+use base 'Kernel::Output::HTML::Base';
+
 use strict;
 use warnings;
 
@@ -16,16 +18,6 @@ our @ObjectDependencies = (
     'Kernel::Config',
     'Kernel::Output::HTML::Layout',
 );
-
-sub new {
-    my ( $Type, %Param ) = @_;
-
-    # allocate new hash for object
-    my $Self = {};
-    bless( $Self, $Type );
-
-    return $Self;
-}
 
 sub Run {
     my ( $Self, %Param ) = @_;

--- a/Kernel/Output/HTML/ToolBar/TicketLocked.pm
+++ b/Kernel/Output/HTML/ToolBar/TicketLocked.pm
@@ -8,6 +8,8 @@
 
 package Kernel::Output::HTML::ToolBar::TicketLocked;
 
+use base 'Kernel::Output::HTML::Base';
+
 use strict;
 use warnings;
 
@@ -18,19 +20,6 @@ our @ObjectDependencies = (
     'Kernel::System::Ticket',
     'Kernel::Output::HTML::Layout',
 );
-
-sub new {
-    my ( $Type, %Param ) = @_;
-
-    # allocate new hash for object
-    my $Self = {};
-    bless( $Self, $Type );
-
-    # get UserID param
-    $Self->{UserID} = $Param{UserID} || die "Got no UserID!";
-
-    return $Self;
-}
 
 sub Run {
     my ( $Self, %Param ) = @_;

--- a/Kernel/Output/HTML/ToolBar/TicketResponsible.pm
+++ b/Kernel/Output/HTML/ToolBar/TicketResponsible.pm
@@ -8,6 +8,8 @@
 
 package Kernel::Output::HTML::ToolBar::TicketResponsible;
 
+use base 'Kernel::Output::HTML::Base';
+
 use strict;
 use warnings;
 
@@ -19,19 +21,6 @@ our @ObjectDependencies = (
     'Kernel::System::Ticket',
     'Kernel::Output::HTML::Layout',
 );
-
-sub new {
-    my ( $Type, %Param ) = @_;
-
-    # allocate new hash for object
-    my $Self = {};
-    bless( $Self, $Type );
-
-    # get UserID param
-    $Self->{UserID} = $Param{UserID} || die "Got no UserID!";
-
-    return $Self;
-}
 
 sub Run {
     my ( $Self, %Param ) = @_;

--- a/Kernel/Output/HTML/ToolBar/TicketSearchFulltext.pm
+++ b/Kernel/Output/HTML/ToolBar/TicketSearchFulltext.pm
@@ -8,18 +8,11 @@
 
 package Kernel::Output::HTML::ToolBar::TicketSearchFulltext;
 
+use base 'Kernel::Output::HTML::Base';
+
+
 use strict;
 use warnings;
-
-sub new {
-    my ( $Type, %Param ) = @_;
-
-    # allocate new hash for object
-    my $Self = {};
-    bless( $Self, $Type );
-
-    return $Self;
-}
 
 sub Run {
     my ( $Self, %Param ) = @_;

--- a/Kernel/Output/HTML/ToolBar/TicketSearchProfile.pm
+++ b/Kernel/Output/HTML/ToolBar/TicketSearchProfile.pm
@@ -8,6 +8,8 @@
 
 package Kernel::Output::HTML::ToolBar::TicketSearchProfile;
 
+use base 'Kernel::Output::HTML::Base';
+
 use strict;
 use warnings;
 
@@ -16,19 +18,6 @@ our @ObjectDependencies = (
     'Kernel::Output::HTML::Layout',
     'Kernel::System::SearchProfile'
 );
-
-sub new {
-    my ( $Type, %Param ) = @_;
-
-    # allocate new hash for object
-    my $Self = {};
-    bless( $Self, $Type );
-
-    # get UserID param
-    $Self->{UserID} = $Param{UserID} || die "Got no UserID!";
-
-    return $Self;
-}
 
 sub Run {
     my ( $Self, %Param ) = @_;

--- a/Kernel/Output/HTML/ToolBar/TicketService.pm
+++ b/Kernel/Output/HTML/ToolBar/TicketService.pm
@@ -8,6 +8,8 @@
 
 package Kernel::Output::HTML::ToolBar::TicketService;
 
+use base 'Kernel::Output::HTML::Base';
+
 use strict;
 use warnings;
 
@@ -21,19 +23,6 @@ our @ObjectDependencies = (
     'Kernel::System::Ticket',
     'Kernel::Output::HTML::Layout',
 );
-
-sub new {
-    my ( $Type, %Param ) = @_;
-
-    # allocate new hash for object
-    my $Self = {};
-    bless( $Self, $Type );
-
-    # get UserID param
-    $Self->{UserID} = $Param{UserID} || die "Got no UserID!";
-
-    return $Self;
-}
 
 sub Run {
     my ( $Self, %Param ) = @_;

--- a/Kernel/Output/HTML/ToolBar/TicketWatcher.pm
+++ b/Kernel/Output/HTML/ToolBar/TicketWatcher.pm
@@ -8,6 +8,8 @@
 
 package Kernel::Output::HTML::ToolBar::TicketWatcher;
 
+use base 'Kernel::Output::HTML::Base';
+
 use strict;
 use warnings;
 
@@ -19,19 +21,6 @@ our @ObjectDependencies = (
     'Kernel::Output::HTML::Layout',
     'Kernel::System::Ticket',
 );
-
-sub new {
-    my ( $Type, %Param ) = @_;
-
-    # allocate new hash for object
-    my $Self = {};
-    bless( $Self, $Type );
-
-    # get UserID param
-    $Self->{UserID} = $Param{UserID} || die "Got no UserID!";
-
-    return $Self;
-}
 
 sub Run {
     my ( $Self, %Param ) = @_;


### PR DESCRIPTION
That way they can share a constructor.
Saves about 350 lines of (duplicated) code.