### PR TITLE
Rel 5 0 ut restore database part39

### DIFF
--- a/scripts/test/ObjectManager/Can.t
+++ b/scripts/test/ObjectManager/Can.t
@@ -108,10 +108,13 @@ for my $Directory ( sort @DirectoriesToSearch ) {
                 "$Module | $1->$2()",
             );
 
-            # remember the already checked  operation
+            # remember the already checked operation
             $OperationChecked{"$1->$2()"} = 1;
         }
     }
 }
+
+# cleanup cache
+$Kernel::OM->Get('Kernel::System::Cache')->CleanUp();
 
 1;

--- a/scripts/test/ObjectManager/Dummy.pm
+++ b/scripts/test/ObjectManager/Dummy.pm
@@ -11,8 +11,6 @@ package scripts::test::ObjectManager::Dummy;    ## no critic
 use strict;
 use warnings;
 
-use Kernel::System::ObjectManager;
-
 ## nofilter(TidyAll::Plugin::OTRS::Perl::ObjectDependencies)
 our @ObjectDependencies = ();                   # we want to use an undeclared dependency for testing
 

--- a/scripts/test/ObjectManager/ObjectInstanceRegister.t
+++ b/scripts/test/ObjectManager/ObjectInstanceRegister.t
@@ -10,8 +10,8 @@ use strict;
 use warnings;
 use vars (qw($Self));
 
-use Scalar::Util qw/weaken/;
 use Kernel::System::Time;
+use Kernel::System::ObjectManager;
 
 $Self->Is(
     $Kernel::OM->Get('Kernel::System::UnitTest'),
@@ -19,15 +19,13 @@ $Self->Is(
     "Global OM returns $Self as 'Kernel::System::UnitTest'",
 );
 
-use Kernel::System::ObjectManager;
-
 local $Kernel::OM = Kernel::System::ObjectManager->new();
 
 $Self->True( $Kernel::OM, 'Could build object manager' );
 
 $Self->False(
     exists $Kernel::OM->{Objects}->{'Kernel::System::Time'},
-    'Kernel::System::Time was not yet loaded',
+    'Kernel::System::Time was not loaded yet',
 );
 
 my $TimeObject = Kernel::System::Time->new();

--- a/scripts/test/ObjectManager/ObjectLifecycle.t
+++ b/scripts/test/ObjectManager/ObjectLifecycle.t
@@ -164,7 +164,7 @@ $Self->True( !$Dummy2, 'ObjectsDiscard without arguments deleted Dummy2' );
 
 $Self->True(
     !$Kernel::OM->{Objects}{'scripts::test::ObjectManager::Dummy2'},
-    'ObjecstDiscard also discarded newly autovivified objects'
+    'ObjectsDiscard also discarded newly autovivified objects'
 );
 
 $Dummy = $Kernel::OM->Get('scripts::test::ObjectManager::Dummy');
@@ -192,7 +192,7 @@ $Self->True(
     "Invalid object name causes an exception",
 );
 
-# Clean up
-$Kernel::OM->ObjectsDiscard();
+# cleanup cache
+$Kernel::OM->Get('Kernel::System::Cache')->CleanUp();
 
 1;

--- a/scripts/test/ObjectManager/ObjectManagerDisabled.t
+++ b/scripts/test/ObjectManager/ObjectManagerDisabled.t
@@ -10,8 +10,6 @@ use strict;
 use warnings;
 use vars (qw($Self));
 
-use Scalar::Util qw/weaken/;
-
 $Self->True(
     $Kernel::OM->Get('scripts::test::ObjectManager::Dummy'),
     "Can load custom object",

--- a/scripts/test/ObjectManager/ObjectOnDemand.t
+++ b/scripts/test/ObjectManager/ObjectOnDemand.t
@@ -12,7 +12,7 @@ use vars (qw($Self));
 
 #
 # This test makes sure that object dependencies are only created when
-#   the object actively asks for them, not earlier
+# the object actively asks for them, not earlier.
 #
 
 use Kernel::System::ObjectManager;
@@ -28,12 +28,12 @@ $Self->True(
 
 $Self->False(
     exists $Kernel::OM->{Objects}->{'Kernel::System::Time'},
-    'Kernel::System::Time was not yet loaded',
+    'Kernel::System::Time was not loaded yet',
 );
 
 $Self->False(
     exists $Kernel::OM->{Objects}->{'Kernel::System::Log'},
-    'Kernel::System::Log was not yet loaded',
+    'Kernel::System::Log was not loaded yet',
 );
 
 $Kernel::OM->Get('Kernel::System::Time');

--- a/scripts/test/ObjectManager/ObjectParamAdd.t
+++ b/scripts/test/ObjectManager/ObjectParamAdd.t
@@ -10,8 +10,6 @@ use strict;
 use warnings;
 use vars (qw($Self));
 
-use Scalar::Util qw/weaken/;
-
 use Kernel::System::ObjectManager;
 
 local $Kernel::OM = Kernel::System::ObjectManager->new();


### PR DESCRIPTION
Hi @mgruner 

I updated tests and rollbacked a 'use' for Kernel::System::ObjectManager.  I tested it without it and the test worked, CodePolicy and Travis did not show any error or warning so I thought it is possible to avoid it. 

To be honest I was not sure about that, but sometimes if I am not sure I commit solution in witch I am not sure absolutely, but if it is not possible I can learn something new. Being in comfort zone is good but there we could not improve ourselves :)

I hope it is better now, there were not so much changes but I believe it is better that we correct this typos and some clean caches.

Regards
Zoran