### PR TITLE
Allow X-OTRS-Loop to reenable autoresponses

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,4 +1,5 @@
 #6.0.0.beta1 2016-??-??
+ - 2016-05-10 Allow X-OTRS-Loop to reenable autoresponses.
  - 2016-05-04 Added the possiblity to configure the responsible field as mandatory (enabled by default for AgentTicketResponsible, if responsible feature is enabled), thanks to S7.
  - 2016-04-29 Reduced error log noise by reducing the log level of less important messages, thanks to Pawel Boguslawski.
  - 2016-04-29 Fixed parsing CSV data with quoted values containing newlines, thanks to Pawel Boguslawski.

--- a/Kernel/System/Ticket/Article.pm
+++ b/Kernel/System/Ticket/Article.pm
@@ -2445,7 +2445,7 @@ sub SendAutoResponse {
     }
 
     # log that no auto response was sent!
-    if ( $OrigHeader{'X-OTRS-Loop'} ) {
+    if ( $OrigHeader{'X-OTRS-Loop'} && $OrigHeader{'X-OTRS-Loop'} !~ /(false|no)/i ) {
 
         # add history row
         $Self->HistoryAdd(


### PR DESCRIPTION
Any non-empty value passed to X-OTRS-Loop header in e-mail message
or any postmaster filter disables autoresponse.

This mod forces OTRS to disable autoresponding only if X-OTRS-Loop
is not empty and not false|no. This allowes one to disable
autoresponding in one filter with X-OTRS-Loop=yes and reenable
autoresponding in other filter with X-OTRS-Loop=no
(or X-OTRS-Loop=false).

Related: https://dev.ib.pl/ib/otrs/issues/52
Author-Change-Id: IB#1017277