### PR TITLE
Added MailReprocessSpoolDir option

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,4 +1,5 @@
 #6.0.0.beta1 2016-??-??
+ - 2016-05-12 Added MailReprocessSpoolDir option.
  - 2016-05-04 Added the possiblity to configure the responsible field as mandatory (enabled by default for AgentTicketResponsible, if responsible feature is enabled), thanks to S7.
  - 2016-04-29 Reduced error log noise by reducing the log level of less important messages, thanks to Pawel Boguslawski.
  - 2016-04-29 Fixed parsing CSV data with quoted values containing newlines, thanks to Pawel Boguslawski.

--- a/Kernel/Config/Files/Ticket.xml
+++ b/Kernel/Config/Files/Ticket.xml
@@ -312,6 +312,14 @@
             <String Regex="">&lt;OTRS_CONFIG_Home&gt;/var/article</String>
         </Setting>
     </ConfigItem>
+    <ConfigItem Name="MailReprocessSpoolDir" Required="0" Valid="0" ConfigLevel="200">
+        <Description Translatable="1">Spool directory for mails that could not be imported in the first place and need reprocessing.</Description>
+        <Group>Ticket</Group>
+        <SubGroup>Core::Ticket</SubGroup>
+        <Setting>
+            <String Regex="" Check="Directory">/opt/otrs/var/spool</String>
+        </Setting>
+    </ConfigItem>
     <ConfigItem Name="OTRSEscalationEvents::DecayTime" Required="0" Valid="1">
         <Description Translatable="1">The duration in minutes after emitting an event, in which the new escalation notify and start events are suppressed.</Description>
         <Group>Ticket</Group>

--- a/Kernel/System/Console/Command/Maint/PostMaster/SpoolMailsReprocess.pm
+++ b/Kernel/System/Console/Command/Maint/PostMaster/SpoolMailsReprocess.pm
@@ -30,9 +30,13 @@ sub Configure {
 sub PreRun {
     my ( $Self, %Param ) = @_;
 
-    my $SpoolDir = $Kernel::OM->Get('Kernel::Config')->Get('Home') . '/var/spool';
-    if ( !-d $SpoolDir ) {
-        die "Spool directory $SpoolDir does not exist!\n";
+    # get config object
+    my $ConfigObject = $Kernel::OM->Get('Kernel::Config');
+
+    my $MailReprocessSpoolDir = $ConfigObject->Get('MailReprocessSpoolDir')
+        || $ConfigObject->Get('Home') . '/var/spool';
+    if ( !-d $MailReprocessSpoolDir ) {
+        die "Spool directory ${MailReprocessSpoolDir} does not exist!\n";
     }
 
     return;
@@ -41,13 +45,16 @@ sub PreRun {
 sub Run {
     my ( $Self, %Param ) = @_;
 
-    my $Home     = $Kernel::OM->Get('Kernel::Config')->Get('Home');
-    my $SpoolDir = "$Home/var/spool";
+    # get config object
+    my $ConfigObject = $Kernel::OM->Get('Kernel::Config');
 
-    $Self->Print("<yellow>Processing mails in $SpoolDir...</yellow>\n");
+    my $Home = $ConfigObject->Get('Home');
+    my $MailReprocessSpoolDir = $ConfigObject->Get('MailReprocessSpoolDir') || "$Home/var/spool";
+
+    $Self->Print("<yellow>Processing mails in ${MailReprocessSpoolDir}...</yellow>\n");
 
     my @Files = $Kernel::OM->Get('Kernel::System::Main')->DirectoryRead(
-        Directory => $SpoolDir,
+        Directory => $MailReprocessSpoolDir,
         Filter    => '*',
     );
 

--- a/Kernel/System/MailAccount/IMAP.pm
+++ b/Kernel/System/MailAccount/IMAP.pm
@@ -287,11 +287,15 @@ sub _ProcessFailed {
     # get main object
     my $MainObject = $Kernel::OM->Get('Kernel::System::Main');
 
-    my $Home = $Kernel::OM->Get('Kernel::Config')->Get('Home') . '/var/spool/';
+    # get config object
+    my $ConfigObject = $Kernel::OM->Get('Kernel::Config');
+
+    my $MailReprocessSpoolDir = $ConfigObject->Get('MailReprocessSpoolDir')
+        || $ConfigObject->Get('Home') . '/var/spool/';
     my $MD5  = $MainObject->MD5sum(
         String => \$Content,
     );
-    my $Location = $Home . 'problem-email-' . $MD5;
+    my $Location = $MailReprocessSpoolDir . '/problem-email-' . $MD5;
 
     return $MainObject->FileWrite(
         Location   => $Location,

--- a/Kernel/System/MailAccount/IMAPTLS.pm
+++ b/Kernel/System/MailAccount/IMAPTLS.pm
@@ -285,11 +285,15 @@ sub _ProcessFailed {
     # get main object
     my $MainObject = $Kernel::OM->Get('Kernel::System::Main');
 
-    my $Home = $Kernel::OM->Get('Kernel::Config')->Get('Home') . '/var/spool/';
+    # get config object
+    my $ConfigObject = $Kernel::OM->Get('Kernel::Config');
+
+    my $MailReprocessSpoolDir = $ConfigObject->Get('MailReprocessSpoolDir')
+        || $ConfigObject->Get('Home') . '/var/spool';
     my $MD5  = $MainObject->MD5sum(
         String => \$Param{Email},
     );
-    my $Location = $Home . 'problem-email-' . $MD5;
+    my $Location = $MailReprocessSpoolDir . '/problem-email-' . $MD5;
 
     return $MainObject->FileWrite(
         Location   => $Location,

--- a/Kernel/System/MailAccount/POP3.pm
+++ b/Kernel/System/MailAccount/POP3.pm
@@ -278,11 +278,15 @@ sub _ProcessFailed {
     # get main object
     my $MainObject = $Kernel::OM->Get('Kernel::System::Main');
 
-    my $Home = $Kernel::OM->Get('Kernel::Config')->Get('Home') . '/var/spool/';
+    # get config object
+    my $ConfigObject = $Kernel::OM->Get('Kernel::Config');
+
+    my $MailReprocessSpoolDir = $ConfigObject->Get('MailReprocessSpoolDir')
+        || $ConfigObject->Get('Home') . '/var/spool/';
     my $MD5  = $MainObject->MD5sum(
         String => \$Content,
     );
-    my $Location = $Home . 'problem-email-' . $MD5;
+    my $Location = $MailReprocessSpoolDir . '/problem-email-' . $MD5;
 
     return $MainObject->FileWrite(
         Location   => $Location,

--- a/Kernel/System/PostMaster/NewTicket.pm
+++ b/Kernel/System/PostMaster/NewTicket.pm
@@ -469,11 +469,13 @@ sub Run {
             TicketID => $TicketID,
             UserID   => $Param{InmailUserID},
         );
+        my $MailReprocessSpoolDir = $ConfigObject->Get('MailReprocessSpoolDir')
+            || $ConfigObject->Get('Home') . '/var/spool';
         $Kernel::OM->Get('Kernel::System::Log')->Log(
             Priority => 'error',
             Message  => "Can't process email with MessageID <$GetParam{'Message-ID'}>! "
                 . "Please create a bug report with this email (From: $GetParam{From}, Located "
-                . "under var/spool/problem-email*) on http://bugs.otrs.org/!",
+                . "under ${MailReprocessSpoolDir}/problem-email*) on http://bugs.otrs.org/!",
         );
         return;
     }


### PR DESCRIPTION
This mod introduces new SysConfig option MailReprocessSpoolDir
which allows one to change location of e-mail messages stored
for reprocessing.

Related: https://dev.ib.pl/ib/otrs/issues/54
Author-Change-Id: IB#1017361
