### PR TITLE
Enhanced CSS styling of rich text editor and HTML e-mails

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,4 +1,5 @@
 #6.0.0.beta1 2016-??-??
+ - 2016-03-11 Enhanced CSS styling of rich text editor and HTML e-mails.
  - 2016-03-04 Fixed bug#[11787](http://bugs.otrs.org/show_bug.cgi?id=11787) - No Ticket::StateAfterPending found with manual state update.
  - 2016-03-03 Fixed bug#[11872](http://bugs.otrs.org/show_bug.cgi?id=11872) - TicketGet function returns SolutionTime variable.
  - 2016-03-03 Fixed bug#[8631](http://bugs.otrs.org/show_bug.cgi?id=8631) - "ghost" tickets after merge.

--- a/Kernel/Config/Files/Framework.xml
+++ b/Kernel/Config/Files/Framework.xml
@@ -431,11 +431,27 @@
         </Setting>
     </ConfigItem>
     <ConfigItem Name="Frontend::RichText::DefaultCSS" Required="1" Valid="1">
-        <Description Translatable="1">Defines the default CSS used in rich text editors.</Description>
+        <Description Translatable="1">Defines the default CSS used in rich text editors and HTML mail body.</Description>
         <Group>Framework</Group>
         <SubGroup>Core::Web</SubGroup>
         <Setting>
             <String Regex="">font-family:Geneva,Helvetica,Arial,sans-serif; font-size: 12px;</String>
+        </Setting>
+    </ConfigItem>
+    <ConfigItem Name="Frontend::RichText::EditingAreaCSS" Required="0" Valid="1">
+        <Description Translatable="1">Defines the CSS style to embed in rich text editor. You may put here things like ".cke_editable { line-height: normal; margin: 10px; }" to customize rich text area style.</Description>
+        <Group>Framework</Group>
+        <SubGroup>Core::Web</SubGroup>
+        <Setting>
+            <String Regex=""></String>
+        </Setting>
+    </ConfigItem>
+    <ConfigItem Name="Frontend::RichText::MailCSS" Required="0" Valid="1">
+        <Description Translatable="1">Defines the CSS style to embed in HTML messages. CSS content defined here will be put in head/style node of HTML e-mails (this allows for example to define anchor colors in HTML e-mails or table header styles which is not possible using DefaultCSS parameter).</Description>
+        <Group>Framework</Group>
+        <SubGroup>Core::Web</SubGroup>
+        <Setting>
+            <TextArea></TextArea>
         </Setting>
     </ConfigItem>
     <ConfigItem Name="Frontend::RichText::EnhancedMode" Required="1" Valid="1">

--- a/Kernel/Output/HTML/Templates/Standard/CustomerRichTextEditor.tt
+++ b/Kernel/Output/HTML/Templates/Standard/CustomerRichTextEditor.tt
@@ -13,7 +13,7 @@
     Core.Config.Set('RichText.Height', '[% Config("Frontend::RichTextHeight") %]');
     Core.Config.Set('RichText.TextDir', '[% Env("TextDirection") %]');
     Core.Config.Set('RichText.SpellChecker', '[% Env("BrowserSpellCheckerInline") %]');
-    Core.Config.Set('RichText.EditingAreaCSS', 'body { [% Config("Frontend::RichText::DefaultCSS") %] }');
+    Core.Config.Set('RichText.EditingAreaCSS', "[% Config("Frontend::RichText::EditingAreaCSS") %] body { [% Config("Frontend::RichText::DefaultCSS") %] }");
     Core.Config.Set('RichText.Lang.SplitQuote', '[% Translate('Split Quote') | html %]');
     Core.Config.Set('RichText.Toolbar', [
         ['Bold', 'Italic', 'Underline', 'Strike', '-', 'NumberedList', 'BulletedList', '-', 'Outdent', 'Indent', '-', 'JustifyLeft', 'JustifyCenter', 'JustifyRight', 'JustifyBlock', '-', 'Link', 'Unlink', '-', 'Image', 'HorizontalRule', '-', 'Undo', 'Redo', '-', 'Find', 'SpellCheck'],

--- a/Kernel/Output/HTML/Templates/Standard/RichTextEditor.tt
+++ b/Kernel/Output/HTML/Templates/Standard/RichTextEditor.tt
@@ -26,7 +26,7 @@
 
     Core.Config.Set('RichText.TextDir', '[% Env("TextDirection") %]');
     Core.Config.Set('RichText.SpellChecker', '[% Env("BrowserSpellCheckerInline") %]');
-    Core.Config.Set('RichText.EditingAreaCSS', 'body.cke_editable { [% Config("Frontend::RichText::DefaultCSS") %] }');
+    Core.Config.Set('RichText.EditingAreaCSS', "[% Config("Frontend::RichText::EditingAreaCSS") %] body.cke_editable { [% Config("Frontend::RichText::DefaultCSS") %] }");
     Core.Config.Set('RichText.Lang.SplitQuote', '[% Translate('Split Quote') | html %]');
     Core.Config.Set('RichText.Lang.RemoveQuote', '[% Translate('Remove Quote') | html %]');
 

--- a/Kernel/System/HTMLUtils.pm
+++ b/Kernel/System/HTMLUtils.pm
@@ -606,15 +606,20 @@ sub DocumentComplete {
 
     return $Param{String} if $Param{String} =~ /<html>/i;
 
-    my $Css = $Kernel::OM->Get('Kernel::Config')->Get('Frontend::RichText::DefaultCSS')
+    my $ConfigObject = $Kernel::OM->Get('Kernel::Config');
+
+    my $DefaultCSS = $ConfigObject->Get('Frontend::RichText::DefaultCSS')
         || 'font-size: 12px; font-family:Courier,monospace,fixed;';
+
+    my $MailCSS = $ConfigObject->Get('Frontend::RichText::MailCSS');
+    $MailCSS = ($MailCSS) ? "<style type='text/css'><!--\n" . $MailCSS . "\n--></style>" : '';
 
     # Use the HTML5 doctype because it is compatible with HTML4 and causes the browsers
     #   to render the content in standards mode, which is more safe than quirks mode.
     my $Body = '<!DOCTYPE html><html><head>';
     $Body
         .= '<meta http-equiv="Content-Type" content="text/html; charset=' . $Param{Charset} . '"/>';
-    $Body .= '</head><body style="' . $Css . '">' . $Param{String} . '</body></html>';
+    $Body .= $MailCSS . '</head><body style="' . $DefaultCSS . '">' . $Param{String} . '</body></html>';
     return $Body;
 }
 


### PR DESCRIPTION
This enhancement allows you to modify CSS style of OTRS rich text
editor (i.e. line spacing) using new SysConfig parameter
Frontend::RichText::EditingAreaCSS. Example setting for standard
line spacing and 10px margin around text area:

.cke_editable { line-height: normal; margin: 10px; }

This parameter may contain one line with one or more CSS definitions;
its value is merged into RichText.EditingAreaCSS parameter just
before original

body { [% Config("Frontend::RichText::DefaultCSS") %] }

This modification provides also new SysConfig parameter
Frontend::RichText::MailCSS that allows you to add extra CSS style
definitions that are embedded into html/head/style node of HTML
e-mails; this can be used to modify style of HTML e-mail elements
like anchors or table headers, which cannot be done with standard
DefaultCSS parameter. Example setting of
Frontend::RichText::MailCSS:

a, a:visited, a:active
{
    color: #3D80B2;
    text-decoration: none;
}

a:hover
{
    color: #3D80B2;
    text-decoration: underline;
}

th, td, caption {
    font-family: Verdana, 'Bitstream Vera Sans', 'DejaVu Sans', Tahoma, Geneva, Arial, Sans-serif;
    font-size: 10pt;
}

Related: https://dev.ib.pl/ib/otrs/issues/27
Author-Change-Id: IB#1011028
