### PR TITLE
CustomerNotificationsDisabled option added

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,4 +1,5 @@
 #6.0.0.beta1 2016-??-??
+ - 2016-03-22 CustomerNotificationsDisabled option added.
  - 2016-03-04 Fixed bug#[11787](http://bugs.otrs.org/show_bug.cgi?id=11787) - No Ticket::StateAfterPending found with manual state update.
  - 2016-03-03 Fixed bug#[11872](http://bugs.otrs.org/show_bug.cgi?id=11872) - TicketGet function returns SolutionTime variable.
  - 2016-03-03 Fixed bug#[8631](http://bugs.otrs.org/show_bug.cgi?id=8631) - "ghost" tickets after merge.

--- a/Kernel/Config/Files/Ticket.xml
+++ b/Kernel/Config/Files/Ticket.xml
@@ -7712,7 +7712,18 @@
             </Option>
         </Setting>
     </ConfigItem>
-        <ConfigItem Name="AgentSelfNotifyOnAction" Required="1" Valid="1">
+    <ConfigItem Name="CustomerNotificationsDisabled" Required="1" Valid="1">
+        <Description Translatable="1">Disable sending notifications to customers.</Description>
+        <Group>Ticket</Group>
+        <SubGroup>Core::Ticket</SubGroup>
+        <Setting>
+            <Option SelectedID="0">
+                <Item Key="0">No</Item>
+                <Item Key="1">Yes</Item>
+            </Option>
+        </Setting>
+    </ConfigItem>
+    <ConfigItem Name="AgentSelfNotifyOnAction" Required="1" Valid="1">
         <Description Translatable="1">Specifies if an agent should receive email notification of his own actions.</Description>
         <Group>Ticket</Group>
         <SubGroup>Core::Ticket</SubGroup>

--- a/Kernel/Modules/AdminNotificationEvent.pm
+++ b/Kernel/Modules/AdminNotificationEvent.pm
@@ -726,20 +726,25 @@ sub _Edit {
         $TreeView = 1;
     }
 
+    my %RecipientTypes = (
+        AgentOwner              => Translatable('Agent who owns the ticket'),
+        AgentResponsible        => Translatable('Agent who is responsible for the ticket'),
+        AgentWatcher            => Translatable('All agents watching the ticket'),
+        AgentWritePermissions   => Translatable('All agents with write permission for the ticket'),
+        AgentMyQueues           => Translatable('All agents subscribed to the ticket\'s queue'),
+        AgentMyServices         => Translatable('All agents subscribed to the ticket\'s service'),
+        AgentMyQueuesMyServices => Translatable('All agents subscribed to both the ticket\'s queue and service'),
+    );
+
+    if ( !$ConfigObject->Get('CustomerNotificationsDisabled') ) {
+        $RecipientTypes{'Customer'} = Translatable('Customer of the ticket');
+    }
+
     $Param{RecipientsStrg} = $LayoutObject->BuildSelection(
-        Data => {
-            AgentOwner              => Translatable('Agent who owns the ticket'),
-            AgentResponsible        => Translatable('Agent who is responsible for the ticket'),
-            AgentWatcher            => Translatable('All agents watching the ticket'),
-            AgentWritePermissions   => Translatable('All agents with write permission for the ticket'),
-            AgentMyQueues           => Translatable('All agents subscribed to the ticket\'s queue'),
-            AgentMyServices         => Translatable('All agents subscribed to the ticket\'s service'),
-            AgentMyQueuesMyServices => Translatable('All agents subscribed to both the ticket\'s queue and service'),
-            Customer                => Translatable('Customer of the ticket'),
-        },
+        Data       => \%RecipientTypes,
         Name       => 'Recipients',
         Multiple   => 1,
-        Size       => 8,
+        Size       => scalar(keys %RecipientTypes),
         SelectedID => $Param{Data}->{Recipients},
         Class      => 'Modernize W75pc',
     );

--- a/Kernel/System/Ticket/Event/NotificationEvent.pm
+++ b/Kernel/System/Ticket/Event/NotificationEvent.pm
@@ -671,6 +671,15 @@ sub _RecipientsGet {
             #   other modules then an elsif condition here is useful.
             elsif ( $Recipient eq 'Customer' ) {
 
+                # skip customer recipient if sending notifications to customers is disabled
+                if ( $ConfigObject->Get('CustomerNotificationsDisabled') ) {
+                    $Kernel::OM->Get('Kernel::System::Log')->Log(
+                        Priority => 'notice',
+                        Message  => 'Send no customer notification because sending notifications to customers is disabled (see CustomerNotificationsDisabled)!',
+                    );
+                    next RECIPIENT;
+                }
+
                 # get old article for quoting
                 my %Article = $TicketObject->ArticleLastCustomerArticle(
                     TicketID      => $Param{Data}->{TicketID},


### PR DESCRIPTION
This mod introduces new SysConfig parameter
CustomerNotificationsDisabled that allowes one to disable sending
notifications to customers with Ticket Notifications (extra
protection against customer spamming).

Related: https://dev.ib.pl/ib/otrs/issues/31
Author-Change-Id: IB#1050079