### PR TITLE
Marked title attributes in template files as translatable

### DIFF
--- a/Kernel/Output/HTML/Templates/Standard/AdminGenericInterfaceTransportHTTPSOAP.tt
+++ b/Kernel/Output/HTML/Templates/Standard/AdminGenericInterfaceTransportHTTPSOAP.tt
@@ -420,7 +420,7 @@ $('#UseSSL').on('change', function(){
                                 </ul>
                                 <div class="AddElement">
                                     [% Translate("Add new first level element") | html %]:
-                                    <input type="text" name="Element" title="Element" />
+                                    <input type="text" name="Element" title="[% Translate("Element") | html %]" />
                                     <button class="CallForAction"><span>[% Translate("Add") | html %]</span></button>
                                 </div>
                                 <p class="FieldExplanation">

--- a/Kernel/Output/HTML/Templates/Standard/AdminProcessManagementActivity.tt
+++ b/Kernel/Output/HTML/Templates/Standard/AdminProcessManagementActivity.tt
@@ -87,7 +87,7 @@
                             </ul>
                             <ul class="AllocationList Tablelike W90pc" id="AvailableActivityDialogs">
 [% RenderBlockStart("AvailableActivityDialogRow") %]
-                                <li data-id="[% Data.ID | html %]" title="Name: [% Data.Name | html %] EntityID: [% Data.EntityID | html %]">
+                                <li data-id="[% Data.ID | html %]" title="[% Translate("Name: %s, EntityID: %s", Data.Name, Data.EntityID) | html %]">
                                     [% Data.Name | html %]
                                     <span class="Functions">
                                         <span class="AvailableIn">[% Translate(Data.AvailableIn) | html %]</span>
@@ -114,7 +114,7 @@
                             </ul>
                             <ul class="AllocationList Tablelike W90pc" id="AssignedActivityDialogs">
 [% RenderBlockStart("AssignedActivityDialogRow") %]
-                                <li data-id="[% Data.ID | html %]" title="Name: [% Data.Name | html %] EntityID: [% Data.EntityID | html %]">
+                                <li data-id="[% Data.ID | html %]" title="[% Translate("Name: %s, EntityID: %s", Data.Name, Data.EntityID) | html %]">
                                     [% Data.Name | html %]
                                     <span class="Functions">
                                         <span class="AvailableIn">[% Translate(Data.AvailableIn) | html %]</span>

--- a/Kernel/Output/HTML/Templates/Standard/AdminProcessManagementActivityDialog.tt
+++ b/Kernel/Output/HTML/Templates/Standard/AdminProcessManagementActivityDialog.tt
@@ -169,7 +169,7 @@
                             </ul>
                             <ul class="AllocationList Tablelike W90pc" id="AssignedFields">
 [% RenderBlockStart("AssignedFieldRow") %]
-                                <li data-id="[% Data.Field | html %]" data-entity="[% Data.Field | html %]" data-config="[% Data.FieldConfig | html %]" title="[% Translate("Name: %s", Data.Field) | html %]">
+                                <li data-id="[% Data.Field | html %]" data-entity="[% Data.Field | html %]" data-config="[% Data.FieldConfig | html %]" title="Name: [% Translate(Data.Field) | html %]">
                                     [% Translate(Data.Field) | html %]
                                     <span class="Functions ShowOnAssignedList">
                                         <a href="#" data-id="[% Data.Field | html %]" data-entity="[% Data.Field | html %]" class="FieldDetailsOverlay Icon" title="[% Translate("Edit") | html %]">

--- a/Kernel/Output/HTML/Templates/Standard/AdminProcessManagementActivityDialog.tt
+++ b/Kernel/Output/HTML/Templates/Standard/AdminProcessManagementActivityDialog.tt
@@ -150,7 +150,7 @@
                             </ul>
                             <ul class="AllocationList Tablelike W90pc" id="AvailableFields">
 [% RenderBlockStart("AvailableFieldRow") %]
-                                <li title="Name: [% Data.FieldnameTranslated | html %]" data-name-translated="[% Data.FieldnameTranslated | html %]" data-id="[% Data.Field | html %]" data-config="">
+                                <li title="[% Translate("Name: %s", Data.FieldnameTranslated) | html %]" data-name-translated="[% Data.FieldnameTranslated | html %]" data-id="[% Data.Field | html %]" data-config="">
                                     [% Data.FieldnameTranslated | html %]
                                     <span class="Functions ShowOnAssignedList">
                                         <a href="#" data-id="[% Data.Field | html %]" data-entity="[% Data.Field | html %]" class="FieldDetailsOverlay Icon" title="[% Translate("Edit") | html %]">
@@ -169,7 +169,7 @@
                             </ul>
                             <ul class="AllocationList Tablelike W90pc" id="AssignedFields">
 [% RenderBlockStart("AssignedFieldRow") %]
-                                <li data-id="[% Data.Field | html %]" data-entity="[% Data.Field | html %]" data-config="[% Data.FieldConfig | html %]" title="Name: [% Translate(Data.Field) | html %]">
+                                <li data-id="[% Data.Field | html %]" data-entity="[% Data.Field | html %]" data-config="[% Data.FieldConfig | html %]" title="[% Translate("Name: %s", Data.Field) | html %]">
                                     [% Translate(Data.Field) | html %]
                                     <span class="Functions ShowOnAssignedList">
                                         <a href="#" data-id="[% Data.Field | html %]" data-entity="[% Data.Field | html %]" class="FieldDetailsOverlay Icon" title="[% Translate("Edit") | html %]">

--- a/Kernel/Output/HTML/Templates/Standard/AdminProcessManagementPath.tt
+++ b/Kernel/Output/HTML/Templates/Standard/AdminProcessManagementPath.tt
@@ -80,7 +80,7 @@
                             </ul>
                             <ul class="AllocationList Tablelike W90pc" id="AvailableTransitionActions">
 [% RenderBlockStart("AvailableTransitionActionRow") %]
-                                <li data-id="[% Data.ID | html %]" id="[% Data.EntityID | html %]" title="Name: [% Data.Name | html %] EntityID: [% Data.EntityID | html %]">
+                                <li data-id="[% Data.ID | html %]" id="[% Data.EntityID | html %]" title="[% Translate("Name: %s, EntityID: %s", Data.Name, Data.EntityID) | html %]">
                                     [% Data.Name | html %] ([% Data.EntityID | html %])
                                     <span class="Functions">
                                         <a href="#" data-entity="[% Data.EntityID | html %]" data-id="[% Data.ID | html %]" data-action="AdminProcessManagementTransitionAction" data-subaction="TransitionActionEdit" class="AsPopup_Redirect Edit_Confirm PopupType_TransitionAction Icon" title="[% Translate("Edit") | html %]">

--- a/Kernel/Output/HTML/Templates/Standard/AdminProcessManagementProcessAccordion.tt
+++ b/Kernel/Output/HTML/Templates/Standard/AdminProcessManagementProcessAccordion.tt
@@ -39,7 +39,7 @@
                 <li class="OneRow" data-entity="[% Data.EntityID | html %]" data-id="[% Data.ID | html %]">
                     <div class="AsBlock W80pc" title="[% Data.Name | html %] ([% Data.EntityID | html %])">[% Data.Name | html %]</div>
                     <span>
-                        <a href="#" title="Text{"Delete"}" class="DeleteEntity DeleteActivityDialog"><i class="fa fa-trash-o"></i></a>
+                        <a href="#" title="[% Translate("Delete") | html %]" class="DeleteEntity DeleteActivityDialog"><i class="fa fa-trash-o"></i></a>
                         <a href="[% Env("Baselink") %]Action=AdminProcessManagementActivityDialog;Subaction=ActivityDialogEdit;ID=[% Data.ID | uri %];EntityID=[% Data.EntityID | uri %]" title="[% Translate("Edit") | html %]" class="AsPopup PopupType_ActivityDialog"><i class="fa fa-edit"></i></a>
                         <span class="AvailableIn">[% Translate(Data.AvailableIn) | html %]</span>
                     </span>

--- a/Kernel/Output/HTML/Templates/Standard/AdminSMIMECertRead.tt
+++ b/Kernel/Output/HTML/Templates/Standard/AdminSMIMECertRead.tt
@@ -23,6 +23,6 @@
         </div>
     </div>
     <div class="Footer">
-        <button class="CancelClosePopup" value="Close" type="button" title="Close" id="Close">[% Translate("Close") | html %]</button>
+        <button class="CancelClosePopup" value="Close" type="button" title="[% Translate("Close") | html %]" id="Close">[% Translate("Close") | html %]</button>
     </div>
 </div>

--- a/Kernel/Output/HTML/Templates/Standard/AgentTicketEmail.tt
+++ b/Kernel/Output/HTML/Templates/Standard/AgentTicketEmail.tt
@@ -512,7 +512,7 @@ $('#NewResponsibleID').bind('change', function (Event) {
 [% InsertTemplate("RichTextEditor.tt") %]
 [% RenderBlockEnd("RichText") %]
 
-                        <textarea id="RichText" class="RichText Validate_Required [% Data.BodyInvalid | html %]" name="Body" title="Message body" rows="15" cols="[% Config("Ticket::Frontend::TextAreaEmail") %]">[% Data.Body | html %]</textarea>
+                        <textarea id="RichText" class="RichText Validate_Required [% Data.BodyInvalid | html %]" name="Body" title="[% Translate("Message body") | html %]" rows="15" cols="[% Config("Ticket::Frontend::TextAreaEmail") %]">[% Data.Body | html %]</textarea>
                         <div id="RichTextError" class="TooltipErrorMessage"><p>[% Translate("This field is required.") | html %]</p></div>
                         <div id="RichTextServerError" class="TooltipErrorMessage"><p>[% Translate("This field is required.") | html %]</p></div>
                     </div>

--- a/Kernel/Output/HTML/Templates/Standard/AgentTicketPhone.tt
+++ b/Kernel/Output/HTML/Templates/Standard/AgentTicketPhone.tt
@@ -366,7 +366,7 @@
 [% RenderBlockStart("RichText") %]
 [% InsertTemplate("RichTextEditor.tt") %]
 [% RenderBlockEnd("RichText") %]
-                        <textarea id="RichText" class="RichText Validate_Required [% Data.RichTextInvalid | html %]" name="Body" title="Message body" rows="15" cols="[% Config("Ticket::Frontend::TextAreaNote") %]">[% Data.Body | html %]</textarea>
+                        <textarea id="RichText" class="RichText Validate_Required [% Data.RichTextInvalid | html %]" name="Body" title="[% Translate("Message body") | html %]" rows="15" cols="[% Config("Ticket::Frontend::TextAreaNote") %]">[% Data.Body | html %]</textarea>
                         <div id="RichTextError" class="TooltipErrorMessage">
                             <p>[% Translate("This field is required.") | html %]</p>
                         </div>

--- a/Kernel/Output/HTML/Templates/Standard/AgentTicketPhoneCommon.tt
+++ b/Kernel/Output/HTML/Templates/Standard/AgentTicketPhoneCommon.tt
@@ -93,7 +93,7 @@
 [% InsertTemplate("RichTextEditor.tt") %]
 [% RenderBlockEnd("RichText") %]
 
-                        <textarea id="RichText" name="Body" title="Message body" rows="15" cols="[% Config("Ticket::Frontend::TextAreaNote") %]" class="RichText Validate_Required [% Data.BodyInvalid | html %]">[% Data.Body %]</textarea>
+                        <textarea id="RichText" name="Body" title="[% Translate("Message body") | html %]" rows="15" cols="[% Config("Ticket::Frontend::TextAreaNote") %]" class="RichText Validate_Required [% Data.BodyInvalid | html %]">[% Data.Body %]</textarea>
                         <div id="RichTextError" class="TooltipErrorMessage"><p>[% Translate("This field is required.") | html %]</p></div>
                         <div id="RichTextServerError" class="TooltipErrorMessage"><p>[% Translate("This field is required.") | html %]</p></div>
                     </div>

--- a/Kernel/Output/HTML/Templates/Standard/AgentTicketSearch.tt
+++ b/Kernel/Output/HTML/Templates/Standard/AgentTicketSearch.tt
@@ -42,7 +42,7 @@
             <label>[% Translate("Add another attribute") | html %]:</label>
             <div class="Field">
                 [% Data.AttributesStrg %]
-                <a class="AddButton" href="#" title="Add entry"><i class="fa fa-plus-square-o"></i><span class="InvisibleText">[% Translate("Add") | html %]</span></a>
+                <a class="AddButton" href="#" title="[% Translate("Add entry") | html %]"><i class="fa fa-plus-square-o"></i><span class="InvisibleText">[% Translate("Add") | html %]</span></a>
             </div>
             <div class="Clear"></div>
             <label>[% Translate("Output") | html %]:</label>
@@ -303,7 +303,7 @@
 </div>
 
 <div class="ContentFooter Center">
-    <button id="SearchFormSubmit" class="Primary CallForAction" value="Run search"><span><i class="fa fa-search"></i> [% Translate("Run search") | html %]</span></button>
+    <button id="SearchFormSubmit" class="Primary CallForAction" value="[% Translate("Run search") | html %]"><span><i class="fa fa-search"></i> [% Translate("Run search") | html %]</span></button>
 </div>
 
 <script type="text/javascript">//<![CDATA[

--- a/Kernel/Output/HTML/Templates/Standard/CustomerTicketMessage.tt
+++ b/Kernel/Output/HTML/Templates/Standard/CustomerTicketMessage.tt
@@ -126,7 +126,7 @@
                         <span class="Marker">*</span>
                         [% Translate("Subject") | html %]:
                     </label>
-                    <input title="Subject" type="text" id="Subject" name="Subject" value="[% Data.Subject | html %]" class="Validate_Required [% Data.SubjectInvalid | html %]" />
+                    <input title="[% Translate("Subject") | html %]" type="text" id="Subject" name="Subject" value="[% Data.Subject | html %]" class="Validate_Required [% Data.SubjectInvalid | html %]" />
                     <div id="SubjectError" class="TooltipErrorMessage" ><p>[% Translate("This field is required.") | html %]</p></div>
                     <div id="SubjectServerError" class="TooltipErrorMessage NoJavaScriptMessage[% Data.SubjectInvalid | html %]" ><p>[% Translate("This field is required.") | html %]</p></div>
                     <div class="Clear"></div>
@@ -146,7 +146,7 @@
                 </div>
                 <div>
                     <label for="Attachment">[% Translate("Attachment") | html %]:</label>
-                    <input name="file_upload" id="Attachment" title="Attachment" type="file" size="40" />
+                    <input name="file_upload" id="Attachment" title="[% Translate("Attachment") | html %]" type="file" size="40" />
                     <input type="hidden" id="AttachmentUpload" name="AttachmentUpload" value="0" />
 [% WRAPPER JSOnDocumentComplete %]
 <script type="text/javascript">//<![CDATA[

--- a/Kernel/Output/HTML/Templates/Standard/CustomerTicketSearch.tt
+++ b/Kernel/Output/HTML/Templates/Standard/CustomerTicketSearch.tt
@@ -142,12 +142,12 @@
                     <label for="NoTimeSet">[% Translate("All") | html %]</label>
                 </div>
                 <div>
-                    <input title="Specific date" type="radio" id="Date" name="TimeSearchType"  value="TimePoint" [% Data.item("TimeSearchType::TimePoint") %] />
+                    <input title="[% Translate("Specific date") | html %]" type="radio" id="Date" name="TimeSearchType"  value="TimePoint" [% Data.item("TimeSearchType::TimePoint") %] />
                     <label for="Date">[% Translate("Only tickets created") | html %]</label>
                     [% Data.TicketCreateTimePointStart %] [% Data.TicketCreateTimePoint %] [% Data.TicketCreateTimePointFormat %]
                 </div>
                 <div>
-                    <input title="Date range" type="radio" id="DateRange" name="TimeSearchType" value="TimeSlot" [% Data.item("TimeSearchType::TimeSlot") %] />
+                    <input title="[% Translate("Date range") | html %]" type="radio" id="DateRange" name="TimeSearchType" value="TimeSlot" [% Data.item("TimeSearchType::TimeSlot") %] />
                     <label for="DateRange">[% Translate("Only tickets created between") | html %]</label>
                     [% Data.TicketCreateTimeStart %] [% Translate("and") | html %] [% Data.TicketCreateTimeStop %]
                 </div>

--- a/Kernel/Output/HTML/Templates/Standard/CustomerTicketZoom.tt
+++ b/Kernel/Output/HTML/Templates/Standard/CustomerTicketZoom.tt
@@ -300,7 +300,7 @@
 [% RenderBlockEnd("ChatProtocol") %]
                         <div id="AttachmentHolder">
                             <label for="Attachment">[% Translate("Attachment") | html %]:</label>
-                            <input name="file_upload" title="Attachment" id="Attachment" type="file" size="30" />
+                            <input name="file_upload" title="[% Translate("Attachment") | html %]" id="Attachment" type="file" size="30" />
                             <input type="hidden" id="AttachmentUpload" name="AttachmentUpload" value="0" />
 [% WRAPPER JSOnDocumentComplete %]
 <script type="text/javascript">//<![CDATA[

--- a/var/httpd/htdocs/js/Core.Agent.Responsive.js
+++ b/var/httpd/htdocs/js/Core.Agent.Responsive.js
@@ -41,7 +41,7 @@ Core.Agent.Responsive = (function (TargetNS) {
         // Add trigger icon for pagination
         $('span.Pagination a:first-child').parent().closest('.WidgetSimple').each(function() {
             if (!$(this).find('.ShowPagination').length) {
-                $(this).find('.WidgetAction.Close').after('<div class="WidgetAction ShowPagination"><a title="Close" href=""><i class="fa fa-angle-double-right"></i></a></div>');
+                $(this).find('.WidgetAction.Close').after('<div class="WidgetAction ShowPagination"><a title="[% Translate("Close") | JSON %]" href=""><i class="fa fa-angle-double-right"></i></a></div>');
             }
         });
 

--- a/var/httpd/htdocs/js/Core.Agent.Responsive.js
+++ b/var/httpd/htdocs/js/Core.Agent.Responsive.js
@@ -41,7 +41,7 @@ Core.Agent.Responsive = (function (TargetNS) {
         // Add trigger icon for pagination
         $('span.Pagination a:first-child').parent().closest('.WidgetSimple').each(function() {
             if (!$(this).find('.ShowPagination').length) {
-                $(this).find('.WidgetAction.Close').after('<div class="WidgetAction ShowPagination"><a title="[% Translate("Close") | JSON %]" href=""><i class="fa fa-angle-double-right"></i></a></div>');
+                $(this).find('.WidgetAction.Close').after('<div class="WidgetAction ShowPagination"><a title="Close" href=""><i class="fa fa-angle-double-right"></i></a></div>');
             }
         });
 


### PR DESCRIPTION
All <tt>title=""</tt> attributes are now translatable. Grep helps me to find them:
<kbd>grep --exclude=\*.{t,wadl} -rne 'title="[a-zA-Z]' ./</kbd>
If this PR is acceptable, then I will make an other one to rel-5_0.