### PR TITLE
Changed reply template selection to not include -Reply- anymore but a label instead

### DIFF
--- a/Kernel/Modules/AgentTicketZoom.pm
+++ b/Kernel/Modules/AgentTicketZoom.pm
@@ -2847,22 +2847,13 @@ sub _ArticleMenu {
                 # use this array twice (also for Reply All), so copy it first
                 my @StandardResponseArrayReplyAll = @StandardResponseArray;
 
-                unshift(
-                    @StandardResponseArray,
-                    {
-                        Key   => '0',
-                        Value => '- '
-                            . $LayoutObject->{LanguageObject}->Translate('Reply') . ' -',
-                        Selected => 1,
-                    }
-                );
-
                 # build HTML string
                 my $StandardResponsesStrg = $LayoutObject->BuildSelection(
                     Name  => 'ResponseID',
                     ID    => 'ResponseID',
                     Class => 'Modernize Small',
                     Data  => \@StandardResponseArray,
+                    PossibleNone => 1,
                 );
 
                 push @MenuItems, {

--- a/Kernel/Output/HTML/Templates/Standard/ArticleActionMenu.tt
+++ b/Kernel/Output/HTML/Templates/Standard/ArticleActionMenu.tt
@@ -63,6 +63,7 @@ $(document).on('change', '#[% Item.FormID | html %] select[name=ForwardTemplateI
     [% ELSIF Item.ItemType == 'Dropdown' && Item.DropdownType == 'Reply' %]
 
         <li>
+           <span>[% Translate("Reply") | html %]:</span>
             <form title="[% Translate(Item.Name) | html %]" action="[% Env("CGIHandle") %]" method="get" id="[% Item.FormID | html %]">
                 <input type="hidden" name="Action" value="[% Item.Action | html %]"/>
                 <input type="hidden" name="TicketID" value="[% Data.TicketID | html %]"/>

--- a/Kernel/Output/HTML/Templates/Standard/ArticleActionMenu.tt
+++ b/Kernel/Output/HTML/Templates/Standard/ArticleActionMenu.tt
@@ -63,13 +63,12 @@ $(document).on('change', '#[% Item.FormID | html %] select[name=ForwardTemplateI
     [% ELSIF Item.ItemType == 'Dropdown' && Item.DropdownType == 'Reply' %]
 
         <li>
-           <span>[% Translate("Reply") | html %]:</span>
             <form title="[% Translate(Item.Name) | html %]" action="[% Env("CGIHandle") %]" method="get" id="[% Item.FormID | html %]">
                 <input type="hidden" name="Action" value="[% Item.Action | html %]"/>
                 <input type="hidden" name="TicketID" value="[% Data.TicketID | html %]"/>
                 <input type="hidden" name="ArticleID" value="[% Data.ArticleID | html %]"/>
                 <input type="hidden" name="ReplyAll" value="[% Item.ReplyAll | html %]"/>
-                <label for="[% Item.ResponseElementID | html %]" class="InvisibleText">[% Translate(Item.Name) | html %]:</label>
+                <label for="[% Item.ResponseElementID | html %]">[% Translate(Item.Name) | html %]:</label>
                         [% Item.StandardResponsesStrg %]
             </form>
 


### PR DESCRIPTION
The reply option always had -Reply- as option 0, which was not very user friendly as it was selectable and unselectable without any action triggered. Also under some circumstances, e.g. when there is a template with the name "!!! some template", it happened that these were listed before the -Reply- text.

Cheers, Nils
