### PR TITLE
Fixed handling whitespaces around = in Content-Type/charset token

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,4 +1,5 @@
 #6.0.0.beta1 2016-??-??
+ - 2016-03-23 Fixed handling whitespaces around = in Content-Type/charset token.
  - 2016-03-04 Fixed bug#[11787](http://bugs.otrs.org/show_bug.cgi?id=11787) - No Ticket::StateAfterPending found with manual state update.
  - 2016-03-03 Fixed bug#[11872](http://bugs.otrs.org/show_bug.cgi?id=11872) - TicketGet function returns SolutionTime variable.
  - 2016-03-03 Fixed bug#[8631](http://bugs.otrs.org/show_bug.cgi?id=8631) - "ghost" tickets after merge.

--- a/Kernel/GenericInterface/Operation/Ticket/TicketCreate.pm
+++ b/Kernel/GenericInterface/Operation/Ticket/TicketCreate.pm
@@ -816,9 +816,9 @@ sub _CheckArticle {
 
         # check Charset part
         my $Charset = '';
-        if ( $Article->{ContentType} =~ /charset=/i ) {
+        if ( $Article->{ContentType} =~ /charset\s*=\s*/i ) {
             $Charset = $Article->{ContentType};
-            $Charset =~ s/.+?charset=("|'|)(\w+)/$2/gi;
+            $Charset =~ s/.+?charset\s*=\s*("|'|)(\w+)/$2/gi;
             $Charset =~ s/"|'//g;
             $Charset =~ s/(.+?);.*/$1/g;
         }
@@ -1042,9 +1042,9 @@ sub _CheckAttachment {
 
         # check Charset part
         my $Charset = '';
-        if ( $Attachment->{ContentType} =~ /charset=/i ) {
+        if ( $Attachment->{ContentType} =~ /charset\s*=\s*/i ) {
             $Charset = $Attachment->{ContentType};
-            $Charset =~ s/.+?charset=("|'|)(\w+)/$2/gi;
+            $Charset =~ s/.+?charset\s*=\s*("|'|)(\w+)/$2/gi;
             $Charset =~ s/"|'//g;
             $Charset =~ s/(.+?);.*/$1/g;
         }

--- a/Kernel/GenericInterface/Operation/Ticket/TicketUpdate.pm
+++ b/Kernel/GenericInterface/Operation/Ticket/TicketUpdate.pm
@@ -883,9 +883,9 @@ sub _CheckArticle {
 
         # check Charset part
         my $Charset = '';
-        if ( $Article->{ContentType} =~ /charset=/i ) {
+        if ( $Article->{ContentType} =~ /charset\s*=\s*/i ) {
             $Charset = $Article->{ContentType};
-            $Charset =~ s/.+?charset=("|'|)(\w+)/$2/gi;
+            $Charset =~ s/.+?charset\s*=\s*("|'|)(\w+)/$2/gi;
             $Charset =~ s/"|'//g;
             $Charset =~ s/(.+?);.*/$1/g;
         }
@@ -1143,9 +1143,9 @@ sub _CheckAttachment {
 
         # check Charset part
         my $Charset = '';
-        if ( $Attachment->{ContentType} =~ /charset=/i ) {
+        if ( $Attachment->{ContentType} =~ /charset\s*=\s*/i ) {
             $Charset = $Attachment->{ContentType};
-            $Charset =~ s/.+?charset=("|'|)(\w+)/$2/gi;
+            $Charset =~ s/.+?charset\s*=\s*("|'|)(\w+)/$2/gi;
             $Charset =~ s/"|'//g;
             $Charset =~ s/(.+?);.*/$1/g;
         }

--- a/Kernel/GenericInterface/Transport/HTTP/REST.pm
+++ b/Kernel/GenericInterface/Transport/HTTP/REST.pm
@@ -235,7 +235,7 @@ sub ProviderProcessRequest {
 
     # convert char-set if necessary
     my $ContentCharset;
-    if ( $ENV{'CONTENT_TYPE'} =~ m{ \A .* charset= ["']? ( [^"']+ ) ["']? \z }xmsi ) {
+    if ( $ENV{'CONTENT_TYPE'} =~ m{ \A .* charset\s*=\s* ["']? ( [^"']+ ) ["']? \z }xmsi ) {
         $ContentCharset = $1;
     }
     if ( $ContentCharset && $ContentCharset !~ m{ \A utf [-]? 8 \z }xmsi ) {

--- a/Kernel/GenericInterface/Transport/HTTP/SOAP.pm
+++ b/Kernel/GenericInterface/Transport/HTTP/SOAP.pm
@@ -200,7 +200,7 @@ sub ProviderProcessRequest {
 
     # convert charset if necessary
     my $ContentCharset;
-    if ( $ENV{'CONTENT_TYPE'} =~ m{ \A ( .+ ) ;charset= ["']{0,1} ( .+? ) ["']{0,1} \z }xmsi ) {
+    if ( $ENV{'CONTENT_TYPE'} =~ m{ \A ( .+ ) ;charset\s*=\s* ["']{0,1} ( .+? ) ["']{0,1} \z }xmsi ) {
 
         # remember content type for the response
         $Self->{ContentType} = $1;

--- a/Kernel/Output/HTML/Layout.pm
+++ b/Kernel/Output/HTML/Layout.pm
@@ -4311,7 +4311,7 @@ sub RichTextDocumentServe {
 
     # get charset and convert content to internal charset
     my $Charset;
-    if ( $Param{Data}->{ContentType} =~ m/.+?charset=("|'|)(.+)/ig ) {
+    if ( $Param{Data}->{ContentType} =~ m/.+?charset\s*=\s*("|'|)(.+)/ig ) {
         $Charset = $2;
         $Charset =~ s/"|'//g;
     }
@@ -4330,7 +4330,7 @@ sub RichTextDocumentServe {
 
         # replace charset in content
         $Param{Data}->{ContentType} =~ s/\Q$Charset\E/utf-8/gi;
-        $Param{Data}->{Content}     =~ s/(<meta[^>]+charset=("|'|))\Q$Charset\E/$1utf-8/gi;
+        $Param{Data}->{Content}     =~ s/(<meta[^>]+charset\s*=\s*("|'|))\Q$Charset\E/$1utf-8/gi;
     }
 
     # add html links

--- a/Kernel/Output/HTML/Layout/Ticket.pm
+++ b/Kernel/Output/HTML/Layout/Ticket.pm
@@ -546,7 +546,7 @@ sub ArticleQuote {
                 UserID    => $Self->{UserID},
             );
             my $Charset = $AttachmentHTML{ContentType} || '';
-            $Charset =~ s/.+?charset=("|'|)(\w+)/$2/gi;
+            $Charset =~ s/.+?charset\s*=\s*("|'|)(\w+)/$2/gi;
             $Charset =~ s/"|'//g;
             $Charset =~ s/(.+?);.*/$1/g;
 

--- a/Kernel/System/EmailParser.pm
+++ b/Kernel/System/EmailParser.pm
@@ -409,7 +409,7 @@ sub GetReturnContentType {
     my $Self = shift;
 
     my $ContentType = $Self->GetContentType();
-    $ContentType =~ s/(charset=)(.*)/$1utf-8/ig;
+    $ContentType =~ s/charset\s*=.*/charset=utf-8/ig;
 
     # debug
     if ( $Self->{Debug} > 0 ) {

--- a/Kernel/System/Ticket/Article.pm
+++ b/Kernel/System/Ticket/Article.pm
@@ -162,9 +162,9 @@ sub ArticleCreate {
             }
         }
         $Param{Charset} = '';
-        if ( $Param{ContentType} =~ /charset=/i ) {
+        if ( $Param{ContentType} =~ /charset\s*=\s*/i ) {
             $Param{Charset} = $Param{ContentType};
-            $Param{Charset} =~ s/.+?charset=("|'|)(\w+)/$2/gi;
+            $Param{Charset} =~ s/.+?charset\s*=\s*("|'|)(\w+)/$2/gi;
             $Param{Charset} =~ s/"|'//g;
             $Param{Charset} =~ s/(.+?);.*/$1/g;
 
@@ -320,7 +320,7 @@ sub ArticleCreate {
     for my $Attachment (@AttachmentConvert) {
 
         if (
-            $Attachment->{ContentType} eq "text/html; charset=\"$Param{Charset}\""
+            $Attachment->{ContentType} =~ /^text\/html; charset\s*=\s*"$Param{Charset}"$/i
             && $Attachment->{Filename} eq 'file-2'
             )
         {
@@ -1539,9 +1539,9 @@ sub ArticleGet {
         $Ticket{EscalationTime}         = $Data{EscalationTime};
         $Ticket{Changed}                = $Row[36];
 
-        if ( $Data{ContentType} && $Data{ContentType} =~ /charset=/i ) {
+        if ( $Data{ContentType} && $Data{ContentType} =~ /charset\s*=\s*/i ) {
             $Data{Charset} = $Data{ContentType};
-            $Data{Charset} =~ s/.+?charset=("|'|)(\w+)/$2/gi;
+            $Data{Charset} =~ s/.+?charset\s*=\s*("|'|)(\w+)/$2/gi;
             $Data{Charset} =~ s/"|'//g;
             $Data{Charset} =~ s/(.+?);.*/$1/g;
 

--- a/scripts/test/Layout/RichTextDocumentServe.t
+++ b/scripts/test/Layout/RichTextDocumentServe.t
@@ -328,6 +328,19 @@ EOF
             ContentType => 'text/html; charset="utf-8"',
         },
     },
+    {
+        Name => 'Standard - extra spaces after charset and = tokens',
+        Data => {
+            Content     => 'Some Content',
+            ContentType => 'text/html; charset = "utf-8"',
+        },
+        Attachments => {},
+        URL         => 'Action=SomeAction;FileID=',
+        Result      => {
+            Content     => 'Some Content',
+            ContentType => 'text/html; charset = "utf-8"',
+        },
+    },
 );
 
 for my $Test (@Tests) {


### PR DESCRIPTION
This mod allowes OTRS to handle spaces around = in Content-Type/charset
like in message below:

    Return-Path: <test@test.loc>
    Date: Wed, 30 Apr 2014 12:04:07 +0200
    From: test <test@test.loc>
    To: <test@test.loc>
    Subject: test
    MIME-Version: 1.0
    Content-Type: text/plain; charset = "utf-8"
    Content-Transfer-Encoding: 8bit
    Message-ID: <test1003@test.loc>

    żółw

Extra spaces are tolerated by http://tools.ietf.org/tools/msglint/
validator (warnings only) and e-mail clients like Mozilla Thunderbird;
OTRS should allow it too.

Related: https://dev.ib.pl/ib/otrs/issues/34
Author-Change-Id: IB#1015440