### PR TITLE
Rel-5_0 - improved tests -  ported Language object to OM

### DIFF
--- a/scripts/test/Selenium/Agent/Admin/AdminACL.t
+++ b/scripts/test/Selenium/Agent/Admin/AdminACL.t
@@ -13,7 +13,6 @@ use utf8;
 use vars (qw($Self));
 
 use Selenium::Remote::WDKeys;
-use Kernel::Language;
 
 # get selenium object
 my $Selenium = $Kernel::OM->Get('Kernel::System::UnitTest::Selenium');
@@ -150,9 +149,13 @@ JAVASCRIPT
             "\$('.ItemAddLevel1').val('Properties').trigger('redraw.InputField').trigger('change');"
         );
 
-        my $LanguageObject = Kernel::Language->new(
-            UserLanguage => $Language,
+        # get language object
+        $Kernel::OM->ObjectParamAdd(
+            'Kernel::Language' => {
+                UserLanguage => $Language,
+            },
         );
+        my $LanguageObject = $Kernel::OM->Get('Kernel::Language');
 
         $Self->Is(
             $Selenium->execute_script("return window.getLastAlert()"),

--- a/scripts/test/Selenium/Agent/Admin/AdminDynamicField.t
+++ b/scripts/test/Selenium/Agent/Admin/AdminDynamicField.t
@@ -12,8 +12,6 @@ use utf8;
 
 use vars (qw($Self));
 
-use Kernel::Language;
-
 # get selenium object
 my $Selenium = $Kernel::OM->Get('Kernel::System::UnitTest::Selenium');
 
@@ -23,8 +21,18 @@ $Selenium->RunTest(
         # get helper object
         my $Helper = $Kernel::OM->Get('Kernel::System::UnitTest::Helper');
 
+        # set test user language
+        my $Language = 'de';
+
+        # get language object
+        $Kernel::OM->ObjectParamAdd(
+            'Kernel::Language' => {
+                UserLanguage => $Language,
+            },
+        );
+        my $LanguageObject = $Kernel::OM->Get('Kernel::Language');
+
         # create test user and login
-        my $Language      = 'de';
         my $TestUserLogin = $Helper->TestUserCreate(
             Groups   => ['admin'],
             Language => $Language,
@@ -142,10 +150,6 @@ JAVASCRIPT
                 $Selenium->find_element(
                     "//a[contains(\@data-query-string, \'Subaction=DynamicFieldDelete;ID=$DynamicFieldID' )]"
                 )->click();
-
-                my $LanguageObject = Kernel::Language->new(
-                    UserLanguage => $Language,
-                );
 
                 $Self->Is(
                     $Selenium->execute_script("return window.getLastConfirm()"),

--- a/scripts/test/Selenium/Agent/Admin/AdminEmail.t
+++ b/scripts/test/Selenium/Agent/Admin/AdminEmail.t
@@ -41,7 +41,7 @@ $Selenium->RunTest(
         $SysConfigObject->ConfigItemUpdate(
             Valid => 1,
             Key   => 'SendmailModule',
-            Value => 'Kernel::System::Email::Test',
+            Value => 'Kernel::System::Email::DoNotSendEmail',
         );
 
         my $TestUserLogin = $Helper->TestUserCreate(

--- a/scripts/test/Selenium/Agent/Admin/AdminRole.t
+++ b/scripts/test/Selenium/Agent/Admin/AdminRole.t
@@ -12,8 +12,6 @@ use utf8;
 
 use vars (qw($Self));
 
-use Kernel::Language;
-
 # get selenium object
 my $Selenium = $Kernel::OM->Get('Kernel::System::UnitTest::Selenium');
 
@@ -52,9 +50,14 @@ $Selenium->RunTest(
             $Selenium->find_element( "table tbody tr td", 'css' );
         }
         else {
-            my $LanguageObject = Kernel::Language->new(
-                UserLanguage => $Language,
+
+            # get language object
+            $Kernel::OM->ObjectParamAdd(
+                'Kernel::Language' => {
+                    UserLanguage => $Language,
+                },
             );
+            my $LanguageObject = $Kernel::OM->Get('Kernel::Language');
 
             $Self->True(
                 index(

--- a/scripts/test/Selenium/Agent/AgentPreferences.t
+++ b/scripts/test/Selenium/Agent/AgentPreferences.t
@@ -11,7 +11,6 @@ use warnings;
 use utf8;
 
 use vars (qw($Self));
-use Kernel::Language;
 
 # get needed objects
 my $Selenium = $Kernel::OM->Get('Kernel::System::UnitTest::Selenium');
@@ -117,9 +116,13 @@ JAVASCRIPT
         # we should not be able to submit the form without an alert
         $Selenium->find_element("//button[\@id='NotificationEventTransportUpdate'][\@type='submit']")->VerifiedClick();
 
-        my $LanguageObject = Kernel::Language->new(
-            UserLanguage => $Language,
+        # get language object
+        $Kernel::OM->ObjectParamAdd(
+            'Kernel::Language' => {
+                UserLanguage => $Language,
+            },
         );
+        my $LanguageObject = $Kernel::OM->Get('Kernel::Language');
 
         $Self->Is(
             $Selenium->execute_script("return window.getLastAlert()"),
@@ -196,10 +199,18 @@ JAVASCRIPT
                 "#UserLanguage updated value",
             );
 
-            # create language object
-            my $LanguageObject = Kernel::Language->new(
-                UserLanguage => "$Language",
+            # discard language object
+            $Kernel::OM->ObjectsDiscard(
+                Objects => ['Kernel::Language'],
             );
+
+            # get language object
+            $Kernel::OM->ObjectParamAdd(
+                'Kernel::Language' => {
+                    UserLanguage => $Language,
+                },
+            );
+            my $LanguageObject = $Kernel::OM->Get('Kernel::Language');
 
             # check for correct translation
             $Self->True(

--- a/scripts/test/Selenium/Agent/Language.t
+++ b/scripts/test/Selenium/Agent/Language.t
@@ -11,7 +11,6 @@ use warnings;
 use utf8;
 
 use vars (qw($Self));
-use Kernel::Language;
 
 # get selenium object
 my $Selenium = $Kernel::OM->Get('Kernel::System::UnitTest::Selenium');
@@ -53,11 +52,20 @@ $Selenium->RunTest(
             );
             $Selenium->find_element( "select#UserLanguage", 'css' )->VerifiedSubmit();
 
-            # now check if the language was correctly applied in the interface
-            my $LanguageObject = Kernel::Language->new(
-                UserLanguage => $Language,
+            # discard language object
+            $Kernel::OM->ObjectsDiscard(
+                Objects => ['Kernel::Language'],
             );
 
+            # get language object
+            $Kernel::OM->ObjectParamAdd(
+                'Kernel::Language' => {
+                    UserLanguage => $Language,
+                },
+            );
+            my $LanguageObject = $Kernel::OM->Get('Kernel::Language');
+
+            # now check if the language was correctly applied in the interface
             my $Element = $Selenium->find_element( 'Label[for=UserLanguage]', 'css' );
             $Self->Is(
                 substr( $Element->get_text(), 0, -1 ),

--- a/scripts/test/Selenium/Customer/CustomerPreferences.t
+++ b/scripts/test/Selenium/Customer/CustomerPreferences.t
@@ -12,8 +12,6 @@ use utf8;
 
 use vars (qw($Self));
 
-use Kernel::Language;
-
 # get selenium object
 my $Selenium = $Kernel::OM->Get('Kernel::System::UnitTest::Selenium');
 
@@ -103,10 +101,18 @@ $Selenium->RunTest(
                 "#UserLanguage updated value",
             );
 
-            # create language object
-            my $LanguageObject = Kernel::Language->new(
-                UserLanguage => "$Language",
+            # discard language object
+            $Kernel::OM->ObjectsDiscard(
+                Objects => ['Kernel::Language'],
             );
+
+            # get language object
+            $Kernel::OM->ObjectParamAdd(
+                'Kernel::Language' => {
+                    UserLanguage => $Language,
+                },
+            );
+            my $LanguageObject = $Kernel::OM->Get('Kernel::Language');
 
             # check for correct translation
             $Self->True(


### PR DESCRIPTION
Hi @mgruner 

Herby I updated some tests with ported Language object to OM. 
In AdminEmail.t there is added sysconfig SendmailModule  'Kernel::System::Email::DoNotSendEmail'. I think that it is better if there is such sysconfig in all tests where some mails/notifications are sent.

Regards
Zoran