### PR TITLE
Removed dummy 'Move' options from queue select.

### DIFF
--- a/Kernel/Output/HTML/Templates/Standard/AgentTicketZoom.tt
+++ b/Kernel/Output/HTML/Templates/Standard/AgentTicketZoom.tt
@@ -201,7 +201,7 @@ $('#[% Data.FormID | html %] select[name=[% Data.PhoneElementID | html %]]').bin
                                     <input type="hidden" name="Action" value="AgentTicketMove"/>
                                     <input type="hidden" name="QueueID" value="[% Data.QueueID | html %]"/>
                                     <input type="hidden" name="TicketID" value="[% Data.TicketID | html %]"/>
-                                    <label for="DestQueueID" class="InvisibleText">[% Translate("Queue") | html %]:</label>
+                                    <label for="DestQueueID">[% Translate("Queue") | html %]:</label>
                                     [% Data.MoveQueuesStrg %]
                                 </form>
 [% WRAPPER JSOnDocumentComplete %]
@@ -215,7 +215,7 @@ $('#[% Data.FormID | html %] select[name=[% Data.PhoneElementID | html %]]').bin
 [% RenderBlockEnd("MoveLink") %]
 [% RenderBlockStart("MoveForm") %]
                             <li>
-                                <a href="[% Env("Baselink") %]Action=AgentTicketMove;TicketID=[% Data.TicketID | uri %];" class="AsPopup PopupType_TicketAction" title="[% Translate("Change Queue") | html %]">[% Translate("Queue") | html %]</a>
+                                <a href="[% Env("Baselink") %]Action=AgentTicketMove;TicketID=[% Data.TicketID | uri %];" class="AsPopup PopupType_TicketAction" title="[% Translate("Queue") | html %]">[% Translate("Queue") | html %]</a>
                             </li>
 [% RenderBlockEnd("MoveForm") %]
                         </ul>


### PR DESCRIPTION
The queue select in agent ticket zoom should be displayed the same way as the new reply and forward selects.