### PR TITLE
Removed unnecessary comma at the end of list

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,4 +1,5 @@
 #6.0.0.beta1 2016-??-??
+ - 2016-03-31 Removed unnecessary comma at the end of list.
  - 2016-03-04 Fixed bug#[11787](http://bugs.otrs.org/show_bug.cgi?id=11787) - No Ticket::StateAfterPending found with manual state update.
  - 2016-03-03 Fixed bug#[11872](http://bugs.otrs.org/show_bug.cgi?id=11872) - TicketGet function returns SolutionTime variable.
  - 2016-03-03 Fixed bug#[8631](http://bugs.otrs.org/show_bug.cgi?id=8631) - "ghost" tickets after merge.

--- a/Kernel/Modules/AgentTicketPhone.pm
+++ b/Kernel/Modules/AgentTicketPhone.pm
@@ -102,7 +102,12 @@ sub Run {
                 my $CustomerDisabled = '';
 
                 if ( !$IsUpload ) {
-                    $GetParam{From} .= $CustomerElement . ',';
+                    if ( $GetParam{From} ) {
+                        $GetParam{From} .= ', ' . $CustomerElement;
+                    }
+                    else {
+                        $GetParam{From} = $CustomerElement;
+                    }
 
                     # check email address
                     for my $Email ( Mail::Address->parse($CustomerElement) ) {

--- a/Kernel/System/Email/SMTP.pm
+++ b/Kernel/System/Email/SMTP.pm
@@ -144,7 +144,12 @@ sub Send {
     # get recipients
     my $ToString = '';
     for my $To ( @{ $Param{ToArray} } ) {
-        $ToString .= $To . ',';
+        if ( $ToString ) {
+            $ToString .= ', ' . $To;
+        }
+        else {
+            $ToString = $To;
+        }
         if ( !$SMTP->to($To) ) {
             my $Error = $SMTP->code() . $SMTP->message();
             $Kernel::OM->Get('Kernel::System::Log')->Log(


### PR DESCRIPTION
Resolved problem with unnecessary comma at the end of list in
AgentTicketPhone.pm (From list) and SMTP.pm (debug message).

Related: 91648a4a2a69797cb26de77c2dd1a5322705b7bb
Related: https://dev.ib.pl/ib/otrs/issues/37
Author-Change-Id: IB#1007956