### PR TITLE
Master - proposal for fix too long DF label and fix some bugs

### DIFF
--- a/Kernel/Output/HTML/Templates/Standard/AgentTicketZoom/TicketInformation.tt
+++ b/Kernel/Output/HTML/Templates/Standard/AgentTicketZoom/TicketInformation.tt
@@ -157,7 +157,7 @@
 # show ticket dynamic fields
                     <fieldset class="TableLike FixedLabelSmall Narrow">
 [% RenderBlockStart("TicketDynamicField") %]
-                        <label>[% Translate(Data.Label) | html %]:</label>
+                        <label title="[% Translate(Data.Label) | html %]">[% Translate(Data.Label) | truncate(15) | html %]:</label>
                         <p class="Value">
 [% RenderBlockStart("TicketDynamicFieldLink") %]
                             <span title="[% Data.Title %]"><a href="[% Data.Link | Interpolate %]" target="_blank" class="DynamicFieldLink">[% Data.Value %]</a></span>

--- a/Kernel/Output/HTML/TicketZoom/LinkTable.pm
+++ b/Kernel/Output/HTML/TicketZoom/LinkTable.pm
@@ -22,7 +22,7 @@ sub Run {
     my $LinkListWithData =
         $Kernel::OM->Get('Kernel::System::LinkObject')->LinkListWithData(
         Object           => 'Ticket',
-        Key              => $Self->{TicketID},
+        Key              => $Param{Ticket}{TicketID},
         State            => 'Valid',
         UserID           => $Self->{UserID},
         ObjectParameters => {


### PR DESCRIPTION
Hi @mgruner 

There is our proposal for fix long label of DynamicField. I only truncated on frontend, it is the simplest way. Maybe I can invest more time if you  don't like this fix.  

Working on this I saw some bug I think it i s because of the previous changes with 

`use base 'Kernel::Output::HTML::Base';`

There was a problem because there are not some params in $Self. I saw these issues in the Fred.

This is example how it looks if DF label is too long:
![df_long_label](https://cloud.githubusercontent.com/assets/6348760/13461767/d9b1c162-e083-11e5-9362-8f564e88fce4.jpg)


Regards
Zoran