### PR TITLE
Fixed wrong proposed default article type when replying/forwarding

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,4 +1,5 @@
 #6.0.0.beta1 2016-??-??
+ - 2016-04-27 Fixed wrong proposed default article type when replying/forwarding.
  - 2016-04-22 Added possibility to set the ticket title in Postmaster filters, thanks to Renée Bäcker.
  - 2016-04-15 Added possibility to use multiple named captures in Postmaster filters, thanks to Renée Bäcker.
  - 2016-04-08 Removed dummy 'Reply All' and 'Forward' options to align with 'Reply' select, thanks to Nils Leideck.

--- a/Kernel/Modules/AgentTicketCompose.pm
+++ b/Kernel/Modules/AgentTicketCompose.pm
@@ -1685,7 +1685,20 @@ sub _Mask {
 
         my %Selected;
         if ( $Param{ArticleTypeID} ) {
-            $Selected{SelectedID} = $Param{ArticleTypeID};
+
+            # use email-internal article type if replying to article with internal type; otherwise use email-internal
+            my $ArticleTypeSelected = $TicketObject->ArticleTypeLookup( ArticleTypeID => $Param{ArticleTypeID} );
+            if ( $ArticleTypeSelected ) {
+                if ( $ArticleTypeSelected =~ m{internal} ) {
+                    $Selected{SelectedID} = $TicketObject->ArticleTypeLookup( ArticleType => 'email-internal' );
+                }
+                else {
+                    $Selected{SelectedID} = $TicketObject->ArticleTypeLookup( ArticleType => 'email-external' );
+                }
+            }
+            else {
+                $Selected{SelectedValue} = $Config->{DefaultArticleType};
+            }
         }
         else {
             $Selected{SelectedValue} = $Config->{DefaultArticleType};

--- a/Kernel/Modules/AgentTicketForward.pm
+++ b/Kernel/Modules/AgentTicketForward.pm
@@ -1370,8 +1370,21 @@ sub _Mask {
         }
 
         my %Selected;
-        if ( $Self->{GetParam}->{ArticleTypeID} ) {
-            $Selected{SelectedID} = $Self->{GetParam}->{ArticleTypeID};
+        if ( $Param{ArticleTypeID} ) {
+
+            # use email-internal article type if forwarding article with internal type; otherwise use email-internal
+            my $ArticleTypeSelected = $TicketObject->ArticleTypeLookup( ArticleTypeID => $Param{ArticleTypeID} );
+            if ( $ArticleTypeSelected ) {
+                if ( $ArticleTypeSelected =~ m{internal} ) {
+                    $Selected{SelectedID} = $TicketObject->ArticleTypeLookup( ArticleType => 'email-internal' );
+                }
+                else {
+                    $Selected{SelectedID} = $TicketObject->ArticleTypeLookup( ArticleType => 'email-external' );
+                }
+            }
+            else {
+                $Selected{SelectedValue} = $Config->{DefaultArticleType};
+            }
         }
         else {
             $Selected{SelectedValue} = $Config->{ArticleTypeDefault};


### PR DESCRIPTION
When you reply to phone article (incoming or outgoing) AgentTicketCompose
form proposes email-internal as default article type if agent uses Polish
language in web frontend and email-external if agent uses English
language in web frontend.

When forwarding from article with internal type - email-external is
proposed as default in AgentTicketForward form.

With this fix OTRS proposes email-internal in AgentTicketForward and
AgentTicketCompose if sending from article with "internal"
type and email-external otherwise.

Related: https://dev.ib.pl/ib/otrs/issues/46
Author-Change-Id: IB#1014394