### PR TITLE
Fixed bug: Possible Internal Server Error in AdminGenericAgent.

### DIFF
--- a/Kernel/Modules/AdminGenericAgent.pm
+++ b/Kernel/Modules/AdminGenericAgent.pm
@@ -12,6 +12,7 @@ use strict;
 use warnings;
 
 use Kernel::System::VariableCheck qw(:all);
+use Kernel::Language qw(Translatable);
 
 our $ObjectManagerDisabled = 1;
 


### PR DESCRIPTION
Currently the code won't reach this point, but it's possible (in the future) that the "Translatable" function is called in the first lines of _StopWordsServerErrorsGet. Translatable is not defined since the added line `use Kernel::Language qw(Translatable);` was missing.

We found this while researching for this bug and other files where it might occure, too:

http://bugs.otrs.org/show_bug.cgi?id=11937

Fix:
https://github.com/OTRS/otrs/commit/66f68e1e3c882ede5d688eef31682866070d285a