### PR TITLE
Set X-Mailer to undef if "Secure::DisableBanner" is active

### DIFF
--- a/Kernel/System/Email.pm
+++ b/Kernel/System/Email.pm
@@ -293,6 +293,12 @@ sub Send {
         $Header{'X-Mailer'}     = "$Product Mail Service ($Version)";
         $Header{'X-Powered-By'} = 'OTRS - Open Ticket Request System (http://otrs.org/)';
     }
+    else {
+        # set X-Mailer to undef explicitly to avoid MIME::Tools to set it to "MIME-tools"
+        # as this is handled as spam by some mail servers
+        $Header{'X-Mailer'} = undef;
+    }
+    
     $Header{Type} = $Param{MimeType} || 'text/plain';
 
     # define email encoding

--- a/Kernel/System/Email.pm
+++ b/Kernel/System/Email.pm
@@ -294,6 +294,7 @@ sub Send {
         $Header{'X-Powered-By'} = 'OTRS - Open Ticket Request System (http://otrs.org/)';
     }
     else {
+        
         # set X-Mailer to undef explicitly to avoid MIME::Tools to set it to "MIME-tools"
         # as this is handled as spam by some mail servers
         $Header{'X-Mailer'} = undef;


### PR DESCRIPTION
If "Secure::DisableBanner" is active and the X-Mailer header isn't set to undef, MIME::Tools adds its own X-Mailer header. There are some mail servers that handles mails sent by MIME::Tools as spam mails (as MIME::Tools is seen as a program that is sometimes used to send mass mails).