### PR TITLE
Add the possibility to use variables in URL config

### DIFF
--- a/Kernel/Output/HTML/Templates/Standard/AgentCustomerTableView.tt
+++ b/Kernel/Output/HTML/Templates/Standard/AgentCustomerTableView.tt
@@ -38,7 +38,7 @@
 [% RenderBlockStart("CustomerItemRow") %]
         <li>
             <i class="fa [% Data.IconName %] [% Data.CSSClass %]"></i>
-            <a class="[% Data.CSSClass %]" [% FOREACH Attribute IN Data.HTMLData %]data-[% Attribute.key | html %]="[% Attribute.value | html %]" [% END %]href="[% Data.URL %]" target="[% Data.Target %]" title="[% Translate(Data.Text) | html %]">
+            <a class="[% Data.CSSClass %]" [% FOREACH Attribute IN Data.HTMLData %]data-[% Attribute.key | html %]="[% Attribute.value | html %]" [% END %]href="[% Data.URL | Interpolate %]" target="[% Data.Target %]" title="[% Translate(Data.Text) | html %]">
                 [% Translate(Data.Text) | html %][% Data.Extension | html %]
             </a>
         </li>


### PR DESCRIPTION
Currently it's not possible to build OTRS internal links via a 'Frontend::CustomerUser::Item' SysConfig using the  Kernel/Output/HTML/CustomerUser/Generic.pm backend. It's only possible to configure absolute URLs.

This change makes it possible to make configurations like:

```xml
...
                <Item Key="Required">UserID</Item>
                <Item Key="Attributes">UserID</Item>
                <Item Key="URL">[% Env("CGIHandle") %]?Action=AgentTicketCustomAction;CustomerUserID=[% Data.UserID | uri %]
...
</Item>
```

possible.