### PR TITLE
Fixed inline image corruption when uploading file with the same name

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,4 +1,5 @@
 #6.0.0.beta1 2016-??-??
+ - 2016-05-10 Fixed inline image corruption when uploading file with the same name.
  - 2016-05-04 Added the possiblity to configure the responsible field as mandatory (enabled by default for AgentTicketResponsible, if responsible feature is enabled), thanks to S7.
  - 2016-04-29 Reduced error log noise by reducing the log level of less important messages, thanks to Pawel Boguslawski.
  - 2016-04-29 Fixed parsing CSV data with quoted values containing newlines, thanks to Pawel Boguslawski.


### PR DESCRIPTION
In ticket compose screen, when you upload inline image from file
(say plik.jpg) using upload function in ckedit and than upload
same file (plik.jpg) as message attachment, than inline image
will became corrupted.

This mod fixes it by generating random filenames for uploaded images
(file name format like for pasted images).

Related: https://dev.ib.pl/ib/otrs/issues/51
Author-Change-Id: IB#1016490