### PR TITLE
Allow quoting font family names in Frontend::RichText::DefaultCSS

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,4 +1,5 @@
 #6.0.0.beta1 2016-??-??
+ - 2016-03-11 Allow quoted font family names in Frontend::RichText::DefaultCSS.
  - 2016-03-04 Fixed bug#[11787](http://bugs.otrs.org/show_bug.cgi?id=11787) - No Ticket::StateAfterPending found with manual state update.
  - 2016-03-03 Fixed bug#[11872](http://bugs.otrs.org/show_bug.cgi?id=11872) - TicketGet function returns SolutionTime variable.
  - 2016-03-03 Fixed bug#[8631](http://bugs.otrs.org/show_bug.cgi?id=8631) - "ghost" tickets after merge.

--- a/Kernel/Output/HTML/Templates/Standard/CustomerRichTextEditor.tt
+++ b/Kernel/Output/HTML/Templates/Standard/CustomerRichTextEditor.tt
@@ -13,7 +13,7 @@
     Core.Config.Set('RichText.Height', '[% Config("Frontend::RichTextHeight") %]');
     Core.Config.Set('RichText.TextDir', '[% Env("TextDirection") %]');
     Core.Config.Set('RichText.SpellChecker', '[% Env("BrowserSpellCheckerInline") %]');
-    Core.Config.Set('RichText.EditingAreaCSS', 'body { [% Config("Frontend::RichText::DefaultCSS") %] }');
+    Core.Config.Set('RichText.EditingAreaCSS', "body { [% Config("Frontend::RichText::DefaultCSS") %] }");
     Core.Config.Set('RichText.Lang.SplitQuote', '[% Translate('Split Quote') | html %]');
     Core.Config.Set('RichText.Toolbar', [
         ['Bold', 'Italic', 'Underline', 'Strike', '-', 'NumberedList', 'BulletedList', '-', 'Outdent', 'Indent', '-', 'JustifyLeft', 'JustifyCenter', 'JustifyRight', 'JustifyBlock', '-', 'Link', 'Unlink', '-', 'Image', 'HorizontalRule', '-', 'Undo', 'Redo', '-', 'Find', 'SpellCheck'],

--- a/Kernel/Output/HTML/Templates/Standard/RichTextEditor.tt
+++ b/Kernel/Output/HTML/Templates/Standard/RichTextEditor.tt
@@ -26,7 +26,7 @@
 
     Core.Config.Set('RichText.TextDir', '[% Env("TextDirection") %]');
     Core.Config.Set('RichText.SpellChecker', '[% Env("BrowserSpellCheckerInline") %]');
-    Core.Config.Set('RichText.EditingAreaCSS', 'body.cke_editable { [% Config("Frontend::RichText::DefaultCSS") %] }');
+    Core.Config.Set('RichText.EditingAreaCSS', "body.cke_editable { [% Config("Frontend::RichText::DefaultCSS") %] }");
     Core.Config.Set('RichText.Lang.SplitQuote', '[% Translate('Split Quote') | html %]');
     Core.Config.Set('RichText.Lang.RemoveQuote', '[% Translate('Remove Quote') | html %]');
 


### PR DESCRIPTION
If you want to quote font family name containing spaces
in Frontend::RichText::DefaultCSS and try to put single quotation
marks like

font-family: Verdana, 'Bitstream Vera Sans', Tahoma; font-size: 10pt; color: #000000;

you'll break rich editor CSS styling; if you try to use double quotes -
it won't work in HTML e-mail body where DefaultCSS content is
already put inside double quotes of style attribute.

This patch fixes it and allowes Frontend::RichText::DefaultCSS to
contain single quotes.

Related: https://dev.ib.pl/ib/otrs/issues/26
Author-Change-Id: IB#1004607
