### PR TITLE
Master - Translate strings directly in JavaScript files - part 1

### DIFF
--- a/Kernel/Output/HTML/Templates/Standard/AgentCustomerSearch.tt
+++ b/Kernel/Output/HTML/Templates/Standard/AgentCustomerSearch.tt
@@ -10,9 +10,6 @@
 [% WRAPPER JSOnDocumentComplete %]
 <script type="text/javascript">//<![CDATA[
     Core.Config.Set('CustomerSearch.ShowCustomerTickets', "[% Config("Ticket::Frontend::ShowCustomerTickets") %]");
-    Core.Config.Set('Duplicated.TitleText', [% Translate("Duplicated entry") | JSON %]);
-    Core.Config.Set('Duplicated.ContentText', [% Translate("This address already exists on the address list.") | JSON %]);
-    Core.Config.Set('Duplicated.RemoveText', [% Translate("It is going to be deleted from the field, please try again.") | JSON %]);
     Core.Config.Set('Ticket::Frontend::AgentTicketPhone::AllowMultipleFrom', "[% Config("Ticket::Frontend::AgentTicketPhone::AllowMultipleFrom") %]");
     Core.Agent.CustomerSearch.Init($("#CustomerAutoComplete, .CustomerAutoComplete"));
 //]]></script>

--- a/Kernel/Output/HTML/Templates/Standard/AgentDashboardCommon.tt
+++ b/Kernel/Output/HTML/Templates/Standard/AgentDashboardCommon.tt
@@ -74,7 +74,7 @@ $('#Dashboard' + Core.App.EscapeSelector('[% Data.Name | html %]') + '_toggle').
 [% END %]
 [% RenderBlockEnd("ContentSmallRefresh") %]
                 <div class="WidgetAction Close">
-                    <a href="[% Env("Baselink") %]Action=[% Env("Action") %];Subaction=UpdateRemove;Name=[% Data.Name | uri %];CustomerID=[% Data.CustomerID | uri %];[% Env("ChallengeTokenParam") | html %]" title="[% Translate("Close this dialog") | html %]">
+                    <a href="[% Env("Baselink") %]Action=[% Env("Action") %];Subaction=UpdateRemove;Name=[% Data.Name | uri %];CustomerID=[% Data.CustomerID | uri %];[% Env("ChallengeTokenParam") | html %]" title="[% Translate("Close this widget") | html %]">
                         <i class="fa fa-times"></i>
                     </a>
                 </div>
@@ -171,7 +171,7 @@ Core.UI.RegisterToggleTwoContainer($('#Dashboard' + Core.App.EscapeSelector('[% 
 [% END %]
 [% RenderBlockEnd("ContentLargePreferences") %]
                 <div class="WidgetAction Close">
-                    <a href="[% Env("Baselink") %]Action=[% Env("Action") %];Subaction=UpdateRemove;Name=[% Data.Name | uri %];CustomerID=[% Data.CustomerID | uri %];[% Env("ChallengeTokenParam") | html %]" title="[% Translate("Close this dialog") | html %]">
+                    <a href="[% Env("Baselink") %]Action=[% Env("Action") %];Subaction=UpdateRemove;Name=[% Data.Name | uri %];CustomerID=[% Data.CustomerID | uri %];[% Env("ChallengeTokenParam") | html %]" title="[% Translate("Close this widget") | html %]">
                         <i class="fa fa-times"></i>
                     </a>
                 </div>

--- a/Kernel/Output/HTML/Templates/Standard/AgentDashboardCommon.tt
+++ b/Kernel/Output/HTML/Templates/Standard/AgentDashboardCommon.tt
@@ -74,7 +74,7 @@ $('#Dashboard' + Core.App.EscapeSelector('[% Data.Name | html %]') + '_toggle').
 [% END %]
 [% RenderBlockEnd("ContentSmallRefresh") %]
                 <div class="WidgetAction Close">
-                    <a href="[% Env("Baselink") %]Action=[% Env("Action") %];Subaction=UpdateRemove;Name=[% Data.Name | uri %];CustomerID=[% Data.CustomerID | uri %];[% Env("ChallengeTokenParam") | html %]" title="[% Translate("Close this widget") | html %]">
+                    <a href="[% Env("Baselink") %]Action=[% Env("Action") %];Subaction=UpdateRemove;Name=[% Data.Name | uri %];CustomerID=[% Data.CustomerID | uri %];[% Env("ChallengeTokenParam") | html %]" title="[% Translate("Close this dialog") | html %]">
                         <i class="fa fa-times"></i>
                     </a>
                 </div>
@@ -171,7 +171,7 @@ Core.UI.RegisterToggleTwoContainer($('#Dashboard' + Core.App.EscapeSelector('[% 
 [% END %]
 [% RenderBlockEnd("ContentLargePreferences") %]
                 <div class="WidgetAction Close">
-                    <a href="[% Env("Baselink") %]Action=[% Env("Action") %];Subaction=UpdateRemove;Name=[% Data.Name | uri %];CustomerID=[% Data.CustomerID | uri %];[% Env("ChallengeTokenParam") | html %]" title="[% Translate("Close this widget") | html %]">
+                    <a href="[% Env("Baselink") %]Action=[% Env("Action") %];Subaction=UpdateRemove;Name=[% Data.Name | uri %];CustomerID=[% Data.CustomerID | uri %];[% Env("ChallengeTokenParam") | html %]" title="[% Translate("Close this dialog") | html %]">
                         <i class="fa fa-times"></i>
                     </a>
                 </div>

--- a/Kernel/Output/HTML/Templates/Standard/CustomerFooterJS.tt
+++ b/Kernel/Output/HTML/Templates/Standard/CustomerFooterJS.tt
@@ -40,11 +40,6 @@ Core.App.Ready(function() {
         Autocomplete: Core.JSON.Parse('[% Data.AutocompleteConfig %]'),
 [% RenderBlockEnd("AutoCompleteConfig") %]
         // translation
-        ValidateServerErrorTitle: [% Translate("Error") | JSON %],
-        ValidateServerErrorMsg: [% Translate("One or more errors occurred!") | JSON %],
-        DialogCloseMsg: [% Translate("Close this dialog") | JSON %],
-        PopupBlockerMsg: [% Translate("Could not open popup window. Please disable any popup blockers for this application.") | JSON %],
-        PopupAlreadyOpenMsg: [% Translate("A popup of this screen is already open. Do you want to close it and load this one instead?") | JSON %],
         SearchMsg: [% Translate("Search") | JSON %],
         ApplyButtonText: [% Translate("Apply") | JSON %],
         NoElementsToSelectFromMsg: [% Translate("There are currently no elements available to select from.") | JSON %],

--- a/Kernel/Output/HTML/Templates/Standard/FooterJS.tt
+++ b/Kernel/Output/HTML/Templates/Standard/FooterJS.tt
@@ -51,11 +51,6 @@ Core.App.Ready(function () {
 [% RenderBlockEnd("SearchFrontendConfig") %]
         CheckSearchStringsForStopWords: [% Config("Ticket::SearchIndex::WarnOnStopWordUsage") and Config("Ticket::SearchIndexModule") == 'Kernel::System::Ticket::ArticleSearchIndex::StaticDB' ? 1 : 0 %],
         // translations
-        ValidateServerErrorTitle: [% Translate("Error") | JSON %],
-        ValidateServerErrorMsg: [% Translate("One or more errors occurred!") | JSON %],
-        DialogCloseMsg: [% Translate("Close this dialog") | JSON %],
-        PopupBlockerMsg: [% Translate("Could not open popup window. Please disable any popup blockers for this application.") | JSON %],
-        PopupAlreadyOpenMsg: [% Translate("A popup of this screen is already open. Do you want to close it and load this one instead?") | JSON %],
         LoadingMsg: [% Translate("Loading...") | JSON %],
         EmptySearchMsg: [% Translate("Please enter at least one search value or * to find anything.") | JSON %],
         SearchMsg: [% Translate("Search") | JSON %],

--- a/var/httpd/htdocs/js/Core.Agent.CustomerSearch.js
+++ b/var/httpd/htdocs/js/Core.Agent.CustomerSearch.js
@@ -638,7 +638,7 @@ Core.Agent.CustomerSearch = (function (TargetNS) {
     TargetNS.ShowDuplicatedDialog = function(Field){
         Core.UI.Dialog.ShowAlert(
             Core.Language.Translate('Duplicated entry'),
-            Core.Language.Translate('This address already exists on the address list. It is going to be deleted from the field, please try again.'),
+            Core.Language.Translate('This address already exists on the address list.') + ' ' + Core.Language.Translate('It is going to be deleted from the field, please try again.'),
             function () {
                 Core.UI.Dialog.CloseDialog($('.Alert'));
                 $('#' + Field).val('');

--- a/var/httpd/htdocs/js/Core.Agent.CustomerSearch.js
+++ b/var/httpd/htdocs/js/Core.Agent.CustomerSearch.js
@@ -637,8 +637,8 @@ Core.Agent.CustomerSearch = (function (TargetNS) {
      */
     TargetNS.ShowDuplicatedDialog = function(Field){
         Core.UI.Dialog.ShowAlert(
-            Core.Config.Get('Duplicated.TitleText'),
-            Core.Config.Get('Duplicated.ContentText') + ' ' + Core.Config.Get('Duplicated.RemoveText'),
+            Core.Language.Translate('Duplicated entry'),
+            Core.Language.Translate('Duplicated entry') + ' ' + Core.Config.Get('It is going to be deleted from the field, please try again.'),
             function () {
                 Core.UI.Dialog.CloseDialog($('.Alert'));
                 $('#' + Field).val('');

--- a/var/httpd/htdocs/js/Core.Agent.CustomerSearch.js
+++ b/var/httpd/htdocs/js/Core.Agent.CustomerSearch.js
@@ -638,7 +638,7 @@ Core.Agent.CustomerSearch = (function (TargetNS) {
     TargetNS.ShowDuplicatedDialog = function(Field){
         Core.UI.Dialog.ShowAlert(
             Core.Language.Translate('Duplicated entry'),
-            Core.Language.Translate('Duplicated entry') + ' ' + Core.Config.Get('It is going to be deleted from the field, please try again.'),
+            Core.Language.Translate('This address already exists on the address list. It is going to be deleted from the field, please try again.'),
             function () {
                 Core.UI.Dialog.CloseDialog($('.Alert'));
                 $('#' + Field).val('');

--- a/var/httpd/htdocs/js/Core.Agent.TicketAction.js
+++ b/var/httpd/htdocs/js/Core.Agent.TicketAction.js
@@ -209,7 +209,7 @@ Core.Agent.TicketAction = (function (TargetNS) {
                     Core.App.Publish('Event.Agent.TicketAction.NeedSpellCheck', [$('#RichText')]);
                     Core.UI.Dialog.ShowContentDialog('<p>' + Core.Config.Get('SpellCheckNeededMsg') + '</p>', '', '150px', 'Center', true, [
                         {
-                            Label: '<span>' + Core.Language.Translate('Close this widget') + '</span>',
+                            Label: '<span>' + Core.Language.Translate('Close this dialog') + '</span>',
                             Function: function () {
                                 Core.UI.Dialog.CloseDialog($('.Dialog:visible'));
                                 Core.Form.EnableForm($('#RichText').closest('form'));

--- a/var/httpd/htdocs/js/Core.Agent.TicketAction.js
+++ b/var/httpd/htdocs/js/Core.Agent.TicketAction.js
@@ -209,7 +209,7 @@ Core.Agent.TicketAction = (function (TargetNS) {
                     Core.App.Publish('Event.Agent.TicketAction.NeedSpellCheck', [$('#RichText')]);
                     Core.UI.Dialog.ShowContentDialog('<p>' + Core.Config.Get('SpellCheckNeededMsg') + '</p>', '', '150px', 'Center', true, [
                         {
-                            Label: '<span>' + Core.Language.Translate('Close') + '</span>',
+                            Label: '<span>' + Core.Language.Translate('Close this widget') + '</span>',
                             Function: function () {
                                 Core.UI.Dialog.CloseDialog($('.Dialog:visible'));
                                 Core.Form.EnableForm($('#RichText').closest('form'));

--- a/var/httpd/htdocs/js/Core.Agent.TicketAction.js
+++ b/var/httpd/htdocs/js/Core.Agent.TicketAction.js
@@ -209,7 +209,7 @@ Core.Agent.TicketAction = (function (TargetNS) {
                     Core.App.Publish('Event.Agent.TicketAction.NeedSpellCheck', [$('#RichText')]);
                     Core.UI.Dialog.ShowContentDialog('<p>' + Core.Config.Get('SpellCheckNeededMsg') + '</p>', '', '150px', 'Center', true, [
                         {
-                            Label: '<span>' + Core.Config.Get('DialogCloseMsg') + '</span>',
+                            Label: '<span>' + Core.Language.Translate('Close') + '</span>',
                             Function: function () {
                                 Core.UI.Dialog.CloseDialog($('.Dialog:visible'));
                                 Core.Form.EnableForm($('#RichText').closest('form'));

--- a/var/httpd/htdocs/js/Core.Form.Validate.js
+++ b/var/httpd/htdocs/js/Core.Form.Validate.js
@@ -764,7 +764,7 @@ Core.Form.Validate = (function (TargetNS) {
                 $ServerErrors.eq(0).focus();
             };
 
-            Core.UI.Dialog.ShowAlert(Core.Config.Get('ValidateServerErrorTitle'), Core.Config.Get('ValidateServerErrorMsg'), ServerErrorDialogCloseFunction);
+            Core.UI.Dialog.ShowAlert(Core.Language.Translate('Error'), Core.Language.Translate('One or more errors occurred!'), ServerErrorDialogCloseFunction);
         }
     };
 

--- a/var/httpd/htdocs/js/Core.UI.Popup.js
+++ b/var/httpd/htdocs/js/Core.UI.Popup.js
@@ -452,7 +452,7 @@ Core.UI.Popup = (function (TargetNS) {
             // perform only if popups are not unlinked
             if (!Unlinked) {
                 if (typeof PopupObject !== 'undefined') {
-                    ConfirmClosePopup = window.confirm(Core.Config.Get('PopupAlreadyOpenMsg'));
+                    ConfirmClosePopup = window.confirm(Core.Language.Translate('A popup of this screen is already open. Do you want to close it and load this one instead?'));
                     if (ConfirmClosePopup) {
                         TargetNS.ClosePopup(PopupObject);
                     }
@@ -509,7 +509,7 @@ Core.UI.Popup = (function (TargetNS) {
                     // currently, popup windows cannot easily be detected in chrome, because it will
                     //      load the entire content in an invisible window.
                     if (!NewWindow || NewWindow.closed || typeof NewWindow.closed === 'undefined') {
-                        window.alert(Core.Config.Get('PopupBlockerMsg'));
+                        window.alert(Core.Language.Translate('Could not open popup window. Please disable any popup blockers for this application.'));
                     }
                     else {
                         OpenPopups[Type] = NewWindow;


### PR DESCRIPTION
Hi @zottto 

There is first PR with refactoring JS where is used translate directly in JS. 
I started removing string from CustomerFooterJS.tt and FooterJS.tt, I suppose it is OK. 
I saw that these strings are also used in some else packages.  For example Duplicated.TitleText and Duplicated.RemoveText are used in OTRSBussines, but now they are removed in the framework. I suppose we should update these packages as well, when we finish refactoring here in the framework.

I update in AgentCustomerSearch.tt as a example that you follow-up if I have done this well. 
 
You also mentioned in the mail:

> in all other tt files there is even more translated text in JavaScript blocks
> if the translation is used directly, please ignore it for the moment 

I think you meant on something like  that:

https://github.com/OTRS/otrs/blob/master/Kernel/Output/HTML/Templates/Standard/AdminACLEdit.tt#L263

Instead of DialogCloseMsg I used only Close, as I have see you used in 
https://github.com/OTRS/otrs/commit/344fdd109526357fe00a9827ca6eb0235ebb65dd#diff-b9564e1cf513f62502507520701c60b5R197

Please check this, and I will be able to continue to work on this task.

Regards
Zoran

