### PR TITLE
Update Core.UI.Autocomplete.js

### DIFF
--- a/var/httpd/htdocs/js/Core.UI.Autocomplete.js
+++ b/var/httpd/htdocs/js/Core.UI.Autocomplete.js
@@ -166,11 +166,11 @@ Core.UI.Autocomplete = (function (TargetNS) {
                     var FieldID = $SingleElement.attr('id'),
                         LoaderHTML = '<span id="' + AJAXLoaderPrefix + FieldID + '" class="AJAXLoader"></span>';
 
-                    $Loader = $('#' + AJAXLoaderPrefix + FieldID);
+                    $Loader = $('#' + AJAXLoaderPrefix + Core.App.EscapeSelector(FieldID));
 
                     if (!$Loader.length) {
                         $SingleElement.after(LoaderHTML);
-                        $Loader = $('#' + AJAXLoaderPrefix + FieldID);
+                        $Loader = $('#' + AJAXLoaderPrefix + Core.App.EscapeSelector(FieldID));
                     }
                     else {
                         $Loader.show();


### PR DESCRIPTION
Modification fixes use of CI-attribute type "Customer" if used as sub-attribute. If not applied, auto complete does not start because of JS error on ids which contain double-colons.

PS: check if update required on HEAD/MASTER as well