### PR TITLE
Remove warning message about invalid encoding

### DIFF
--- a/Kernel/System/Encode.pm
+++ b/Kernel/System/Encode.pm
@@ -133,7 +133,6 @@ sub Convert {
         # check if string is valid utf-8
         if ( $Param{Check} && !eval { Encode::is_utf8( $Param{Text}, 1 ) } ) {
             Encode::_utf8_off( $Param{Text} );
-            print STDERR "No valid '$Param{To}' string: '$Param{Text}'!\n";
 
             # strip invalid chars / 0 = will put a substitution character in
             # place of a malformed character


### PR DESCRIPTION
I don't see the value in printing it, and it potentially prints the whole
body of an email message (when called from within the postmaster), which can
be several megabytes, and completely blow up log files.

If removing this warning is not acceptable, there should at least be a length limit to the printed string.