### PR TITLE
Rel-5_0 - fixed visibility of navigation menu items

### DIFF
--- a/var/httpd/htdocs/js/Core.Agent.js
+++ b/var/httpd/htdocs/js/Core.Agent.js
@@ -224,7 +224,7 @@ Core.Agent = (function (TargetNS) {
 
                     if ($('body').hasClass('Visible-ScreenXL')) {
 
-                        $('#NavigationContainer').css('height', '300px');
+                        $('#NavigationContainer').css('height', '500px');
 
                         // If Timeout is set for this nav element, clear it
                         ClearSubnavCloseTimeout($Element);


### PR DESCRIPTION
Hi @mgruner and @mrcbnsls 

There is an issue with navigation manu items in case there are many menu items. You can see following image:

![manu-items](https://cloud.githubusercontent.com/assets/6348760/14531578/382faa32-025e-11e6-81d6-fa52812ae3e0.png)

It is my suggestion how we can solve that, but maybe it could be better if we refactoring this and add min-height and height:auto for NavigationContainer. I am not sure about that, but @mrcbnsls is definitely better with frontend and your opinion is welcomed about that.

Regards
Zoran
