### PR TITLE
Improved widget close icon title

### DIFF
--- a/Kernel/Output/HTML/Templates/Standard/AgentDashboardCommon.tt
+++ b/Kernel/Output/HTML/Templates/Standard/AgentDashboardCommon.tt
@@ -74,7 +74,7 @@ $('#Dashboard' + Core.App.EscapeSelector('[% Data.Name | html %]') + '_toggle').
 [% END %]
 [% RenderBlockEnd("ContentSmallRefresh") %]
                 <div class="WidgetAction Close">
-                    <a href="[% Env("Baselink") %]Action=[% Env("Action") %];Subaction=UpdateRemove;Name=[% Data.Name | uri %];CustomerID=[% Data.CustomerID | uri %];[% Env("ChallengeTokenParam") | html %]" title="[% Translate("Close") | html %]">
+                    <a href="[% Env("Baselink") %]Action=[% Env("Action") %];Subaction=UpdateRemove;Name=[% Data.Name | uri %];CustomerID=[% Data.CustomerID | uri %];[% Env("ChallengeTokenParam") | html %]" title="[% Translate("Close this widget") | html %]">
                         <i class="fa fa-times"></i>
                     </a>
                 </div>
@@ -171,7 +171,7 @@ Core.UI.RegisterToggleTwoContainer($('#Dashboard' + Core.App.EscapeSelector('[% 
 [% END %]
 [% RenderBlockEnd("ContentLargePreferences") %]
                 <div class="WidgetAction Close">
-                    <a href="[% Env("Baselink") %]Action=[% Env("Action") %];Subaction=UpdateRemove;Name=[% Data.Name | uri %];CustomerID=[% Data.CustomerID | uri %];[% Env("ChallengeTokenParam") | html %]" title="[% Translate("Close") | html %]">
+                    <a href="[% Env("Baselink") %]Action=[% Env("Action") %];Subaction=UpdateRemove;Name=[% Data.Name | uri %];CustomerID=[% Data.CustomerID | uri %];[% Env("ChallengeTokenParam") | html %]" title="[% Translate("Close this widget") | html %]">
                         <i class="fa fa-times"></i>
                     </a>
                 </div>


### PR DESCRIPTION
Hi @mgruner 

This PR has two purpose:
1.) According to <a href="http://otrs.github.io/doc/manual/developer/stable/en/html/accessibility.html#id-1.6.8.5.2">developer manual</a>, it should be used <q><em>real, understandable and precise sentences</em></q>. In the manual there is exactly the same example: <em>"Close this widget" is much better than "Close"</em>.
2.) In some languages (e. g. in Hungarian) there are different words for closing a ticket (in this case "close" is "<strong>le</strong>zárás" in Hungarian) and closing a window or widget (in this case "close" is "<strong>be</strong>zárás" in Hungarian). Because of the structure of the .po file, there is not possible to translate the two kind of "close" differently, as it contains only one instance of "close".

This also affects rel-5_0.