### PR TITLE
Added Hungarian stats

### DIFF
--- a/var/stats/ListOfOpenTicketsSortedByTimeLeftUntilEscalationDeadlineExpires.hu.xml
+++ b/var/stats/ListOfOpenTicketsSortedByTimeLeftUntilEscalationDeadlineExpires.hu.xml
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<otrs_stats>
+<Cache>0</Cache>
+<Description>A nyitott jegyek listája aszerint rendezve, hogy mennyi idő van hátra, amíg az eszkaláció határideje lejár.
+
+MEGJEGYZÉS: Alaposan nézze át a statisztikák kimenetét és beállításait, hogy meggyőződjön arról, hogy azokat az eredményeket állítják elő, amiket elvár. Ha szükséges, akkor változtassa meg a beállításokat, mielőtt a statisztikákat termelési környezetben használná.</Description>
+<File></File>
+<Format>CSV</Format>
+<Format>Excel</Format>
+<Format>Print</Format>
+<GraphSize></GraphSize>
+<Object>TicketList</Object>
+<ObjectModule>Kernel::System::Stats::Dynamic::TicketList</ObjectModule>
+<ObjectName>Ticketlist</ObjectName>
+<Permission>stats</Permission>
+<StatType>dynamic</StatType>
+<SumCol>0</SumCol>
+<SumRow>0</SumRow>
+<Title>Nyitott jegyek listája az eszkalációs határidő lejáratáig hátralévő idő szerint rendezve</Title>
+<UseAsRestriction Element="StateIDs" Fixed="1">
+<SelectedValues>new</SelectedValues>
+<SelectedValues>open</SelectedValues>
+<SelectedValues>pending auto close-</SelectedValues>
+<SelectedValues>pending auto close+</SelectedValues>
+<SelectedValues>pending reminder</SelectedValues>
+</UseAsRestriction>
+<UseAsValueSeries Element="OrderBy" Fixed="1">
+<SelectedValues>EscalationTimeWorkingTime</SelectedValues>
+</UseAsValueSeries>
+<UseAsValueSeries Element="SortSequence" Fixed="1">
+<SelectedValues>Up</SelectedValues>
+</UseAsValueSeries>
+<UseAsXvalue Element="TicketAttributes" Fixed="1">
+</UseAsXvalue>
+<Valid>1</Valid>
+</otrs_stats>

--- a/var/stats/ListOfOpenTicketsSortedByTimeLeftUntilResponseDeadlineExpires.hu.xml
+++ b/var/stats/ListOfOpenTicketsSortedByTimeLeftUntilResponseDeadlineExpires.hu.xml
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<otrs_stats>
+<Cache>0</Cache>
+<Description>A nyitott jegyek listája aszerint rendezve, hogy mennyi idő van hátra, amíg a válaszadási határidő lejár.
+
+MEGJEGYZÉS: Alaposan nézze át a statisztikák kimenetét és beállításait, hogy meggyőződjön arról, hogy azokat az eredményeket állítják elő, amiket elvár. Ha szükséges, akkor változtassa meg a beállításokat, mielőtt a statisztikákat termelési környezetben használná.</Description>
+<File></File>
+<Format>CSV</Format>
+<Format>Excel</Format>
+<Format>Print</Format>
+<GraphSize></GraphSize>
+<Object>TicketList</Object>
+<ObjectModule>Kernel::System::Stats::Dynamic::TicketList</ObjectModule>
+<ObjectName>Ticketlist</ObjectName>
+<Permission>stats</Permission>
+<StatType>dynamic</StatType>
+<SumCol>0</SumCol>
+<SumRow>0</SumRow>
+<Title>Nyitott jegyek listája a válasz lejáratáig hátralévő idő szerint rendezve</Title>
+<UseAsRestriction Element="StateIDs" Fixed="1">
+<SelectedValues>new</SelectedValues>
+<SelectedValues>open</SelectedValues>
+<SelectedValues>pending auto close-</SelectedValues>
+<SelectedValues>pending auto close+</SelectedValues>
+<SelectedValues>pending reminder</SelectedValues>
+</UseAsRestriction>
+<UseAsValueSeries Element="OrderBy" Fixed="1">
+<SelectedValues>UpdateTimeDestinationDate</SelectedValues>
+</UseAsValueSeries>
+<UseAsValueSeries Element="SortSequence" Fixed="1">
+<SelectedValues>Up</SelectedValues>
+</UseAsValueSeries>
+<UseAsXvalue Element="TicketAttributes" Fixed="1">
+</UseAsXvalue>
+<Valid>1</Valid>
+</otrs_stats>

--- a/var/stats/ListOfOpenTicketsSortedByTimeLeftUntilSolutionDeadlineExpires.hu.xml
+++ b/var/stats/ListOfOpenTicketsSortedByTimeLeftUntilSolutionDeadlineExpires.hu.xml
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<otrs_stats>
+<Cache>0</Cache>
+<Description>A nyitott jegyek listája aszerint rendezve, hogy mennyi idő van hátra, amíg a megoldás határideje lejár.
+
+MEGJEGYZÉS: Alaposan nézze át a statisztikák kimenetét és beállításait, hogy meggyőződjön arról, hogy azokat az eredményeket állítják elő, amiket elvár. Ha szükséges, akkor változtassa meg a beállításokat, mielőtt a statisztikákat termelési környezetben használná.</Description>
+<File></File>
+<Format>CSV</Format>
+<Format>Excel</Format>
+<Format>Print</Format>
+<GraphSize></GraphSize>
+<Object>TicketList</Object>
+<ObjectModule>Kernel::System::Stats::Dynamic::TicketList</ObjectModule>
+<ObjectName>Ticketlist</ObjectName>
+<Permission>stats</Permission>
+<StatType>dynamic</StatType>
+<SumCol>0</SumCol>
+<SumRow>0</SumRow>
+<Title>Nyitott jegyek listája a megoldási határidő lejáratáig hátralévő idő szerint rendezve</Title>
+<UseAsRestriction Element="StateIDs" Fixed="1">
+<SelectedValues>new</SelectedValues>
+<SelectedValues>open</SelectedValues>
+<SelectedValues>pending auto close-</SelectedValues>
+<SelectedValues>pending auto close+</SelectedValues>
+<SelectedValues>pending reminder</SelectedValues>
+</UseAsRestriction>
+<UseAsValueSeries Element="OrderBy" Fixed="1">
+<SelectedValues>SolutionTimeDestinationDate</SelectedValues>
+</UseAsValueSeries>
+<UseAsValueSeries Element="SortSequence" Fixed="1">
+<SelectedValues>Up</SelectedValues>
+</UseAsValueSeries>
+<UseAsXvalue Element="TicketAttributes" Fixed="1">
+</UseAsXvalue>
+<Valid>1</Valid>
+</otrs_stats>

--- a/var/stats/ListOfTheMostTimeConsumingTickets.hu.xml
+++ b/var/stats/ListOfTheMostTimeConsumingTickets.hu.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<otrs_stats>
+<Cache>0</Cache>
+<Description>A múlt hónapban lezárt jegyek listája, amelyek a legtöbb időt igényelték a feldolgozáshoz.
+
+MEGJEGYZÉS: Alaposan nézze át a statisztikák kimenetét és beállításait, hogy meggyőződjön arról, hogy azokat az eredményeket állítják elő, amiket elvár. Ha szükséges, akkor változtassa meg a beállításokat, mielőtt a statisztikákat termelési környezetben használná.</Description>
+<File></File>
+<Format>CSV</Format>
+<Format>Excel</Format>
+<Format>Print</Format>
+<GraphSize></GraphSize>
+<Object>TicketList</Object>
+<ObjectModule>Kernel::System::Stats::Dynamic::TicketList</ObjectModule>
+<ObjectName>Ticketlist</ObjectName>
+<Permission>stats</Permission>
+<StatType>dynamic</StatType>
+<SumCol>0</SumCol>
+<SumRow>0</SumRow>
+<Title>Legidőigényesebb jegyek listája</Title>
+<UseAsRestriction Element="Limit" Fixed="1">
+<SelectedValues>5</SelectedValues>
+</UseAsRestriction>
+<UseAsRestriction Element="CloseTime" Fixed="1" TimeRelativeCount="1" TimeRelativeUpcomingCount="0" TimeRelativeUnit="Month">
+</UseAsRestriction>
+<UseAsValueSeries Element="OrderBy" Fixed="1">
+<SelectedValues>AccountedTime</SelectedValues>
+</UseAsValueSeries>
+<UseAsValueSeries Element="SortSequence" Fixed="1">
+<SelectedValues>Down</SelectedValues>
+</UseAsValueSeries>
+<UseAsXvalue Element="TicketAttributes" Fixed="1">
+</UseAsXvalue>
+<Valid>1</Valid>
+</otrs_stats>

--- a/var/stats/ListOfTicketsClosedLastMonth.hu.xml
+++ b/var/stats/ListOfTicketsClosedLastMonth.hu.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<otrs_stats>
+<Cache>0</Cache>
+<Description>A múlt hónapban lezárt összes jegy listája kor szerint rendezve.
+
+MEGJEGYZÉS: Alaposan nézze át a statisztikák kimenetét és beállításait, hogy meggyőződjön arról, hogy azokat az eredményeket állítják elő, amiket elvár. Ha szükséges, akkor változtassa meg a beállításokat, mielőtt a statisztikákat termelési környezetben használná.</Description>
+<File></File>
+<Format>CSV</Format>
+<Format>Excel</Format>
+<Format>Print</Format>
+<GraphSize></GraphSize>
+<Object>TicketList</Object>
+<ObjectModule>Kernel::System::Stats::Dynamic::TicketList</ObjectModule>
+<ObjectName>Ticketlist</ObjectName>
+<Permission>stats</Permission>
+<StatType>dynamic</StatType>
+<SumCol>0</SumCol>
+<SumRow>0</SumRow>
+<Title>Múlt hónapban lezárt jegyek listája</Title>
+<UseAsRestriction Element="Limit" Fixed="1">
+<SelectedValues>unlimited</SelectedValues>
+</UseAsRestriction>
+<UseAsRestriction Element="CloseTime" Fixed="1" TimeRelativeCount="1" TimeRelativeUpcomingCount="0" TimeRelativeUnit="Month">
+</UseAsRestriction>
+<UseAsValueSeries Element="OrderBy" Fixed="1">
+<SelectedValues>Age</SelectedValues>
+</UseAsValueSeries>
+<UseAsValueSeries Element="SortSequence" Fixed="1">
+<SelectedValues>Down</SelectedValues>
+</UseAsValueSeries>
+<UseAsXvalue Element="TicketAttributes" Fixed="1">
+</UseAsXvalue>
+<Valid>1</Valid>
+</otrs_stats>

--- a/var/stats/ListOfTicketsClosedSortedByResponseTime.hu.xml
+++ b/var/stats/ListOfTicketsClosedSortedByResponseTime.hu.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<otrs_stats>
+<Cache>0</Cache>
+<Description>A múlt hónapban lezárt összes jegy listája válaszidő szerint rendezve.
+
+MEGJEGYZÉS: Alaposan nézze át a statisztikák kimenetét és beállításait, hogy meggyőződjön arról, hogy azokat az eredményeket állítják elő, amiket elvár. Ha szükséges, akkor változtassa meg a beállításokat, mielőtt a statisztikákat termelési környezetben használná.</Description>
+<File></File>
+<Format>CSV</Format>
+<Format>Excel</Format>
+<Format>Print</Format>
+<GraphSize></GraphSize>
+<Object>TicketList</Object>
+<ObjectModule>Kernel::System::Stats::Dynamic::TicketList</ObjectModule>
+<ObjectName>Ticketlist</ObjectName>
+<Permission>stats</Permission>
+<StatType>dynamic</StatType>
+<SumCol>0</SumCol>
+<SumRow>0</SumRow>
+<Title>Lezárt jegyek listája válaszidő szerint rendezve</Title>
+<UseAsRestriction Element="CloseTime" Fixed="1" TimeRelativeCount="1" TimeRelativeUpcomingCount="0" TimeRelativeUnit="Month">
+</UseAsRestriction>
+<UseAsValueSeries Element="OrderBy" Fixed="1">
+<SelectedValues>FirstResponseDiffInMin</SelectedValues>
+</UseAsValueSeries>
+<UseAsValueSeries Element="SortSequence" Fixed="1">
+<SelectedValues>Up</SelectedValues>
+</UseAsValueSeries>
+<UseAsXvalue Element="TicketAttributes" Fixed="1">
+</UseAsXvalue>
+<Valid>1</Valid>
+</otrs_stats>

--- a/var/stats/ListOfTicketsClosedSortedBySolutionTime.hu.xml
+++ b/var/stats/ListOfTicketsClosedSortedBySolutionTime.hu.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<otrs_stats>
+<Cache>0</Cache>
+<Description>A múlt hónapban lezárt jegyek listája megoldási idő szerint rendezve.
+
+MEGJEGYZÉS: Alaposan nézze át a statisztikák kimenetét és beállításait, hogy meggyőződjön arról, hogy azokat az eredményeket állítják elő, amiket elvár. Ha szükséges, akkor változtassa meg a beállításokat, mielőtt a statisztikákat termelési környezetben használná.</Description>
+<File></File>
+<Format>CSV</Format>
+<Format>Excel</Format>
+<Format>Print</Format>
+<GraphSize></GraphSize>
+<Object>TicketList</Object>
+<ObjectModule>Kernel::System::Stats::Dynamic::TicketList</ObjectModule>
+<ObjectName>Ticketlist</ObjectName>
+<Permission>stats</Permission>
+<StatType>dynamic</StatType>
+<SumCol>0</SumCol>
+<SumRow>0</SumRow>
+<Title>Lezárt jegyek listája megoldási idő szerint rendezve</Title>
+<UseAsRestriction Element="CloseTime" Fixed="1" TimeRelativeCount="1" TimeRelativeUpcomingCount="0" TimeRelativeUnit="Month">
+</UseAsRestriction>
+<UseAsValueSeries Element="OrderBy" Fixed="1">
+<SelectedValues>SolutionDiffInMin</SelectedValues>
+</UseAsValueSeries>
+<UseAsValueSeries Element="SortSequence" Fixed="1">
+<SelectedValues>Up</SelectedValues>
+</UseAsValueSeries>
+<UseAsXvalue Element="TicketAttributes" Fixed="1">
+</UseAsXvalue>
+<Valid>1</Valid>
+</otrs_stats>

--- a/var/stats/ListOfTicketsCreatedLastMonth.hu.xml
+++ b/var/stats/ListOfTicketsCreatedLastMonth.hu.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<otrs_stats>
+<Cache>0</Cache>
+<Description>A múlt hónapban létrehozott összes jegy listája kor szerint rendezve.
+
+MEGJEGYZÉS: Alaposan nézze át a statisztikák kimenetét és beállításait, hogy meggyőződjön arról, hogy azokat az eredményeket állítják elő, amiket elvár. Ha szükséges, akkor változtassa meg a beállításokat, mielőtt a statisztikákat termelési környezetben használná.</Description>
+<File></File>
+<Format>CSV</Format>
+<Format>Excel</Format>
+<Format>Print</Format>
+<GraphSize></GraphSize>
+<Object>TicketList</Object>
+<ObjectModule>Kernel::System::Stats::Dynamic::TicketList</ObjectModule>
+<ObjectName>Ticketlist</ObjectName>
+<Permission>stats</Permission>
+<StatType>dynamic</StatType>
+<SumCol>0</SumCol>
+<SumRow>0</SumRow>
+<Title>Múlt hónapban létrehozott jegyek listája</Title>
+<UseAsRestriction Element="Limit" Fixed="1">
+<SelectedValues>unlimited</SelectedValues>
+</UseAsRestriction>
+<UseAsRestriction Element="CreateTime" Fixed="1" TimeRelativeCount="1" TimeRelativeUpcomingCount="0" TimeRelativeUnit="Month">
+</UseAsRestriction>
+<UseAsValueSeries Element="OrderBy" Fixed="1">
+<SelectedValues>Age</SelectedValues>
+</UseAsValueSeries>
+<UseAsValueSeries Element="SortSequence" Fixed="1">
+<SelectedValues>Up</SelectedValues>
+</UseAsValueSeries>
+<UseAsXvalue Element="TicketAttributes" Fixed="1">
+</UseAsXvalue>
+<Valid>1</Valid>
+</otrs_stats>

--- a/var/stats/Stats.NewTickets.hu.xml
+++ b/var/stats/Stats.NewTickets.hu.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="utf-8"?>
+<otrs_stats>
+<Cache>1</Cache>
+<Title>Új jegyek</Title>
+<Description>Az új jegyek összes száma naponta és várólistánként, amelyek a múlt hónap során lettek létrehozva.</Description>
+<Format>CSV</Format>
+<Format>D3::BarChart</Format>
+<Format>D3::LineChart</Format>
+<Format>D3::StackedAreaChart</Format>
+<Format>Excel</Format>
+<Format>Print</Format>
+<Object>Ticket</Object>
+<ObjectModule>Kernel::System::Stats::Dynamic::Ticket</ObjectModule>
+<Permission>stats</Permission>
+<StatType>dynamic</StatType>
+<SumCol>1</SumCol>
+<SumRow>1</SumRow>
+<UseAsValueSeries Element="QueueIDs" Fixed="1">
+</UseAsValueSeries>
+<UseAsXvalue Element="CreateTime" Fixed="1" TimeRelativeCount="1" TimeRelativeUpcomingCount="0" TimeRelativeUnit="Month" TimeScaleCount="1">
+<SelectedValues>Day</SelectedValues>
+</UseAsXvalue>
+<Valid>1</Valid>
+</otrs_stats>

--- a/var/stats/Stats.StatusActionOverview.hu.xml
+++ b/var/stats/Stats.StatusActionOverview.hu.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="utf-8"?>
+<otrs_stats>
+<Cache>1</Cache>
+<Description>Havi áttekintő, amely egy kiválasztott hónapban történt napi állapotváltozásokat mutatja ki.</Description>
+<Format>CSV</Format>
+<Format>D3::BarChart</Format>
+<Format>D3::LineChart</Format>
+<Format>D3::StackedAreaChart</Format>
+<Format>Excel</Format>
+<Format>Print</Format>
+<Object></Object>
+<ObjectModule>Kernel::System::Stats::Static::StateAction</ObjectModule>
+<Permission>stats</Permission>
+<StatType>static</StatType>
+<SumCol>1</SumCol>
+<SumRow>1</SumRow>
+<Title>Állapot változásai egy havi áttekintőben</Title>
+<Valid>1</Valid>
+</otrs_stats>

--- a/var/stats/Stats.TicketOverview.hu.xml
+++ b/var/stats/Stats.TicketOverview.hu.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="utf-8"?>
+<otrs_stats>
+<Cache>0</Cache>
+<Title>Áttekintő a rendszeren lévő összes jegyről</Title>
+<Description>A rendszeren lévő összes jegy jelenlegi állapota időkorlátozások nélkül.</Description>
+<Format>CSV</Format>
+<Format>D3::BarChart</Format>
+<Format>D3::LineChart</Format>
+<Format>D3::StackedAreaChart</Format>
+<Format>Excel</Format>
+<Format>Print</Format>
+<Object>Ticket</Object>
+<ObjectModule>Kernel::System::Stats::Dynamic::Ticket</ObjectModule>
+<Permission>stats</Permission>
+<StatType>dynamic</StatType>
+<SumCol>1</SumCol>
+<SumRow>1</SumRow>
+<UseAsValueSeries Element="QueueIDs" Fixed="1">
+</UseAsValueSeries>
+<UseAsXvalue Element="StateIDs" Fixed="1">
+</UseAsXvalue>
+<Valid>1</Valid>
+</otrs_stats>


### PR DESCRIPTION
Hi @mgruner 
Here is the localized (Hungarian) stats for OTRS. As this XML files contains only the localization, it would be good to also add to rel-5_0, because there are the same files both in rel-5_0 and master.

Suggestion:
These XML files are redundant. All of them contain the same lines. The only difference between *_en.xml, *_de.xml and now *_hu.xml is the &lt;Description&gt; and the &lt;Title&gt; element.
These XML files can be merged into one with a lang="" attribute (like in OTRS packages). For example:

ListOfOpenTicketsSortedByTimeLeftUntilEscalationDeadlineExpires.xml
&lt;Title lang="de"&gt;Ticketliste aller offenen Tickets geordnet nach der verbleibenden Zeit bis um Ablauf der Eskalationsfrist&lt;/Title&gt;
&lt;Title lang="en"&gt;List of open tickets, sorted by time left until escalation deadline expires&lt;/Title&gt;
&lt;Title lang="hu"&gt;Nyitott jegyek listája az eszkalációs határidő lejáratáig hátralévő idő szerint rendezve&lt;/Title&gt;

And the same with the &lt;Description&gt; tag.