### PR TITLE
Fixed link recognition

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,4 +1,5 @@
 #6.0.0.beta1 2016-??-??
+ - 2016-03-30 Fixed link recognition.
  - 2016-03-04 Fixed bug#[11787](http://bugs.otrs.org/show_bug.cgi?id=11787) - No Ticket::StateAfterPending found with manual state update.
  - 2016-03-03 Fixed bug#[11872](http://bugs.otrs.org/show_bug.cgi?id=11872) - TicketGet function returns SolutionTime variable.
  - 2016-03-03 Fixed bug#[8631](http://bugs.otrs.org/show_bug.cgi?id=8631) - "ghost" tickets after merge.

--- a/Kernel/System/HTMLUtils.pm
+++ b/Kernel/System/HTMLUtils.pm
@@ -820,13 +820,17 @@ sub LinkQuote {
         (                                          # $3
             (?: [a-z0-9\-]+ \. )*                  # get subdomains, optional
             [a-z0-9\-]+                            # get top level domain
+            (?:                                    # optional port number
+                [:]
+                [0-9]+
+            )?
             (?:                                    # file path element
                 [\/\.]
-                | [a-zA-Z0-9\-]
+                | [a-zA-Z0-9\-_%=]
             )*
             (?:                                    # param string
                 [\?]                               # if param string is there, "?" must be present
-                [a-zA-Z0-9&;=%\-_]*                # param string content, this will also catch entities like &amp;
+                [a-zA-Z0-9&;=%\-_\.]*              # param string content, this will also catch entities like &amp;
             )?
             (?:                                    # link hash string
                 [\#]                               #

--- a/scripts/test/HTMLUtils/LinkQuote.t
+++ b/scripts/test/HTMLUtils/LinkQuote.t
@@ -308,6 +308,38 @@ my @Tests = (
         Name   => 'LinkQuote - just TLD given;',
         Target => '',
     },
+    {
+        Input =>
+            '<br />http://www.server.nl:80/%7Eguido/Python.html<br />',
+        Result =>
+            '<br /><a href="http://www.server.nl:80/%7Eguido/Python.html" title="http://www.server.nl:80/%7Eguido/Python.html">http://www.server.nl:80/%7Eguido/Python.html</a><br />',
+        Name   => 'LinkQuote - address with port given;',
+        Target => '',
+    },
+    {
+        Input =>
+            '<br />https://aa.bb.com/wiki/Obs%C5%82uga_ABC#Sekcja<br />',
+        Result =>
+            '<br /><a href="https://aa.bb.com/wiki/Obs%C5%82uga_ABC#Sekcja" title="https://aa.bb.com/wiki/Obs%C5%82uga_ABC#Sekcja">https://aa.bb.com/wiki/Obs%C5%82uga_ABC#Sekcja</a><br />',
+        Name   => 'LinkQuote - address with URL encodings and hash; ',
+        Target => '',
+    },
+    {
+        Input =>
+            '<br />http://msdn.microsoft.com/en-us/library/windows/hardware/ff557211%28v=vs.85%29.aspx<br />',
+        Result =>
+            '<br /><a href="http://msdn.microsoft.com/en-us/library/windows/hardware/ff557211%28v=vs.85%29.aspx" title="http://msdn.microsoft.com/en-us/library/windows/hardware/ff557211%28v=vs.85%29.aspx">http://msdn.microsoft.com/en-us/library/windows/hardware/ff557211%28v=vs.85%29.aspx</a><br />',
+        Name   => 'LinkQuote - address with =; ',
+        Target => '',
+    },
+    {
+        Input =>
+            '<br />https://git.proxmox.com/?p=qemu-server.git;a=commit;h=445f06cdb193557c72b5aa83d347fbad1acac283<br />',
+        Result =>
+            '<br /><a href="https://git.proxmox.com/?p=qemu-server.git;a=commit;h=445f06cdb193557c72b5aa83d347fbad1acac283" title="https://git.proxmox.com/?p=qemu-server.git;a=commit;h=445f06cdb193557c72b5aa83d347fbad1acac283">https://git.proxmox.com/?p=qemu-server.git;a=commit;h=445f06cdb193557c72b5aa83d347fbad1acac283</a><br />',
+        Name   => 'LinkQuote - address with dot; ',
+        Target => '',
+    },
 );
 
 for my $Test (@Tests) {


### PR DESCRIPTION
This allowes OTRS to recognize links like

    http://www.server.nl:80/%7Eguido/Python.html
    https://aa.bb.com/wiki/Obs%C5%82uga_ABC#Sekcja
    http://msdn.microsoft.com/en-us/library/windows/hardware/ff557211%28v=vs.85%29.aspx
    https://git.proxmox.com/?p=qemu-server.git;a=commit;h=445f06cdb193557c72b5aa83d347fbad1acac283

Related: https://dev.ib.pl/ib/otrs/issues/36
Author-Change-Id: IB#1008598