### PR TITLE
Translatable out of office message

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,4 +1,5 @@
 #6.0.0.beta1 2016-??-??
+ - 2016-03-07 Out of office message should is now translatable.
  - 2016-03-04 Fixed bug#[11787](http://bugs.otrs.org/show_bug.cgi?id=11787) - No Ticket::StateAfterPending found with manual state update.
  - 2016-03-03 Fixed bug#[11872](http://bugs.otrs.org/show_bug.cgi?id=11872) - TicketGet function returns SolutionTime variable.
  - 2016-03-03 Fixed bug#[8631](http://bugs.otrs.org/show_bug.cgi?id=8631) - "ghost" tickets after merge.

--- a/Kernel/System/User.pm
+++ b/Kernel/System/User.pm
@@ -278,12 +278,19 @@ sub GetUserData {
             my $TimeEnd = $TimeObject->TimeStamp2SystemTime(
                 String => $End,
             );
-            my $Till = int( ( $TimeEnd - $Time ) / 60 / 60 / 24 );
-            my $TillDate
-                = "$Preferences{OutOfOfficeEndYear}-$Preferences{OutOfOfficeEndMonth}-$Preferences{OutOfOfficeEndDay}";
             if ( $TimeStart < $Time && $TimeEnd > $Time ) {
                 my $LanguageObject = $Kernel::OM->Get('Kernel::Language');
-                $Preferences{OutOfOfficeMessage} = '*** ' . $LanguageObject->Translate('out of office till') . " $TillDate ($Till " . $LanguageObject->Translate('days') . ') ***';
+                my $TillDate = $LanguageObject->FormatTimeString(
+                    sprintf(
+                        '%04d-%02d-%02d 00:00:00',
+                        $Preferences{OutOfOfficeEndYear},
+                        $Preferences{OutOfOfficeEndMonth},
+                        $Preferences{OutOfOfficeEndDay}
+                    ),
+                    'DateFormatShort',
+                );
+                my $Till = int( ( $TimeEnd - $Time ) / 60 / 60 / 24 );
+                $Preferences{OutOfOfficeMessage} = $LanguageObject->Translate('*** out of office to %s (%s d left) ***', $TillDate, $Till);
                 $Data{UserLastname} .= ' ' . $Preferences{OutOfOfficeMessage};
             }
 

--- a/Kernel/System/User.pm
+++ b/Kernel/System/User.pm
@@ -16,6 +16,7 @@ use Digest::SHA;
 
 our @ObjectDependencies = (
     'Kernel::Config',
+    'Kernel::Language',
     'Kernel::System::Cache',
     'Kernel::System::CheckItem',
     'Kernel::System::DB',
@@ -281,7 +282,8 @@ sub GetUserData {
             my $TillDate
                 = "$Preferences{OutOfOfficeEndYear}-$Preferences{OutOfOfficeEndMonth}-$Preferences{OutOfOfficeEndDay}";
             if ( $TimeStart < $Time && $TimeEnd > $Time ) {
-                $Preferences{OutOfOfficeMessage} = "*** out of office till $TillDate/$Till d ***";
+                my $LanguageObject = $Kernel::OM->Get('Kernel::Language');
+                $Preferences{OutOfOfficeMessage} = '*** ' . $LanguageObject->Translate('out of office till') . " $TillDate ($Till " . $LanguageObject->Translate('days') . ') ***';
                 $Data{UserLastname} .= ' ' . $Preferences{OutOfOfficeMessage};
             }
 


### PR DESCRIPTION
Out of office strings in user name like

   User Name *** out of office till YYYY-D-M/2d ***

should be translatable not hardcoded english string.

Related: https://dev.ib.pl/ib/otrs/issues/24
Author-Change-Id: IB#1004603