### PR TITLE
Do not cache ticket data when no ticket was found

### DIFF
--- a/Kernel/System/Ticket.pm
+++ b/Kernel/System/Ticket.pm
@@ -1307,17 +1307,23 @@ sub TicketGet {
         }
     }
 
-    # cache user result
-    $Kernel::OM->Get('Kernel::System::Cache')->Set(
-        Type => $Self->{CacheType},
-        TTL  => $Self->{CacheTTL},
-        Key  => $CacheKeyDynamicFields,
+    # use cache only when a ticket number is found otherwise a non-existant ticket
+    # is cached. That can cause errors when the cache isn't expired and postmaster
+    # creates that ticket
+    if ( $Ticket{TicketNumber} ) {
 
-        # make a local copy of the ticket data to avoid it being altered in-memory later
-        Value          => {%Ticket},
-        CacheInMemory  => 1,
-        CacheInBackend => 0,
-    );
+        # cache user result
+        $Kernel::OM->Get('Kernel::System::Cache')->Set(
+            Type => $Self->{CacheType},
+            TTL  => $Self->{CacheTTL},
+            Key  => $CacheKeyDynamicFields,
+
+            # make a local copy of the ticket data to avoid it being altered in-memory later
+            Value          => {%Ticket},
+            CacheInMemory  => 1,
+            CacheInBackend => 0,
+        );
+    }
 
     return %Ticket;
 }

--- a/scripts/test/Ticket/TicketCreateAfterGet.t
+++ b/scripts/test/Ticket/TicketCreateAfterGet.t
@@ -1,0 +1,130 @@
+# --
+# Copyright (C) 2001-2016 OTRS AG, http://otrs.com/
+# --
+# This software comes with ABSOLUTELY NO WARRANTY. For details, see
+# the enclosed file COPYING for license information (AGPL). If you
+# did not receive this file, see http://www.gnu.org/licenses/agpl.txt.
+# --
+
+use strict;
+use warnings;
+use utf8;
+
+use vars (qw($Self));
+
+# get needed objects
+my $QueueObject   = $Kernel::OM->Get('Kernel::System::Queue');
+my $ServiceObject = $Kernel::OM->Get('Kernel::System::Service');
+my $SLAObject     = $Kernel::OM->Get('Kernel::System::SLA');
+my $StateObject   = $Kernel::OM->Get('Kernel::System::State');
+my $TicketObject  = $Kernel::OM->Get('Kernel::System::Ticket');
+my $TimeObject    = $Kernel::OM->Get('Kernel::System::Time');
+my $TypeObject    = $Kernel::OM->Get('Kernel::System::Type');
+my $UserObject    = $Kernel::OM->Get('Kernel::System::User');
+
+# get helper object
+$Kernel::OM->ObjectParamAdd(
+    'Kernel::System::UnitTest::Helper' => {
+        RestoreDatabase => 1,
+    },
+);
+my $Helper = $Kernel::OM->Get('Kernel::System::UnitTest::Helper');
+
+# set fixed time
+$Helper->FixedTimeSet();
+
+my $TicketID = $TicketObject->TicketCreate(
+    Title        => 'Some Ticket_Title',
+    Queue        => 'Raw',
+    Lock         => 'unlock',
+    Priority     => '3 normal',
+    State        => 'closed successful',
+    CustomerNo   => '123465',
+    CustomerUser => 'customer@example.com',
+    OwnerID      => 1,
+    UserID       => 1,
+);
+$Self->True(
+    $TicketID,
+    'TicketCreate()',
+);
+
+
+# try to get a non-existant ticket
+my %Ticket = $TicketObject->TicketGet(
+    TicketID => $TicketID + 1,
+);
+$Self->False(
+    $Ticket{Title},
+    'TicketGet() (Title) is empty',
+);
+
+my $TestUserLogin = $Helper->TestUserCreate(
+    Groups => [ 'users', ],
+);
+
+my $TestUserID = $UserObject->UserLookup(
+    UserLogin => $TestUserLogin,
+);
+
+my $TicketIDCreatedBy = $TicketObject->TicketCreate(
+    Title        => 'Some Ticket_Title',
+    Queue        => 'Raw',
+    Lock         => 'unlock',
+    Priority     => '3 normal',
+    State        => 'closed successful',
+    CustomerNo   => '123465',
+    CustomerUser => 'customer@example.com',
+    OwnerID      => 1,
+    UserID       => $TestUserID,
+);
+
+my %CheckCreatedBy = $TicketObject->TicketGet(
+    TicketID => $TicketIDCreatedBy,
+    UserID   => $TestUserID,
+);
+
+$Self->Is(
+    $CheckCreatedBy{ChangeBy},
+    $TestUserID,
+    'TicketGet() (ChangeBy - not system ID 1 user)',
+);
+
+$Self->Is(
+    $CheckCreatedBy{CreateBy},
+    $TestUserID,
+    'TicketGet() (CreateBy - not system ID 1 user)',
+);
+
+$TicketObject->TicketOwnerSet(
+    TicketID  => $TicketIDCreatedBy,
+    NewUserID => $TestUserID,
+    UserID    => 1,
+);
+
+%CheckCreatedBy = $TicketObject->TicketGet(
+    TicketID => $TicketIDCreatedBy,
+    UserID   => $TestUserID,
+);
+
+$Self->Is(
+    $CheckCreatedBy{CreateBy},
+    $TestUserID,
+    'TicketGet() (CreateBy - still the same after OwnerSet)',
+);
+
+$Self->Is(
+    $CheckCreatedBy{OwnerID},
+    $TestUserID,
+    'TicketOwnerSet()',
+);
+
+$Self->Is(
+    $CheckCreatedBy{ChangeBy},
+    1,
+    'TicketOwnerSet() (ChangeBy - System ID 1 now)',
+);
+
+# cleanup is done by RestoreDatabase
+
+1;


### PR DESCRIPTION
Use cache only when a ticket number is found otherwise a non-existent ticket is cached. That can cause errors when the cache isn't expired and e.g. postmaster creates that ticket.