### PR TITLE
[Rel-5_0] - UnitTest - CustomerRealName - bug 4640

### DIFF
--- a/Kernel/System/TemplateGenerator.pm
+++ b/Kernel/System/TemplateGenerator.pm
@@ -1462,7 +1462,7 @@ sub _Replace {
                 }
 
                 # try to get the real name directly from the data
-                $From //= $Recipient{RealName};
+                $From //= $Recipient{Realname};
 
                 # get real name based on reply-to
                 if ( $Data{ReplyTo} ) {

--- a/Kernel/System/Ticket/Event/NotificationEvent.pm
+++ b/Kernel/System/Ticket/Event/NotificationEvent.pm
@@ -311,7 +311,9 @@ sub Run {
                 );
 
                 # remember to have sent
-                $AlreadySent{ $Bundle->{Recipient}->{UserID} } = 1;
+                if ( $Bundle->{Recipient}->{UserID} ) {
+                    $AlreadySent{ $Bundle->{Recipient}->{UserID} } = 1;
+                }
 
             }
 

--- a/scripts/test/TemplateGenerator/CustomerRealName.t
+++ b/scripts/test/TemplateGenerator/CustomerRealName.t
@@ -13,10 +13,14 @@ use utf8;
 use vars (qw($Self));
 
 # get needed objects
-my $AutoResponseObject = $Kernel::OM->Get('Kernel::System::AutoResponse');
-my $CommandObject      = $Kernel::OM->Get('Kernel::System::Console::Command::Maint::PostMaster::Read');
-my $TicketObject       = $Kernel::OM->Get('Kernel::System::Ticket');
-my $DBObject           = $Kernel::OM->Get('Kernel::System::DB');
+my $AutoResponseObject      = $Kernel::OM->Get('Kernel::System::AutoResponse');
+my $CommandObject           = $Kernel::OM->Get('Kernel::System::Console::Command::Maint::PostMaster::Read');
+my $TicketObject            = $Kernel::OM->Get('Kernel::System::Ticket');
+my $DBObject                = $Kernel::OM->Get('Kernel::System::DB');
+my $NotificationEventObject = $Kernel::OM->Get('Kernel::System::NotificationEvent');
+
+# define needed variable
+my $RandomID = $Kernel::OM->Get('Kernel::System::UnitTest::Helper')->GetRandomID();
 
 $Kernel::OM->ObjectParamAdd(
     'Kernel::System::UnitTest::Helper' => {
@@ -59,10 +63,9 @@ $Self->True(
 );
 
 # add auto response
-my $AutoResponseNameRand0 = 'AutoResponse' . $RandomID;
-
-my $AutoResponseID = $AutoResponseObject->AutoResponseAdd(
-    Name        => $AutoResponseNameRand0,
+my $AutoResponseNameRand = 'AutoResponse' . $RandomID;
+my $AutoResponseID       = $AutoResponseObject->AutoResponseAdd(
+    Name        => $AutoResponseNameRand,
     Subject     => 'Unit Test AutoResponse Bug#4640',
     Response    => 'OTRS_CUSTOMER_REALNAME tag: <OTRS_CUSTOMER_REALNAME>',
     Comment     => 'Unit test auto response',
@@ -74,7 +77,7 @@ my $AutoResponseID = $AutoResponseObject->AutoResponseAdd(
 );
 $Self->True(
     $AutoResponseID,
-    "AutoResponseAdd() - $AutoResponseNameRand0, $AutoResponseID",
+    "AutoResponseAdd() - $AutoResponseNameRand, $AutoResponseID",
 );
 
 # assign auto response to queue
@@ -88,24 +91,102 @@ $Self->True(
     "AutoResponseQueue() - success"
 );
 
+# add customer user
+my $CustomerUser   = 'Customer' . $RandomID;
+my $CustomerUserID = $Kernel::OM->Get('Kernel::System::CustomerUser')->CustomerUserAdd(
+    Source         => 'CustomerUser',
+    UserFirstname  => $CustomerUser,
+    UserLastname   => $CustomerUser,
+    UserCustomerID => 'TestCompany',
+    UserLogin      => $CustomerUser,
+    UserPassword   => $CustomerUser,
+    UserEmail      => $CustomerUser . '@home.com',
+    ValidID        => 1,
+    UserID         => 1,
+);
+$Self->True(
+    $CustomerUserID,
+    "CustomerUserAdd() - $CustomerUser, $CustomerUserID",
+);
+
+# add notificaiton with customer as recipient
+my $NotificationName = 'Notification' . $RandomID;
+my $NotificationID   = $NotificationEventObject->NotificationAdd(
+    Name    => $NotificationName,
+    Comment => 'Unit Test Notification <OTRS_CUSTOMER_REALNAME> tag',
+    Data    => {
+        Transports => ['Email'],
+        Events     => ['NotificationNewTicket'],
+        Recipients => ['Customer'],
+        QueueID    => [$QueueID],
+    },
+    Message => {
+        en => {
+            Subject     => 'Notification subject',
+            Body        => 'OTRS_CUSTOMER_REALNAME tag: <OTRS_CUSTOMER_REALNAME>',
+            ContentType => 'text/plain',
+        },
+    },
+    ValidID => 1,
+    UserID  => 1,
+);
+$Self->True(
+    $NotificationID,
+    "NotificationAdd() - $NotificationName, $NotificationID",
+);
+
 # get test data
 my @Tests = (
     {
         Name => 'Email without Reply-To tag',
         Email =>
             "From: TestFrom\@home.com\nTo: TestTo\@home.com\nSubject: Email without Reply-To tag\nTest Body Email.\n",
-        Result => {
+        ResultAutoResponse => {
             To   => 'TestFrom@home.com',
             Body => 'OTRS_CUSTOMER_REALNAME tag: TestTo@home.com',
+        },
+        ResultNotification => {
+            To   => 'TestFrom@home.com',
+            Body => 'OTRS_CUSTOMER_REALNAME tag: TestFrom@home.com',
             }
     },
     {
         Name => 'Email with Reply-To tag',
         Email =>
             "From: TestFrom\@home.com\nTo: TestTo\@home.com\nReply-To: TestReplyTo\@home.com\nSubject: Email with Reply-To tag\nTest Body Email.\n",
-        Result => {
+        ResultAutoResponse => {
             To   => 'TestReplyTo@home.com',
             Body => 'OTRS_CUSTOMER_REALNAME tag: TestReplyTo@home.com',
+        },
+        ResultNotification => {
+            To   => 'TestFrom@home.com',
+            Body => 'OTRS_CUSTOMER_REALNAME tag: TestReplyTo@home.com',
+            }
+    },
+    {
+        Name => 'Email with CustomerID',
+        Email =>
+            "From: $CustomerUser\@home.com\nTo: TestTo\@home.com\nSubject: Email with valid CustomerID\nTest Body Email.\n",
+        ResultAutoResponse => {
+            To   => "$CustomerUser\@home.com",
+            Body => "OTRS_CUSTOMER_REALNAME tag: $CustomerUser $CustomerUser",
+        },
+        ResultNotification => {
+            To   => "$CustomerUser\@home.com",
+            Body => "OTRS_CUSTOMER_REALNAME tag: $CustomerUser $CustomerUser",
+            }
+    },
+    {
+        Name => 'Email with Customer as Recipient',
+        Email =>
+            "From: TestRecipient\@home.com\nTo: TestTo\@home.com\nSubject: Email with Recipient\nTest Body Email.\n",
+        ResultAutoResponse => {
+            To   => 'TestRecipient@home.com',
+            Body => 'OTRS_CUSTOMER_REALNAME tag: TestTo@home.com',
+        },
+        ResultNotification => {
+            To   => 'TestRecipient@home.com',
+            Body => 'OTRS_CUSTOMER_REALNAME tag: TestRecipient@home.com',
             }
     },
 );
@@ -123,6 +204,11 @@ for my $Test (@Tests) {
         open STDOUT, '>:utf8', \$Result;          ## no critic
 
         $ExitCode = $CommandObject->Execute( '--target-queue', $QueueNameRand, '--debug' );
+
+        # reset CGI object from previous runs
+        CGI::initialize_globals();
+
+        # discard Web::Request from OM to prevent duplicated entries
         $Kernel::OM->ObjectsDiscard( Objects => ['Kernel::System::PostMaster'] );
     }
 
@@ -149,13 +235,35 @@ for my $Test (@Tests) {
     );
 
     # check auto response article values
-    for my $Key ( sort keys %{ $Test->{Result} } ) {
+    for my $AutoResponseKey ( sort keys $Test->{ResultAutoResponse} ) {
 
         $Self->Is(
-            $ArticleAutoResponse{$Key},
-            $Test->{Result}->{$Key},
-            "$Test->{Name}, tag $Key",
+            $ArticleAutoResponse{$AutoResponseKey},
+            $Test->{ResultAutoResponse}->{$AutoResponseKey},
+            "AutoResponse: $Test->{Name}, tag $AutoResponseKey",
         );
+    }
+
+    # get notification article data
+    my %ArticleNotification = $TicketObject->ArticleGet(
+        ArticleID => $ArticleIDs[2],
+        UserID    => 1,
+    );
+
+    for my $NotificationKey ( sort keys $Test->{ResultNotification} ) {
+        if ( $NotificationKey eq 'To' ) {
+            $Self->Is(
+                $ArticleNotification{$NotificationKey},
+                $Test->{ResultNotification}->{$NotificationKey},
+                "Notification: $Test->{Name}, tag $NotificationKey",
+            );
+        }
+        else {
+            $Self->True(
+                $ArticleNotification{$NotificationKey} =~ /$Test->{ResultNotification}->{$NotificationKey}/,
+                "Notification: $Test->{Name}, $Test->{ResultNotification}->{$NotificationKey}, tag $NotificationKey"
+            );
+        }
     }
 }
 

--- a/scripts/test/TemplateGenerator/CustomerRealName.t
+++ b/scripts/test/TemplateGenerator/CustomerRealName.t
@@ -13,11 +13,9 @@ use utf8;
 use vars (qw($Self));
 
 # get needed objects
-my $AutoResponseObject      = $Kernel::OM->Get('Kernel::System::AutoResponse');
-my $CommandObject           = $Kernel::OM->Get('Kernel::System::Console::Command::Maint::PostMaster::Read');
-my $DBObject                = $Kernel::OM->Get('Kernel::System::DB');
-my $NotificationEventObject = $Kernel::OM->Get('Kernel::System::NotificationEvent');
-my $ConfigObject            = $Kernel::OM->Get('Kernel::Config');
+my $AutoResponseObject = $Kernel::OM->Get('Kernel::System::AutoResponse');
+my $CommandObject      = $Kernel::OM->Get('Kernel::System::Console::Command::Maint::PostMaster::Read');
+my $ConfigObject       = $Kernel::OM->Get('Kernel::Config');
 
 $Kernel::OM->ObjectParamAdd(
     'Kernel::System::UnitTest::Helper' => {
@@ -26,6 +24,12 @@ $Kernel::OM->ObjectParamAdd(
 );
 my $Helper   = $Kernel::OM->Get('Kernel::System::UnitTest::Helper');
 my $RandomID = $Helper->GetRandomID();
+
+# do not check email addresses
+$ConfigObject->Set(
+    Key   => 'CheckEmailAddresses',
+    Value => 0,
+);
 
 # do not really send emails
 $ConfigObject->Set(
@@ -114,7 +118,7 @@ $Self->True(
 
 # add notificaiton with customer as recipient
 my $NotificationName = 'Notification' . $RandomID;
-my $NotificationID   = $NotificationEventObject->NotificationAdd(
+my $NotificationID   = $Kernel::OM->Get('Kernel::System::NotificationEvent')->NotificationAdd(
     Name    => $NotificationName,
     Comment => 'Unit Test Notification <OTRS_CUSTOMER_REALNAME> tag',
     Data    => {

--- a/scripts/test/TemplateGenerator/CustomerRealName.t
+++ b/scripts/test/TemplateGenerator/CustomerRealName.t
@@ -99,7 +99,7 @@ $Self->True(
 );
 
 # add customer user
-my $CustomerUser   = 'Customer' . $RandomID;
+my $CustomerUser   = $RandomID;
 my $CustomerUserID = $Kernel::OM->Get('Kernel::System::CustomerUser')->CustomerUserAdd(
     Source         => 'CustomerUser',
     UserFirstname  => $CustomerUser,
@@ -267,7 +267,7 @@ for my $Test (@Tests) {
         }
         else {
             $Self->True(
-                $ArticleNotification{$NotificationKey} =~ /$Test->{ResultNotification}->{$NotificationKey}/,
+                index( $ArticleNotification{$NotificationKey}, $Test->{ResultNotification}->{$NotificationKey} ) > -1,
                 "Notification: $Test->{Name}, $Test->{ResultNotification}->{$NotificationKey}, tag $NotificationKey"
             );
         }

--- a/scripts/test/TemplateGenerator/CustomerRealName.t
+++ b/scripts/test/TemplateGenerator/CustomerRealName.t
@@ -242,7 +242,7 @@ for my $Test (@Tests) {
     );
 
     # check auto response article values
-    for my $AutoResponseKey ( sort keys $Test->{ResultAutoResponse} ) {
+    for my $AutoResponseKey ( sort keys %{ $Test->{ResultAutoResponse} } ) {
 
         $Self->Is(
             $ArticleAutoResponse{$AutoResponseKey},
@@ -257,7 +257,7 @@ for my $Test (@Tests) {
         UserID    => 1,
     );
 
-    for my $NotificationKey ( sort keys $Test->{ResultNotification} ) {
+    for my $NotificationKey ( sort keys %{ $Test->{ResultNotification} } ) {
         if ( $NotificationKey eq 'To' ) {
             $Self->Is(
                 $ArticleNotification{$NotificationKey},


### PR DESCRIPTION
Hello @mrcbnsls ,

Hereby is extended unit test for CustomerRealName from the bug #795 . There was an issue when $From needs to be taken from Recipients, param RealName doesn't exists in Recipients. Corrected typo to param Realname and now it perform as expected.

In unit test added 2 more scenarios when there is customer ID and one more with recipient, Additionally included notification tag check, since it differs then auto response.

Please let me know what do you think about this proposal and if there are any questions regarding this PR, feel free to ask.

Regards,
Sanjin