### PR TITLE
Disabled comsat and added postmaster pipe waiting in procmail sample config

### DIFF
--- a/.procmailrc.dist
+++ b/.procmailrc.dist
@@ -16,6 +16,7 @@ MONTHFOLDER=`date +%Y-%m`
 YEARFOLDER=`date +%Y`
 LOGFILE=$SYS_HOME/var/log/procmail-$MONTHFOLDER.log
 VERBOSE=on
+COMSAT=no
 
 
 # Remove all X-OTRS Header (allow this only for trusted email)
@@ -68,7 +69,7 @@ VERBOSE=on
 
 # Pipe all email into the PostMaster process.
 
-:0 :
+:0 w:
 | $SYS_HOME/bin/otrs.Console.pl Maint::PostMaster::Read
 
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,4 +1,5 @@
 #6.0.0.beta1 2016-??-??
+ - 2016-03-18 Disabled comsat and added postmaster pipe waiting in procmail sample config.
  - 2016-03-04 Fixed bug#[11787](http://bugs.otrs.org/show_bug.cgi?id=11787) - No Ticket::StateAfterPending found with manual state update.
  - 2016-03-03 Fixed bug#[11872](http://bugs.otrs.org/show_bug.cgi?id=11872) - TicketGet function returns SolutionTime variable.
  - 2016-03-03 Fixed bug#[8631](http://bugs.otrs.org/show_bug.cgi?id=8631) - "ghost" tickets after merge.


### PR DESCRIPTION
This mod disables spamming procmail logs with [comsat](http://www.mhonarc.org/archive/html/procmail/1998-04/msg00041.html) messages like
```
procmail: Notified comsat: "otrs@:/opt/otrs/bin/otrs.Console.pl Maint::PostMaster::Read"
```
It also adds waiting ("w" flag) for OTRS posmaster pipe to finish; without it, if someone remove pipe locking like this
```
:0
| /opt/otrs/bin/otrs.Console.pl Maint::PostMaster::Read
```
to enable OTRS postmaster concurrency (i.e. allow a few postfix processes to insert mail to OTRS concurrently) then errors returned by OTRS postmaster (i.e. when OTRS database is down) won't be noticed by procmail and unprocessed mail won't reach spool rule
```
:0 :
$SYS_HOME/var/spool/.
```
Using
```
:0 w
| /opt/otrs/bin/otrs.Console.pl Maint::PostMaster::Read
```
(no procmail locking) works ok in case of OTRS postmaster errors.

Related: https://dev.ib.pl/ib/otrs/issues/30
Author-Change-Id: IB#1018485