### PR TITLE
[rel-5_0] Ported back translatable messages from master - part9

### DIFF
--- a/Kernel/Language.pm
+++ b/Kernel/Language.pm
@@ -404,9 +404,9 @@ sub FormatTimeString {
         $ReturnString =~ s/\%M/$M/g;
         $ReturnString =~ s/\%Y/$Y/g;
 
-        $ReturnString =~ s{(\%A)}{defined $WD ? $Self->Get($DAYS[$WD]) : '';}egx;
+        $ReturnString =~ s{(\%A)}{defined $WD ? $Self->Translate($DAYS[$WD]) : '';}egx;
         $ReturnString
-            =~ s{(\%B)}{(defined $M && $M =~ m/^\d+$/) ? $Self->Get($MONS[$M-1]) : '';}egx;
+            =~ s{(\%B)}{(defined $M && $M =~ m/^\d+$/) ? $Self->Translate($MONS[$M-1]) : '';}egx;
 
         if ( $Self->{TimeZone} && $Config ne 'DateFormatShort' ) {
             return $ReturnString . " ($Self->{TimeZone})";
@@ -561,9 +561,9 @@ sub Time {
         $ReturnString =~ s/\%M/$M/g;
         $ReturnString =~ s/\%Y/$Y/g;
         $ReturnString =~ s/\%Y/$Y/g;
-        $ReturnString =~ s{(\%A)}{defined $WD ? $Self->Get($DAYS[$WD]) : '';}egx;
+        $ReturnString =~ s{(\%A)}{defined $WD ? $Self->Translate($DAYS[$WD]) : '';}egx;
         $ReturnString
-            =~ s{(\%B)}{(defined $M && $M =~ m/^\d+$/) ? $Self->Get($MONS[$M-1]) : '';}egx;
+            =~ s{(\%B)}{(defined $M && $M =~ m/^\d+$/) ? $Self->Translate($MONS[$M-1]) : '';}egx;
         return $ReturnString;
     }
 

--- a/scripts/database/otrs-initial_insert.xml
+++ b/scripts/database/otrs-initial_insert.xml
@@ -121,7 +121,7 @@
     </Insert>
 
     <Insert Table="link_state">
-        <Data Key="name" Type="Quote">Valid</Data>
+        <Data Key="name" Type="Quote" Translatable="1">Valid</Data>
         <Data Key="valid_id">1</Data>
         <Data Key="create_by">1</Data>
         <Data Key="create_time">current_timestamp</Data>
@@ -1470,7 +1470,7 @@ Your OTRS Group
     <Insert Table="notification_event_item">
         <Data Key="notification_id">1</Data>
         <Data Key="event_key" Type="Quote">VisibleForAgentTooltip</Data>
-        <Data Key="event_value" Type="Quote">You will receive a notification each time a new ticket is created in one of your "My Queues" or "My Services".</Data>
+        <Data Key="event_value" Type="Quote" Translatable="1">You will receive a notification each time a new ticket is created in one of your "My Queues" or "My Services".</Data>
     </Insert>
     <Insert Table="notification_event_item">
         <Data Key="notification_id">1</Data>
@@ -1521,7 +1521,7 @@ Your OTRS Group
     <Insert Table="notification_event_item">
         <Data Key="notification_id">2</Data>
         <Data Key="event_key" Type="Quote">VisibleForAgentTooltip</Data>
-        <Data Key="event_value" Type="Quote">You will receive a notification if a customer sends a follow-up to an unlocked ticket which is in your "My Queues" or "My Services".</Data>
+        <Data Key="event_value" Type="Quote" Translatable="1">You will receive a notification if a customer sends a follow-up to an unlocked ticket which is in your "My Queues" or "My Services".</Data>
     </Insert>
     <Insert Table="notification_event_item">
         <Data Key="notification_id">2</Data>
@@ -1587,7 +1587,7 @@ Your OTRS Group
     <Insert Table="notification_event_item">
         <Data Key="notification_id">3</Data>
         <Data Key="event_key" Type="Quote">VisibleForAgentTooltip</Data>
-        <Data Key="event_value" Type="Quote">You will receive a notification if a customer sends a follow-up to a locked ticket of which you are the ticket owner or responsible.</Data>
+        <Data Key="event_value" Type="Quote" Translatable="1">You will receive a notification if a customer sends a follow-up to a locked ticket of which you are the ticket owner or responsible.</Data>
     </Insert>
     <Insert Table="notification_event_item">
         <Data Key="notification_id">3</Data>
@@ -1653,7 +1653,7 @@ Your OTRS Group
     <Insert Table="notification_event_item">
         <Data Key="notification_id">4</Data>
         <Data Key="event_key" Type="Quote">VisibleForAgentTooltip</Data>
-        <Data Key="event_value" Type="Quote">You will receive a notification as soon as a ticket owned by you is automatically unlocked.</Data>
+        <Data Key="event_value" Type="Quote" Translatable="1">You will receive a notification as soon as a ticket owned by you is automatically unlocked.</Data>
     </Insert>
     <Insert Table="notification_event_item">
         <Data Key="notification_id">4</Data>
@@ -1802,7 +1802,7 @@ Your OTRS Group
     <Insert Table="notification_event_item">
         <Data Key="notification_id">8</Data>
         <Data Key="event_key" Type="Quote">VisibleForAgentTooltip</Data>
-        <Data Key="event_value" Type="Quote">You will receive a notification if a ticket is moved into one of your "My Queues".</Data>
+        <Data Key="event_value" Type="Quote" Translatable="1">You will receive a notification if a ticket is moved into one of your "My Queues".</Data>
     </Insert>
     <Insert Table="notification_event_item">
         <Data Key="notification_id">8</Data>
@@ -2032,7 +2032,7 @@ Your OTRS Group
     <Insert Table="notification_event_item">
         <Data Key="notification_id">13</Data>
         <Data Key="event_key" Type="Quote">VisibleForAgentTooltip</Data>
-        <Data Key="event_value" Type="Quote">You will receive a notification if a ticket's service is changed to one of your "My Services".</Data>
+        <Data Key="event_value" Type="Quote" Translatable="1">You will receive a notification if a ticket's service is changed to one of your "My Services".</Data>
     </Insert>
     <Insert Table="notification_event_item">
         <Data Key="notification_id">13</Data>


### PR DESCRIPTION
Hi @mgruner
This PR contains backported translatable messages from master. In this part only Kernel/Language.pm and scripts/database/otrs-initial_insert.xml files are included. I found them with diff, so each messages exactly the same in master. If you disagree with some changes, it should be fixed in master, too.