### PR TITLE
Add support for X-OTRS-Title in PostMaster/NewTicket

### DIFF
--- a/Kernel/Config/Files/Ticket.xml
+++ b/Kernel/Config/Files/Ticket.xml
@@ -10049,6 +10049,7 @@
                 <Item>X-OTRS-Type</Item>
                 <Item>X-OTRS-Service</Item>
                 <Item>X-OTRS-SLA</Item>
+                <Item>X-OTRS-Title</Item>
                 <Item>X-OTRS-CustomerNo</Item>
                 <Item>X-OTRS-CustomerUser</Item>
                 <Item>X-OTRS-SenderType</Item>
@@ -10063,6 +10064,7 @@
                 <Item>X-OTRS-FollowUp-SLA</Item>
                 <Item>X-OTRS-FollowUp-SenderType</Item>
                 <Item>X-OTRS-FollowUp-ArticleType</Item>
+                <Item>X-OTRS-FollowUp-Title</Item>
             </Array>
         </Setting>
     </ConfigItem>

--- a/Kernel/System/PostMaster/FollowUp.pm
+++ b/Kernel/System/PostMaster/FollowUp.pm
@@ -494,6 +494,19 @@ sub Run {
         }
     }
 
+    # set ticket title
+    if ( $GetParam{'X-OTRS-FollowUp-Title'} ) {
+        $TicketObject->TicketTitleUpdate(
+            Title    => $GetParam{'X-OTRS-FollowUp-Title'},
+            TicketID => $Param{TicketID},
+            UserID   => $Param{InmailUserID},
+        );
+
+        if ( $Self->{Debug} > 0 ) {
+            print "Title: $GetParam{'X-OTRS-FollowUp-Title'}\n";
+        }
+    }
+
     # write log
     $Kernel::OM->Get('Kernel::System::Log')->Log(
         Priority => 'notice',

--- a/Kernel/System/PostMaster/NewTicket.pm
+++ b/Kernel/System/PostMaster/NewTicket.pm
@@ -228,7 +228,7 @@ sub Run {
     my $NewTn    = $TicketObject->TicketCreateNumber();
     my $TicketID = $TicketObject->TicketCreate(
         TN           => $NewTn,
-        Title        => $GetParam{Subject},
+        Title        => $GetParam{'X-OTRS-Title'} || $GetParam{Subject},
         QueueID      => $QueueID,
         Lock         => $GetParam{'X-OTRS-Lock'} || 'unlock',
         Priority     => $Priority,

--- a/scripts/test/PostMaster/X-OTRS-Title.t
+++ b/scripts/test/PostMaster/X-OTRS-Title.t
@@ -1,0 +1,157 @@
+# --
+# Copyright (C) 2001-2016 OTRS AG, http://otrs.com/
+# --
+# This software comes with ABSOLUTELY NO WARRANTY. For details, see
+# the enclosed file COPYING for license information (AGPL). If you
+# did not receive this file, see http://www.gnu.org/licenses/agpl.txt.
+# --
+
+use strict;
+use warnings;
+use utf8;
+
+use vars (qw($Self));
+
+use Kernel::System::PostMaster;
+
+$Kernel::OM->ObjectParamAdd(
+    'Kernel::System::UnitTest::Helper' => {
+        RestoreDatabase => 1,
+    },
+);
+my $Helper = $Kernel::OM->Get('Kernel::System::UnitTest::Helper');
+
+# get needed objects
+my $ConfigObject = $Kernel::OM->Get('Kernel::Config');
+my $MainObject   = $Kernel::OM->Get('Kernel::System::Main');
+
+# ensure that the appropriate X-Headers are available in the config
+my %NeededXHeaders = (
+    'X-OTRS-Title'          => 1,
+    'X-OTRS-FollowUp-Title' => 1,
+);
+
+my $XHeaders          = $ConfigObject->Get('PostmasterX-Header');
+my @PostmasterXHeader = @{$XHeaders};
+
+HEADER:
+for my $Header ( sort keys %NeededXHeaders ) {
+    next HEADER if ( grep $_ eq $Header, @PostmasterXHeader );
+    push @PostmasterXHeader, $Header;
+}
+
+$ConfigObject->Set(
+    Key   => 'PostmasterX-Header',
+    Value => \@PostmasterXHeader
+);
+
+# filter test
+my @Tests = (
+    {
+        Name  => '#1 - Body Test',
+        Email => 'From: Sender <sender@example.com>
+To: Some Name <recipient@example.com>
+Subject: A simple question
+X-OTRS-Title: UnitTest-1
+
+This is a multiline
+email for server: example.tld
+
+The IP address: 192.168.0.1
+        ',
+        Return => 1, # it's a new ticket
+        Check => {
+            Title => 'UnitTest-1',
+        },
+    },
+    {
+        Name  => '#2 - Subject Test',
+        Email => 'From: Sender <sender@example.com>
+To: Some Name <recipient@example.com>
+Subject: [#1] Another question
+X-OTRS-FollowUp-Title: UnitTest-1 - Response 1
+
+This is a multiline
+email for server: example.tld
+
+The IP address: 192.168.0.1
+        ',
+        Return => 2, # it's a followup
+        Check => {
+            Title => 'UnitTest-1 - Response 1',
+        },
+    },
+);
+
+my %TicketNumbers;
+my %TicketIDs;
+
+my $Index = 1;
+for my $Test (@Tests) {
+    my $Name  = $Test->{Name};
+    my $Email = $Test->{Email};
+
+    $Email =~ s{\[#([0-9]+)\]}{[Ticket#$TicketNumbers{$1}]};
+
+    my @Return;
+    {
+        my $PostMasterObject = Kernel::System::PostMaster->new(
+            Email => \$Email,
+        );
+
+        @Return = $PostMasterObject->Run();
+    }
+    $Self->Is(
+        $Return[0] || 0,
+        $Test->{Return},
+        "$Name - NewTicket/FollowUp",
+    );
+    $Self->True(
+        $Return[1] || 0,
+        "$Name - TicketID",
+    );
+
+    # new/clear ticket object
+    $Kernel::OM->ObjectsDiscard( Objects => ['Kernel::System::Ticket'] );
+    my $TicketObject = $Kernel::OM->Get('Kernel::System::Ticket');
+
+    my %Ticket = $TicketObject->TicketGet(
+        TicketID      => $Return[1],
+        DynamicFields => 1,
+    );
+
+    for my $Key ( sort keys %{ $Test->{Check} } ) {
+        $Self->Is(
+            $Ticket{$Key},
+            $Test->{Check}->{$Key},
+            "Run('$Test->{Name}') - $Key",
+        );
+    }
+
+    $TicketNumbers{$Index} = $Ticket{TicketNumber};
+    $TicketIDs{ $Return[1] }++;
+
+    $Index++;
+}
+
+for my $TicketID ( keys %TicketIDs ) {
+
+    # new/clear ticket object
+    $Kernel::OM->ObjectsDiscard( Objects => ['Kernel::System::Ticket'] );
+    my $TicketObject = $Kernel::OM->Get('Kernel::System::Ticket');
+
+    # delete ticket
+    my $Delete = $TicketObject->TicketDelete(
+        TicketID => $TicketID,
+        UserID   => 1,
+    );
+
+    $Self->True(
+        $Delete || 0,
+        "#Filter TicketDelete()",
+    );
+}
+
+# cleanup is done by RestoreDatabase
+
+1;


### PR DESCRIPTION
This is an improved version of #972 
It now supports X-OTRS-Title in PostMaster/NewTicket and X-OTRS-FollowUp-Title in PostMaster/FollowUp. The two new headers are added to the Postmaster::XHeaders sysconfig option and a UnitTest script is added.