### PR TITLE
NotificationEmailDefaultTemplate option added

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,4 +1,5 @@
 #6.0.0.beta1 2016-??-??
+ - 2016-03-22 NotificationEmailDefaultTemplate option added.
  - 2016-03-04 Fixed bug#[11787](http://bugs.otrs.org/show_bug.cgi?id=11787) - No Ticket::StateAfterPending found with manual state update.
  - 2016-03-03 Fixed bug#[11872](http://bugs.otrs.org/show_bug.cgi?id=11872) - TicketGet function returns SolutionTime variable.
  - 2016-03-03 Fixed bug#[8631](http://bugs.otrs.org/show_bug.cgi?id=8631) - "ghost" tickets after merge.

--- a/Kernel/Config/Files/Framework.xml
+++ b/Kernel/Config/Files/Framework.xml
@@ -6242,6 +6242,14 @@ via the Preferences button after logging in.
             </Option>
         </Setting>
     </ConfigItem>
+    <ConfigItem Name="NotificationEmailDefaultTemplate" Required="0" Valid="1">
+        <Description Translatable="1">Default template for notification e-mails (see Kernel/Output/HTML/Templates/Standard/NotificationEvent/Email directory for available templates).</Description>
+        <Group>Framework</Group>
+        <SubGroup>Core</SubGroup>
+        <Setting>
+            <String Regex="">Default</String>
+        </Setting>
+    </ConfigItem>
     <ConfigItem Name="StandardTemplate2QueueByCreating" Required="0" Valid="0">
         <Description Translatable="1">List of default Standard Templates which are assigned automatically to new Queues upon creation.</Description>
         <Group>Framework</Group>

--- a/Kernel/System/Ticket/Event/NotificationEvent/Transport/Email.pm
+++ b/Kernel/System/Ticket/Event/NotificationEvent/Transport/Email.pm
@@ -134,10 +134,11 @@ sub SendNotification {
 
     if ( $Param{Notification}->{ContentType} && $Param{Notification}->{ContentType} eq 'text/html' ) {
 
-        # Get configured template with fallback to Default.
-        my $EmailTemplate = $Param{Notification}->{Data}->{TransportEmailTemplate}->[0] || 'Default';
+        # Get configured template with fallback to default.
+        my $EmailTemplate = $Param{Notification}->{Data}->{TransportEmailTemplate}->[0]
+            || $ConfigObject->Get('NotificationEmailDefaultTemplate') || 'Default';
 
-        my $Home              = $Kernel::OM->Get('Kernel::Config')->Get('Home');
+        my $Home              = $ConfigObject->Get('Home');
         my $TemplateDir       = "$Home/Kernel/Output/HTML/Templates/Standard/NotificationEvent/Email";
         my $CustomTemplateDir = "$Home/Custom/Kernel/Output/HTML/Templates/Standard/NotificationEvent/Email";
 
@@ -331,7 +332,8 @@ sub TransportSettingsDisplayGet {
         $Param{$Key} = $Param{Data}->{$Key}->[0];
     }
 
-    my $Home              = $Kernel::OM->Get('Kernel::Config')->Get('Home');
+    my $ConfigObject      = $Kernel::OM->Get('Kernel::Config');
+    my $Home              = $ConfigObject->Get('Home');
     my $TemplateDir       = "$Home/Kernel/Output/HTML/Templates/Standard/NotificationEvent/Email";
     my $CustomTemplateDir = "$Home/Custom/Kernel/Output/HTML/Templates/Standard/NotificationEvent/Email";
 
@@ -377,7 +379,7 @@ sub TransportSettingsDisplayGet {
         Data        => \%Templates,
         Name        => 'TransportEmailTemplate',
         Translation => 0,
-        SelectedID  => $Param{Data}->{TransportEmailTemplate},
+        SelectedID  => $Param{Data}->{TransportEmailTemplate} || $ConfigObject->Get('NotificationEmailDefaultTemplate'),
         Class       => 'Modernize',
     );
 


### PR DESCRIPTION
This mod introduces new SysConfig parameter
```
NotificationEmailDefaultTemplate
```
that allowes one to specify default template (from
Kernel/Output/HTML/Templates/Standard/NotificationEvent/Email
directory) to use when sending notification e-mails.

Related: https://dev.ib.pl/ib/otrs/issues/33
Author-Change-Id: IB#1050091