### PR TITLE
add new feature: import and export postmaster filters

### DIFF
--- a/Kernel/Config/Files/Framework.xml
+++ b/Kernel/Config/Files/Framework.xml
@@ -5186,6 +5186,19 @@ via the Preferences button after logging in.
             </FrontendModuleReg>
         </Setting>
     </ConfigItem>
+    <ConfigItem Name="Frontend::Module###AdminImportExportPostmasterFilter" Required="0" Valid="1">
+        <Description Translatable="1">Frontend module registration for postmaster filter import/export module.</Description>
+        <Group>Framework</Group>
+        <SubGroup>Frontend::Admin::ModuleRegistration</SubGroup>
+        <Setting>
+            <FrontendModuleReg>
+                <Group>admin</Group>
+                <Description>Import/Export Postmaster Filter</Description>
+                <NavBarName>Admin</NavBarName>
+                <Title>Import/Export Postmaster Filter</Title>
+            </FrontendModuleReg>
+        </Setting>
+    </ConfigItem>
     <ConfigItem Name="Frontend::Module###AdminEmail" Required="0" Valid="1">
         <Description Translatable="1">Frontend module registration for the agent interface.</Description>
         <Group>Framework</Group>
@@ -6890,6 +6903,17 @@ via the Preferences button after logging in.
         <SubGroup>Core::Fetchmail</SubGroup>
         <Setting>
             <String Regex="[/|\w]+fetchmail$" Check="File">/usr/bin/fetchmail</String>
+        </Setting>
+    </ConfigItem>
+   <ConfigItem Name="PostmasterFilterImport::DoOverride" Required="0" Valid="1">
+        <Description Translatable="1">Override existing Postmaster filter when a filter with an existing name is imported</Description>
+        <Group>Framework</Group>
+        <SubGroup>Core::Postmaster</SubGroup>
+        <Setting>
+            <Option SelectedID="0">
+                <Item Key="0">No</Item>
+                <Item Key="1">Yes</Item>
+            </Option>
         </Setting>
     </ConfigItem>
 </otrs_config>

--- a/Kernel/Modules/AdminImportExportPostmasterFilter.pm
+++ b/Kernel/Modules/AdminImportExportPostmasterFilter.pm
@@ -1,0 +1,114 @@
+# --
+# Kernel/Modules/AdminImportExportPostmasterFilter.pm - import/export postmaster filter
+# Copyright (C) 2014 Perl-Services.de, http://perl-services.de
+# --
+# This software comes with ABSOLUTELY NO WARRANTY. For details, see
+# the enclosed file COPYING for license information (AGPL). If you
+# did not receive this file, see http://www.gnu.org/licenses/agpl.txt.
+# --
+
+package Kernel::Modules::AdminImportExportPostmasterFilter;
+
+use strict;
+use warnings;
+
+use List::Util qw( first );
+
+my @ObjectDependencies = qw(
+    Kernel::System::Web::Request
+    Kernel::Output::HTML::Layout
+    Kernel::System::PostMaster::ImportExport
+);
+
+sub new {
+    my ( $Type, %Param ) = @_;
+
+    # allocate new hash for object
+    my $Self = {};
+    bless( $Self, $Type );
+
+    my $LayoutObject = $Kernel::OM->Get('Kernel::Output::HTML::Layout');
+
+    # check needed objects
+    for my $NeededData (qw(Subaction UserID)) {
+        if ( !$Param{$NeededData} ) {
+            $LayoutObject->FatalError( Message => "Got no $NeededData!" );
+        }
+        $Self->{$NeededData} = $Param{$NeededData};
+    }
+
+    return $Self;
+}
+
+sub Run {
+    my ( $Self, %Param ) = @_;
+
+    my $ParamObject  = $Kernel::OM->Get('Kernel::System::Web::Request');
+    my $LayoutObject = $Kernel::OM->Get('Kernel::Output::HTML::Layout');
+    my $ImExObject   = $Kernel::OM->Get('Kernel::System::PostMaster::ImportExport');
+
+    if ( $Self->{Subaction} eq 'Export' ) {
+
+        my %Opts;
+
+        my $Name = $ParamObject->GetParam( Param => 'Name' );
+        if ( $Name ) {
+            $Opts{IDs} = [ $Name ];
+        }
+
+        my $JSON = $ImExObject->PostmasterFilterExport(
+            %Opts,
+        );
+
+        return $LayoutObject->Attachment(
+            Filename    => 'PostmasterFilter.json',
+            Content     => $JSON,
+            ContentType => 'text/json',
+        );
+
+    }
+
+    # ---------------------------------------------------------- #
+    # show import screen
+    # ---------------------------------------------------------- #
+    elsif ( $Self->{Subaction} eq 'Import' ) {
+
+        my $Error = 0;
+
+        # get params
+        $Param{Status} = $ParamObject->GetParam( Param => 'Status' );
+
+        # importing
+        if ( $Param{Status} && $Param{Status} eq 'Action' ) {
+
+            # challenge token check for write action
+            $LayoutObject->ChallengeTokenCheck();
+
+            my $Uploadfile = '';
+            if ( $Uploadfile = $ParamObject->GetParam( Param => 'file_upload' ) ) {
+                my %UploadStuff = $ParamObject->GetUploadAll(
+                    Param    => 'file_upload',
+                    Encoding => 'Raw'
+                );
+
+                my $Success = $ImExObject->PostmasterFilterImport(
+                    Filters => $UploadStuff{Content},
+                );
+            }
+        }
+
+        # show import form
+        my $Output = $LayoutObject->Header( Title => 'Import' );
+        $Output .= $LayoutObject->NavigationBar();
+        $Output .= $LayoutObject->Output( TemplateFile => 'AdminImportPostmasterFilter' );
+        $Output .= $LayoutObject->Footer();
+        return $Output;
+    }
+
+    # ---------------------------------------------------------- #
+    # show error screen
+    # ---------------------------------------------------------- #
+    return $LayoutObject->ErrorScreen( Message => 'Invalid Subaction process!' );
+}
+
+1;

--- a/Kernel/Output/HTML/Templates/Standard/AdminImportPostmasterFilter.tt
+++ b/Kernel/Output/HTML/Templates/Standard/AdminImportPostmasterFilter.tt
@@ -1,0 +1,40 @@
+# --
+# AdminImportPostmasterFilter.dtl
+# Copyright (C) 2014 Perl-Services.de, http://perl-services.de
+# --
+# This software comes with ABSOLUTELY NO WARRANTY. For details, see
+# the enclosed file COPYING for license information (AGPL). If you
+# did not receive this file, see http://www.gnu.org/licenses/agpl.txt.
+# --
+
+
+<div class="MainBox AriaRoleMain SpacingTopLarge">
+    <div class="W50pc SpacingBottomLarge CenterBox">
+        <div class="WidgetSimple">
+            <div class="Header">
+                <h2>[% Translate("Import Postmaster Filter") | html %]</h2>
+            </div>
+            <div class="Content">
+
+                <form action="[% Env("CGIHandle") %]" method="post" enctype="multipart/form-data">
+                    <input type="hidden" name="Action"    value="[% Env("Action") %]"/>
+                    <input type="hidden" name="Subaction" value="Import"/>
+                    <input type="hidden" name="Status"    value="Action"/>
+
+                    <fieldset class="TableLike">
+                        <label for="file_upload">[% Translate("File") | html %]:</label>
+                        <div class="Field">
+                            <input name="file_upload" id="file_upload" type="file" size="30"/>
+                            <input type="hidden" name="ImportType" value="Upload"/>
+                        </div>
+                    </fieldset>
+
+                    <p class="Center">
+                        <button class="Primary" accesskey="g" title="[% Translate("Import") | html %] (g)" type="submit" value="[% Translate("Import") | html %]">[% Translate("Import") | html %]</button>
+                        <a href="[% Env("Baselink") %]Action=AdminPostMasterFilter">[% Translate("Cancel") | html %]</a>
+                    </p>
+                </form>
+            </div>
+        </div>
+    </div>
+</div>

--- a/Kernel/Output/HTML/Templates/Standard/AdminPostMasterFilter.tt
+++ b/Kernel/Output/HTML/Templates/Standard/AdminPostMasterFilter.tt
@@ -54,6 +54,25 @@
             </div>
         </div>
 
+        <div class="SidebarColumn">
+            <div class="WidgetSimple">
+                <div class="Header">
+                    <h2>[% Translate("Import/Export") | html %]</h2>
+                </div>
+                <div class="Content">
+                    <ul class="ActionList">
+                        <li>
+                            <a href="[% Env("CGIHandle") %]?Action=AdminImportExportPostmasterFilter;Subaction=Export;Name=[% Data.Name %]" class="CallForAction"><span>[% Translate("Export") | html %]</span></a>
+                        </li>
+                        <li>
+                            <a href="[% Env("CGIHandle") %]?Action=AdminImportExportPostmasterFilter;Subaction=Import" class="CallForAction"><span>[% Translate("Import") | html %]</span></a>
+                        </li>
+                    </ul>
+                </div>
+            </div>
+        </div>
+
+
     </div>
 
     <div class="ContentColumn">

--- a/Kernel/System/PostMaster/ImportExport.pm
+++ b/Kernel/System/PostMaster/ImportExport.pm
@@ -1,0 +1,200 @@
+# --
+# Kernel/System/PostMaster/ImportExport.pm - Utility module for PostMasters provided by Perl-Services.de
+# Copyright (C) 2013 - 2016 Perl-Services.de, http://perl-services.de
+# --
+# This software comes with ABSOLUTELY NO WARRANTY. For details, see
+# the enclosed file COPYING for license information (AGPL). If you
+# did not receive this file, see http://www.gnu.org/licenses/agpl.txt.
+# --
+
+package Kernel::System::PostMaster::ImportExport;
+
+use strict;
+use warnings;
+
+use JSON;
+
+our @ObjectDependencies = qw(
+    Kernel::Config
+    Kernel::System::Log
+    Kernel::System::DB
+    Kernel::System::JSON
+);
+
+sub new {
+    my ( $Type, %Param ) = @_;
+
+    # allocate new hash for object
+    my $Self = {%Param};
+    bless( $Self, $Type );
+
+    my $ConfigObject = $Kernel::OM->Get('Kernel::Config');
+    my $DBObject     = $Kernel::OM->Get('Kernel::System::DB');
+
+    # get the cache TTL (in seconds)
+    $Self->{CacheTTL} = int( $ConfigObject->Get('PostMaster::CacheTTL') || 3600 );
+
+    # set lower if database is case sensitive
+    $Self->{Lower} = '';
+    if ( !$DBObject->GetDatabaseFunction('CaseInsensitive') ) {
+        $Self->{Lower} = 'LOWER';
+    }
+
+    if ( $Self->_OTRSVersionGet() >= 3.3 ) {
+        $Self->{f_not} = 1;
+    }
+
+    return $Self;
+}
+
+sub PostmasterFilterExport {
+    my ($Self, %Param) = @_;
+
+    my $JSONObject = $Kernel::OM->Get('Kernel::System::JSON');
+    my $DBObject   = $Kernel::OM->Get('Kernel::System::DB');
+
+    my $FNot = '';
+    if ( $Self->{f_not} ) {
+        $FNot = ', f_not';
+    }
+
+    my $SQL = "SELECT f_name, f_stop, f_type, f_key, f_value $FNot "
+        . ' FROM postmaster_filter';
+
+    my @Bind;
+    if ( $Param{IDs} && ref $Param{IDs} eq 'ARRAY' && @{$Param{IDs}} ) {
+        my $Placeholder = join ', ', ('?') x @{$Param{IDs}};
+
+        $SQL .= ' WHERE f_name IN( ' . $Placeholder . ')';
+        @Bind = map{ \$_ }@{$Param{IDs}};
+    }
+
+    $SQL .= " ORDER BY f_key";
+
+    return '{}' if !$DBObject->Prepare(
+        SQL  => $SQL,
+        Bind => \@Bind,
+    );
+
+    my %Filters;
+    while ( my @Row = $DBObject->FetchrowArray() ) {
+        my %Filter = (
+            Stop  => $Row[1],
+            Type  => $Row[2],
+            Key   => $Row[3],
+            Value => $Row[4],
+            Not   => $Row[5],
+        );
+
+        push @{$Filters{$Row[0]}}, \%Filter;
+    }
+
+    my $JSON = $JSONObject->Encode(
+        Data     => \%Filters,
+        SortKeys => 1,
+    ); 
+
+    return $JSON;
+}
+
+sub PostmasterFilterImport {
+    my ($Self, %Param) = @_;
+
+    my $JSONObject   = $Kernel::OM->Get('Kernel::System::JSON');
+    my $DBObject     = $Kernel::OM->Get('Kernel::System::DB');
+    my $LogObject    = $Kernel::OM->Get('Kernel::System::Log');
+    my $ConfigObject = $Kernel::OM->Get('Kernel::Config');
+
+    for my $Needed ( qw(Filters) ) {
+        if ( !$Param{$Needed} ) {
+            $LogObject->Log(
+                Priority => 'error',
+                Message  => "Need $Needed!",
+            );
+
+            return;
+        }
+    }
+
+    my $DoOverride = $ConfigObject->Get( 'PostmasterFilterImport::DoOverride' );
+
+    my $Filters;
+    eval {
+        #$Filters = $JSONObject->Decode(
+        #    Data => $Param{Filters},
+        #);
+        $Filters = JSON->new->allow_nonref(1)->utf8(1)->decode( $Param{Filters} );
+    };
+
+    return if !$Filters;
+
+    my ($FNot, $Placeholder) = ('','');
+    if ( $Self->{f_not} ) {
+        $FNot        = ', f_not';
+        $Placeholder = ', ?';
+    }
+
+    my $InsertSQL = 'INSERT INTO postmaster_filter ('
+        . "f_name, f_stop, f_type, f_key, f_value $FNot) "
+        . " VALUES (?, ?, ?, ?, ? $Placeholder )";
+
+    my $CheckSQL  = "SELECT f_name FROM postmaster_filter WHERE f_name = ?";
+
+    my $DeleteSQL = 'DELETE FROM postmaster_filter WHERE f_name = ?';
+
+    FILTER:
+    for my $Filter ( keys %{$Filters} ) {
+
+        next FILTER if ref $Filters->{$Filter} ne 'ARRAY';
+        next FILTER if !@{ $Filters->{$Filter} };
+
+        next FILTER if !$DBObject->Prepare(
+            SQL   => $CheckSQL,
+            Bind  => [ \$Filter ],
+            Limit => 1,
+        );
+
+        my $Name;
+        while ( my @Row = $DBObject->FetchrowArray() ) {
+            $Name = $Row[0];
+        }
+
+        next FILTER if $Name && !$DoOverride;
+
+        if ( $Name ) {
+            next FILTER if !$DBObject->Do(
+                SQL  => $DeleteSQL,
+                Bind => [ \$Filter ],
+            );
+        } 
+
+        for my $Part ( @{ $Filters->{$Filter} } ) {
+            next FILTER if !$DBObject->Do(
+                SQL  => $InsertSQL,
+                Bind => [
+                    \$Filter,
+                    \$Part->{Stop},
+                    \$Part->{Type},
+                    \$Part->{Key},
+                    \$Part->{Value},
+                    ($Self->{f_not} ? \$Part->{Not} : ()),
+                ],
+            );
+        }
+    }
+
+    return 1;
+}
+
+sub _OTRSVersionGet {
+    my ($Self) = @_;
+
+    my $ConfigObject = $Kernel::OM->Get('Kernel::Config');
+
+    my $Version    = $ConfigObject->Get( 'Version' );
+    my ($MajorMin) = $Version =~ m{(\d+\.\d+)};
+
+    return $MajorMin;
+}
+
+1;

--- a/Kernel/System/System/Console/Command/Maint/PostmasterFilter/Export.pm
+++ b/Kernel/System/System/Console/Command/Maint/PostmasterFilter/Export.pm
@@ -1,0 +1,85 @@
+# --
+# Copyright (C) 2016 Perl-Services.de, http://perl-services.de
+# --
+# This software comes with ABSOLUTELY NO WARRANTY. For details, see
+# the enclosed file COPYING for license information (AGPL). If you
+# did not receive this file, see http://www.gnu.org/licenses/agpl.txt.
+# --
+
+package Kernel::System::Console::Command::Maint::PostmasterFilter::Export;
+
+use strict;
+use warnings;
+
+use base qw(Kernel::System::Console::BaseCommand);
+
+our @ObjectDependencies = qw(
+    Kernel::Config
+    Kernel::System::Main
+    Kernel::System::PostMaster::ImportExport
+);
+
+sub Configure {
+    my ( $Self, %Param ) = @_;
+
+    $Self->Description('Export DynamicField configuration');
+    $Self->AddOption(
+        Name        => 'filter',
+        Description => "Name of the filter that should be exported.",
+        Required    => 0,
+        HasValue    => 1,
+        Multiple    => 1,
+        ValueRegex  => qr/.*/smx,
+    );
+
+    $Self->AddOption(
+        Name        => 'file',
+        Description => "Write the configuration to that file",
+        Required    => 0,
+        HasValue    => 1,
+        ValueRegex  => qr/.*/smx,
+    );
+
+
+    return;
+}
+
+sub Run {
+    my ( $Self, %Param ) = @_;
+
+    $Self->Print("<yellow>Export PostmasterFilter configuration...</yellow>\n");
+
+    my $UtilObject = $Kernel::OM->Get('Kernel::System::PostMaster::ImportExport');
+    my $MainObject = $Kernel::OM->Get('Kernel::System::Main');
+
+    my @Names = @{ $Self->GetOption('filter') || [] };
+    my $JSON = $UtilObject->PostmasterFilterExport(
+        IDs => \@Names,
+    );
+
+    my $File = $Self->GetOption('file');
+    if ( !$File ) {
+        print $JSON;
+    }
+    else {
+        $MainObject->FileWrite(
+            Location => $File,
+            Content  => \$JSON,
+            Mode     => 'utf-8',
+        );
+    }
+
+    return $Self->ExitCodeOk();
+}
+
+1;
+
+=back
+
+=head1 TERMS AND CONDITIONS
+
+This software comes with ABSOLUTELY NO WARRANTY. For details, see
+the enclosed file COPYING for license information (AGPL). If you
+did not receive this file, see L<http://www.gnu.org/licenses/agpl.txt>.
+
+=cut

--- a/Kernel/System/System/Console/Command/Maint/PostmasterFilter/Import.pm
+++ b/Kernel/System/System/Console/Command/Maint/PostmasterFilter/Import.pm
@@ -1,0 +1,71 @@
+# --
+# Copyright (C) 2016 Perl-Services.de, http://perl-services.de
+# --
+# This software comes with ABSOLUTELY NO WARRANTY. For details, see
+# the enclosed file COPYING for license information (AGPL). If you
+# did not receive this file, see http://www.gnu.org/licenses/agpl.txt.
+# --
+
+package Kernel::System::Console::Command::Maint::PostmasterFilter::Import;
+
+use strict;
+use warnings;
+
+use base qw(Kernel::System::Console::BaseCommand);
+
+our @ObjectDependencies = qw(
+    Kernel::Config
+    Kernel::System::Main
+    Kernel::System::PostMaster::ImportExport
+);
+
+sub Configure {
+    my ( $Self, %Param ) = @_;
+
+    $Self->Description('Import PostMaster filter configuration');
+
+    $Self->AddOption(
+        Name        => 'file',
+        Description => "Read the configuration from that file",
+        Required    => 1,
+        HasValue    => 1,
+        ValueRegex  => qr/.*/smx,
+    );
+
+
+    return;
+}
+
+sub Run {
+    my ( $Self, %Param ) = @_;
+
+    $Self->Print("<yellow>Import PostMaster filter configuration...</yellow>\n");
+
+    my $UtilObject = $Kernel::OM->Get('Kernel::System::PostMaster::ImportExport');
+    my $MainObject = $Kernel::OM->Get('Kernel::System::Main');
+
+    my $File       = $Self->GetOption('file');
+    my $ContentRef = $MainObject->FileRead(
+        Location => $File,
+        Mode     => 'utf-8',
+    );
+
+    $UtilObject->PostmasterFilterImport(
+        Filters => ${$ContentRef},
+        UserID  => 1,
+    );
+
+    return $Self->ExitCodeOk();
+}
+
+1;
+
+=back
+
+=head1 TERMS AND CONDITIONS
+
+This software comes with ABSOLUTELY NO WARRANTY. For details, see
+the enclosed file COPYING for license information (AGPL). If you
+did not receive this file, see L<http://www.gnu.org/licenses/agpl.txt>.
+
+=cut

--- a/scripts/test/PostMaster/ImportExportFilter.t
+++ b/scripts/test/PostMaster/ImportExportFilter.t
@@ -1,0 +1,151 @@
+# --
+# Copyright (C) 2001-2016 OTRS AG, http://otrs.com/
+# --
+# This software comes with ABSOLUTELY NO WARRANTY. For details, see
+# the enclosed file COPYING for license information (AGPL). If you
+# did not receive this file, see http://www.gnu.org/licenses/agpl.txt.
+# --
+
+use strict;
+use warnings;
+use utf8;
+
+use vars (qw($Self));
+
+use Kernel::System::PostMaster;
+
+$Kernel::OM->ObjectParamAdd(
+    'Kernel::System::UnitTest::Helper' => {
+        RestoreDatabase => 1,
+    },
+);
+my $Helper = $Kernel::OM->Get('Kernel::System::UnitTest::Helper');
+
+# get needed objects
+my $ConfigObject = $Kernel::OM->Get('Kernel::Config');
+my $MainObject   = $Kernel::OM->Get('Kernel::System::Main');
+
+my %NeededXHeaders = (
+    'From' => 1,
+    'To'   => 1,
+);
+
+my $XHeaders          = $ConfigObject->Get('PostmasterX-Header');
+my @PostmasterXHeader = @{$XHeaders};
+
+HEADER:
+for my $Header ( sort keys %NeededXHeaders ) {
+    next HEADER if ( grep $_ eq $Header, @PostmasterXHeader );
+    push @PostmasterXHeader, $Header;
+}
+
+$ConfigObject->Set(
+    Key   => 'PostmasterX-Header',
+    Value => \@PostmasterXHeader
+);
+
+# disable not needed event module
+$ConfigObject->Set(
+    Key => 'Ticket::EventModulePost###TicketDynamicFieldDefault',
+);
+
+# filter test
+my @ExportTests = (
+    {
+        Name  => 'Export#1 - Simple Test' . time,
+        Match => {
+            From => 'test@test.tld',
+        },
+        Set => {
+            'X-OTRS-Priority' => '2 low',
+        },
+        Expect => '{"x":[{"Key":"From","Not":null,"Stop":0,"Type":"Match","Value":"test@test.tld"},{"Key":"X-OTRS-Priority","Not":null,"Stop":0,"Type":"Set","Value":"2 low"}]}',
+    },
+);
+
+my @ImportTests = (
+    {
+        Name  => 'Import#1 - Simple Test' . time,
+        JSON   => '{"x":[{"Key":"From","Type":"Match","Not":null,"Value":"test@test.de","Stop":0},{"Key":"X-OTRS-Priority","Type":"Set","Not":null,"Value":"2 low","Stop":0}]}',
+        Check  => {
+            Match => { From => 'test@test.de' },
+            Set   => { 'X-OTRS-Priority' => '2 low' },
+        },
+    },
+);
+
+$Kernel::OM->ObjectsDiscard( Objects => ['Kernel::System::PostMaster::Filter', 'Kernel::System::PostMaster::ImportExport'] );
+my $PostMasterFilter = $Kernel::OM->Get('Kernel::System::PostMaster::Filter');
+my $ImportExport     = $Kernel::OM->Get('Kernel::System::PostMaster::ImportExport');
+
+for my $Test (@ExportTests) {
+    my $Name = $Test->{Name};
+
+    $Test->{Expect} =~ s{"x"}{"$Name"};
+
+    my $Success = $PostMasterFilter->FilterAdd(
+        Name           => $Name,
+        StopAfterMatch => 0,
+        %{$Test},
+    );
+
+    $Self->True(
+        $Success,
+        "#Filter Added " . $Name,
+    );
+
+    my %List = $PostMasterFilter->FilterList();
+    my $ID   = $List{$Name};
+
+    my $JSON = $ImportExport->PostmasterFilterExport(
+        IDs => [$ID],
+    );
+
+    $Self->True(
+        $JSON,
+        "#Filter exported " . $Name,
+    );
+
+    $Self->Is(
+        $JSON,
+        $Test->{Expect},
+        "#Filter exported - JSON ok " . $Name,
+    );
+
+    # remove filter
+    $PostMasterFilter->FilterDelete( Name => $Test->{Name} );
+}
+
+for my $Test ( @ImportTests ) {
+    my $Name = $Test->{Name};
+
+    $Test->{JSON} =~ s{"x"}{"$Name"};
+
+    my $Success = $ImportExport->PostmasterFilterImport(
+        Filters => $Test->{JSON},
+    );
+
+    $Self->True(
+        $Success,
+        "#Filter import $Name",
+    );
+
+    my %Filter = $PostMasterFilter->FilterGet( Name => $Name );
+
+    for my $Type ( qw(Match Set) ) {
+        for my $Check ( keys %{ $Test->{Check}->{$Type} } ) {
+            $Self->Is(
+                $Filter{$Type}->{$Check},
+                $Test->{Check}->{$Type}->{$Check},
+                "#Filter import check - $Name - $Type - $Check",
+            );
+        }
+    }
+
+    # remove filter
+    $PostMasterFilter->FilterDelete( Name => $Test->{Name} );
+}
+
+# cleanup is done by RestoreDatabase
+
+1;


### PR DESCRIPTION
This feature adds a new widget in the postmaster filter admin page. There you can download postmaster filters as JSON and you can upload a file with PostmasterFilters in JSON format.

This is very helpful when you have a test- and a live system and you want to keep the filters in sync.

With this import/export feature admins do not have to check/create the filters in their systems manually, but just upload the file.
