### PR TITLE
Fixed an error while self-creating customer account

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,4 +1,5 @@
 #6.0.0.beta1 2016-??-??
+ - 2016-03-06 Fixed error while self-creating customer account.
  - 2016-03-04 Fixed bug#[11787](http://bugs.otrs.org/show_bug.cgi?id=11787) - No Ticket::StateAfterPending found with manual state update.
  - 2016-03-03 Fixed bug#[11872](http://bugs.otrs.org/show_bug.cgi?id=11872) - TicketGet function returns SolutionTime variable.
  - 2016-03-03 Fixed bug#[8631](http://bugs.otrs.org/show_bug.cgi?id=8631) - "ghost" tickets after merge.

--- a/Kernel/System/Web/InterfaceCustomer.pm
+++ b/Kernel/System/Web/InterfaceCustomer.pm
@@ -839,7 +839,7 @@ sub Run {
         );
         my $Add = $UserObject->CustomerUserAdd(
             %GetParams,
-            Comment => $LayoutObject->{LayoutObject}->Translate( 'Added via Customer Panel (%s)', $Now ),
+            Comment => $LayoutObject->{LanguageObject}->Translate( 'Added via Customer Panel (%s)', $Now ),
             ValidID => 1,
             UserID  => $ConfigObject->Get('CustomerPanelUserID'),
         );


### PR DESCRIPTION
When one tries to self-create customer account from customer panel,
OTRS throws an error

Can't call method "Translate" on an undefined value at
/opt/otrs/Kernel/System/Web/InterfaceCustomer.pm line 840.

Related: https://dev.ib.pl/ib/otrs/issues/25
Author-Change-Id: IB#1049592