### PR TITLE
Fixed error log flooding with less important messages

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,4 +1,5 @@
 #6.0.0.beta1 2016-??-??
+ - 2016-04-28 Fixed error log flooding with less important messages.
  - 2016-04-26 Added possibility to push custom data directly from Perl code to JavaScript without having to embed it into templates.
  - 2016-04-26 Added possibility to translate strings directly in JavaScript files.
  - 2016-04-22 Added possibility to set the ticket title in Postmaster filters, thanks to Renée Bäcker.

--- a/Kernel/System/CheckItem.pm
+++ b/Kernel/System/CheckItem.pm
@@ -176,7 +176,7 @@ sub CheckEmail {
                 if ( !@MXRecords ) {
 
                     $Kernel::OM->Get('Kernel::System::Log')->Log(
-                        Priority => 'notice',
+                        Priority => 'debug',
                         Message =>
                             "$Host has no mail exchanger (MX) defined, trying A resource record instead.",
                     );
@@ -188,7 +188,7 @@ sub CheckEmail {
                         $Error = "$Host has no mail exchanger (MX) or A resource record defined.";
 
                         $Kernel::OM->Get('Kernel::System::Log')->Log(
-                            Priority => 'error',
+                            Priority => 'debug',
                             Message  => $Error,
                         );
                     }

--- a/Kernel/System/CustomerUser/LDAP.pm
+++ b/Kernel/System/CustomerUser/LDAP.pm
@@ -248,10 +248,22 @@ sub CustomerName {
     );
 
     if ( $Result->code() ) {
-        $Kernel::OM->Get('Kernel::System::Log')->Log(
-            Priority => 'error',
-            Message  => 'Search failed! ' . $Result->error(),
-        );
+        if ( $Result->code() == 4 ) {
+
+            # Result code 4 (LDAP_SIZELIMIT_EXCEEDED) is normal if there
+            # are more items in LDAP than search limit defined in OTRS or
+            # in LDAP server. Avoid spamming logs with such errors.
+            $Kernel::OM->Get('Kernel::System::Log')->Log(
+                Priority => 'debug',
+                Message  => 'LDAP size limit exceeded (' . $Result->error() . ').',
+            );
+        }
+        else {
+            $Kernel::OM->Get('Kernel::System::Log')->Log(
+                Priority => 'error',
+                Message  => 'Search failed! ' . $Result->error(),
+            );
+        }
         return;
     }
 
@@ -383,10 +395,22 @@ sub CustomerSearch {
 
     # log ldap errors
     if ( $Result->code() ) {
-        $Kernel::OM->Get('Kernel::System::Log')->Log(
-            Priority => 'error',
-            Message  => $Result->error(),
-        );
+        if ( $Result->code() == 4 ) {
+
+            # Result code 4 (LDAP_SIZELIMIT_EXCEEDED) is normal if there
+            # are more items in LDAP than search limit defined in OTRS or
+            # in LDAP server. Avoid spamming logs with such errors.
+            $Kernel::OM->Get('Kernel::System::Log')->Log(
+                Priority => 'debug',
+                Message  => 'LDAP size limit exceeded (' . $Result->error() . ').',
+            );
+        }
+        else {
+            $Kernel::OM->Get('Kernel::System::Log')->Log(
+                Priority => 'error',
+                Message  => 'Search failed! ' . $Result->error(),
+            );
+        }
     }
 
     my %Users;

--- a/Kernel/System/Log.pm
+++ b/Kernel/System/Log.pm
@@ -79,6 +79,11 @@ sub new {
     $Self->{LogPrefix} = $Param{LogPrefix} || '?LogPrefix?';
     $Self->{LogPrefix} .= '-' . $SystemID;
 
+    # configured log level (debug by default)
+    $Self->{MinimumLevel}    = $ConfigObject->Get('MinimumLogLevel') || 'debug';
+    $Self->{MinimumLevel}    = lc $Self->{MinimumLevel};
+    $Self->{MinimumLevelNum} = $LogLevel{ $Self->{MinimumLevel} };
+
     # load log backend
     my $GenericModule = $ConfigObject->Get('LogModule') || 'Kernel::System::Log::SysLog';
     if ( !eval "require $GenericModule" ) {    ## no critic
@@ -96,10 +101,6 @@ sub new {
     $Self->{IPC}     = 1;
     $Self->{IPCKey}  = '444423' . $SystemID;
     $Self->{IPCSize} = $ConfigObject->Get('LogSystemCacheSize') || 32 * 1024;
-
-    $Self->{MinimumLevel}    = $ConfigObject->Get('MinimumLogLevel') || 'debug';
-    $Self->{MinimumLevel}    = lc $Self->{MinimumLevel};
-    $Self->{MinimumLevelNum} = $LogLevel{ $Self->{MinimumLevel} };
 
     # init session data mem
     if ( !eval { $Self->{Key} = shmget( $Self->{IPCKey}, $Self->{IPCSize}, oct(1777) ) } ) {


### PR DESCRIPTION
In case of

* unsuccessful MX validation of e-mail address entered by agent,
* more matching LDAP entries than configured limit,

OTRS generates error log message.

Such events are not real errors and can flood error logs in bigger
systems which makes it difficult to search logs for real errors.

This mod changes such log messages priority from error to debug;
this stops error log flooding to apache error log and allow one
to disable logging it to syslog also by setting MinimumLogLevel
higher than debug.

This mod also changes order of MinimumLevelNum initialization
which may be skipped if IPC::SysV is not available.

Related: https://dev.ib.pl/ib/otrs/issues/48
Author-Change-Id: IB#1050078