### PR TITLE
Rel-5_0 - improved tests - set SendmailModule

### DIFF
--- a/scripts/test/Selenium/Agent/AgentTicketBounce.t
+++ b/scripts/test/Selenium/Agent/AgentTicketBounce.t
@@ -53,6 +53,13 @@ $Selenium->RunTest(
             Value => 0
         );
 
+        # use DoNotSendEmail email backend
+        $SysConfigObject->ConfigItemUpdate(
+            Valid => 1,
+            Key   => 'SendmailModule',
+            Value => 'Kernel::System::Email::DoNotSendEmail',
+        );
+
         # get ticket object
         my $TicketObject = $Kernel::OM->Get('Kernel::System::Ticket');
 

--- a/scripts/test/Selenium/Agent/AgentTicketCompose.t
+++ b/scripts/test/Selenium/Agent/AgentTicketCompose.t
@@ -62,6 +62,13 @@ $Selenium->RunTest(
             Value => 0
         );
 
+        # use DoNotSendEmail email backend
+        $SysConfigObject->ConfigItemUpdate(
+            Valid => 1,
+            Key   => 'SendmailModule',
+            Value => 'Kernel::System::Email::DoNotSendEmail',
+        );
+
         # get standard template object
         my $StandardTemplateObject = $Kernel::OM->Get('Kernel::System::StandardTemplate');
 

--- a/scripts/test/Selenium/Agent/AgentTicketEmail.t
+++ b/scripts/test/Selenium/Agent/AgentTicketEmail.t
@@ -53,6 +53,13 @@ $Selenium->RunTest(
             Value => 0,
         );
 
+        # use DoNotSendEmail email backend
+        $SysConfigObject->ConfigItemUpdate(
+            Valid => 1,
+            Key   => 'SendmailModule',
+            Value => 'Kernel::System::Email::DoNotSendEmail',
+        );
+
         # create test user and login
         my $TestUserLogin = $Helper->TestUserCreate(
             Groups => [ 'admin', 'users' ],

--- a/scripts/test/Selenium/Agent/AgentTicketEmailOutbound.t
+++ b/scripts/test/Selenium/Agent/AgentTicketEmailOutbound.t
@@ -53,6 +53,13 @@ $Selenium->RunTest(
             Value => 0
         );
 
+        # use DoNotSendEmail email backend
+        $SysConfigObject->ConfigItemUpdate(
+            Valid => 1,
+            Key   => 'SendmailModule',
+            Value => 'Kernel::System::Email::DoNotSendEmail',
+        );
+
         # create test user and login
         my $TestUserLogin = $Helper->TestUserCreate(
             Groups => [ 'admin', 'users' ],

--- a/scripts/test/Selenium/Agent/AgentTicketForward.t
+++ b/scripts/test/Selenium/Agent/AgentTicketForward.t
@@ -53,6 +53,13 @@ $Selenium->RunTest(
             Value => 0
         );
 
+        # use DoNotSendEmail email backend
+        $SysConfigObject->ConfigItemUpdate(
+            Valid => 1,
+            Key   => 'SendmailModule',
+            Value => 'Kernel::System::Email::DoNotSendEmail',
+        );
+
         # get ticket object
         my $TicketObject = $Kernel::OM->Get('Kernel::System::Ticket');
 


### PR DESCRIPTION
Hi @mgruner 

Herby I updated some tests, actually I set SendmailModule to Kernel::System::Email::DoNotSendEmail'. As I mentioned in the previous PR, I think that it is improvement because I saw testing some of these test that if this sysconfig Item is not set well test could work more than 1 minute.

Regards
Zoran