### PR TITLE
Fixed bug #11430: (Ticket )Cache won't get updated on DynamicField Va…

### DIFF
--- a/Kernel/System/DynamicField/Backend.pm
+++ b/Kernel/System/DynamicField/Backend.pm
@@ -621,6 +621,11 @@ sub ValueDelete {
         }
     }
 
+    my $OldValue = $Self->ValueGet(
+        DynamicFieldConfig => $Param{DynamicFieldConfig},
+        ObjectID           => $Param{ObjectID},
+    );
+
     # set the dynamic field specific backend
     my $DynamicFieldBackend = 'DynamicField' . $Param{DynamicFieldConfig}->{FieldType} . 'Object';
 
@@ -632,7 +637,30 @@ sub ValueDelete {
         return;
     }
 
-    return $Self->{$DynamicFieldBackend}->ValueDelete(%Param);
+    my $Success = $Self->{$DynamicFieldBackend}->ValueDelete(%Param);
+
+    if ( !$Success ) {
+        $Kernel::OM->Get('Kernel::System::Log')->Log(
+            Priority => 'error',
+            Message  => "Could not update field $Param{DynamicFieldConfig}->{Name} for "
+                . "$Param{DynamicFieldConfig}->{ObjectType} ID $Param{ObjectID} !",
+        );
+        return;
+    }
+
+    # set the dyanamic field object handler
+    my $DynamicFieldObjectHandler =
+        'DynamicField' . $Param{DynamicFieldConfig}->{ObjectType} . 'HandlerObject';
+
+    # If an ObjectType handler is registered, use it.
+    if ( ref $Self->{$DynamicFieldObjectHandler} ) {
+        return $Self->{$DynamicFieldObjectHandler}->PostValueSet(
+            OldValue => $OldValue,
+            %Param,
+        );
+    }
+
+    return 1;
 }
 
 =item AllValuesDelete()

--- a/Kernel/System/Ticket.pm
+++ b/Kernel/System/Ticket.pm
@@ -588,6 +588,32 @@ sub TicketDelete {
         }
     }
 
+    # get dynamic field objects
+    my $DynamicFieldObject        = $Kernel::OM->Get('Kernel::System::DynamicField');
+    my $DynamicFieldBackendObject = $Kernel::OM->Get('Kernel::System::DynamicField::Backend');
+
+    # get all dynamic fields for the object type Ticket
+    my $DynamicFieldListTicket = $DynamicFieldObject->DynamicFieldListGet(
+        ObjectType => 'Ticket',
+        Valid      => 0,
+    );
+
+    # delete dynamicfield values for this ticket
+    DYNAMICFIELD:
+    for my $DynamicFieldConfig ( @{$DynamicFieldListTicket} ) {
+
+        next DYNAMICFIELD if !$DynamicFieldConfig;
+        next DYNAMICFIELD if !IsHashRefWithData($DynamicFieldConfig);
+        next DYNAMICFIELD if !$DynamicFieldConfig->{Name};
+        next DYNAMICFIELD if !IsHashRefWithData( $DynamicFieldConfig->{Config} );
+
+        $DynamicFieldBackendObject->ValueDelete(
+            DynamicFieldConfig => $DynamicFieldConfig,
+            ObjectID           => $Param{TicketID},
+            UserID             => $Param{UserID},
+        );
+    }
+
     # clear ticket cache
     $Self->_TicketCacheClear( TicketID => $Param{TicketID} );
 
@@ -631,32 +657,6 @@ sub TicketDelete {
         return if !$Self->ArticleDelete(
             ArticleID => $ArticleID,
             %Param,
-        );
-    }
-
-    # get dynamic field objects
-    my $DynamicFieldObject        = $Kernel::OM->Get('Kernel::System::DynamicField');
-    my $DynamicFieldBackendObject = $Kernel::OM->Get('Kernel::System::DynamicField::Backend');
-
-    # get all dynamic fields for the object type Ticket
-    my $DynamicFieldListTicket = $DynamicFieldObject->DynamicFieldListGet(
-        ObjectType => 'Ticket',
-        Valid      => 0,
-    );
-
-    # delete dynamicfield values for this ticket
-    DYNAMICFIELD:
-    for my $DynamicFieldConfig ( @{$DynamicFieldListTicket} ) {
-
-        next DYNAMICFIELD if !$DynamicFieldConfig;
-        next DYNAMICFIELD if !IsHashRefWithData($DynamicFieldConfig);
-        next DYNAMICFIELD if !$DynamicFieldConfig->{Name};
-        next DYNAMICFIELD if !IsHashRefWithData( $DynamicFieldConfig->{Config} );
-
-        $DynamicFieldBackendObject->ValueDelete(
-            DynamicFieldConfig => $DynamicFieldConfig,
-            ObjectID           => $Param{TicketID},
-            UserID             => $Param{UserID},
         );
     }
 

--- a/scripts/test/DynamicField/Backend.t
+++ b/scripts/test/DynamicField/Backend.t
@@ -48,8 +48,9 @@ $Self->True(
 );
 
 # create a dynamic field
+my $DynamicFieldName = "dynamicfieldtest$RandomID";
 my $FieldID = $DynamicFieldObject->DynamicFieldAdd(
-    Name       => "dynamicfieldtest$RandomID",
+    Name       => $DynamicFieldName,
     Label      => 'a description',
     FieldOrder => 9991,
     FieldType  => 'Text',
@@ -59,6 +60,10 @@ my $FieldID = $DynamicFieldObject->DynamicFieldAdd(
     },
     ValidID => 1,
     UserID  => 1,
+);
+
+my $DynamicFieldConfig = $DynamicFieldObject->DynamicFieldGet(
+    ID => $FieldID,
 );
 
 # sanity check
@@ -782,23 +787,51 @@ for my $Test (@Tests) {
 my $Value = 123;
 
 $BackendObject->ValueSet(
-    DynamicFieldConfig => {
-        ID         => $FieldID,
-        ObjectType => 'Ticket',
-        FieldType  => 'Text',
-    },
-    ObjectID => $TicketID,
-    Value    => $Value,
-    UserID   => 1,
+    DynamicFieldConfig => $DynamicFieldConfig,
+    ObjectID           => $TicketID,
+    Value              => $Value,
+    UserID             => 1,
+);
+
+my %TicketValueDeleteData = $TicketObject->TicketGet(
+    TicketID      => $TicketID,
+    DynamicFields => 1,
+    UserID        => 1,
+);
+
+$Self->Is(
+    $TicketValueDeleteData{'DynamicField_'. $DynamicFieldName},
+    $Value,
+    "Should have value '$Value' set.",
+);
+
+$BackendObject->ValueDelete(
+    DynamicFieldConfig => $DynamicFieldConfig,
+    ObjectID           => $TicketID,
+    UserID             => 1,
+);
+
+%TicketValueDeleteData = $TicketObject->TicketGet(
+    TicketID      => $TicketID,
+    DynamicFields => 1,
+    UserID        => 1,
+);
+
+$Self->False(
+    $TicketValueDeleteData{'DynamicField_'. $DynamicFieldName},
+    "Ticket shouldn't have a value.",
+);
+
+$BackendObject->ValueSet(
+    DynamicFieldConfig => $DynamicFieldConfig,
+    ObjectID           => $TicketID,
+    Value              => $Value,
+    UserID             => 1,
 );
 my $ReturnValue1 = $BackendObject->ValueGet(
-    DynamicFieldConfig => {
-        ID         => $FieldID,
-        ObjectType => 'Ticket',
-        FieldType  => 'Text',
-    },
-    ObjectID => $TicketID,
-    UserID   => 1,
+    DynamicFieldConfig => $DynamicFieldConfig,
+    ObjectID           => $TicketID,
+    UserID             => 1,
 );
 
 $Self->Is(
@@ -820,13 +853,9 @@ $Self->True(
 );
 
 my $ReturnValue2 = $BackendObject->ValueGet(
-    DynamicFieldConfig => {
-        ID         => $FieldID,
-        ObjectType => 'Ticket',
-        FieldType  => 'Text',
-    },
-    ObjectID => $TicketID,
-    UserID   => 1,
+    DynamicFieldConfig => $DynamicFieldConfig,
+    ObjectID           => $TicketID,
+    UserID             => 1,
 );
 
 $Self->Is(
@@ -836,12 +865,8 @@ $Self->Is(
 );
 
 my $ValuesDelete = $BackendObject->AllValuesDelete(
-    DynamicFieldConfig => {
-        ID         => $FieldID,
-        ObjectType => 'Ticket',
-        FieldType  => 'Text',
-    },
-    UserID => 1,
+    DynamicFieldConfig => $DynamicFieldConfig,
+    UserID             => 1,
 );
 
 # sanity check


### PR DESCRIPTION
…lueDelete.

Please see: http://bugs.otrs.org/show_bug.cgi?id=11430

We ran in this issue again in one of our package UnitTests.

Basically this is what's wrong:

- Create Ticket with DF value
- Delete DF Value via DFBackendObject->ValueDelete
- Perform a TicketGet including DFs (in the same process as DF Delete)
- Notice that DF is still set in TicketGet result

A workaround for the TicketGet issue is:

```perl
# clear ticket cache
$TicketObject->_TicketCacheClear( TicketID => $TicketID );
```

Additionally there is no entry in the TicketHistory where the deletion of the value is logged mismatching the behavior of ValueSet which gets logged in TicketHistory.

If there are any questions please let me know.
  Thorsten