### PR TITLE
Marked TimeInputFormat types as translatable

### DIFF
--- a/Kernel/Config/Files/Framework.xml
+++ b/Kernel/Config/Files/Framework.xml
@@ -504,8 +504,8 @@
         <SubGroup>Core::Time</SubGroup>
         <Setting>
             <Option SelectedID="Option">
-                <Item Key="Option">Option</Item>
-                <Item Key="Input">Input</Item>
+                <Item Key="Option" Translatable="1">Option</Item>
+                <Item Key="Input" Translatable="1">Input</Item>
             </Option>
         </Setting>
     </ConfigItem>


### PR DESCRIPTION
Hi @mgruner 
This small PR makes translatable the types of TimeInputFormat in SysConfig. Branch rel-5_0 is also affected.