### PR TITLE
Option to exclude customer from cc list for auto responses

### DIFF
--- a/Kernel/Config/Files/Ticket.xml
+++ b/Kernel/Config/Files/Ticket.xml
@@ -10377,6 +10377,17 @@ Thanks for your help!
             </Option>
         </Setting>
     </ConfigItem>
+    <ConfigItem Name="AutoResponseNoCustomerCc" Required="1" Valid="1">
+        <Description Translatable="1">If this option is set to 'Yes', the customer won't be added to the Cc recipients for auto responses.</Description>
+        <Group>Ticket</Group>
+        <SubGroup>Core::PostMaster</SubGroup>
+        <Setting>
+            <Option SelectedID="0">
+                <Item Key="0" Translatable="1">No</Item>
+                <Item Key="1" Translatable="1">Yes</Item>
+            </Option>
+        </Setting>
+    </ConfigItem>
     <ConfigItem Name="LinkObject::PossibleLink###0200" Required="0" Valid="1">
         <Description Translatable="1">Links 2 tickets with a "Normal" type link.</Description>
         <Group>Ticket</Group>

--- a/Kernel/System/Ticket/Article.pm
+++ b/Kernel/System/Ticket/Article.pm
@@ -2552,7 +2552,7 @@ sub SendAutoResponse {
     my $Cc;
 
     # also send CC to customer user if customer user id is used and addresses do not match
-    if ( $Ticket{CustomerUserID} ) {
+    if ( $Ticket{CustomerUserID} && !$Kernel::OM->Get('Kernel::Config')->Get('AutoResponseNoCustomerCc') ) {
 
         my %CustomerUser = $Kernel::OM->Get('Kernel::System::CustomerUser')->CustomerUserDataGet(
             User => $Ticket{CustomerUserID},


### PR DESCRIPTION
One might want to disable that the customer is added to the Cc list of auto responses automatically. Imagine you have intensive communication with a supplier, then you don't want that your customer gets all those notifications that a follow up was created etc....