### PR TITLE
Missing space from error message

### DIFF
--- a/Kernel/Modules/AgentLinkObject.pm
+++ b/Kernel/Modules/AgentLinkObject.pm
@@ -356,11 +356,8 @@ sub Run {
                         $Output .= $LayoutObject->Notify(
                             Priority => 'Error',
                             Data     => $LayoutObject->{LanguageObject}->Translate(
-                                "Can not create link with %s!",
+                                'Can not create link with %s! Object already linked as %s.',
                                 $TargetObjectDescription{Normal},
-                                )
-                                . $LayoutObject->{LanguageObject}->Translate(
-                                "Object already linked as %s.",
                                 $TypeName,
                                 ),
                         );


### PR DESCRIPTION
Hi @mgruner 
There was no space character between the two strings. The concatenation is unnecessary. Rel-5_0 is also affected.