### PR TITLE
Master - Changed sysconfig name for AgenTicketPhoneCommon state default

### DIFF
--- a/Kernel/Config/Files/Ticket.xml
+++ b/Kernel/Config/Files/Ticket.xml
@@ -3041,7 +3041,7 @@
             <TextArea></TextArea>
         </Setting>
     </ConfigItem>
-    <ConfigItem Name="Ticket::Frontend::AgentTicketPhoneOutbound###State" Required="0" Valid="1">
+    <ConfigItem Name="Ticket::Frontend::AgentTicketPhoneOutbound###StateDefault" Required="0" Valid="1">
         <Description Translatable="1">Defines the default ticket next state after adding a phone note in the ticket phone outbound screen of the agent interface.</Description>
         <Group>Ticket</Group>
         <SubGroup>Frontend::Agent::Ticket::ViewPhoneOutbound</SubGroup>
@@ -3130,7 +3130,7 @@
             <TextArea></TextArea>
         </Setting>
     </ConfigItem>
-    <ConfigItem Name="Ticket::Frontend::AgentTicketPhoneInbound###State" Required="0" Valid="1">
+    <ConfigItem Name="Ticket::Frontend::AgentTicketPhoneInbound###StateDefault" Required="0" Valid="1">
         <Description Translatable="1">Defines the default ticket next state after adding a phone note in the ticket phone inbound screen of the agent interface.</Description>
         <Group>Ticket</Group>
         <SubGroup>Frontend::Agent::Ticket::ViewPhoneInbound</SubGroup>

--- a/Kernel/Modules/AgentTicketPhoneCommon.pm
+++ b/Kernel/Modules/AgentTicketPhoneCommon.pm
@@ -1090,8 +1090,8 @@ sub _MaskPhone {
     if ( $Param{NextStateID} ) {
         $Selected{SelectedID} = $Param{NextStateID};
     }
-    elsif ( $Config->{State} ) {
-        $Selected{SelectedValue} = $Config->{State};
+    elsif ( $Config->{StateDefault} ) {
+        $Selected{SelectedValue} = $Config->{StateDefault};
     }
     else {
         $Param{NextStates}->{''} = '-';

--- a/scripts/test/Selenium/Agent/AgentTicketPhoneCommon.t
+++ b/scripts/test/Selenium/Agent/AgentTicketPhoneCommon.t
@@ -53,6 +53,20 @@ $Selenium->RunTest(
             Value => 0
         );
 
+        # set default state
+        my $OutboundStateDefault = 'closed successful';
+        my $InboundStateDefault  = 'open';
+        $SysConfigObject->ConfigItemUpdate(
+            Valid => 1,
+            Key   => 'Ticket::Frontend::AgentTicketPhoneOutbound###StateDefault',
+            Value => $OutboundStateDefault,
+        );
+        $SysConfigObject->ConfigItemUpdate(
+            Valid => 1,
+            Key   => 'Ticket::Frontend::AgentTicketPhoneInbound###StateDefault',
+            Value => $InboundStateDefault,
+        );
+
         # create test user and login
         my $TestUserLogin = $Helper->TestUserCreate(
             Groups => [ 'admin', 'users' ],
@@ -91,12 +105,14 @@ $Selenium->RunTest(
         # get test data
         my @Test = (
             {
-                Name        => 'AgentTicketPhoneOutbound',
-                HistoryText => 'PhoneCallAgent',
+                Name         => 'AgentTicketPhoneOutbound',
+                HistoryText  => 'PhoneCallAgent',
+                StateDefault => $OutboundStateDefault,
             },
             {
-                Name        => 'AgentTicketPhoneInbound',
-                HistoryText => 'PhoneCallCustomer',
+                Name         => 'AgentTicketPhoneInbound',
+                HistoryText  => 'PhoneCallCustomer',
+                StateDefault => $InboundStateDefault,
             },
         );
 
@@ -119,6 +135,13 @@ $Selenium->RunTest(
                 $Element->is_enabled();
                 $Element->is_displayed();
             }
+
+            # check default state
+            $Self->Is(
+                $Selenium->execute_script("return \$('#NextStateID option:selected').text();"),
+                $Action->{StateDefault},
+                "Default state in action $Action->{Name} is set correctly",
+            );
 
             # add body text and submit
             my $ActionText = $Action->{Name} . " Selenium Test";


### PR DESCRIPTION
Hi @mgruber

Hereby is updated name for  AgentTicketPhoneOutbound###State and AgentTicketPhoneInbound###State. I saw that such sysconfig items for other screen is named StateDefault. I thought it would be better if there is consistently name for this item here as well. It is not so important but if you agree with me you can merge this.
There is updated Selenium test where this item is checked.

Regards
Zoran