### PR TITLE
Do not use hard coded action for cancel link

### DIFF
--- a/Kernel/Output/HTML/Templates/Standard/AdminTemplate.tt
+++ b/Kernel/Output/HTML/Templates/Standard/AdminTemplate.tt
@@ -199,7 +199,7 @@
                         <div class="Field">
                             <button class="Primary CallForAction" type="submit" value="[% Translate("Save") | html %]"><span>[% Translate("Save") | html %]</span></button>
                             [% Translate("or") | html %]
-                            <a href="[% Env("Baselink") %]Action=AdminTemplate">[% Translate("Cancel") | html %]</a>
+                            <a href="[% Env("Baselink") %]Action=[% Env("Action") %]">[% Translate("Cancel") | html %]</a>
                         </div>
                         <div class="Clear"></div>
                     </fieldset>


### PR DESCRIPTION
Until now the action in the cancel link is hard coded. Creating it dynamicly allows a same behavior like the "Go to overview" link.