### PR TITLE
Fixed empty sender name in response

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,4 +1,5 @@
 #6.0.0.beta1 2016-??-??
+ - 2016-03-04 Fixed empty sender name in response.
  - 2016-03-04 Fixed bug#[11787](http://bugs.otrs.org/show_bug.cgi?id=11787) - No Ticket::StateAfterPending found with manual state update.
  - 2016-03-03 Fixed bug#[11872](http://bugs.otrs.org/show_bug.cgi?id=11872) - TicketGet function returns SolutionTime variable.
  - 2016-03-03 Fixed bug#[8631](http://bugs.otrs.org/show_bug.cgi?id=8631) - "ghost" tickets after merge.

--- a/Kernel/Modules/AgentTicketCompose.pm
+++ b/Kernel/Modules/AgentTicketCompose.pm
@@ -1148,6 +1148,11 @@ sub Run {
         $Data{OrigFromName} =~ s/<.*>|\(.*\)|\"|;|,//g;
         $Data{OrigFromName} =~ s/( $)|(  $)//g;
 
+        # fallback to OrigFrom if realname part is empty
+        if ( !$Data{OrigFromName} ) {
+            $Data{OrigFromName} = $Data{OrigFrom};
+        }
+
         # get customer data
         my %Customer;
         if ( $Ticket{CustomerUserID} ) {


### PR DESCRIPTION
If there is empty sender name in e-mail message From header like

From: "" test@somewhere.pl.test

than OTRS default response format (defined in
Ticket::Frontend::ResponseFormat) will produce empty sender name
in response text i.e.

[...]
2016-03-04 15:38 - <<<nothing here>>> wrote:
[...]

Related: https://dev.ib.pl/ib/otrs/issues/22
Author-Change-Id: IB#1049472
