### PR TITLE
Insert current time and version into the generated POT file

### DIFF
--- a/Kernel/System/Console/Command/Dev/Tools/TranslationsUpdate.pm
+++ b/Kernel/System/Console/Command/Dev/Tools/TranslationsUpdate.pm
@@ -11,7 +11,6 @@ package Kernel::System::Console::Command::Dev::Tools::TranslationsUpdate;
 use strict;
 use warnings;
 
-use POSIX qw(strftime);
 use base qw(Kernel::System::Console::BaseCommand);
 
 use File::Basename;
@@ -27,6 +26,7 @@ our @ObjectDependencies = (
     'Kernel::System::Encode',
     'Kernel::System::Main',
     'Kernel::System::SysConfig',
+    'Kernel::System::Time',
 );
 
 sub Configure {
@@ -593,19 +593,26 @@ sub WritePOFile {
 sub WritePOTFile {
     my ( $Self, %Param ) = @_;
 
+    my $TimeObject = $Kernel::OM->Get('Kernel::System::Time');
+
     my @POTEntries;
 
     $Kernel::OM->Get('Kernel::System::Main')->Require('Locale::PO') || die "Could not load Locale::PO";
 
     my $Package      = $Param{Module} // 'OTRS';
     my $Version      = $Kernel::OM->Get('Kernel::Config')->Get('Version');
-    my $CreationDate = strftime( '%Y-%m-%d %H:%M+0200', localtime );
+    my $CreationDate = $TimeObject->SystemTime2TimeStamp(
+        SystemTime => $TimeObject->SystemTime(),
+    );
+
+    # only YEAR-MO-DA HO:MI is needed without seconds
+    $CreationDate = substr( $CreationDate, 0, -3 );
 
     push @POTEntries, Locale::PO->new(
         -msgid => '',
         -msgstr =>
             "Project-Id-Version: $Package-$Version\n" .
-            "POT-Creation-Date: $CreationDate\n" .
+            "POT-Creation-Date: $CreationDate+0200\n" .
             "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n" .
             "Last-Translator: FULL NAME <EMAIL\@ADDRESS>\n" .
             "Language-Team: LANGUAGE <LL\@li.org>\n" .

--- a/Kernel/System/Console/Command/Dev/Tools/TranslationsUpdate.pm
+++ b/Kernel/System/Console/Command/Dev/Tools/TranslationsUpdate.pm
@@ -11,6 +11,7 @@ package Kernel::System::Console::Command::Dev::Tools::TranslationsUpdate;
 use strict;
 use warnings;
 
+use POSIX qw(strftime);
 use base qw(Kernel::System::Console::BaseCommand);
 
 use File::Basename;
@@ -596,13 +597,15 @@ sub WritePOTFile {
 
     $Kernel::OM->Get('Kernel::System::Main')->Require('Locale::PO') || die "Could not load Locale::PO";
 
-    my $Package = $Param{Module} // 'OTRS';
+    my $Package      = $Param{Module} // 'OTRS';
+    my $Version      = $Kernel::OM->Get('Kernel::Config')->Get('Version');
+    my $CreationDate = strftime( '%Y-%m-%d %H:%M+0200', localtime );
 
     push @POTEntries, Locale::PO->new(
         -msgid => '',
         -msgstr =>
-            "Project-Id-Version: $Package\n" .
-            "POT-Creation-Date: 2014-08-08 19:10+0200\n" .
+            "Project-Id-Version: $Package-$Version\n" .
+            "POT-Creation-Date: $CreationDate\n" .
             "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n" .
             "Last-Translator: FULL NAME <EMAIL\@ADDRESS>\n" .
             "Language-Team: LANGUAGE <LL\@li.org>\n" .


### PR DESCRIPTION
Fixed <a href="http://bugs.otrs.org/show_bug.cgi?id=11892">BUG#11892</a>
However the header of the generated POT file is still wrong (see <a href="http://bugs.otrs.org/show_bug.cgi?id=11909">BUG#11909</a>).
This PR can be cherry-picked into REL_5-0, because those one is also affected.