### PR TITLE
Replace link of inline content regexp fix

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,4 +1,5 @@
 #6.0.0.beta1 2016-??-??
+ - 2016-03-07 Replace link of inline content regexp fix.
  - 2016-03-04 Fixed bug#[11787](http://bugs.otrs.org/show_bug.cgi?id=11787) - No Ticket::StateAfterPending found with manual state update.
  - 2016-03-03 Fixed bug#[11872](http://bugs.otrs.org/show_bug.cgi?id=11872) - TicketGet function returns SolutionTime variable.
  - 2016-03-03 Fixed bug#[8631](http://bugs.otrs.org/show_bug.cgi?id=8631) - "ghost" tickets after merge.

--- a/Kernel/Output/HTML/Layout.pm
+++ b/Kernel/Output/HTML/Layout.pm
@@ -4256,7 +4256,7 @@ sub _RichTextReplaceLinkOfInlineContent {
 
     # replace image link with content id for uploaded images
     ${ $Param{String} } =~ s{
-        (<img.+?src=("|'))[^>]+ContentID=(.+?)("|')([^>]+>)
+        (<img.+?src=("|'))[^"']+?ContentID=(.+?)("|')(.*?>)
     }
     {
         my ($Start, $CID, $Close, $End) = ($1, $3, $4, $5);

--- a/scripts/test/Layout/RichTextReplaceLinkOfInlineContent.t
+++ b/scripts/test/Layout/RichTextReplaceLinkOfInlineContent.t
@@ -53,6 +53,30 @@ my @Tests = (
         Result =>
             '<img width="140" vspace="10" hspace="1" height="38" border="0" alt="AltText" src="http://www.otrs.com/fileadmin/templates/skins/skin_otrs/css/images/logo.gif" /> This text should be displayed <img width="400" height="81" border="0" alt="Description: cid:image001.jpg@01CC3AFE.F81F0B30" src="cid:image001.jpg@01CC4216.1E22E9A0" id="Picture_x0020_1"/>',
     },
+    {
+        Name =>
+            '_RichTextReplaceLinkOfInlineContent() - generated itself, ContentID in src, > just after src',
+        String =>
+            '<img src="/app/index.pl?Action=PictureUpload&amp;FormID=1111111111.2222222.33333333&amp;ContentID=test1@test"></img>',
+        Result =>
+            '<img src="cid:test1@test"></img>',
+    },
+    {
+        Name =>
+            '_RichTextReplaceLinkOfInlineContent() - generated itself, ContentID in other attribute than src, ContentID in src also',
+        String =>
+            '<img src="/app/index.pl?Action=PictureUpload&amp;FormID=1111111111.2222222.33333333&amp;ContentID=test1@test" other_attribute_with_different_contentid="ContentID=test2@test" style="color: #000;">',
+        Result =>
+            '<img src="cid:test1@test" other_attribute_with_different_contentid="ContentID=test2@test" style="color: #000;">',
+    },
+    {
+        Name =>
+            '_RichTextReplaceLinkOfInlineContent() - generated itself, ContentID in other attribute than src, no ContentID in src',
+        String =>
+            '<img src="/app/index.pl?Action=PictureUpload&amp;FormID=1111111111.2222222.33333333" other_attribute_with_different_contentid="ContentID=test2@test" style="color: #000;">',
+        Result =>
+            '<img src="/app/index.pl?Action=PictureUpload&amp;FormID=1111111111.2222222.33333333" other_attribute_with_different_contentid="ContentID=test2@test" style="color: #000;">',
+    },
 );
 
 for my $Test (@Tests) {


### PR DESCRIPTION
Upstream regexp fix introduced in
http://bugs.otrs.org/show_bug.cgi?id=7516#c1
may be too loose in some corner cases, i.e. if other img attribute also
has ContenID string inside like

```
<img src="/app/index.pl?Action=PictureUpload&amp;FormID=1111111111.2222222.33333333&amp;ContentID=11112323234343434344434342343234@aaaaaa"other_img_attribute="ContentID=foo@bbbbbb">
```

ContentID in regexp should be rather searched only inside src attribute
not whole img.

Related: https://dev.ib.pl/ib/otrs/issues/23
Author-Change-Id: IB#1049566