### PR TITLE
Image pasting as data URI reenabled

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,4 +1,5 @@
 #6.0.0.beta1 2016-??-??
+ - 2016-04-20 Image pasting as data URI reenabled.
  - 2016-04-15 Added possibility to use multiple named captures in Postmaster filters, thanks to Renée Bäcker.
  - 2016-04-08 Removed dummy 'Reply All' and 'Forward' options to align with 'Reply' select, thanks to Nils Leideck.
  - 2016-04-01 Fixed dropdown for CustomerTicketOverview.

--- a/Kernel/Config/Files/Framework.xml
+++ b/Kernel/Config/Files/Framework.xml
@@ -449,6 +449,17 @@
             </Option>
         </Setting>
     </ConfigItem>
+    <ConfigItem Name="Frontend::RichText::PreventImagePaste" Required="0" Valid="0">
+        <Description Translatable="1">Defines if image pasting into rich text area as data URI should be disabled (data URI allows to embed inline images on AdminEmail messages, signatures and templates using image copy/paste in modern web browsers). Note: signature and template content size must not exceed target column size in database (i.e. 64 kB in MySQL) - too big images will cause signature/template content to be truncated and corrupted.</Description>
+        <Group>Framework</Group>
+        <SubGroup>Core::Web</SubGroup>
+        <Setting>
+            <Option SelectedID="0">
+                <Item Key="0" Translatable="1">No</Item>
+                <Item Key="1" Translatable="1">Yes</Item>
+            </Option>
+        </Setting>
+    </ConfigItem>
     <ConfigItem Name="DisableIFrameOriginRestricted" Required="0" Valid="1">
         <Description Translatable="1">Disable HTTP header "X-Frame-Options: SAMEORIGIN" to allow OTRS to be included as an IFrame in other websites. Disabling this HTTP header can be a security issue! Only disable it, if you know what you are doing!</Description>
         <Group>Framework</Group>

--- a/Kernel/Output/HTML/Templates/Standard/CustomerRichTextEditor.tt
+++ b/Kernel/Output/HTML/Templates/Standard/CustomerRichTextEditor.tt
@@ -13,6 +13,7 @@
     Core.Config.Set('RichText.Height', '[% Config("Frontend::RichTextHeight") %]');
     Core.Config.Set('RichText.TextDir', '[% Env("TextDirection") %]');
     Core.Config.Set('RichText.SpellChecker', '[% Env("BrowserSpellCheckerInline") %]');
+    Core.Config.Set('RichText.PreventImagePaste', '[% Config("Frontend::RichText::PreventImagePaste") %]');
     Core.Config.Set('RichText.EditingAreaCSS', 'body { [% Config("Frontend::RichText::DefaultCSS") %] }');
     Core.Config.Set('RichText.Lang.SplitQuote', '[% Translate('Split Quote') | html %]');
     Core.Config.Set('RichText.Toolbar', [

--- a/Kernel/Output/HTML/Templates/Standard/RichTextEditor.tt
+++ b/Kernel/Output/HTML/Templates/Standard/RichTextEditor.tt
@@ -26,6 +26,7 @@
 
     Core.Config.Set('RichText.TextDir', '[% Env("TextDirection") %]');
     Core.Config.Set('RichText.SpellChecker', '[% Env("BrowserSpellCheckerInline") %]');
+    Core.Config.Set('RichText.PreventImagePaste', '[% Config("Frontend::RichText::PreventImagePaste") %]');
     Core.Config.Set('RichText.EditingAreaCSS', 'body.cke_editable { [% Config("Frontend::RichText::DefaultCSS") %] }');
     Core.Config.Set('RichText.Lang.SplitQuote', '[% Translate('Split Quote') | html %]');
     Core.Config.Set('RichText.Lang.RemoveQuote', '[% Translate('Remove Quote') | html %]');

--- a/var/httpd/htdocs/js/Core.UI.RichTextEditor.js
+++ b/var/httpd/htdocs/js/Core.UI.RichTextEditor.js
@@ -68,7 +68,8 @@ Core.UI.RichTextEditor = (function (TargetNS) {
         var EditorID = '',
             Editor,
             UserLanguage,
-            UploadURL = '';
+            UploadURL = '',
+            ExtraPlugins;
 
         if (isJQueryObject($EditorArea) && $EditorArea.hasClass('HasCKEInstance')) {
             return false;
@@ -127,6 +128,15 @@ Core.UI.RichTextEditor = (function (TargetNS) {
                     + '=' + Core.Config.Get('SessionID');
         }
 
+        // configure extra plugins
+        ExtraPlugins = 'splitquote';
+        if (Core.Config.Get('RichText.SpellChecker')) {
+            ExtraPlugins += ',aspell';
+        }
+        if (Core.Config.Get('RichText.PreventImagePaste') === '1') {
+            ExtraPlugins += ',preventimagepaste';
+        }
+
         /*eslint-disable camelcase */
         Editor = CKEDITOR.replace(EditorID,
         {
@@ -148,7 +158,7 @@ Core.UI.RichTextEditor = (function (TargetNS) {
             toolbar: CheckFormID().length ? Core.Config.Get('RichText.Toolbar') : Core.Config.Get('RichText.ToolbarWithoutImage'),
             filebrowserBrowseUrl: '',
             filebrowserUploadUrl: UploadURL,
-            extraPlugins: Core.Config.Get('RichText.SpellChecker') ? 'aspell,splitquote,preventimagepaste' : 'splitquote,preventimagepaste',
+            extraPlugins: ExtraPlugins,
             entities: false,
             skin: 'bootstrapck'
         });


### PR DESCRIPTION
This mod reenables pasting images as data URIs to signatures, templates
and AdminEmail messages. It also fixes problem with embedding inline
images using copy/paste on messages sent from AdminEmail (now such
images will be converted to attachments in e-mail which is more
compatible with poor mail readers).

This mod introduces also new SysConfig option
Frontend::RichText::PreventImagePaste (disabled by default) which
allowes one to disable pasting images as data URIs to rich text areas.

Fixes: 74fe26ecdb3be0fffe5551cce8349e0a40806193
Related: https://dev.ib.pl/ib/otrs/issues/41
Related: http://bugs.otrs.org/show_bug.cgi?id=11944
Author-Change-Id: IB#1051028
