### PR TITLE
Ambiguous labels while adding new GenericAgent job

### DIFF
--- a/Kernel/Output/HTML/Templates/Standard/AdminGenericAgent.tt
+++ b/Kernel/Output/HTML/Templates/Standard/AdminGenericAgent.tt
@@ -689,13 +689,13 @@ Core.Agent.Admin.GenericAgent.Init({
                         </div>
                         <div class="Clear"></div>
 
-                        <label for="NewCustomerUserLogin">[% Translate("New customer") | html %]:</label>
+                        <label for="NewCustomerUserLogin">[% Translate("New customer user") | html %]:</label>
                         <div class="Field">
                             <input type="text" name="NewCustomerUserLogin" id="NewCustomerUserLogin" value="[% Data.NewCustomerUserLogin | html %]" class="W33pc"/>
                         </div>
                         <div class="Clear"></div>
 
-                        <label for="NewCustomerID">[% Translate("New customer ID") | html %]:</label>
+                        <label for="NewCustomerID">[% Translate("New customer") | html %]:</label>
                         <div class="Field">
                             <input type="text" name="NewCustomerID" id="NewCustomerID" value="[% Data.NewCustomerID | html %]" class="W33pc"/>
                         </div>


### PR DESCRIPTION
There are ambiguous labels on AdminGenericAgent screen. The first one refers to "NewCustomerUserLogin", but the label tells "New customer". It should be "New customer user" instead. In the second one the "ID" is unnecessary, because it is a user interface. "New customer" is enough. See the change in this screenshot:
![genericagent_update](https://cloud.githubusercontent.com/assets/1006118/13923058/4ed2eb7e-ef7f-11e5-8172-863652afdd30.png)
Please, also apply this PR on rel-5_0!