### PR TITLE
Fixed bug 11990: Kernel/Config/ files matching regex .pm may throw an…

### DIFF
--- a/Kernel/Config/Defaults.pm
+++ b/Kernel/Config/Defaults.pm
@@ -2000,7 +2000,7 @@ sub new {
                 $File =~ s/^\///g;
                 $File =~ s/\/\//\//g;
                 $File =~ s/\//::/g;
-                $File =~ s/.pm//g;
+                $File =~ s/\.pm$//g;
                 $File->Load($Self);
             }
             else {


### PR DESCRIPTION
… error while loading.

See: http://bugs.otrs.org/show_bug.cgi?id=11990 for further information.