### PR TITLE
Full-size buttons in package manager

### DIFF
--- a/Kernel/Output/HTML/Templates/Standard/AdminPackageManager.tt
+++ b/Kernel/Output/HTML/Templates/Standard/AdminPackageManager.tt
@@ -432,28 +432,28 @@
                         </li>
 [% RenderBlockStart("PackageDownloadLocal") %]
                         <li>
-                            <a href="[% Env("Baselink") %]Action=[% Env("Action") %];Subaction=Download;Name=[% Data.Name | uri %];Version=[% Data.Version | uri %]" class="CallForAction">
+                            <a href="[% Env("Baselink") %]Action=[% Env("Action") %];Subaction=Download;Name=[% Data.Name | uri %];Version=[% Data.Version | uri %]" class="CallForAction Fullsize Center">
                                 <span>[% Translate("Download package") | html %]</span>
                             </a>
                         </li>
 [% RenderBlockEnd("PackageDownloadLocal") %]
 [% RenderBlockStart("PackageDownloadRemote") %]
                         <li>
-                            <a href="[% Env("Baselink") %]Action=[% Env("Action") %];Subaction=DownloadRemote;File=[% Data.File | uri %]" class="CallForAction">
+                            <a href="[% Env("Baselink") %]Action=[% Env("Action") %];Subaction=DownloadRemote;File=[% Data.File | uri %]" class="CallForAction Fullsize Center">
                                 <span>[% Translate("Download package") | html %]</span>
                             </a>
                         </li>
 [% RenderBlockEnd("PackageDownloadRemote") %]
 [% RenderBlockStart("PackageRebuild") %]
                         <li>
-                            <a href="[% Env("Baselink") %]Action=[% Env("Action") %];Subaction=RebuildPackage;Name=[% Data.Name | uri %];Version=[% Data.Version | uri %];[% Env("ChallengeTokenParam") | html %]" class="CallForAction">
+                            <a href="[% Env("Baselink") %]Action=[% Env("Action") %];Subaction=RebuildPackage;Name=[% Data.Name | uri %];Version=[% Data.Version | uri %];[% Env("ChallengeTokenParam") | html %]" class="CallForAction Fullsize Center">
                                 <span>[% Translate("Rebuild package") | html %]</span>
                             </a>
                         </li>
 [% RenderBlockEnd("PackageRebuild") %]
 [% RenderBlockStart("PackageReinstall") %]
                         <li>
-                            <a href="[% Env("Baselink") %]Action=[% Env("Action") %];Subaction=Reinstall;Name=[% Data.Name | uri %];Version=[% Data.Version | uri %];[% Env("ChallengeTokenParam") | html %]" class="CallForAction">
+                            <a href="[% Env("Baselink") %]Action=[% Env("Action") %];Subaction=Reinstall;Name=[% Data.Name | uri %];Version=[% Data.Version | uri %];[% Env("ChallengeTokenParam") | html %]" class="CallForAction Fullsize Center">
                                 <span>[% Translate("Reinstall package") | html %]</span>
                             </a>
                         </li>
@@ -632,7 +632,7 @@
                 <div class="Content">
                     <ul class="ActionList">
                         <li>
-                            <a href="[% Env("Baselink") %]Action=[% Env("Action") %];Subaction=View;Name=[% Data.Name | uri %];Version=[% Data.Version | uri %]" class="CallForAction">
+                            <a href="[% Env("Baselink") %]Action=[% Env("Action") %];Subaction=View;Name=[% Data.Name | uri %];Version=[% Data.Version | uri %]" class="CallForAction Fullsize Center">
                                 <span>[% Translate("Go to overview") | html %]</span>
                             </a>
                         </li>


### PR DESCRIPTION
Hi @mgruner 
This PR makes the buttons full-size in package manager. Rel-5_0 is also affected.

![package-buttons](https://cloud.githubusercontent.com/assets/1006118/15195827/e344c8b4-17c9-11e6-80ed-106957d82171.png)
