### PR TITLE
Added ExtFQDN option, parameter name fixed, internal data removed from some Message-IDs

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,4 +1,5 @@
 #6.0.0.beta1 2016-??-??
+ - 2016-04-19 Added ExtFQDN option, parameter name fixed, internal data removed from some Message-IDs.
  - 2016-04-15 Added possibility to use multiple named captures in Postmaster filters, thanks to Renée Bäcker.
  - 2016-04-08 Removed dummy 'Reply All' and 'Forward' options to align with 'Reply' select, thanks to Nils Leideck.
  - 2016-04-01 Fixed dropdown for CustomerTicketOverview.

--- a/Kernel/Config/Files/Framework.xml
+++ b/Kernel/Config/Files/Framework.xml
@@ -80,6 +80,14 @@
             <String Regex="">yourhost.example.com</String>
         </Setting>
     </ConfigItem>
+    <ConfigItem Name="ExtFQDN" Required="1" Valid="1" ConfigLevel="200">
+        <Description Translatable="1">Defines the fully qualified domain name for external IDs generation (i.e. Message-ID).</Description>
+        <Group>Framework</Group>
+        <SubGroup>Core</SubGroup>
+        <Setting>
+            <String Regex="">yourexternal.address.com</String>
+        </Setting>
+    </ConfigItem>
     <ConfigItem Name="NodeID" Required="0" Valid="0" ConfigLevel="200">
         <Description Translatable="1">Defines the cluster node identifier. This is only used in cluster configurations where there is more than one OTRS frontend system. Note: only values from 1 to 99 are allowed.</Description>
         <Group>Framework</Group>

--- a/Kernel/Config/Files/Framework.xml
+++ b/Kernel/Config/Files/Framework.xml
@@ -80,8 +80,8 @@
             <String Regex="">yourhost.example.com</String>
         </Setting>
     </ConfigItem>
-    <ConfigItem Name="ExtFQDN" Required="1" Valid="1" ConfigLevel="200">
-        <Description Translatable="1">Defines the fully qualified domain name for external IDs generation (i.e. Message-ID).</Description>
+    <ConfigItem Name="ExtFQDN" Required="0" Valid="0" ConfigLevel="200">
+        <Description Translatable="1">Defines the fully qualified domain name for external IDs generation (i.e. Message-ID, ContentID).</Description>
         <Group>Framework</Group>
         <SubGroup>Core</SubGroup>
         <Setting>

--- a/Kernel/System/Email.pm
+++ b/Kernel/System/Email.pm
@@ -909,7 +909,8 @@ sub _EncodeMIMEWords {
 sub _MessageIDCreate {
     my ( $Self, %Param ) = @_;
 
-    my $ExtFQDN = $Kernel::OM->Get('Kernel::Config')->Get('ExtFQDN');
+    my $ConfigObject = $Kernel::OM->Get('Kernel::Config');
+    my $ExtFQDN = $ConfigObject->Get('ExtFQDN') || $ConfigObject->Get('FQDN');
 
     return 'Message-ID: <' . time() . '.' . rand(999999) . '@' . $ExtFQDN . '>';
 }

--- a/Kernel/System/Email.pm
+++ b/Kernel/System/Email.pm
@@ -909,9 +909,9 @@ sub _EncodeMIMEWords {
 sub _MessageIDCreate {
     my ( $Self, %Param ) = @_;
 
-    my $FQDN = $Kernel::OM->Get('Kernel::Config')->Get('FQDN');
+    my $ExtFQDN = $Kernel::OM->Get('Kernel::Config')->Get('ExtFQDN');
 
-    return 'Message-ID: <' . time() . '.' . rand(999999) . '@' . $FQDN . '>';
+    return 'Message-ID: <' . time() . '.' . rand(999999) . '@' . $ExtFQDN . '>';
 }
 
 1;

--- a/Kernel/System/HTMLUtils.pm
+++ b/Kernel/System/HTMLUtils.pm
@@ -1188,14 +1188,14 @@ sub EmbeddedImagesExtract {
         return;
     }
 
-    my $FQDN = $Kernel::OM->Get('Kernel::Config')->Get('FQDN');
+    my $ExtFQDN = $Kernel::OM->Get('Kernel::Config')->Get('ExtFQDN');
     ${ $Param{DocumentRef} } =~ s{(src=")(data:image/)(png|gif|jpg|jpeg|bmp)(;base64,)(.+?)(")}{
 
         my $Base64String = $5;
 
         my $FileName     = 'pasted-' . time() . '-' . int(rand(1000000)) . '.' . $3;
         my $ContentType  = "image/$3; name=\"$FileName\"";
-        my $ContentID    = 'pasted.' . time() . '.' . int(rand(1000000)) . '@' . $FQDN;
+        my $ContentID    = 'pasted.' . time() . '.' . int(rand(1000000)) . '@' . $ExtFQDN;
 
         my $AttachmentData = {
             Content     => decode_base64($Base64String),

--- a/Kernel/System/HTMLUtils.pm
+++ b/Kernel/System/HTMLUtils.pm
@@ -1188,7 +1188,8 @@ sub EmbeddedImagesExtract {
         return;
     }
 
-    my $ExtFQDN = $Kernel::OM->Get('Kernel::Config')->Get('ExtFQDN');
+    my $ConfigObject = $Kernel::OM->Get('Kernel::Config');
+    my $ExtFQDN = $ConfigObject->Get('ExtFQDN') || $ConfigObject->Get('FQDN');
     ${ $Param{DocumentRef} } =~ s{(src=")(data:image/)(png|gif|jpg|jpeg|bmp)(;base64,)(.+?)(")}{
 
         my $Base64String = $5;

--- a/Kernel/System/Ticket/Article.pm
+++ b/Kernel/System/Ticket/Article.pm
@@ -2233,10 +2233,12 @@ sub ArticleSend {
         AttachmentsRef => $Param{Attachment},
     );
 
+    my $ConfigObject = $Kernel::OM->Get('Kernel::Config');
+
     # create article
     my $Time      = $Kernel::OM->Get('Kernel::System::Time')->SystemTime();
     my $Random    = rand 999999;
-    my $ExtFQDN   = $Kernel::OM->Get('Kernel::Config')->Get('ExtFQDN');
+    my $ExtFQDN   = $ConfigObject->Get('ExtFQDN') || $ConfigObject->Get('FQDN');
     my $MessageID = "<$Time.$Random\@$ExtFQDN>";
     my $ArticleID = $Self->ArticleCreate(
         %Param,
@@ -2318,10 +2320,12 @@ sub ArticleBounce {
         }
     }
 
+    my $ConfigObject = $Kernel::OM->Get('Kernel::Config');
+
     # create message id
     my $Time         = $Kernel::OM->Get('Kernel::System::Time')->SystemTime();
     my $Random       = rand 999999;
-    my $ExtFQDN      = $Kernel::OM->Get('Kernel::Config')->Get('ExtFQDN');
+    my $ExtFQDN      = $ConfigObject->Get('ExtFQDN') || $ConfigObject->Get('FQDN');
     my $NewMessageID = "<$Time.$Random.0\@$ExtFQDN>";
     my $Email        = $Self->ArticlePlain( ArticleID => $Param{ArticleID} );
 

--- a/Kernel/System/Ticket/Article.pm
+++ b/Kernel/System/Ticket/Article.pm
@@ -2236,8 +2236,8 @@ sub ArticleSend {
     # create article
     my $Time      = $Kernel::OM->Get('Kernel::System::Time')->SystemTime();
     my $Random    = rand 999999;
-    my $FQDN      = $Kernel::OM->Get('Kernel::Config')->Get('FQDN');
-    my $MessageID = "<$Time.$Random.$Param{TicketID}.$Param{UserID}\@$FQDN>";
+    my $ExtFQDN   = $Kernel::OM->Get('Kernel::Config')->Get('ExtFQDN');
+    my $MessageID = "<$Time.$Random\@$ExtFQDN>";
     my $ArticleID = $Self->ArticleCreate(
         %Param,
         MessageID => $MessageID,
@@ -2321,8 +2321,8 @@ sub ArticleBounce {
     # create message id
     my $Time         = $Kernel::OM->Get('Kernel::System::Time')->SystemTime();
     my $Random       = rand 999999;
-    my $FQDN         = $Kernel::OM->Get('Kernel::Config')->Get('FQDN');
-    my $NewMessageID = "<$Time.$Random.$Param{TicketID}.0.$Param{UserID}\@$FQDN>";
+    my $ExtFQDN      = $Kernel::OM->Get('Kernel::Config')->Get('ExtFQDN');
+    my $NewMessageID = "<$Time.$Random.0\@$ExtFQDN>";
     my $Email        = $Self->ArticlePlain( ArticleID => $Param{ArticleID} );
 
     # check if plain email exists
@@ -2336,10 +2336,10 @@ sub ArticleBounce {
 
     # pipe all into sendmail
     return if !$Kernel::OM->Get('Kernel::System::Email')->Bounce(
-        MessageID => $NewMessageID,
-        From      => $Param{From},
-        To        => $Param{To},
-        Email     => $Email,
+        'Message-ID' => $NewMessageID,
+        From         => $Param{From},
+        To           => $Param{To},
+        Email        => $Email,
     );
 
     # write history

--- a/Kernel/System/Web/UploadCache/DB.pm
+++ b/Kernel/System/Web/UploadCache/DB.pm
@@ -96,7 +96,8 @@ sub FormIDAddFile {
     if ( !$ContentID && lc $Disposition eq 'inline' ) {
 
         my $Random = rand 999999;
-        my $ExtFQDN = $Kernel::OM->Get('Kernel::Config')->Get('ExtFQDN');
+        my $ConfigObject = $Kernel::OM->Get('Kernel::Config');
+        my $ExtFQDN = $ConfigObject->Get('ExtFQDN') || $ConfigObject->Get('FQDN');
 
         $ContentID = "$Disposition$Random.$Param{FormID}\@$ExtFQDN";
     }

--- a/Kernel/System/Web/UploadCache/DB.pm
+++ b/Kernel/System/Web/UploadCache/DB.pm
@@ -96,9 +96,9 @@ sub FormIDAddFile {
     if ( !$ContentID && lc $Disposition eq 'inline' ) {
 
         my $Random = rand 999999;
-        my $FQDN   = $Kernel::OM->Get('Kernel::Config')->Get('FQDN');
+        my $ExtFQDN = $Kernel::OM->Get('Kernel::Config')->Get('ExtFQDN');
 
-        $ContentID = "$Disposition$Random.$Param{FormID}\@$FQDN";
+        $ContentID = "$Disposition$Random.$Param{FormID}\@$ExtFQDN";
     }
 
     # write attachment to db

--- a/Kernel/System/Web/UploadCache/FS.pm
+++ b/Kernel/System/Web/UploadCache/FS.pm
@@ -91,7 +91,8 @@ sub FormIDAddFile {
     if ( !$ContentID && lc $Disposition eq 'inline' ) {
 
         my $Random = rand 999999;
-        my $ExtFQDN = $Kernel::OM->Get('Kernel::Config')->Get('ExtFQDN');
+        my $ConfigObject = $Kernel::OM->Get('Kernel::Config');
+        my $ExtFQDN = $ConfigObject->Get('ExtFQDN') || $ConfigObject->Get('FQDN');
 
         $ContentID = "$Disposition$Random.$Param{FormID}\@$ExtFQDN";
     }

--- a/Kernel/System/Web/UploadCache/FS.pm
+++ b/Kernel/System/Web/UploadCache/FS.pm
@@ -91,9 +91,9 @@ sub FormIDAddFile {
     if ( !$ContentID && lc $Disposition eq 'inline' ) {
 
         my $Random = rand 999999;
-        my $FQDN   = $Kernel::OM->Get('Kernel::Config')->Get('FQDN');
+        my $ExtFQDN = $Kernel::OM->Get('Kernel::Config')->Get('ExtFQDN');
 
-        $ContentID = "$Disposition$Random.$Param{FormID}\@$FQDN";
+        $ContentID = "$Disposition$Random.$Param{FormID}\@$ExtFQDN";
     }
 
     # get main object


### PR DESCRIPTION
OTRS uses the fully qualified domain name (FQDN SysConfig setting)
for external IDs generation (i.e. Message-ID in e-mail messages,
ContentID for pasted images). If OTRS instance uses internal
domain for FQDN, this internal domain name will leak to third
parties in e-mail message headers which may be not desirable.

This mod introduces new SysConfig option ExtFQDN which allowes
one to define the fully qualified domain name for external IDs
generation (i.e. Message-ID in e-mail messages, Content-ID for
pasted images).

It also fixes parameter name in Bounce() call and removes UserID
and TicketID from some Message-IDs generated by OTRS (this
is internal data and it's not necessary to expose it to third
parties in e-mail message headers).

Related: https://dev.ib.pl/ib/otrs/issues/40
Related: http://bugs.otrs.org/show_bug.cgi?id=9003
Author-Change-Id: IB#1009570