### PR TITLE
Fixed translatable messages to display translations

### DIFF
--- a/Kernel/Modules/AdminPackageManager.pm
+++ b/Kernel/Modules/AdminPackageManager.pm
@@ -527,7 +527,7 @@ sub Run {
             $Output .= $LayoutObject->Notify(
                 Priority => 'Error',
                 Data     => "$Name $Version - "
-                    . Translatable(
+                    . $LayoutObject->{LanguageObject}->Translate(
                     "Package not verified by the OTRS Group! It is recommended not to use this package."
                     ),
             );
@@ -1660,7 +1660,9 @@ sub Run {
         $Output .= $LayoutObject->Notify(
             Priority => 'Error',
             Data     => "$Package $NotVerifiedPackages{$Package} - "
-                . Translatable("Package not verified by the OTRS Group! It is recommended not to use this package."),
+                . $LayoutObject->{LanguageObject}->Translate(
+                "Package not verified by the OTRS Group! It is recommended not to use this package."
+                ),
         );
     }
 
@@ -1675,7 +1677,9 @@ sub Run {
             $Output .= $LayoutObject->Notify(
                 Priority => 'Error',
                 Data     => "$Package $UnknownVerficationPackages{$Package} - "
-                    . Translatable("Package not verified due a communication issue with verification server!"),
+                    . $LayoutObject->{LanguageObject}->Translate(
+                    "Package not verified due a communication issue with verification server!"
+                    ),
             );
         }
     }

--- a/Kernel/Output/HTML/Notification/UIDCheck.pm
+++ b/Kernel/Output/HTML/Notification/UIDCheck.pm
@@ -32,9 +32,8 @@ sub Run {
     return $LayoutObject->Notify(
         Priority => 'Error',
         Link     => $LayoutObject->{Baselink} . 'Action=AdminUser',
-        Data =>
-            $LayoutObject->{LanguageObject}->Translate(
-            "Don't use the Superuser account to work with OTRS! Create new Agents and work with these accounts instead."
+        Info     => Translatable(
+            'Don\'t use the Superuser account to work with OTRS! Create new Agents and work with these accounts instead.'
             ),
     );
 }

--- a/Kernel/Output/HTML/Notification/UIDCheck.pm
+++ b/Kernel/Output/HTML/Notification/UIDCheck.pm
@@ -33,7 +33,7 @@ sub Run {
         Priority => 'Error',
         Link     => $LayoutObject->{Baselink} . 'Action=AdminUser',
         Data =>
-            Translatable(
+            $LayoutObject->{LanguageObject}->Translate(
             "Don't use the Superuser account to work with OTRS! Create new Agents and work with these accounts instead."
             ),
     );


### PR DESCRIPTION
Hi @mgruner 
This messages have complex HTML structure, when they are displayed on the notification bar, so they need to translated in place. Otherwise they remains untranslated.