### PR TITLE
Fixed bug: Missing EscapeSelector.

### DIFF
--- a/var/httpd/htdocs/js/Core.Agent.Search.js
+++ b/var/httpd/htdocs/js/Core.Agent.Search.js
@@ -151,7 +151,7 @@ Core.Agent.Search = (function (TargetNS) {
                 // label id, use the remaining name as name string for accessing
                 // the form input's value
                 ElementName = $(this).attr('id').substring(5);
-                $Element = $('#SearchForm input[name=' + ElementName + ']');
+                $Element = $('#SearchForm input[name=' + Core.App.EscapeSelector(ElementName) + ']');
 
                 // If there's no input element with the selected name
                 // find the next "select" element and use that one for checking


### PR DESCRIPTION
Hi there,

we stumbled over an issue while using the search for ITSM ConfigItems where the attribute is a subelement like: "Building::Room". The '::' are causing a jQuery selector exception. Using Core.App.EscapeSelector fixes this.