### PR TITLE
Improved SysConfig edit header translation

### DIFF
--- a/Kernel/Output/HTML/Templates/Standard/AdminSysConfigEdit.tt
+++ b/Kernel/Output/HTML/Templates/Standard/AdminSysConfigEdit.tt
@@ -34,7 +34,7 @@
     <div class="ContentColumn">
         <div class="WidgetSimple">
             <div class="Header">
-                <h2>[% Translate("Edit Config Settings") | html %] in [% Data.Group | html %] -&gt; [% Data.SubGroup %]</h2>
+                <h2>[% Translate("Edit Config Settings in %s → %s", Data.Group, Data.SubGroup) | html %]</h2>
             </div>
             <div class="Content">
 


### PR DESCRIPTION
The word "in" was no translatable. This also affects rel-5_0.