### PR TITLE
Fixed parsing CSV data with quoted values containing newlines

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,4 +1,5 @@
 #6.0.0.beta1 2016-??-??
+ - 2016-04-25 Fixed parsing CSV data with quoted values containing newlines.
  - 2016-04-22 Added possibility to set the ticket title in Postmaster filters, thanks to Renée Bäcker.
  - 2016-04-15 Added possibility to use multiple named captures in Postmaster filters, thanks to Renée Bäcker.
  - 2016-04-08 Removed dummy 'Reply All' and 'Forward' options to align with 'Reply' select, thanks to Nils Leideck.

--- a/scripts/test/CSV.t
+++ b/scripts/test/CSV.t
@@ -173,6 +173,106 @@ $Self->Is(
     '#4 CSV2Array() - with dos file',
 );
 
+# values with \n quoted; other not quoted
+my $String = 'c1;c2;c3' . "\n"
+    . 'v1;"v2 line1' . "\n" . 'v2 line 2";v3' . "\n";
+$Array = $CSVObject->CSV2Array(
+    String    => $String,
+    Separator => ';',
+    Quote     => '"',
+);
+
+$Self->Is(
+    $Array->[0]->[0] || '',
+    'c1',
+    '#5 CSV2Array() - values with \n quoted; other not quoted',
+);
+$Self->Is(
+    $Array->[0]->[1] || '',
+    'c2',
+    '#5 CSV2Array() - values with \n quoted; other not quoted',
+);
+$Self->Is(
+    $Array->[0]->[2] || '',
+    'c3',
+    '#5 CSV2Array() - values with \n quoted; other not quoted',
+);
+$Self->Is(
+    $Array->[1]->[0] || '',
+    'v1',
+    '#5 CSV2Array() - values with \n quoted; other not quoted',
+);
+$Self->Is(
+    $Array->[1]->[1] || '',
+    "v2 line1\nv2 line 2",
+    '#5 CSV2Array() - values with \n quoted; other not quoted',
+);
+$Self->Is(
+    $Array->[1]->[2] || '',
+    'v3',
+    '#5 CSV2Array() - values with \n quoted; other not quoted',
+);
+$Self->Is(
+    $#{$Array} || '',
+    1,
+    '#5 CSV2Array() - values with \n quoted; other not quoted',
+);
+$Self->Is(
+    $#{ $Array->[1] } || '',
+    2,
+    '#5 CSV2Array() - values with \n quoted; other not quoted',
+);
+
+# values with \r quoted; other not quoted
+my $String = 'c1;c2;c3' . "\r"
+    . 'v1;"v2 line1' . "\r" . 'v2 line 2";v3' . "\r";
+$Array = $CSVObject->CSV2Array(
+    String    => $String,
+    Separator => ';',
+    Quote     => '"',
+);
+
+$Self->Is(
+    $Array->[0]->[0] || '',
+    'c1',
+    '#6 CSV2Array() - values with \r quoted; other not quoted',
+);
+$Self->Is(
+    $Array->[0]->[1] || '',
+    'c2',
+    '#6 CSV2Array() - values with \r quoted; other not quoted',
+);
+$Self->Is(
+    $Array->[0]->[2] || '',
+    'c3',
+    '#6 CSV2Array() - values with \r quoted; other not quoted',
+);
+$Self->Is(
+    $Array->[1]->[0] || '',
+    'v1',
+    '#6 CSV2Array() - values with \r quoted; other not quoted',
+);
+$Self->Is(
+    $Array->[1]->[1] || '',
+    "v2 line1\nv2 line 2",
+    '#6 CSV2Array() - values with \r quoted; other not quoted',
+);
+$Self->Is(
+    $Array->[1]->[2] || '',
+    'v3',
+    '#6 CSV2Array() - values with \r quoted; other not quoted',
+);
+$Self->Is(
+    $#{$Array} || '',
+    1,
+    '#6 CSV2Array() - values with \r quoted; other not quoted',
+);
+$Self->Is(
+    $#{ $Array->[1] } || '',
+    2,
+    '#6 CSV2Array() - values with \r quoted; other not quoted',
+);
+
 # -------------------------------------------------
 # tests because of the double "" problem bug# 2263
 # -------------------------------------------------


### PR DESCRIPTION
OTRS CSV parser does not handle quoted values with newlines. Parsing file like

    c1;c2;c3
    "c1 value line1
    c1 value line2";c2 value;c3 value

produces errors.

According to

* https://metacpan.org/pod/Text::CSV_XS#Embedded-newlines
* http://perlmaven.com/how-to-read-a-csv-file-using-perl

for parsing such data one should use getline().

Related: https://dev.ib.pl/ib/otrs/issues/44
Author-Change-Id: IB#1013124