### PR TITLE
OTRS Console Command "Dev::Tools::Shell" - a OTRS REPL

### DIFF
--- a/Kernel/System/Console/Command/Dev/Tools/Shell.pm
+++ b/Kernel/System/Console/Command/Dev/Tools/Shell.pm
@@ -28,11 +28,20 @@ sub Configure {
 sub PreRun {
     my ( $Self, %Param ) = @_;
 
-    return if $Kernel::OM->Get('Kernel::System::Main')->Require(
-        'Devel::REPL',
-    );
+    my @Dependencies = ('Devel::REPL', 'Data::Printer');
 
-    die "Required Perl module 'Devel::REPL' not found. Please install and retry.";
+    DEPENDENCY:
+    for my $Dependency ( @Dependencies ) {
+
+        next DEPENDENCY if $Kernel::OM->Get('Kernel::System::Main')->Require(
+            $Dependency,
+            Silent => 1,
+        );
+
+        die "Required Perl module '$Dependency' not found. Please make sure the following dependencies are installed: ". join(' ', @Dependencies);
+    }
+
+    return 1;
 }
 
 sub Run {

--- a/Kernel/System/Console/Command/Dev/Tools/Shell.pm
+++ b/Kernel/System/Console/Command/Dev/Tools/Shell.pm
@@ -1,5 +1,5 @@
 # --
-# Copyright (C) 2001-2015 OTRS AG, http://otrs.com/
+# Copyright (C) 2001-2016 OTRS AG, http://otrs.com/
 # --
 # This software comes with ABSOLUTELY NO WARRANTY. For details, see
 # the enclosed file COPYING for license information (AGPL). If you
@@ -22,23 +22,32 @@ sub Configure {
 
     $Self->Description('An interactive REPL shell for the OTRS context.');
 
+    $Self->AddOption(
+        Name        => 'eval',
+        Description => 'Perl code that should get evaluated and printed in the OTRS context.',
+        Required    => 0,
+        HasValue    => 1,
+        ValueRegex  => qr/.*/smx,
+    );
+
     return;
 }
 
 sub PreRun {
     my ( $Self, %Param ) = @_;
 
-    my @Dependencies = ('Devel::REPL', 'Data::Printer');
+    my @Dependencies = ( 'Devel::REPL', 'Data::Printer' );
 
     DEPENDENCY:
-    for my $Dependency ( @Dependencies ) {
+    for my $Dependency (@Dependencies) {
 
         next DEPENDENCY if $Kernel::OM->Get('Kernel::System::Main')->Require(
             $Dependency,
             Silent => 1,
         );
 
-        die "Required Perl module '$Dependency' not found. Please make sure the following dependencies are installed: ". join(' ', @Dependencies);
+        die "Required Perl module '$Dependency' not found. Please make sure the following dependencies are installed: "
+            . join( ' ', @Dependencies );
     }
 
     return 1;
@@ -49,19 +58,44 @@ sub Run {
 
     my $Repl = Devel::REPL->new();
 
-    for my $Plugin ( qw(History LexEnv MultiLine::PPI FancyPrompt OTRS) ) {
-        $Repl->load_plugin( $Plugin );
+    for my $Plugin (qw(History LexEnv MultiLine::PPI FancyPrompt OTRS)) {
+        $Repl->load_plugin($Plugin);
     }
 
     # fancy things are made with love <3
-    $Repl->fancy_prompt(sub {
-        my $self = shift;
-        sprintf 'OTRS: %03d%s> ',
-            $self->lines_read,
-            $self->can('line_depth') ? ':' . $self->line_depth : '';
-    });
+    $Repl->fancy_prompt(
+        sub {    ## no critic
+            my $self = shift;
+            sprintf 'OTRS: %03d%s> ',
+                $self->lines_read,    ## no critic
+                $self->can('line_depth') ? ':' . $self->line_depth : '';    ## no critic
+        }
+    );
 
-    $Repl->run();
+    my $Code = $Self->GetOption('eval');
+
+    if ($Code) {
+
+        # force the output to STDOUT
+        # so we can handle it properly
+        # in the UnitTest context
+        $Repl->{out_fh} = \*STDOUT;
+
+        # we need to push the code to the history
+        # to simulate the regular History functionality
+        # which is not called since we don't use
+        # the $Repl-read function to get the code
+        $Repl->push_history($Code);
+
+        # evaluate the code
+        my @Result = $Repl->eval($Code);
+
+        # and print it to STDOUT
+        $Repl->print(@Result) if !$Repl->exit_repl;    ## no critic
+    }
+    else {
+        $Repl->run();                                  ## no critic
+    }
 
     return $Self->ExitCodeOk();
 }

--- a/Kernel/System/Console/Command/Dev/Tools/Shell.pm
+++ b/Kernel/System/Console/Command/Dev/Tools/Shell.pm
@@ -1,0 +1,72 @@
+# --
+# Copyright (C) 2001-2015 OTRS AG, http://otrs.com/
+# --
+# This software comes with ABSOLUTELY NO WARRANTY. For details, see
+# the enclosed file COPYING for license information (AGPL). If you
+# did not receive this file, see http://www.gnu.org/licenses/agpl.txt.
+# --
+
+package Kernel::System::Console::Command::Dev::Tools::Shell;
+
+use strict;
+use warnings;
+
+use base qw(Kernel::System::Console::BaseCommand);
+
+our @ObjectDependencies = (
+    'Kernel::System::Main',
+);
+
+sub Configure {
+    my ( $Self, %Param ) = @_;
+
+    $Self->Description('An interactive REPL shell for the OTRS context.');
+
+    return;
+}
+
+sub PreRun {
+    my ( $Self, %Param ) = @_;
+
+    return if $Kernel::OM->Get('Kernel::System::Main')->Require(
+        'Devel::REPL',
+    );
+
+    die "Required Perl module 'Devel::REPL' not found. Please install and retry.";
+}
+
+sub Run {
+    my ( $Self, %Param ) = @_;
+
+    my $Repl = Devel::REPL->new();
+
+    for my $Plugin ( qw(History LexEnv MultiLine::PPI FancyPrompt OTRS) ) {
+        $Repl->load_plugin( $Plugin );
+    }
+
+    # fancy things are made with love <3
+    $Repl->fancy_prompt(sub {
+        my $self = shift;
+        sprintf 'OTRS: %03d%s> ',
+            $self->lines_read,
+            $self->can('line_depth') ? ':' . $self->line_depth : '';
+    });
+
+    $Repl->run();
+
+    return $Self->ExitCodeOk();
+}
+
+1;
+
+=back
+
+=head1 TERMS AND CONDITIONS
+
+This software is part of the OTRS project (L<http://otrs.org/>).
+
+This software comes with ABSOLUTELY NO WARRANTY. For details, see
+the enclosed file COPYING for license information (AGPL). If you
+did not receive this file, see L<http://www.gnu.org/licenses/agpl.txt>.
+
+=cut

--- a/Kernel/cpan-lib/Devel/REPL/Plugin/OTRS.pm
+++ b/Kernel/cpan-lib/Devel/REPL/Plugin/OTRS.pm
@@ -1,0 +1,111 @@
+# Copy of:
+# https://github.com/tsibley/Devel-REPL-Plugin-DDP/blob/master/lib/Devel/REPL/Plugin/DDP.pm
+
+# ---
+# OTRS
+# ---
+# package Devel::REPL::Plugin::DDP;
+package Devel::REPL::Plugin::OTRS;
+# ---
+
+use strict;
+use 5.008_005;
+our $VERSION = '0.05';
+
+use Devel::REPL::Plugin;
+use Data::Printer use_prototypes => 0;
+
+around 'format_result' => sub {
+    my $orig = shift;
+    my $self = shift;
+    my @to_dump = @_;
+# ---
+# OTRS
+# ---
+#     my $out;
+    my $out = "\n";
+
+    # try to determine output format by looking up
+    # the last line with a leading variable
+    # to prevent unreadable outputs for Hashes and Arrays
+    if (
+        scalar @to_dump > 1
+        || $to_dump[0]
+    ) {
+        my @ReversedHistoryLines = reverse @{ $self->{history} };
+
+        LINE:
+        for my $HistoryLine (@ReversedHistoryLines) {
+
+            next LINE if $HistoryLine !~ m{ \A \s* (?:my \s+)?(?:our \s+)? (\\? [%@\$]) }xms;
+
+            my $VariableType = $1;
+            if ( $VariableType eq '%' ) {
+                my %Hash = @_;
+                @to_dump = ();
+                push @to_dump, \%Hash;
+            }
+            elsif ( $VariableType eq '@' ) {
+                my @Array = @_;
+                @to_dump = ();
+                push @to_dump, \@Array;
+            }
+
+            last LINE;
+        }
+    }
+# ---
+
+    for (@to_dump) {
+        my $buf;
+        p(\$_,
+          output        => \$buf,
+          colored       => 1,
+          caller_info   => 0 );
+        $out .= $buf;
+    }
+# ---
+# OTRS
+# ---
+#     chomp $out if defined $out;
+    $out .= "\n";
+# ---
+    $self->$orig($out);
+};
+
+1;
+
+__END__
+
+=encoding utf-8
+
+=head1 NAME
+
+Devel::REPL::Plugin::DDP - Format return values with Data::Printer
+
+=head1 DESCRIPTION
+
+Use this in your Devel::REPL profile or load it from your C<re.pl> script.
+
+You'll also want to make sure your profile or script runs the following:
+
+    $_REPL->normal_color("reset");
+
+or disables the L<standard Colors plugin|Devel::REPL::Plugin::Colors>.
+
+=head1 AUTHOR
+
+Thomas Sibley E<lt>tsibley@cpan.orgE<gt>
+
+=head1 COPYRIGHT
+
+Copyright 2013- Thomas Sibley
+
+=head1 LICENSE
+
+This library is free software; you can redistribute it and/or modify
+it under the same terms as Perl itself.
+
+=head1 SEE ALSO
+
+=cut

--- a/bin/otrs.CheckModules.pl
+++ b/bin/otrs.CheckModules.pl
@@ -455,6 +455,16 @@ my @NeededModules = (
             zypper => 'perl-YAML-LibYAML',
         },
     },
+    {
+        Module    => 'Devel::REPL',
+        Required  => 0,
+        Comment   => 'Required for using the Console command "Dev::Tools::Shell".',
+        InstTypes => {
+            aptget => 'libdevel-repl-perl',
+            emerge => 'dev-perl/Devel-REPL',
+            zypper => 'perl-Devel-REPL',
+        },
+    },
 );
 
 if ($PackageList) {

--- a/bin/otrs.CheckModules.pl
+++ b/bin/otrs.CheckModules.pl
@@ -455,16 +455,6 @@ my @NeededModules = (
             zypper => 'perl-YAML-LibYAML',
         },
     },
-    {
-        Module    => 'Devel::REPL',
-        Required  => 0,
-        Comment   => 'Required for using the Console command "Dev::Tools::Shell".',
-        InstTypes => {
-            aptget => 'libdevel-repl-perl',
-            emerge => 'dev-perl/Devel-REPL',
-            zypper => 'perl-Devel-REPL',
-        },
-    },
 );
 
 if ($PackageList) {

--- a/scripts/test/Console/Command/Dev/Tools/Shell.t
+++ b/scripts/test/Console/Command/Dev/Tools/Shell.t
@@ -1,0 +1,63 @@
+# --
+# Copyright (C) 2001-2016 OTRS AG, http://otrs.com/
+# --
+# This software comes with ABSOLUTELY NO WARRANTY. For details, see
+# the enclosed file COPYING for license information (AGPL). If you
+# did not receive this file, see http://www.gnu.org/licenses/agpl.txt.
+# --
+
+use strict;
+use warnings;
+use utf8;
+
+use vars (qw($Self));
+
+my $ConfigObject  = $Kernel::OM->Get('Kernel::Config');
+my $CommandObject = $Kernel::OM->Get('Kernel::System::Console::Command::Dev::Tools::Shell');
+
+my @Tests = (
+    {
+        Name     => 'Hello World',
+        Code     => "print 'Hello World!';",
+        Result   => 'Hello World!1',           # since print returns the string + 1 as result
+        ExitCode => 0,
+    },
+    {
+        Name => 'OTRS Version printed',
+        Code => 'print $Kernel::OM->Get("Kernel::Config")->Get("Version");',
+        Result   => $ConfigObject->Get('Version') . '1',    # since print returns the string + 1 as result
+        ExitCode => 0,
+    },
+    {
+        Name     => 'OTRS Version variable',
+        Code     => 'my $OTRSVersion = $Kernel::OM->Get("Kernel::Config")->Get("Version");',
+        Result   => $ConfigObject->Get('Version'),
+        ExitCode => 0,
+    },
+);
+
+for my $Test (@Tests) {
+
+    my $Result;
+    my $ExitCode;
+    {
+        local *STDOUT;
+        open STDOUT, '>:encoding(UTF-8)', \$Result;
+        $ExitCode = $CommandObject->Execute( '--eval', $Test->{Code} );
+        $Kernel::OM->Get('Kernel::System::Encode')->EncodeInput( \$Result );
+    }
+
+    $Self->Is(
+        $ExitCode,
+        $Test->{ExitCode},
+        "Dev::Tools::Shell exit code '$Test->{Name}'",
+    );
+
+    $Self->Is(
+        $Result,
+        $Test->{Result},
+        "Dev::Tools::Shell output '$Test->{Name}'",
+    );
+}
+
+1;


### PR DESCRIPTION
Hi there,

as discussed with @mgruner I want to share our approach for a REPL / shell for the OTRS context as a OTRS Console command. It is based on the Perl module "Devel::REPL" which can be installed via CPAN if you want to use this feature. I've added it as optional to the "otrs.CheckModules.pl" script. If not installed you will get an error message telling you about it, see https://github.com/OTRS/otrs/pull/1091/files#diff-18f4874b62331c044aef188c6fd8fcb4R35.

Here are some basic example screenshots:

Initializing the TicketObject:
![bildschirmfoto 2016-03-25 um 17 25 51](https://cloud.githubusercontent.com/assets/3873515/14048479/c59a891a-f2ae-11e5-9b0f-edf7ff295e7b.png)

Getting the Ticket with TicketID 1:
![bildschirmfoto 2016-03-25 um 17 26 19](https://cloud.githubusercontent.com/assets/3873515/14048478/c599f54a-f2ae-11e5-979a-c9feb998ef8f.png)

The use case would be to avoid writing a "whole" test script just for executing one command in the OTRS context. Classic scenarios would be debugging or testing. Looking inside the DB or adding debug lines can cause false information because some functions like ACLs might not be executed yet. 

I had some issues writing tests for the command since it keeps in the state of waiting for user input. I was not able to "kill" the process or exit the loop without exiting the test completely. I'm open for proposals to write proper tests.

Additionally I created a custom Devel::REPL plugin for formatting purposes which is based on the default DDP plugin. It basically adds a newline before and after the output and tries to determine the last variable type for proper formatting. See https://github.com/OTRS/otrs/pull/1091/files#diff-7345d00a44c8d5e75deff2b36b73072aR28 .

That should be all. If you have any questions or feedback I'm glad to hear it.

  Thorsten