### PR TITLE
Fixed customer login blocks

### DIFF
--- a/var/httpd/htdocs/skins/Customer/default/css/Core.Login.css
+++ b/var/httpd/htdocs/skins/Customer/default/css/Core.Login.css
@@ -40,6 +40,7 @@
 #PreLogin {
     width: 500px;
     height: 260px;
+    padding-top: 5px;
     padding-left: 142px;
     position: relative;
 }


### PR DESCRIPTION
This PR fixes the customer login page. In case of some language which have accentuated letters, the top of these letters in the forgotten password block was visible (see attached screenshots - Chrome and Firefox):

Wrong in Chrome:
![chrome_bad](https://cloud.githubusercontent.com/assets/1006118/13672045/6802f044-e6d3-11e5-9ba4-97cd2dcf7d36.jpg)
Correct after fix in Chrome:
![chrome_good](https://cloud.githubusercontent.com/assets/1006118/13672047/682ac718-e6d3-11e5-860d-fd450f2c875a.jpg)

Wrong in Firefox:
![firefox_bad](https://cloud.githubusercontent.com/assets/1006118/13672046/6829acb6-e6d3-11e5-839b-0baa59572468.jpg)
Correct after fix in Firefox:
![firefox_good](https://cloud.githubusercontent.com/assets/1006118/13672048/682a9ef0-e6d3-11e5-8d53-108e770dc767.jpg)

Can you commit this PR to rel_5-0, too?