### PR TITLE
Added extended agent properties synchronization from LDAP backend

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,4 +1,5 @@
 #6.0.0.beta1 2016-??-??
+ - 2016-04-27 Added extended agent properties synchronization from LDAP backend.
  - 2016-04-22 Added possibility to set the ticket title in Postmaster filters, thanks to Renée Bäcker.
  - 2016-04-15 Added possibility to use multiple named captures in Postmaster filters, thanks to Renée Bäcker.
  - 2016-04-08 Removed dummy 'Reply All' and 'Forward' options to align with 'Reply' select, thanks to Nils Leideck.

--- a/Kernel/System/Auth/Sync/LDAP.pm
+++ b/Kernel/System/Auth/Sync/LDAP.pm
@@ -270,12 +270,12 @@ sub Sync {
         # add new user
         if ( %SyncUser && !$UserID ) {
             $UserID = $UserObject->UserAdd(
-                UserTitle => 'Mr/Mrs',
                 UserLogin => $Param{User},
                 %SyncUser,
                 UserType     => 'User',
                 ValidID      => 1,
                 ChangeUserID => 1,
+                Extended     => 1,
             );
             if ( !$UserID ) {
                 $Kernel::OM->Get('Kernel::System::Log')->Log(
@@ -336,7 +336,10 @@ sub Sync {
             my $AttributeChange;
             ATTRIBUTE:
             for my $Attribute ( sort keys %SyncUser ) {
-                next ATTRIBUTE if $SyncUser{$Attribute} eq $UserData{$Attribute};
+                # treat undef and empty string as equal
+                my $SyncUserAttribute = $SyncUser{$Attribute} || '';
+                my $UserDataAttribute = $UserData{$Attribute} || '';
+                next ATTRIBUTE if $SyncUserAttribute eq $UserDataAttribute;
                 $AttributeChange = 1;
                 last ATTRIBUTE;
             }
@@ -349,6 +352,7 @@ sub Sync {
                     %SyncUser,
                     UserType     => 'User',
                     ChangeUserID => 1,
+                    Extended     => 1,
                 );
             }
         }


### PR DESCRIPTION
This mod allows to synchronize extended OTRS agent properties from LDAP
backend (i.e. OpenLDAP or Active Directory). It also fixes problems with
empty UserMobile properties in user_preferences tables that may be
created after new agent creation and handles better undef/empty string
comparisons that may occur between data stored in OTRS DB and data
comming from LDAP.

With this mod you can specify additional User* properties
in AuthSyncModule::LDAP::UserSyncMap mapping (i.e. UserPhone,
UserDepartment, UserJobTitle) in addition to properties supported
by standard OTRS (UserFirstname, UserLastname, UserEmail, UserMobile).
Extended property names must begin with "User"; you can use it
in signature templates for example.

Usage example: the following setting

    $Self->{'AuthSyncModule::LDAP::UserSyncMap'} = {
        # DB -> LDAP
        UserFirstname   => 'givenName',
        UserLastname    => 'sn',
        UserEmail       => 'mail',
        UserMobile      => 'mobile',
        UserPhone       => 'telephoneNumber',
        UserDepartment  => 'department',
        UserJobTitle    => 'title',
    };

will allow you to use extra properties from Active Directory
in signature templates like this:

    Regards,
    <OTRS_AGENT_UserFirstname> <OTRS_AGENT_UserLastname>
    <OTRS_AGENT_UserJobTitle>
    <OTRS_AGENT_UserDepartment>
    M: <OTRS_AGENT_UserMobile>, T: <OTRS_AGENT_UserPhone>

Extended properties from LDAP are stored in OTRS database
in user_preferences table.

Related: https://dev.ib.pl/ib/otrs/issues/47
Author-Change-Id: IB#1014533