### PR TITLE
Be sure that a outputfilter post hook is always generated

### DIFF
--- a/Kernel/Output/Template/Document.pm
+++ b/Kernel/Output/Template/Document.pm
@@ -84,27 +84,30 @@ sub _InstallOTRSExtensions {
                 my $BlockName = $stash->get('BlockName');
                 my $ParentBlock = $stash->get('ParentBlock') || $stash->{_BlockTree};
 
-                return if !exists $ParentBlock->{Children};
-                return if !exists $ParentBlock->{Children}->{$BlockName};
-
                 my $TemplateName = $stash->get('template')->{name} // '';
                 $TemplateName = substr( $TemplateName, 0, -3 );    # remove .tt extension
                 my $GenerateBlockHook =
                     $Context->{LayoutObject}->{_BlockHookSubscriptions}->{$TemplateName}->{$BlockName};
 
-                for my $TargetBlock ( @{ $ParentBlock->{Children}->{$BlockName} } ) {
-                    $output .= "<!--HookStart${BlockName}-->\n" if $GenerateBlockHook;
-                    $output .= $Context->process(
-                        $TargetBlock->{Path},
-                        {
-                            'Data'        => $TargetBlock->{Data},
-                            'ParentBlock' => $TargetBlock,
-                        },
-                    );
-                    $output .= "<!--HookEnd${BlockName}-->\n" if $GenerateBlockHook;
-                }
-                delete $ParentBlock->{Children}->{$BlockName};
+                if ( exists $ParentBlock->{Children} && exists $ParentBlock->{Children}->{$BlockName} ) {
+                    for my $TargetBlock ( @{ $ParentBlock->{Children}->{$BlockName} } ) {
+                        $output .= "<!--HookStart${BlockName}-->\n" if $GenerateBlockHook;
+                        $output .= $Context->process(
+                            $TargetBlock->{Path},
+                            {
+                                'Data'        => $TargetBlock->{Data},
+                                'ParentBlock' => $TargetBlock,
+                            },
+                        );
+                        $output .= "<!--HookEnd${BlockName}-->\n" if $GenerateBlockHook;
+                    }
 
+                    delete $ParentBlock->{Children}->{$BlockName};
+                }
+                elsif ( $GenerateBlockHook ) {
+                    $output .= "<!--HookStart${BlockName}-->\n";
+                    $output .= "<!--HookEnd${BlockName}-->\n";
+                }
             };
             $stash = $Context->delocalise();
 


### PR DESCRIPTION
Hi,
what about to change the behaviour of the hooks generation to always render it by minimum 1 to be sure that the hook get always rendered. In my opinion this makes the hooks much greater and i think that the current behaviour can make a lot of trouble, here my example:

You want to add code after the "DynamicField" block in different masks. If you now use the hook and some masks do not define dynamic fields in sysconfig then also the outputfilter will not match, because the hook does not exist.

Best regards,
Rolf