### PR TITLE
Fixed IMAPS server TLS certificate verification

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,4 +1,5 @@
 #6.0.0.beta1 2016-??-??
+ - 2016-05-11 Fixed IMAPS server TLS certificate verification.
  - 2016-05-04 Added the possiblity to configure the responsible field as mandatory (enabled by default for AgentTicketResponsible, if responsible feature is enabled), thanks to S7.
  - 2016-04-29 Reduced error log noise by reducing the log level of less important messages, thanks to Pawel Boguslawski.
  - 2016-04-29 Fixed parsing CSV data with quoted values containing newlines, thanks to Pawel Boguslawski.

--- a/Kernel/Config/Files/Framework.xml.orig
+++ b/Kernel/Config/Files/Framework.xml.orig
@@ -7556,25 +7556,6 @@
             </Option>
         </Setting>
     </ConfigItem>
-    <ConfigItem Name="TLS::VerifyPeer" Required="1" Valid="1">
-        <Description Translatable="1">If this option is enabled (default, recommended), then the remote peer TLS certificates are verified against configured CA (see below). When disabled (not recommended for security reasons) peer TLS certificates are not verified. Please note: this option is currently used for mail account IMAPS connections only.</Description>
-        <Group>Framework</Group>
-        <SubGroup>Crypt::TLS</SubGroup>
-        <Setting>
-            <Option SelectedID="1">
-                <Item Key="0" Translatable="1">No</Item>
-                <Item Key="1" Translatable="1">Yes</Item>
-            </Option>
-        </Setting>
-    </ConfigItem>
-    <ConfigItem Name="TLS::CAPath" Required="1" Valid="1">
-        <Description Translatable="1">Specifies the directory where TLS trusted CA certificates for TLS peer certificate verification are stored. This setting is used if TLS::VerifyPeer is enabled (see above). Please note: this option is currently used for mail account IMAPS connections only.</Description>
-        <Group>Framework</Group>
-        <SubGroup>Crypt::TLS</SubGroup>
-        <Setting>
-            <String Regex="" Check="Directory">/etc/ssl/certs</String>
-        </Setting>
-    </ConfigItem>
     <ConfigItem Name="NotificationSenderName" Required="1" Valid="1">
         <Description Translatable="1">Specifies the name that should be used by the application when sending notifications. The sender name is used to build the complete display name for the notification master (i.e. "OTRS Notifications" otrs@your.example.com).</Description>
         <Group>Framework</Group>

--- a/Kernel/System/MailAccount/IMAPS.pm
+++ b/Kernel/System/MailAccount/IMAPS.pm
@@ -16,6 +16,7 @@ use IO::Socket::SSL;
 use base qw(Kernel::System::MailAccount::IMAP);
 
 our @ObjectDependencies = (
+    'Kernel::Config',
     'Kernel::System::Log',
 );
 
@@ -35,15 +36,40 @@ sub Connect {
 
     my $Type = 'IMAPS';
 
+    # get config object
+    my $ConfigObject = $Kernel::OM->Get('Kernel::Config');
+
+    # TLS verification settings
+    my $TLSVerifyPeer = $ConfigObject->Get('TLS::VerifyPeer') // 1;
+    my $TLSCAPath = $ConfigObject->Get('TLS::CAPath') || '/etc/ssl/certs';
+
+    my $SSLOptions = [
+        SSL_verify_mode => IO::Socket::SSL::SSL_VERIFY_PEER(),
+        SSL_ca_path     => $TLSCAPath,
+        SSL_verifycn_scheme => 'default',    # allows wildcards; see IO::Socket::SSL manual for details
+    ];
+
+    if ($TLSVerifyPeer) {
+        if ( ( !-d $TLSCAPath ) || ( !-r $TLSCAPath ) ) {
+            return (
+                Successful => 0,
+                Message    => "$Type: Can't connect to $Param{Host} (incorrect TLS::CAPath)!"
+            );
+        }
+    }
+    else {
+        $SSLOptions = [
+            SSL_verify_mode => IO::Socket::SSL::SSL_VERIFY_NONE(),
+        ];
+    }
+
     # connect to host
     my $IMAPObject = Net::IMAP::Simple->new(
         $Param{Host},
         timeout     => $Param{Timeout},
         debug       => $Param{Debug},
         use_ssl     => 1,
-        ssl_options => [
-            SSL_verify_mode => IO::Socket::SSL::SSL_VERIFY_NONE(),
-        ],
+        ssl_options => $SSLOptions,
     );
     if ( !$IMAPObject ) {
         return (


### PR DESCRIPTION
OTRS does not verify IMAPS server TLS certificate, thus IMAPS connections
are not protected against man-in-the-middle attacks.

This mod introduces two SysConfig settings:

    TLS::VerifyPeer
    Allows to enable or disable TLS peer certificate verification.

    TLS::CAPath
    Allows to specify path with trusted CA certs for peer cert
    verification.

Both settings are used now for IMAPS connections.

This mod fixes only IMAPS mail mode for fetching e-mails
from remote IMAP servers to OTRS; there are more places in OTRS
which should be fixed in similar way, i.e. POP3S, POP3TLS,
IMAPTLS mail fetching modules, maybe other OTRS connection
routines if use TLS connections.

Related: https://dev.ib.pl/ib/otrs/issues/53
Related: http://search.cpan.org/~sullr/IO-Socket-SSL-2.027/lib/IO/Socket/SSL.pod#Common_Usage_Errors
Author-Change-Id: IB#1017358