### PR TITLE
Master - Translate strings directly in JavaScript part 4

### DIFF
--- a/Kernel/Output/HTML/Templates/Standard/AdminDynamicField.tt
+++ b/Kernel/Output/HTML/Templates/Standard/AdminDynamicField.tt
@@ -113,7 +113,7 @@ $('#ShowContextSettingsDialog').bind('click', function (Event) {
     Core.UI.Dialog.ShowContentDialog($('#ContextSettingsDialogContainer'), [% Translate("Settings") | JSON %], '20%', 'Center', true,
         [
             {
-                Label: [% Translate("Save") | JSON %],
+                Label: Core.Language.Translate('Save'),
                 Type: 'Submit',
                 Class: 'Primary'}
         ]);
@@ -223,8 +223,8 @@ $('.DynamicFieldDelete').bind('click', function (Event) {
     if (window.confirm([% Translate("Do you really want to delete this dynamic field? ALL associated data will be LOST!") | JSON %])) {
 
         Core.UI.Dialog.ShowDialog({
-            Title: [% Translate("Delete field") | JSON %],
-            HTML: [% Translate("Deleting the field and its data. This may take a while...") | JSON %],
+            Title: Core.Language.Translate('Delete field'),
+            HTML: Core.Language.Translate('Deleting the field and its data. This may take a while...'),
             Modal: true,
             CloseOnClickOutside: false,
             CloseOnEscape: false,

--- a/Kernel/Output/HTML/Templates/Standard/AdminDynamicField.tt
+++ b/Kernel/Output/HTML/Templates/Standard/AdminDynamicField.tt
@@ -113,7 +113,7 @@ $('#ShowContextSettingsDialog').bind('click', function (Event) {
     Core.UI.Dialog.ShowContentDialog($('#ContextSettingsDialogContainer'), [% Translate("Settings") | JSON %], '20%', 'Center', true,
         [
             {
-                Label: Core.Language.Translate('Save'),
+                Label: [% Translate("Save") | JSON %],
                 Type: 'Submit',
                 Class: 'Primary'}
         ]);
@@ -223,8 +223,8 @@ $('.DynamicFieldDelete').bind('click', function (Event) {
     if (window.confirm([% Translate("Do you really want to delete this dynamic field? ALL associated data will be LOST!") | JSON %])) {
 
         Core.UI.Dialog.ShowDialog({
-            Title: Core.Language.Translate('Delete field'),
-            HTML: Core.Language.Translate('Deleting the field and its data. This may take a while...'),
+            Title: [% Translate("Delete field") | JSON %],
+            HTML: [% Translate("Deleting the field and its data. This may take a while...") | JSON %],
             Modal: true,
             CloseOnClickOutside: false,
             CloseOnEscape: false,

--- a/Kernel/Output/HTML/Templates/Standard/AdminGenericInterfaceDebugger.tt
+++ b/Kernel/Output/HTML/Templates/Standard/AdminGenericInterfaceDebugger.tt
@@ -135,12 +135,12 @@
 Core.Agent.Admin.GenericInterfaceDebugger.Init({
     WebserviceID: [% Data.WebserviceID | html %],
     Localization: {
-        CommunicationErrorMsg: [% Translate("An error occurred during communication.") | JSON %],
-        NoDataFoundMsg: [% Translate("No data found.") | JSON %],
-        ToggleContentMsg: [% Translate("Show or hide the content.") | JSON %],
-        ClearDebugLogMsg: [% Translate("Clear debug log") | JSON %],
-        ClearMsg: [% Translate("Clear") | JSON %],
-        CancelMsg: [% Translate("Cancel") | JSON %]
+        CommunicationErrorMsg: Core.Language.Translate('An error occurred during communication.'),
+        NoDataFoundMsg: Core.Language.Translate('No data found.'),
+        ToggleContentMsg: Core.Language.Translate('Show or hide the content.'),
+        ClearDebugLogMsg: Core.Language.Translate('Clear debug log'),
+        ClearMsg: Core.Language.Translate('Clear'),
+        CancelMsg: Core.Language.Translate('Cancel')
     }
 });
 

--- a/Kernel/Output/HTML/Templates/Standard/AdminGenericInterfaceDebugger.tt
+++ b/Kernel/Output/HTML/Templates/Standard/AdminGenericInterfaceDebugger.tt
@@ -132,17 +132,7 @@
 [% WRAPPER JSOnDocumentComplete %]
 <script type="text/javascript">//<![CDATA[
 
-Core.Agent.Admin.GenericInterfaceDebugger.Init({
-    WebserviceID: [% Data.WebserviceID | html %],
-    Localization: {
-        CommunicationErrorMsg: Core.Language.Translate('An error occurred during communication.'),
-        NoDataFoundMsg: Core.Language.Translate('No data found.'),
-        ToggleContentMsg: Core.Language.Translate('Show or hide the content.'),
-        ClearDebugLogMsg: Core.Language.Translate('Clear debug log'),
-        ClearMsg: Core.Language.Translate('Clear'),
-        CancelMsg: Core.Language.Translate('Cancel')
-    }
-});
+Core.Agent.Admin.GenericInterfaceDebugger.Init([% Data.WebserviceID | html %]);
 
 $('#FilterRefresh').bind('click', Core.Agent.Admin.GenericInterfaceDebugger.GetRequestList);
 $('#DeleteButton').bind('click', Core.Agent.Admin.GenericInterfaceDebugger.ShowDeleteDialog);

--- a/Kernel/Output/HTML/Templates/Standard/AdminGenericInterfaceWebserviceHistory.tt
+++ b/Kernel/Output/HTML/Templates/Standard/AdminGenericInterfaceWebserviceHistory.tt
@@ -121,17 +121,7 @@
 [% WRAPPER JSOnDocumentComplete %]
 <script type="text/javascript">//<![CDATA[
 
-Core.Agent.Admin.GenericInterfaceWebserviceHistory.Init({
-    WebserviceID: [% Data.WebserviceID | html %],
-    Localization: {
-        WebserviceHistoryErrorMsg: Core.Language.Translate('An error occurred during communication.'),
-        NoDataFoundMsg: Core.Language.Translate('No data found.'),
-        ToggleContentMsg: Core.Language.Translate('Show or hide the content.'),
-        RollbackLogMsg: Core.Language.Translate('Restore web service configuration'),
-        RollbackMsg: Core.Language.Translate('Restore'),
-        CancelMsg: Core.Language.Translate('Cancel')
-    }
-});
+Core.Agent.Admin.GenericInterfaceWebserviceHistory.Init([% Data.WebserviceID | html %]);
 
 //Load Webservice list on startup without active filter
 Core.Agent.Admin.GenericInterfaceWebserviceHistory.GetWebserviceList();

--- a/Kernel/Output/HTML/Templates/Standard/AdminGenericInterfaceWebserviceHistory.tt
+++ b/Kernel/Output/HTML/Templates/Standard/AdminGenericInterfaceWebserviceHistory.tt
@@ -124,12 +124,12 @@
 Core.Agent.Admin.GenericInterfaceWebserviceHistory.Init({
     WebserviceID: [% Data.WebserviceID | html %],
     Localization: {
-        WebserviceHistoryErrorMsg: [% Translate("An error occurred during communication.") | JSON %],
-        NoDataFoundMsg: [% Translate("No data found.") | JSON %],
-        ToggleContentMsg: [% Translate("Show or hide the content.") | JSON %],
-        RollbackLogMsg: [% Translate("Restore web service configuration") | JSON %],
-        RollbackMsg: [% Translate("Restore") | JSON %],
-        CancelMsg: [% Translate("Cancel") | JSON %]
+        WebserviceHistoryErrorMsg: Core.Language.Translate('An error occurred during communication.'),
+        NoDataFoundMsg: Core.Language.Translate('No data found.'),
+        ToggleContentMsg: Core.Language.Translate('Show or hide the content.'),
+        RollbackLogMsg: Core.Language.Translate('Restore web service configuration'),
+        RollbackMsg: Core.Language.Translate('Restore'),
+        CancelMsg: Core.Language.Translate('Cancel')
     }
 });
 

--- a/Kernel/Output/HTML/Templates/Standard/AdminNotificationEvent.tt
+++ b/Kernel/Output/HTML/Templates/Standard/AdminNotificationEvent.tt
@@ -144,7 +144,7 @@
 <script type="text/javascript">//<![CDATA[
 $('.NotificationDelete').bind('click', function (Event) {
 
-    if (window.confirm(Core.Language.Translate('Do you really want to delete this notification?'))) {
+    if (window.confirm([% Translate('Do you really want to delete this notification?') | JSON %])) {
         window.location = $(this).attr('href');
     }
 

--- a/Kernel/Output/HTML/Templates/Standard/AdminNotificationEvent.tt
+++ b/Kernel/Output/HTML/Templates/Standard/AdminNotificationEvent.tt
@@ -144,7 +144,7 @@
 <script type="text/javascript">//<![CDATA[
 $('.NotificationDelete').bind('click', function (Event) {
 
-    if (window.confirm([% Translate("Do you really want to delete this notification?") | JSON %])) {
+    if (window.confirm(Core.Language.Translate('Do you really want to delete this notification?'))) {
         window.location = $(this).attr('href');
     }
 
@@ -679,7 +679,7 @@ $('.NotificationDelete').bind('click', function (Event) {
 <script type="text/javascript">//<![CDATA[
 Core.Agent.Admin.NotificationEvent.Init({
     Localization: {
-        DeleteNotificationLanguageMsg: [% Translate("Do you really want to delete this notification language?") | JSON %]
+        DeleteNotificationLanguageMsg: Core.Language.Translate('Do you really want to delete this notification language?')
     }
 });
 //]]></script>

--- a/Kernel/Output/HTML/Templates/Standard/AdminNotificationEvent.tt
+++ b/Kernel/Output/HTML/Templates/Standard/AdminNotificationEvent.tt
@@ -677,11 +677,7 @@ $('.NotificationDelete').bind('click', function (Event) {
 
 [% WRAPPER JSOnDocumentComplete %]
 <script type="text/javascript">//<![CDATA[
-Core.Agent.Admin.NotificationEvent.Init({
-    Localization: {
-        DeleteNotificationLanguageMsg: Core.Language.Translate('Do you really want to delete this notification language?')
-    }
-});
+Core.Agent.Admin.NotificationEvent.Init();
 //]]></script>
 [% END %]
 

--- a/Kernel/Output/HTML/Templates/Standard/AdminProcessManagementActivity.tt
+++ b/Kernel/Output/HTML/Templates/Standard/AdminProcessManagementActivity.tt
@@ -143,7 +143,7 @@ Core.Agent.Admin.ProcessManagement.InitActivityEdit();
 
 // Localizations
 Core.Agent.Admin.ProcessManagement.Localization = {
-    EditConfirm: "[% Translate("As soon as you use this button or link, you will leave this screen and its current state will be saved automatically. Do you want to continue?") | html %]"
+    EditConfirm: Core.Language.Translate('As soon as you use this button or link, you will leave this screen and its current state will be saved automatically. Do you want to continue?')
 };
 //]]></script>
 [% END %]

--- a/Kernel/Output/HTML/Templates/Standard/AdminProcessManagementActivity.tt
+++ b/Kernel/Output/HTML/Templates/Standard/AdminProcessManagementActivity.tt
@@ -140,10 +140,5 @@
 [% WRAPPER JSOnDocumentComplete %]
 <script type="text/javascript">//<![CDATA[
 Core.Agent.Admin.ProcessManagement.InitActivityEdit();
-
-// Localizations
-Core.Agent.Admin.ProcessManagement.Localization = {
-    EditConfirm: Core.Language.Translate('As soon as you use this button or link, you will leave this screen and its current state will be saved automatically. Do you want to continue?')
-};
 //]]></script>
 [% END %]

--- a/Kernel/Output/HTML/Templates/Standard/AdminProcessManagementActivityDialog.tt
+++ b/Kernel/Output/HTML/Templates/Standard/AdminProcessManagementActivityDialog.tt
@@ -244,10 +244,10 @@ Core.Agent.Admin.ProcessManagement.InitActivityDialogEdit();
 
 //Localizations
 Core.Agent.Admin.ProcessManagement.Localization = {
-        CancelMsg: "[% Translate("Cancel") | html %]",
-        SaveMsg: "[% Translate("Save") | html %]",
-        DialogTitle: "[% Translate("Edit Field Details") | html %]",
-        WrongArticleTypeMsg: "[% Translate("Customer interface does not support internal article types.") | html %]"
+        CancelMsg: Core.Language.Translate('Cancel'),
+        SaveMsg: Core.Language.Translate('Save'),
+        DialogTitle: Core.Language.Translate('Edit Field Details'),
+        WrongArticleTypeMsg: Core.Language.Translate('Customer interface does not support internal article types.')
 };
 //]]></script>
 [% END %]

--- a/Kernel/Output/HTML/Templates/Standard/AdminProcessManagementActivityDialog.tt
+++ b/Kernel/Output/HTML/Templates/Standard/AdminProcessManagementActivityDialog.tt
@@ -241,13 +241,5 @@
 [% WRAPPER JSOnDocumentComplete %]
 <script type="text/javascript">//<![CDATA[
 Core.Agent.Admin.ProcessManagement.InitActivityDialogEdit();
-
-//Localizations
-Core.Agent.Admin.ProcessManagement.Localization = {
-        CancelMsg: Core.Language.Translate('Cancel'),
-        SaveMsg: Core.Language.Translate('Save'),
-        DialogTitle: Core.Language.Translate('Edit Field Details'),
-        WrongArticleTypeMsg: Core.Language.Translate('Customer interface does not support internal article types.')
-};
 //]]></script>
 [% END %]

--- a/Kernel/Output/HTML/Templates/Standard/AdminProcessManagementPath.tt
+++ b/Kernel/Output/HTML/Templates/Standard/AdminProcessManagementPath.tt
@@ -128,7 +128,7 @@ Core.Agent.Admin.ProcessManagement.InitPathEdit();
 
 // Localizations
 Core.Agent.Admin.ProcessManagement.Localization = {
-    EditConfirm: "[% Translate("As soon as you use this button or link, you will leave this screen and its current state will be saved automatically. Do you want to continue?") | html %]"
+    EditConfirm: Core.Language.Translate('As soon as you use this button or link, you will leave this screen and its current state will be saved automatically. Do you want to continue?')
 };
 //]]></script>
 [% END %]

--- a/Kernel/Output/HTML/Templates/Standard/AdminProcessManagementPath.tt
+++ b/Kernel/Output/HTML/Templates/Standard/AdminProcessManagementPath.tt
@@ -125,10 +125,5 @@
 [% WRAPPER JSOnDocumentComplete %]
 <script type="text/javascript">//<![CDATA[
 Core.Agent.Admin.ProcessManagement.InitPathEdit();
-
-// Localizations
-Core.Agent.Admin.ProcessManagement.Localization = {
-    EditConfirm: Core.Language.Translate('As soon as you use this button or link, you will leave this screen and its current state will be saved automatically. Do you want to continue?')
-};
 //]]></script>
 [% END %]

--- a/Kernel/Output/HTML/Templates/Standard/AdminProcessManagementProcessEdit.tt
+++ b/Kernel/Output/HTML/Templates/Standard/AdminProcessManagementProcessEdit.tt
@@ -309,7 +309,6 @@
     Core.Config.Set('Config.ActivityDialog', [% Data.ActivityDialogConfig %] );
     Core.Config.Set('Config.Transition', [% Data.TransitionConfig %] );
     Core.Config.Set('Config.TransitionAction', [% Data.TransitionActionConfig %] );
-
     Core.Config.Set('Config.ImagePath', "[% Config("Frontend::ImagePath") %]");
     Core.Config.Set('Config.PopupPathActivity', "[% Env("Baselink") %]Action=AdminProcessManagementActivity;Subaction=ActivityEdit;");
     Core.Config.Set('Config.PopupPathPath', "[% Env("Baselink") %]Action=AdminProcessManagementPath;Subaction=PathEdit;");
@@ -320,27 +319,5 @@
 [% WRAPPER JSOnDocumentComplete %]
 <script type="text/javascript">//<![CDATA[
 Core.Agent.Admin.ProcessManagement.InitProcessEdit();
-
-//Localizations
-Core.Agent.Admin.ProcessManagement.Localization = {
-        CancelMsg: "[% Translate("Cancel") | html %]",
-        ShowEntityIDs: "[% Translate("Show EntityIDs") | html %]",
-        HideEntityIDs: "[% Translate("Hide EntityIDs") | html %]",
-        DeleteMsg: "[% Translate("Delete") | html %]",
-        DeleteEntityTitle: "[% Translate("Delete Entity") | html %]",
-        RemoveEntityCanvasTitle: "[% Translate("Remove Entity from canvas") | html %]",
-        ActivityAlreadyPlaced: "[% Translate("This Activity is already used in the Process. You cannot add it twice!") | html %]",
-        ActivityCannotBeDeleted: "[% Translate("This Activity cannot be deleted because it is the Start Activity.") | html %]",
-        TransitionAlreadyPlaced: "[% Translate("This Transition is already used for this Activity. You cannot use it twice!") | html %]",
-        TransitionActionAlreadyPlaced: "[% Translate("This TransitionAction is already used in this Path. You cannot use it twice!") | html %]",
-        TransitionDeleteLink: "[% Translate("Remove the Transition from this Process") | html %]",
-        TransitionEditLink: "[% Translate("Edit this transition") | html %]",
-        NoTransitionActionsAssigned: "[% Translate("No TransitionActions assigned.") | html %]",
-        StartEventCapChange: "[% Translate("The Start Event cannot loose the Start Transition!") | html %]",
-        RemoveActivityMsg: "[% Translate("Do you really want to remove this activity from the canvas? This can only be undone by leaving this screen without saving.") | html %]",
-        RemoveTransitionMsg: "[% Translate("Do you really want to remove this transition from the canvas? This can only be undone by leaving this screen without saving.") | html %]",
-        NoDialogsAssigned: "[% Translate("No dialogs assigned yet. Just pick an activity dialog from the list on the left and drag it here.") | html %]",
-        UnconnectedTransition: "[% Translate("An unconnected transition is already placed on the canvas. Please connect this transition first before placing another transition.") | html %]"
-};
 //]]></script>
 [% END %]

--- a/Kernel/Output/HTML/Templates/Standard/AdminProcessManagementTransition.tt
+++ b/Kernel/Output/HTML/Templates/Standard/AdminProcessManagementTransition.tt
@@ -286,10 +286,5 @@
 [% WRAPPER JSOnDocumentComplete %]
 <script type="text/javascript">//<![CDATA[
 Core.Agent.Admin.ProcessManagement.InitTransitionEdit();
-
-// Localizations
-Core.Agent.Admin.ProcessManagement.Localization = {
-    EditConfirm: Core.Language.Translate('As soon as you use this button or link, you will leave this screen and its current state will be saved automatically. Do you want to continue?')
-};
 //]]></script>
 [% END %]

--- a/Kernel/Output/HTML/Templates/Standard/AdminProcessManagementTransition.tt
+++ b/Kernel/Output/HTML/Templates/Standard/AdminProcessManagementTransition.tt
@@ -289,7 +289,7 @@ Core.Agent.Admin.ProcessManagement.InitTransitionEdit();
 
 // Localizations
 Core.Agent.Admin.ProcessManagement.Localization = {
-    EditConfirm: "[% Translate("As soon as you use this button or link, you will leave this screen and its current state will be saved automatically. Do you want to continue?") | html %]"
+    EditConfirm: Core.Language.Translate('As soon as you use this button or link, you will leave this screen and its current state will be saved automatically. Do you want to continue?')
 };
 //]]></script>
 [% END %]

--- a/Kernel/Output/HTML/Templates/Standard/AdminRegistration.tt
+++ b/Kernel/Output/HTML/Templates/Standard/AdminRegistration.tt
@@ -149,7 +149,7 @@
     $('#RegistrationMoreInfo').bind('click', function() {
         Core.UI.Dialog.ShowDialog({
             Modal: true,
-            Title: [% Translate("System Registration") | JSON %],
+            Title: Core.Language.Translate('System Registration'),
             HTML: $('#QADialog').html(),
             PositionTop: '70px',
             PositionLeft: 'Center',
@@ -161,7 +161,7 @@
     $('#RegistrationDataProtection').bind('click', function() {
         Core.UI.Dialog.ShowDialog({
             Modal: true,
-            Title: [% Translate("Data Protection") | JSON %],
+            Title: Core.Language.Translate('Data Protection'),
             HTML: $('#DPDialog').html(),
             PositionTop: '10px',
             PositionLeft: 'Center',

--- a/Kernel/Output/HTML/Templates/Standard/AdminRegistration.tt
+++ b/Kernel/Output/HTML/Templates/Standard/AdminRegistration.tt
@@ -149,7 +149,7 @@
     $('#RegistrationMoreInfo').bind('click', function() {
         Core.UI.Dialog.ShowDialog({
             Modal: true,
-            Title: Core.Language.Translate('System Registration'),
+            Title: [% Translate('System Registration') | JSON %],
             HTML: $('#QADialog').html(),
             PositionTop: '70px',
             PositionLeft: 'Center',
@@ -161,7 +161,7 @@
     $('#RegistrationDataProtection').bind('click', function() {
         Core.UI.Dialog.ShowDialog({
             Modal: true,
-            Title: Core.Language.Translate('Data Protection'),
+            Title: [% Translate('Data Protection') | JSON %],
             HTML: $('#DPDialog').html(),
             PositionTop: '10px',
             PositionLeft: 'Center',

--- a/Kernel/Output/HTML/Templates/Standard/AdminSupportDataCollector.tt
+++ b/Kernel/Output/HTML/Templates/Standard/AdminSupportDataCollector.tt
@@ -72,10 +72,10 @@
                     return;
                 }
 
-            var ResponseMessage = [% Translate("Support Data information was successfully sent.") | JSON %];
+            var ResponseMessage = Core.Language.Translate('Support Data information was successfully sent.')';
 
             if ( Response === 0) {
-                ResponseMessage = [% Translate("Was not possible to send Support Data information.") | JSON %];
+                ResponseMessage = Core.Language.Translate('Was not possible to send Support Data information.');
                 TextClass = 'Error';
             }
 
@@ -86,7 +86,7 @@
                 true,
                 [
                     {
-                        Label: [% Translate("Close") | JSON %],
+                        Label: Core.Language.Translate('Close'),
                         Class: 'Primary',
                         Function: function () {
                             Core.UI.Dialog.CloseDialog($('.SendUpdateResultDialog'));
@@ -146,7 +146,7 @@
             Core.UI.Dialog.CloseDialog($('.LoadingSupportBundleDialog'));
 
             if ( !Response.Success ) {
-                var ResponseMessage = [% Translate("It was not possible to generate the Support Bundle.") | JSON %],
+                var ResponseMessage = Core.Language.Translate('It was not possible to generate the Support Bundle.'),
                 TextClass = 'Error';
 
                 Core.UI.Dialog.ShowContentDialog(
@@ -156,7 +156,7 @@
                     true,
                     [
                         {
-                            Label: [% Translate("Close") | JSON %],
+                            Label: Core.Language.Translate('Close'),
                             Class: 'Primary',
                             Function: function () {
                                 Core.UI.Dialog.CloseDialog($('.NoSupportBunle'));

--- a/Kernel/Output/HTML/Templates/Standard/AdminSupportDataCollector.tt
+++ b/Kernel/Output/HTML/Templates/Standard/AdminSupportDataCollector.tt
@@ -72,10 +72,10 @@
                     return;
                 }
 
-            var ResponseMessage = Core.Language.Translate('Support Data information was successfully sent.')';
+            var ResponseMessage = [% Translate('Support Data information was successfully sent.') | JSON %];
 
             if ( Response === 0) {
-                ResponseMessage = Core.Language.Translate('Was not possible to send Support Data information.');
+                ResponseMessage = [% Translate('Was not possible to send Support Data information.') | JSON %];
                 TextClass = 'Error';
             }
 
@@ -86,7 +86,7 @@
                 true,
                 [
                     {
-                        Label: Core.Language.Translate('Close'),
+                        Label: [% Translate('Close') | JSON %],
                         Class: 'Primary',
                         Function: function () {
                             Core.UI.Dialog.CloseDialog($('.SendUpdateResultDialog'));
@@ -146,7 +146,7 @@
             Core.UI.Dialog.CloseDialog($('.LoadingSupportBundleDialog'));
 
             if ( !Response.Success ) {
-                var ResponseMessage = Core.Language.Translate('It was not possible to generate the Support Bundle.'),
+                var ResponseMessage = [% Translate('It was not possible to generate the Support Bundle.') | JSON %],
                 TextClass = 'Error';
 
                 Core.UI.Dialog.ShowContentDialog(
@@ -156,7 +156,7 @@
                     true,
                     [
                         {
-                            Label: Core.Language.Translate('Close'),
+                            Label: [% Translate('Close') | JSON %],
                             Class: 'Primary',
                             Function: function () {
                                 Core.UI.Dialog.CloseDialog($('.NoSupportBunle'));

--- a/var/httpd/htdocs/js/Core.Agent.Admin.GenericInterfaceDebugger.js
+++ b/var/httpd/htdocs/js/Core.Agent.Admin.GenericInterfaceDebugger.js
@@ -59,13 +59,12 @@ Core.Agent.Admin.GenericInterfaceDebugger = (function (TargetNS) {
      * @name Init
      * @memberof Core.Agent.Admin.GenericInterfaceDebugger
      * @function
-     * @param {Object} Params
+     * @param {Number} WebserviceID - ID of the webservice
      * @description
      *      Initializes the module functions.
      */
-    TargetNS.Init = function (Params) {
-        TargetNS.WebserviceID = parseInt(Params.WebserviceID, 10);
-        TargetNS.Localization = Params.Localization;
+    TargetNS.Init = function (WebserviceID) {
+        TargetNS.WebserviceID = parseInt(WebserviceID, 10);
     };
 
     /**
@@ -96,14 +95,14 @@ Core.Agent.Admin.GenericInterfaceDebugger = (function (TargetNS) {
             var HTML = '';
 
             if (!Response || !Response.LogData) {
-                alert(TargetNS.Localization.CommunicationErrorMsg);
+                alert(Core.Language.Translate('An error occurred during communication.'));
                 return;
             }
 
             $('.RequestListWidget').removeClass('Loading');
 
             if (!Response.LogData.length) {
-                $('#RequestList tbody').empty().append('<tr><td colspan="3">' + TargetNS.Localization.NoDataFoundMsg + '</td></tr>');
+                $('#RequestList tbody').empty().append('<tr><td colspan="3">' + Core.Language.Translate('No data found.') + '</td></tr>');
                 return;
             }
 
@@ -152,7 +151,7 @@ Core.Agent.Admin.GenericInterfaceDebugger = (function (TargetNS) {
 
         Core.AJAX.FunctionCall(Core.Config.Get('CGIHandle'), Data, function (Response) {
             if (!Response || !Response.LogData || !Response.LogData.Data) {
-                alert(TargetNS.Localization.CommunicationErrorMsg);
+                alert(Core.Language.Translate('An error occurred during communication.'));
                 return;
             }
 
@@ -160,7 +159,7 @@ Core.Agent.Admin.GenericInterfaceDebugger = (function (TargetNS) {
             $('.RequestListWidget').removeClass('Loading');
 
             if (!Response.LogData.Data.length) {
-                $('#CommunicationDetails > .Content').append('<p class="ErrorMessage">' + TargetNS.Localization.NoDataFoundMsg + '</p>');
+                $('#CommunicationDetails > .Content').append('<p class="ErrorMessage">' + Core.Language.Translate('No data found.') + '</p>');
                 $('#CommunicationDetails').css('visibility', 'visible').show();
             }
             else {
@@ -169,7 +168,7 @@ Core.Agent.Admin.GenericInterfaceDebugger = (function (TargetNS) {
                         $Header = $('<div class="Header"></div>'),
                         $Content = $('<div class="Content"></div>');
 
-                    $Header.append('<div class="WidgetAction Toggle"><a href="#" title="' + TargetNS.Localization.ToggleContentMsg + '"><i class="fa fa-caret-right"></i><i class="fa fa-caret-down"></i></a></div>');
+                    $Header.append('<div class="WidgetAction Toggle"><a href="#" title="' + Core.Language.Translate('Show or hide the content.') + '"><i class="fa fa-caret-right"></i><i class="fa fa-caret-down"></i></a></div>');
                     $Header.append('<h3 class="DebugLevel_' + this.DebugLevel + '">' + this.Summary + ' (' + this.Created + ', ' + this.DebugLevel + ')</h3>');
                     $Container.append($Header);
 
@@ -203,19 +202,19 @@ Core.Agent.Admin.GenericInterfaceDebugger = (function (TargetNS) {
     TargetNS.ShowDeleteDialog = function(Event){
         Core.UI.Dialog.ShowContentDialog(
             $('#DeleteDialogContainer'),
-            TargetNS.Localization.ClearDebugLogMsg,
+            Core.Language.Translate('Clear debug log'),
             '240px',
             'Center',
             true,
             [
                {
-                   Label: TargetNS.Localization.CancelMsg,
+                   Label: Core.Language.Translate('Cancel'),
                    Function: function () {
                        Core.UI.Dialog.CloseDialog($('#DeleteDialog'));
                    }
                },
                {
-                   Label: TargetNS.Localization.ClearMsg,
+                   Label: Core.Language.Translate('Clear'),
                    Function: function () {
                        var Data = {
                             Action: 'AdminGenericInterfaceDebugger',
@@ -228,7 +227,7 @@ Core.Agent.Admin.GenericInterfaceDebugger = (function (TargetNS) {
 
                         Core.AJAX.FunctionCall(Core.Config.Get('CGIHandle'), Data, function (Response) {
                             if (!Response || !Response.Success) {
-                                alert(TargetNS.Localization.CommunicationErrorMsg);
+                                alert(Core.Language.Translate('An error occurred during communication.'));
                                 return;
                             }
 

--- a/var/httpd/htdocs/js/Core.Agent.Admin.GenericInterfaceWebserviceHistory.js
+++ b/var/httpd/htdocs/js/Core.Agent.Admin.GenericInterfaceWebserviceHistory.js
@@ -25,13 +25,12 @@ Core.Agent.Admin.GenericInterfaceWebserviceHistory = (function (TargetNS) {
      * @name Init
      * @memberof Core.Agent.Admin.GenericInterfaceWebserviceHistory
      * @function
-     * @param {Object} Params - Initialization and internationalization parameters.
+     * @param {Number} WebserviceID - ID of the webservice
      * @description
      *      This function initialize the module.
      */
-    TargetNS.Init = function (Params) {
-        TargetNS.WebserviceID = parseInt(Params.WebserviceID, 10);
-        TargetNS.Localization = Params.Localization;
+    TargetNS.Init = function (WebserviceID) {
+        TargetNS.WebserviceID = parseInt(WebserviceID, 10);
     };
 
     /**
@@ -58,14 +57,14 @@ Core.Agent.Admin.GenericInterfaceWebserviceHistory = (function (TargetNS) {
                 Counter;
 
             if (!Response || !Response.LogData) {
-                alert(TargetNS.Localization.WebserviceHistoryErrorMsg);
+                alert(Core.Language.Translate('An error occurred during communication.'));
                 return;
             }
 
             $('.WebserviceListWidget').removeClass('Loading');
 
             if (!Response.LogData.length) {
-                $('#WebserviceList tbody').empty().append('<tr><td colspan="3">' + TargetNS.Localization.NoDataFoundMsg + '</td></tr>');
+                $('#WebserviceList tbody').empty().append('<tr><td colspan="3">' + Core.Language.Translate('No data found.') + '</td></tr>');
             }
             else {
                 $('#WebserviceList tbody').empty();
@@ -122,7 +121,7 @@ Core.Agent.Admin.GenericInterfaceWebserviceHistory = (function (TargetNS) {
 
         Core.AJAX.FunctionCall(Core.Config.Get('CGIHandle'), Data, function (Response) {
             if (!Response || !Response.LogData) {
-                alert(TargetNS.Localization.WebserviceHistoryErrorMsg);
+                alert(Core.Language.Translate('An error occurred during communication.'));
                 return;
             }
             $('.WebserviceListWidget').removeClass('Loading');
@@ -134,7 +133,7 @@ Core.Agent.Admin.GenericInterfaceWebserviceHistory = (function (TargetNS) {
                 );
                 $('#WebserviceHistoryDetails .ConfigCode pre').empty();
                 $('#WebserviceHistoryDetails .ConfigCode pre').append(
-                    '<span class="ErrorMessage">' + TargetNS.Localization.NoDataFoundMsg + '</span>'
+                    '<span class="ErrorMessage">' + Core.Language.Translate('No data found.') + '</span>'
                 );
                 $('#WebserviceHistoryDetails').css('visibility', 'visible').show();
                 $('#WebserviceHistoryDetails .LightRow').hide();
@@ -172,20 +171,20 @@ Core.Agent.Admin.GenericInterfaceWebserviceHistory = (function (TargetNS) {
 
         Core.UI.Dialog.ShowContentDialog(
             $('#RollbackDialogContainer'),
-            TargetNS.Localization.RollbackLogMsg,
+            Core.Language.Translate('Restore web service configuration'),
             '240px',
             'Center',
             true,
             [
                 {
-                    Label: TargetNS.Localization.CancelMsg,
+                    Label: Core.Language.Translate('Cancel'),
                     Class: 'Primary',
                     Function: function () {
                         Core.UI.Dialog.CloseDialog($('#RollbackDialog'));
                     }
                 },
                 {
-                    Label: TargetNS.Localization.RollbackLogMsg,
+                    Label: Core.Language.Translate('Restore web service configuration'),
                     Function: function () {
                         $('#Subaction').attr('value', 'Rollback');
                         $('#ActionForm').submit();

--- a/var/httpd/htdocs/js/Core.Agent.Admin.NotificationEvent.js
+++ b/var/httpd/htdocs/js/Core.Agent.Admin.NotificationEvent.js
@@ -25,13 +25,10 @@ Core.Agent.Admin.NotificationEvent = (function (TargetNS) {
      * @name Init
      * @memberof Core.Agent.Admin.NotificationEvent
      * @function
-     * @param {Object} Params - Initialization and internationalization parameters.
      * @description
      *      This function initialize correctly all other function according to the local language.
      */
-    TargetNS.Init = function (Params) {
-
-        TargetNS.Localization = Params.Localization;
+    TargetNS.Init = function () {
 
         // bind click function to add button
         $('.LanguageAdd').bind('change', function () {
@@ -42,7 +39,7 @@ Core.Agent.Admin.NotificationEvent = (function (TargetNS) {
         //bind click function to remove button
         $('.LanguageRemove').bind('click', function () {
 
-            if (window.confirm(TargetNS.Localization.DeleteNotificationLanguageMsg)) {
+            if (window.confirm(Core.Language.Translate('Do you really want to delete this notification language?'))) {
                 TargetNS.RemoveLanguage($(this));
             }
             return false;
@@ -135,7 +132,7 @@ Core.Agent.Admin.NotificationEvent = (function (TargetNS) {
         // bind click function to remove button
         $('.LanguageRemove').bind('click', function () {
 
-            if (window.confirm(TargetNS.Localization.DeleteNotificationLanguageMsg)) {
+            if (window.confirm(Core.Language.Translate('Do you really want to delete this notification language?'))) {
                 TargetNS.RemoveLanguage($(this));
             }
             return false;

--- a/var/httpd/htdocs/js/Core.Agent.Admin.ProcessManagement.Canvas.js
+++ b/var/httpd/htdocs/js/Core.Agent.Admin.ProcessManagement.Canvas.js
@@ -121,20 +121,20 @@ Core.Agent.Admin.ProcessManagement.Canvas = (function (TargetNS) {
 
         Core.UI.Dialog.ShowContentDialog(
             $('#Dialogs #' + DialogID),
-            Core.Agent.Admin.ProcessManagement.Localization.RemoveEntityCanvasTitle,
+            Core.Language.Translate('Remove Entity from canvas'),
             '240px',
             'Center',
             true,
             [
                {
-                   Label: Core.Agent.Admin.ProcessManagement.Localization.CancelMsg,
+                   Label:Core.Language.Translate('Cancel'),
                    Class: 'Primary',
                    Function: function () {
                        Core.UI.Dialog.CloseDialog($('.Dialog'));
                    }
                },
                {
-                   Label: Core.Agent.Admin.ProcessManagement.Localization.DeleteMsg,
+                   Label: Core.Language.Translate('Delete'),
                    Function: function () {
                        if (typeof Callback !== 'undefined') {
                            Callback();
@@ -330,7 +330,7 @@ Core.Agent.Admin.ProcessManagement.Canvas = (function (TargetNS) {
             });
         }
         else {
-            text += '<li class="NoDialogsAssigned">' + Core.Agent.Admin.ProcessManagement.Localization.NoTransitionActionsAssigned + '</li>';
+            text += '<li class="NoDialogsAssigned">' + Core.Language.Translate('No TransitionActions assigned.') + '</li>';
         }
         text += "</ul>";
 
@@ -427,7 +427,7 @@ Core.Agent.Admin.ProcessManagement.Canvas = (function (TargetNS) {
             });
         }
         else {
-            text += '<li class="NoDialogsAssigned">' + Core.Agent.Admin.ProcessManagement.Localization.NoDialogsAssigned + '</li>';
+            text += '<li class="NoDialogsAssigned">' + Core.Language.Translate('No dialogs assigned yet. Just pick an activity dialog from the list on the left and drag it here.') + '</li>';
         }
 
         text += "</ul>";
@@ -612,7 +612,7 @@ Core.Agent.Admin.ProcessManagement.Canvas = (function (TargetNS) {
 
         // if Activity is StartActivity, this Activity cannot be removed...
         if (Config.Process[ProcessEntityID].StartActivity === EntityID) {
-            alert(Core.Agent.Admin.ProcessManagement.Localization.ActivityCannotBeDeleted);
+            alert(Core.Language.Translate('This Activity cannot be deleted because it is the Start Activity.'));
             return;
         }
 
@@ -869,7 +869,7 @@ Core.Agent.Admin.ProcessManagement.Canvas = (function (TargetNS) {
         }
 
         if (!$(Connection.canvas).find('.Delete').length) {
-            $(Connection.canvas).append('<a class="Delete" title="' + Core.Agent.Admin.ProcessManagement.Localization.TransitionDeleteLink + '" href="#"><i class="fa fa-trash-o"></i></a>').find('.Delete').bind('click', function(Event) {
+            $(Connection.canvas).append('<a class="Delete" title="' + Core.Language.Translate('Remove the Transition from this Process') + '" href="#"><i class="fa fa-trash-o"></i></a>').find('.Delete').bind('click', function(Event) {
                 ShowRemoveEntityCanvasConfirmationDialog('Path', Config.Transition[TransitionEntityID].Name, TransitionEntityID, function () {
                     jsPlumb.detach(Connection.component);
                     delete Path[StartActivityID][TransitionEntityID];
@@ -882,7 +882,7 @@ Core.Agent.Admin.ProcessManagement.Canvas = (function (TargetNS) {
         }
 
         if (!$(Connection.canvas).find('.Edit').length) {
-            $(Connection.canvas).append('<a class="Edit" title="' + Core.Agent.Admin.ProcessManagement.Localization.TransitionEditLink + '" href="#"><i class="fa fa-edit"></i></a>').find('.Edit').bind('click', function(Event) {
+            $(Connection.canvas).append('<a class="Edit" title="' + Core.Language.Translate('Edit this transition') + '" href="#"><i class="fa fa-edit"></i></a>').find('.Edit').bind('click', function(Event) {
                 if (EndActivity !== 'Dummy') {
                     if (!Core.Config.Get('SessionIDCookie') && PopupPath.indexOf(SessionData[Core.Config.Get('SessionName')]) === -1) {
                         PopupPath += ';' + encodeURIComponent(Core.Config.Get('SessionName')) + '=' + encodeURIComponent(SessionData[Core.Config.Get('SessionName')]);
@@ -1070,7 +1070,7 @@ Core.Agent.Admin.ProcessManagement.Canvas = (function (TargetNS) {
      *      Redraws diagram.
      */
     TargetNS.Redraw = function () {
-        $('#ShowEntityIDs').removeClass('Visible').text(Core.Agent.Admin.ProcessManagement.Localization.ShowEntityIDs);
+        $('#ShowEntityIDs').removeClass('Visible').text(Core.Translate.Language('Show EntityIDs'));
         jsPlumb.reset();
         $('#Canvas').empty();
         TargetNS.Init();

--- a/var/httpd/htdocs/js/Core.Agent.Admin.ProcessManagement.js
+++ b/var/httpd/htdocs/js/Core.Agent.Admin.ProcessManagement.js
@@ -61,7 +61,7 @@ Core.Agent.Admin.ProcessManagement = (function (TargetNS) {
             $('#PopupRedirectStartActivityID').val($(this).data('startactivityid'));
 
             if ($(this).hasClass('Edit_Confirm')) {
-                if (window.confirm(Core.Agent.Admin.ProcessManagement.Localization.EditConfirm)) {
+                if (window.confirm(Core.Language.Translate('As soon as you use this button or link, you will leave this screen and its current state will be saved automatically. Do you want to continue?'))) {
                     // Remove onbeforeunload event only if there is no validation pending on form submit
                     if (!($Form.hasClass("Validate"))) {
                         $(window).unbind("beforeunload.PMPopup");
@@ -107,14 +107,14 @@ Core.Agent.Admin.ProcessManagement = (function (TargetNS) {
             true,
             [
                {
-                   Label: TargetNS.Localization.CancelMsg,
+                   Label: Core.Language.Translate('Cancel'),
                    Class: 'Primary',
                    Function: function () {
                        Core.UI.Dialog.CloseDialog($('.Dialog'));
                    }
                },
                {
-                   Label: TargetNS.Localization.DeleteMsg,
+                   Label: Core.Language.Translate('Delete'),
                    Function: function () {
                        var Data = {
                                Action: 'AdminProcessManagement',
@@ -167,20 +167,20 @@ Core.Agent.Admin.ProcessManagement = (function (TargetNS) {
 
         Core.UI.Dialog.ShowContentDialog(
             $('#Dialogs #' + DialogID),
-            TargetNS.Localization.DeleteEntityTitle,
+            Core.Language.Translate('Delete Entity'),
             '240px',
             'Center',
             true,
             [
                {
-                   Label: TargetNS.Localization.CancelMsg,
+                   Label: Core.Language.Translate('Cancel'),
                    Class: 'Primary',
                    Function: function () {
                        Core.UI.Dialog.CloseDialog($('.Dialog'));
                    }
                },
                {
-                   Label: TargetNS.Localization.DeleteMsg,
+                   Label: Core.Language.Translate('Delete'),
                    Function: function () {
                        var Data = {
                                Action: 'AdminProcessManagement',
@@ -381,7 +381,7 @@ Core.Agent.Admin.ProcessManagement = (function (TargetNS) {
                     TargetNS.Canvas.MakeDraggable();
                 }
                 else {
-                    alert(Core.Agent.Admin.ProcessManagement.Localization.ActivityAlreadyPlaced);
+                    alert(Core.Language.Translate('This Activity is already used in the Process. You cannot add it twice!'));
                 }
             }
             else {
@@ -523,7 +523,7 @@ Core.Agent.Admin.ProcessManagement = (function (TargetNS) {
             // if a dummy activity exists, another transition was placed to the canvas but not yet
             // connected to an end point. One cannot place two unconnected transitions on the canvas.
             if ($('#Dummy').length && DummyActivityConnected(ProcessEntityID)) {
-              alert(Core.Agent.Admin.ProcessManagement.Localization.UnconnectedTransition);
+              alert(Core.Language.Translate('An unconnected transition is already placed on the canvas. Please connect this transition first before placing another transition.'));
               return false;
             }
 
@@ -536,7 +536,7 @@ Core.Agent.Admin.ProcessManagement = (function (TargetNS) {
                 // If this transition is already bind to this activity
                 // you cannot bind it a second time
                 if (Path[Activity] && typeof Path[Activity][EntityID] !== 'undefined') {
-                    alert(Core.Agent.Admin.ProcessManagement.Localization.TransitionAlreadyPlaced);
+                    alert(Core.Language.Translate('This Transition is already used for this Activity. You cannot use it twice!'));
                     return false;
                 }
 
@@ -593,7 +593,7 @@ Core.Agent.Admin.ProcessManagement = (function (TargetNS) {
                     typeof Path[Transition.StartActivity][Transition.TransitionID].TransitionAction !== 'undefined' &&
                     ($.inArray(EntityID, Path[Transition.StartActivity][Transition.TransitionID].TransitionAction) >= 0)
                 ) {
-                    alert(Core.Agent.Admin.ProcessManagement.Localization.TransitionActionAlreadyPlaced);
+                    alert(Core.Language.Translate('This TransitionAction is already used in this Path. You cannot use it twice!'));
                     return false;
                 }
 
@@ -928,11 +928,11 @@ Core.Agent.Admin.ProcessManagement = (function (TargetNS) {
 
         $('#ShowEntityIDs').bind('click', function() {
             if ($(this).hasClass('Visible')) {
-                $(this).removeClass('Visible').text(Core.Agent.Admin.ProcessManagement.Localization.ShowEntityIDs);
+                $(this).removeClass('Visible').text(Core.Translate.Language('Show EntityIDs'));
                 $('em.EntityID').remove();
             }
             else {
-                $(this).addClass('Visible').text(Core.Agent.Admin.ProcessManagement.Localization.HideEntityIDs);
+                $(this).addClass('Visible').text(Core.Language.Translate('Hide EntityIDs'));
                 TargetNS.Canvas.ShowEntityIDs();
             }
             return false;
@@ -1086,13 +1086,13 @@ Core.Agent.Admin.ProcessManagement = (function (TargetNS) {
             // Open dialog
             Core.UI.Dialog.ShowContentDialog(
                 $('#Dialogs #FieldDetails'),
-                TargetNS.Localization.DialogTitle + ': ' + FieldNameTranslated,
+                Core.Language.Translate('Edit Field Details') + ': ' + FieldNameTranslated,
                 '200px',
                 'Center',
                 true,
                 [
                      {
-                         Label: TargetNS.Localization.SaveMsg,
+                         Label: Core.Language.Translate('Save'),
                          Class: 'Primary',
                          Function: function () {
                              var FieldConfigElement = {};
@@ -1110,7 +1110,7 @@ Core.Agent.Admin.ProcessManagement = (function (TargetNS) {
 
                                  // show error if internal article type is set for an interface different than AgentInterface
                                  if ($('#Interface').val() !== 'AgentInterface' && $('#ArticleType').val().match(/-int/i)){
-                                     window.alert(Core.Agent.Admin.ProcessManagement.Localization.WrongArticleTypeMsg);
+                                     window.alert(Core.Language.Translate('Customer interface does not support internal article types.'));
                                      return false;
                                  }
 
@@ -1124,7 +1124,7 @@ Core.Agent.Admin.ProcessManagement = (function (TargetNS) {
                          }
                      },
                      {
-                         Label: TargetNS.Localization.CancelMsg,
+                         Label: Core.Language.Translate('Cancel'),
                          Class: 'CallForAction',
                          Function: function () {
                              Core.UI.Dialog.CloseDialog($('.Dialog'));


### PR DESCRIPTION
Hi @zottto

Hereby are updated some tt modules where strings in JS are translated  directly.
I am not sure should I use Core.Language.Translate in confirm in AdminNotificationEvent.tt 
```
    if (window.confirm(Core.Language.Translate('Do you really want to delete this notification?'))) {
         window.location = $(this).attr('href');
         window.location = $(this).attr('href');
     }
     }

```

Also I have dilemma about EditConfirm strings n some AdminProcessManagement modules. IF there is necessary quotation marks ( EditConfirm: "[%  ...  | html %]" )

```
-    EditConfirm: "[% Translate("As soon as you use this button or link, you will leave this screen and its current state will be saved automatically. Do you want to continue?") | html %]"

+    EditConfirm: Core.Language.Translate('As soon as you use this button or link, you will leave this screen and its current state will be saved automatically. Do you want to continue?')
```

You can see how I have done, but I will be able to update if it is not good. Please let me know what do you think about that.


Regards
Zoran
