### PR TITLE
[rel-5_0] Ported back translatable messages from master - part5

### DIFF
--- a/Kernel/Modules/AdminGenericAgent.pm
+++ b/Kernel/Modules/AdminGenericAgent.pm
@@ -927,9 +927,9 @@ sub _MaskUpdate {
 
         $JobData{'SearchInArchiveStrg'} = $LayoutObject->BuildSelection(
             Data => {
-                ArchivedTickets    => 'Archived tickets',
-                NotArchivedTickets => 'Unarchived tickets',
-                AllTickets         => 'All tickets',
+                ArchivedTickets    => Translatable('Archived tickets'),
+                NotArchivedTickets => Translatable('Unarchived tickets'),
+                AllTickets         => Translatable('All tickets'),
             },
             Name       => 'SearchInArchive',
             SelectedID => $JobData{SearchInArchive} || 'AllTickets',

--- a/Kernel/Modules/AdminMailAccount.pm
+++ b/Kernel/Modules/AdminMailAccount.pm
@@ -349,8 +349,8 @@ sub _MaskUpdateMailAccount {
 
     $Param{DispatchingOption} = $LayoutObject->BuildSelection(
         Data => {
-            From  => 'Dispatching by email To: field.',
-            Queue => 'Dispatching by selected Queue.',
+            From  => Translatable('Dispatching by email To: field.'),
+            Queue => Translatable('Dispatching by selected Queue.'),
         },
         Name       => 'DispatchingBy',
         SelectedID => $Param{DispatchingBy},
@@ -418,8 +418,8 @@ sub _MaskAddMailAccount {
 
     $Param{DispatchingOption} = $LayoutObject->BuildSelection(
         Data => {
-            From  => 'Dispatching by email To: field.',
-            Queue => 'Dispatching by selected Queue.',
+            From  => Translatable('Dispatching by email To: field.'),
+            Queue => Translatable('Dispatching by selected Queue.'),
         },
         Name       => 'DispatchingBy',
         SelectedID => $Param{DispatchingBy},

--- a/Kernel/Modules/AdminPackageManager.pm
+++ b/Kernel/Modules/AdminPackageManager.pm
@@ -527,7 +527,7 @@ sub Run {
             $Output .= $LayoutObject->Notify(
                 Priority => 'Error',
                 Data     => "$Name $Version - "
-                    . $LayoutObject->{LanguageObject}->Translate(
+                    . Translatable(
                     "Package not verified by the OTRS Group! It is recommended not to use this package."
                     ),
             );
@@ -1660,9 +1660,7 @@ sub Run {
         $Output .= $LayoutObject->Notify(
             Priority => 'Error',
             Data     => "$Package $NotVerifiedPackages{$Package} - "
-                . $LayoutObject->{LanguageObject}->Translate(
-                "Package not verified by the OTRS Group! It is recommended not to use this package."
-                ),
+                . Translatable("Package not verified by the OTRS Group! It is recommended not to use this package."),
         );
     }
 
@@ -1677,9 +1675,7 @@ sub Run {
             $Output .= $LayoutObject->Notify(
                 Priority => 'Error',
                 Data     => "$Package $UnknownVerficationPackages{$Package} - "
-                    . $LayoutObject->{LanguageObject}->Translate(
-                    "Package not verified due a communication issue with verification server!"
-                    ),
+                    . Translatable("Package not verified due a communication issue with verification server!"),
             );
         }
     }

--- a/Kernel/Modules/AdminPriority.pm
+++ b/Kernel/Modules/AdminPriority.pm
@@ -105,7 +105,7 @@ sub Run {
         # something has gone wrong
         my $Output = $LayoutObject->Header();
         $Output .= $LayoutObject->NavigationBar();
-        $Output .= $LayoutObject->Notify( Priority => 'Error' );
+        $Output .= $LayoutObject->Notify( Priority => Translatable('Error') );
         $Self->_Edit(
             Action => 'Change',
             Errors => \%Errors,
@@ -186,7 +186,7 @@ sub Run {
         # something has gone wrong
         my $Output = $LayoutObject->Header();
         $Output .= $LayoutObject->NavigationBar();
-        $Output .= $LayoutObject->Notify( Priority => 'Error' );
+        $Output .= $LayoutObject->Notify( Priority => Translatable('Error') );
         $Self->_Edit(
             Action => 'Add',
             Errors => \%Errors,

--- a/Kernel/Modules/AdminProcessManagementActivityDialog.pm
+++ b/Kernel/Modules/AdminProcessManagementActivityDialog.pm
@@ -881,15 +881,15 @@ sub _ShowEdit {
     # create ArticleType selection
     $Param{ArticleTypeSelection} = $LayoutObject->BuildSelection(
         Data => [
-            'note-internal',
-            'note-external',
-            'note-report',
-            'phone',
-            'fax',
-            'sms',
-            'webrequest',
+            Translatable('note-internal'),
+            Translatable('note-external'),
+            Translatable('note-report'),
+            Translatable('phone'),
+            Translatable('fax'),
+            Translatable('sms'),
+            Translatable('webrequest'),
         ],
-        SelectedValue => 'note-internal',
+        SelectedValue => Translatable('note-internal'),
         Name          => 'ArticleType',
         ID            => 'ArticleType',
         Sort          => 'Alphanumeric',

--- a/Kernel/Modules/AdminQueue.pm
+++ b/Kernel/Modules/AdminQueue.pm
@@ -642,7 +642,7 @@ sub _Edit {
     }
     $Param{DefaultSignKeyOption} = $LayoutObject->BuildSelection(
         Data => {
-            '' => '-none-',
+            '' => Translatable('-none-'),
             %DefaultSignKeyList
         },
         Name       => 'DefaultSignKey',

--- a/Kernel/Modules/AgentDashboardCommon.pm
+++ b/Kernel/Modules/AgentDashboardCommon.pm
@@ -79,9 +79,9 @@ sub Run {
                 # replace all line breaks with spaces (otherwise Translate() will not work correctly)
                 $StatsHash->{$StatID}->{Description} =~ s{\r?\n|\r}{ }msxg;
 
-                my $Description = $LayoutObject->{LanguageObject}->Get( $StatsHash->{$StatID}->{Description} );
+                my $Description = $LayoutObject->{LanguageObject}->Translate( $StatsHash->{$StatID}->{Description} );
 
-                my $Title = $LayoutObject->{LanguageObject}->Get( $StatsHash->{$StatID}->{Title} );
+                my $Title = $LayoutObject->{LanguageObject}->Translate( $StatsHash->{$StatID}->{Title} );
                 $Title = $LayoutObject->{LanguageObject}->Translate('Statistic') . ': '
                     . $Title . ' ('
                     . $ConfigObject->Get('Stats::StatsHook')

--- a/Kernel/Modules/AgentTicketQueue.pm
+++ b/Kernel/Modules/AgentTicketQueue.pm
@@ -484,7 +484,7 @@ sub Run {
         View   => $View,
 
         Bulk       => 1,
-        TitleName  => 'QueueView',
+        TitleName  => Translatable('QueueView'),
         TitleValue => $NavBar{SelectedQueue} . $SubQueueIndicatorTitle,
 
         Env        => $Self,

--- a/Kernel/Modules/AgentTicketSearch.pm
+++ b/Kernel/Modules/AgentTicketSearch.pm
@@ -315,7 +315,7 @@ sub Run {
 
         # fill up profile name (e.g. with last-search)
         if ( !$Self->{Profile} || !$Self->{SaveProfile} ) {
-            $Self->{Profile} = 'last-search';
+            $Self->{Profile} = Translatable('last-search');
         }
 
         # save search profile (under last-search or real profile name)
@@ -1763,9 +1763,9 @@ sub Run {
 
             $Param{SearchInArchiveStrg} = $LayoutObject->BuildSelection(
                 Data => {
-                    ArchivedTickets    => 'Archived tickets',
-                    NotArchivedTickets => 'Unarchived tickets',
-                    AllTickets         => 'All tickets',
+                    ArchivedTickets    => Translatable('Archived tickets'),
+                    NotArchivedTickets => Translatable('Unarchived tickets'),
+                    AllTickets         => Translatable('All tickets'),
                 },
                 Name       => 'SearchInArchive',
                 SelectedID => $GetParam{SearchInArchive} || 'NotArchivedTickets',
@@ -1909,12 +1909,12 @@ sub Run {
         );
         $Param{TicketCreateTimePointFormat} = $LayoutObject->BuildSelection(
             Data => {
-                minute => 'minute(s)',
-                hour   => 'hour(s)',
-                day    => 'day(s)',
-                week   => 'week(s)',
-                month  => 'month(s)',
-                year   => 'year(s)',
+                minute => Translatable('minute(s)'),
+                hour   => Translatable('hour(s)'),
+                day    => Translatable('day(s)'),
+                week   => Translatable('week(s)'),
+                month  => Translatable('month(s)'),
+                year   => Translatable('year(s)'),
             },
             Name       => 'TicketCreateTimePointFormat',
             SelectedID => $GetParam{TicketCreateTimePointFormat},

--- a/Kernel/Modules/AgentTicketWatcher.pm
+++ b/Kernel/Modules/AgentTicketWatcher.pm
@@ -165,7 +165,7 @@ sub Run {
     }
 
     $LayoutObject->ErrorScreen(
-        Message => Translatable('Invalid subaction'),
+        Message => Translatable('Invalid Subaction.'),
     );
 }
 

--- a/Kernel/Modules/CustomerTicketSearch.pm
+++ b/Kernel/Modules/CustomerTicketSearch.pm
@@ -1295,7 +1295,7 @@ sub Run {
 
                     $Attribute = $Mapping->{ $GetParam{TicketCreateTimePointStart} };
                     $Value     = $GetParam{TicketCreateTimePoint} . ' '
-                        . $LayoutObject->{LanguageObject}->Get( $GetParam{TicketCreateTimePointFormat} . '(s)' );
+                        . $LayoutObject->{LanguageObject}->Translate( $GetParam{TicketCreateTimePointFormat} . '(s)' );
                 }
             }
 


### PR DESCRIPTION
Hi @mgruner
This PR contains backported translatable messages from master. In this part only Kernel/Modules/*.pm files are included. I found them with diff, so each messages exactly the same in master. If you disagree with some changes, it should be fixed in master, too.