### PR TITLE
auth: Handle Sync before TwoFactor-Auth. possible fix of #11966

### DIFF
--- a/Kernel/System/Auth.pm
+++ b/Kernel/System/Auth.pm
@@ -164,32 +164,6 @@ sub Auth {
             UserLogin => $User,
         );
 
-        # check 2factor auth backends
-        my $TwoFactorAuth;
-        TWOFACTORSOURCE:
-        for my $Count ( '', 1 .. 10 ) {
-
-            # return on no config setting
-            next TWOFACTORSOURCE if !$Self->{"AuthTwoFactorBackend$Count"};
-
-            # 2factor backend
-            my $AuthOk = $Self->{"AuthTwoFactorBackend$Count"}->Auth(
-                TwoFactorToken => $Param{TwoFactorToken},
-                User           => $User,
-                UserID         => $UserID,
-            );
-            $TwoFactorAuth = $AuthOk ? 'passed' : 'failed';
-
-            last TWOFACTORSOURCE if $AuthOk;
-        }
-
-        # if at least one 2factor auth backend was checked but none was successful,
-        # it counts as a failed login
-        if ( $TwoFactorAuth && $TwoFactorAuth ne 'passed' ) {
-            $User = undef;
-            last COUNT;
-        }
-
         # configured auth sync backend
         my $AuthSyncBackend = $ConfigObject->Get("AuthModule::UseSyncBackend$Count");
         if ( !defined $AuthSyncBackend ) {
@@ -220,6 +194,37 @@ sub Auth {
                 # sync backend
                 $Self->{"AuthSyncBackend$Count"}->Sync( %Param, User => $User );
             }
+        }
+
+        # retry getting a valid user after sync to proceed with 2factor auth
+        my $UserID = $UserObject->UserLookup(
+            UserLogin => $Param{User},
+        );
+
+        # check 2factor auth backends
+        my $TwoFactorAuth;
+        TWOFACTORSOURCE:
+        for my $Count ( '', 1 .. 10 ) {
+
+            # return on no config setting
+            next TWOFACTORSOURCE if !$Self->{"AuthTwoFactorBackend$Count"};
+
+            # 2factor backend
+            my $AuthOk = $Self->{"AuthTwoFactorBackend$Count"}->Auth(
+                TwoFactorToken => $Param{TwoFactorToken},
+                User           => $User,
+                UserID         => $UserID,
+            );
+            $TwoFactorAuth = $AuthOk ? 'passed' : 'failed';
+
+            last TWOFACTORSOURCE if $AuthOk;
+        }
+
+        # if at least one 2factor auth backend was checked but none was successful,
+        # it counts as a failed login
+        if ( $TwoFactorAuth && $TwoFactorAuth ne 'passed' ) {
+            $User = undef;
+            last COUNT;
         }
 
         # remember auth backend

--- a/Kernel/System/Auth.pm
+++ b/Kernel/System/Auth.pm
@@ -160,10 +160,6 @@ sub Auth {
         # next on no success
         next COUNT if !$User;
 
-        my $UserID = $UserObject->UserLookup(
-            UserLogin => $User,
-        );
-
         # configured auth sync backend
         my $AuthSyncBackend = $ConfigObject->Get("AuthModule::UseSyncBackend$Count");
         if ( !defined $AuthSyncBackend ) {
@@ -196,8 +192,7 @@ sub Auth {
             }
         }
 
-        # retry getting a valid user after sync to proceed with 2factor auth
-        $UserID = $UserObject->UserLookup(
+        my $UserID = $UserObject->UserLookup(
             UserLogin => $Param{User},
         );
 

--- a/Kernel/System/Auth.pm
+++ b/Kernel/System/Auth.pm
@@ -197,7 +197,7 @@ sub Auth {
         }
 
         # retry getting a valid user after sync to proceed with 2factor auth
-        my $UserID = $UserObject->UserLookup(
+        $UserID = $UserObject->UserLookup(
             UserLogin => $Param{User},
         );
 


### PR DESCRIPTION
some TwoFactor-Modules require a set UserID-field to gather their settings.
this will sync users even when their TwoFactor-Auth would have failed, but
their primary Password lookup must have been successful.