### PR TITLE
Parameter name corrected in message in EmbeddedImagesExtract()

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,4 +1,5 @@
 #6.0.0.beta1 2016-??-??
+ - 2016-03-25 Parameter name corrected in message in EmbeddedImagesExtract().
  - 2016-03-04 Fixed bug#[11787](http://bugs.otrs.org/show_bug.cgi?id=11787) - No Ticket::StateAfterPending found with manual state update.
  - 2016-03-03 Fixed bug#[11872](http://bugs.otrs.org/show_bug.cgi?id=11872) - TicketGet function returns SolutionTime variable.
  - 2016-03-03 Fixed bug#[8631](http://bugs.otrs.org/show_bug.cgi?id=8631) - "ghost" tickets after merge.

--- a/Kernel/System/HTMLUtils.pm
+++ b/Kernel/System/HTMLUtils.pm
@@ -1183,7 +1183,7 @@ sub EmbeddedImagesExtract {
     if ( ref $Param{AttachmentsRef} ne 'ARRAY' ) {
         $Kernel::OM->Get('Kernel::System::Log')->Log(
             Priority => 'error',
-            Message  => "Need DocumentRef!"
+            Message  => "Need AttachmentsRef!"
         );
         return;
     }


### PR DESCRIPTION
Parameter name "DocumentRef" corrected to "AttachmentsRef"
in message in EmbeddedImagesExtract().

Related: https://dev.ib.pl/ib/otrs/issues/35
Author-Change-Id: IB#1006980