### PR TITLE
Internal article type preseved in AgentTicketCompose and AgentTicketF…

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,4 +1,5 @@
 #6.0.0.beta1 2016-??-??
+ - 2016-05-20 Internal article type preseved in AgentTicketCompose and AgentTicketForward.
  - 2016-04-29 Reduced error log noise by reducing the log level of less important messages, thanks to Pawel Boguslawski.
  - 2016-04-29 Fixed parsing CSV data with quoted values containing newlines, thanks to Pawel Boguslawski.
  - 2016-04-29 Added support for real time zones like Europe/Berlin. Dropped support for time offsets like +2.

--- a/Kernel/Config/Files/Ticket.xml
+++ b/Kernel/Config/Files/Ticket.xml
@@ -5394,6 +5394,14 @@
             <String Regex="">email-external</String>
         </Setting>
     </ConfigItem>
+    <ConfigItem Name="Ticket::Frontend::AgentTicketCompose###DefaultArticleTypeInternal" Required="0" Valid="1">
+        <Description Translatable="1">Specifies the default article type for the ticket compose screen in the agent interface if the article type cannot be automatically detected and source article type name contains "internal". Has higher priority than Ticket::Frontend::AgentTicketCompose###DefaultArticleType.</Description>
+        <Group>Ticket</Group>
+        <SubGroup>Frontend::Agent::Ticket::ViewCompose</SubGroup>
+        <Setting>
+            <String Regex="">email-internal</String>
+        </Setting>
+    </ConfigItem>
     <ConfigItem Name="Ticket::Frontend::ResponseFormat" Required="1" Valid="1">
         <Description Translatable="1">Defines the format of responses in the ticket compose screen of the agent interface ([% Data.OrigFrom | html %] is From 1:1, [% Data.OrigFromName | html %] is only realname of From).</Description>
         <Group>Ticket</Group>
@@ -5493,6 +5501,14 @@
         <SubGroup>Frontend::Agent::Ticket::ViewForward</SubGroup>
         <Setting>
             <String Regex="">email-external</String>
+        </Setting>
+    </ConfigItem>
+    <ConfigItem Name="Ticket::Frontend::AgentTicketForward###ArticleTypeDefaultInternal" Required="0" Valid="1">
+        <Description Translatable="1">Defines the default type of forwarded message in the ticket forward screen of the agent interface if the article type cannot be automatically detected and source article type name contains "internal". Has higher priority than Ticket::Frontend::AgentTicketForward###ArticleTypeDefault.</Description>
+        <Group>Ticket</Group>
+        <SubGroup>Frontend::Agent::Ticket::ViewForward</SubGroup>
+        <Setting>
+            <String Regex="">email-internal</String>
         </Setting>
     </ConfigItem>
     <ConfigItem Name="Ticket::Frontend::AgentTicketForward###ArticleTypes" Required="0" Valid="1">


### PR DESCRIPTION
…orward

When composing messages in AgentTicketCompose and AgentTicketForward OTRS
uses parameters

    Ticket::Frontend::AgentTicketForward###ArticleTypeDefault
    Ticket::Frontend::AgentTicketCompose###DefaultArticleType

for proposing default new article type. This may lead to problems
with internal information disclosure in customer web panel (i.e. when
agent replies to or forwards internal message without changing default
"email-external" article type proposed by OTRS).

This mod introduces two SysConfig options

    Ticket::Frontend::AgentTicketCompose###DefaultArticleTypeInternal
    Ticket::Frontend::AgentTicketForward###ArticleTypeDefaultInternal

which allow to define default article type when composing/forwarding
e-mails from source article with type that contains "internal"
in its name. By default both new options are set to "email-internal"
which keeps default "internal" status of messages composed/forwarded
from other "internal" articles.

Fixes: a78dfffa46edf71f4e99a35c0c6121bd4e5f0b8d
Related: https://dev.ib.pl/ib/otrs/issues/49
Author-Change-Id: IB#1051354