### PR TITLE
OTRS version number removed from PDF properties, HTTP and e-mail headers

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,4 +1,5 @@
 #6.0.0.beta1 2016-??-??
+ - 2016-03-15 OTRS version number removed from PDF properties.
  - 2016-03-04 Fixed bug#[11787](http://bugs.otrs.org/show_bug.cgi?id=11787) - No Ticket::StateAfterPending found with manual state update.
  - 2016-03-03 Fixed bug#[11872](http://bugs.otrs.org/show_bug.cgi?id=11872) - TicketGet function returns SolutionTime variable.
  - 2016-03-03 Fixed bug#[8631](http://bugs.otrs.org/show_bug.cgi?id=8631) - "ghost" tickets after merge.

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,4 +1,5 @@
 #6.0.0.beta1 2016-??-??
+ - 2016-03-15 OTRS version number removed from HTTP and e-mail headers.
  - 2016-03-15 OTRS version number removed from PDF properties.
  - 2016-03-04 Fixed bug#[11787](http://bugs.otrs.org/show_bug.cgi?id=11787) - No Ticket::StateAfterPending found with manual state update.
  - 2016-03-03 Fixed bug#[11872](http://bugs.otrs.org/show_bug.cgi?id=11872) - TicketGet function returns SolutionTime variable.

--- a/Kernel/Output/HTML/Templates/Standard/HTTPHeaders.tt
+++ b/Kernel/Output/HTML/Templates/Standard/HTTPHeaders.tt
@@ -9,7 +9,7 @@ Content-Type: text/html; charset=utf-8;
 [% IF Data.ContentDisposition -%]
 Content-Disposition: [% Data.ContentDisposition %]
 [% END -%]
-X-Powered-By: [% Config("Product") %] [% Config("Version") %] - Open Ticket Request System (http://www.otrs.com/)
+X-Powered-By: [% Config("Product") %] - Open Ticket Request System (http://www.otrs.com/)
 X-UA-Compatible: IE=edge,chrome=1
 [% IF !Config("DisableIFrameOriginRestricted") -%]
 X-Frame-Options: SAMEORIGIN

--- a/Kernel/System/Email.pm
+++ b/Kernel/System/Email.pm
@@ -277,11 +277,8 @@ sub Send {
 
     }
 
-    my $Product = $ConfigObject->Get('Product');
-    my $Version = $ConfigObject->Get('Version');
-
     if ( !$ConfigObject->Get('Secure::DisableBanner') ) {
-        $Header{'X-Mailer'}     = "$Product Mail Service ($Version)";
+        $Header{'X-Mailer'} = $ConfigObject->Get('Product') . ' Mail Service';
         $Header{'X-Powered-By'} = 'OTRS - Open Ticket Request System (http://otrs.org/)';
     }
     $Header{Type} = $Param{MimeType} || 'text/plain';

--- a/Kernel/System/PDF.pm
+++ b/Kernel/System/PDF.pm
@@ -99,13 +99,10 @@ sub DocumentNew {
     # get config object
     my $ConfigObject = $Kernel::OM->Get('Kernel::Config');
 
-    # get Product and Version
-    $Self->{Config}->{Project} = $ConfigObject->Get('Product');
-    $Self->{Config}->{Version} = $ConfigObject->Get('Version');
-    my $ProjectVersion = $Self->{Config}->{Project} . ' ' . $Self->{Config}->{Version};
+    my $PDFCreator = $ConfigObject->Get('Product') . ' PDF Creator';
 
     # set document title
-    $Self->{Document}->{Title} = $Param{Title} || $ProjectVersion;
+    $Self->{Document}->{Title} = $Param{Title} || $PDFCreator;
 
     # set document encode
     $Self->{Document}->{Encode} = $Param{Encode} || 'utf-8';
@@ -135,7 +132,7 @@ sub DocumentNew {
 
     # set document infos
     $Self->{PDF}->info(
-        'Author'       => $ProjectVersion,
+        'Author'       => $PDFCreator,
         'CreationDate' => "D:"
             . $NowYear
             . $NowMonth
@@ -144,8 +141,8 @@ sub DocumentNew {
             . $NowMin
             . $NowSec
             . "+01'00'",
-        'Creator'  => $ProjectVersion,
-        'Producer' => "OTRS PDF Creator",
+        'Creator'  => $PDFCreator,
+        'Producer' => $PDFCreator,
         'Title'    => $Self->{Document}->{Title},
         'Subject'  => $Self->{Document}->{Title},
     );


### PR DESCRIPTION
PDF files created by OTRS contain full OTRS version number in their
properties. Such information is presented also in HTTP and e-mail
headers if Secure::DisableBanner is not enabled (default).

Software version number should not be presented to third parties
if not necessary (enhanced security). This modification removes
OTRS version number from PDF files created using OTRS
(i.e. ticket PDF printouts), HTTP and e-mail headers.

Related: https://dev.ib.pl/ib/otrs/issues/28
Author-Change-Id: IB#1004612