### PR TITLE
Marked default public interface as translatable

### DIFF
--- a/Kernel/Output/HTML/Templates/Standard/PublicDefault.tt
+++ b/Kernel/Output/HTML/Templates/Standard/PublicDefault.tt
@@ -9,7 +9,8 @@
     <div class="Content">
         <h2>[% Translate("Welcome") | html %]</h2>
         <p>
-            This is the default public interface of OTRS! There was no action parameter given. <br />You could install a custom public module (via the package manager), for example the FAQ module, which has a public interface.
+            [% Translate("This is the default public interface of OTRS! There was no action parameter given.") | html %] <br />
+            [% Translate("You could install a custom public module (via the package manager), for example the FAQ module, which has a public interface.") | html %]
         </p>
     </div>
 </div>


### PR DESCRIPTION
Hi @mgruner,
This is a small improvement for default public interface. This string is displayed when no modules with public interface are installed. This PR can be cherry-picked into REL_5-0, because the .tt file hasn't changed since then. OTRS 4 is also affected, but it has different template.