### PR TITLE
[Rel-5_0 Bug 12020] - Option CaseSensitive has no impact on external customer database

### DIFF
--- a/Kernel/System/DB.pm
+++ b/Kernel/System/DB.pm
@@ -1377,7 +1377,7 @@ sub QueryCondition {
         # and the parameter $CaseSensitive defines, if the customer database should do case sensitive statements or not.
         # so if the database dont support case sensitivity or the configuration of the customer database want to do this
         # then we prevent the LOWER() statements.
-                    if ( !$Self->GetDatabaseFunction('CaseSensitive') || $CaseSensitive ) {
+                    if ( $Self->GetDatabaseFunction('CaseSensitive') || $CaseSensitive ) {
                         $SQLA .= "$Key $Type $WordSQL";
                     }
                     elsif ( $Self->GetDatabaseFunction('LcaseLikeInLargeText') ) {
@@ -1426,7 +1426,7 @@ sub QueryCondition {
         # and the parameter $CaseSensitive defines, if the customer database should do case sensitive statements or not.
         # so if the database dont support case sensitivity or the configuration of the customer database want to do this
         # then we prevent the LOWER() statements.
-                    if ( !$Self->GetDatabaseFunction('CaseSensitive') || $CaseSensitive ) {
+                    if ( $Self->GetDatabaseFunction('CaseSensitive') || $CaseSensitive ) {
                         $SQLA .= "$Key $Type $WordSQL";
                     }
                     elsif ( $Self->GetDatabaseFunction('LcaseLikeInLargeText') ) {


### PR DESCRIPTION
http://bugs.otrs.org/show_bug.cgi?id=12020

Hello @mgruner ,

Hereby is our solution for fixing reporter issue. There was a small mistake with IF statement in QuerryCondition function. "$Self->GetDatabaseFunction('CaseSensitive')" and "$CaseSensitive" are carrying same value, so function never executed 'else' statement in this part.

Please let me know if you have any questions or issues regarding this fix.

Kind Regards,
Sanjin 