### PR TITLE
Fixed tooltip left

### DIFF
--- a/var/httpd/htdocs/skins/Agent/default/css/Core.Tooltip.css
+++ b/var/httpd/htdocs/skins/Agent/default/css/Core.Tooltip.css
@@ -22,7 +22,7 @@ div.Tooltip {
 }
 
 div.Tooltip.TongueLeft {
-    margin-left: -37px;
+    margin-left: 0px;
 }
 
 /* RTL intentionally the same */
@@ -48,7 +48,7 @@ div.Tooltip.TongueBottom > div.Content {
     margin-top: 15px;
 }
 
-div.Tooltip > div.Content:after, 
+div.Tooltip > div.Content:after,
 div.Tooltip > div.Content:before {
     left: 50%;
     border: solid transparent;
@@ -59,22 +59,22 @@ div.Tooltip > div.Content:before {
     pointer-events: none;
 }
 
-div.Tooltip.TongueTop > div.Content:after, 
+div.Tooltip.TongueTop > div.Content:after,
 div.Tooltip.TongueTop > div.Content:before {
     top: 100%;
 }
 
-div.Tooltip.TongueBottom > div.Content:after, 
+div.Tooltip.TongueBottom > div.Content:after,
 div.Tooltip.TongueBottom > div.Content:before {
     bottom: 100%;
 }
 
-div.Tooltip.TongueLeft > div.Content:after, 
+div.Tooltip.TongueLeft > div.Content:after,
 div.Tooltip.TongueLeft > div.Content:before {
     left: 10%;
 }
 
-div.Tooltip.TongueRight > div.Content:after, 
+div.Tooltip.TongueRight > div.Content:after,
 div.Tooltip.TongueRight > div.Content:before {
     left: 90%;
     right: 10%;

--- a/var/httpd/htdocs/skins/Customer/default/css/Core.Tooltip.css
+++ b/var/httpd/htdocs/skins/Customer/default/css/Core.Tooltip.css
@@ -22,7 +22,7 @@ div.Tooltip {
 }
 
 div.Tooltip.TongueLeft {
-    margin-left: -37px;
+    margin-left: 0px;
 }
 div.Tooltip.TongueRight {
     margin-left: -202px;
@@ -59,12 +59,12 @@ div.Tooltip > div.Content:before {
     pointer-events: none;
 }
 
-div.Tooltip.TongueTop > div.Content:after, 
+div.Tooltip.TongueTop > div.Content:after,
 div.Tooltip.TongueTop > div.Content:before {
     top: 100%;
 }
 
-div.Tooltip.TongueBottom > div.Content:after, 
+div.Tooltip.TongueBottom > div.Content:after,
 div.Tooltip.TongueBottom > div.Content:before {
     bottom: 100%;
 }


### PR DESCRIPTION
Hi @dominikklein,@mgruner and @mrcbnsls 

Working on OTRSDynamicFieldAttachment package we saw that there is mybe a little UX issues with Tooltip for Server errors (max number of attachments and size of attachment)

![attachment_tooltip](https://cloud.githubusercontent.com/assets/6348760/13499297/f514d112-e15d-11e5-90b2-41e0d699b240.png)

Acctually there is wrong style in the framework. I changed  margin-left on 0px. Perhaps it may be completely removed.

Regards
Zoran