### PR TITLE
Fixed missing OTRS tags in AdminTemplate after Frontend::RichText change

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,4 +1,5 @@
 #6.0.0.beta1 2016-??-??
+ - 2016-05-18 Fixed missing OTRS tags in AdminTemplate after Frontend::RichText change.
  - 2016-05-04 Added the possiblity to configure the responsible field as mandatory (enabled by default for AgentTicketResponsible, if responsible feature is enabled), thanks to S7.
  - 2016-04-29 Reduced error log noise by reducing the log level of less important messages, thanks to Pawel Boguslawski.
  - 2016-04-29 Fixed parsing CSV data with quoted values containing newlines, thanks to Pawel Boguslawski.

--- a/Kernel/Modules/AdminTemplate.pm
+++ b/Kernel/Modules/AdminTemplate.pm
@@ -372,6 +372,27 @@ sub _Edit {
         Class        => 'Modernize',
     );
 
+    my $HTMLUtilsObject = $Kernel::OM->Get('Kernel::System::HTMLUtils');
+
+    if ( $LayoutObject->{BrowserRichText} ) {
+
+        # reformat from plain to html
+        if ( $Param{ContentType} && $Param{ContentType} =~ /text\/plain/i ) {
+            $Param{Template} = $HTMLUtilsObject->ToHTML(
+                String => $Param{Template},
+            );
+        }
+    }
+    else {
+
+        # reformat from html to plain
+        if ( $Param{ContentType} && $Param{ContentType} =~ /text\/html/i ) {
+            $Param{Template} = $HTMLUtilsObject->ToAscii(
+                String => $Param{Template},
+            );
+        }
+    }
+
     $LayoutObject->Block(
         Name => 'OverviewUpdate',
         Data => {
@@ -396,30 +417,12 @@ sub _Edit {
         $LayoutObject->Block( Name => 'NameServerError' );
     }
 
-    my $HTMLUtilsObject = $Kernel::OM->Get('Kernel::System::HTMLUtils');
-
     # add rich text editor
     if ( $LayoutObject->{BrowserRichText} ) {
         $LayoutObject->Block(
             Name => 'RichText',
             Data => \%Param,
         );
-
-        # reformat from plain to html
-        if ( $Param{ContentType} && $Param{ContentType} =~ /text\/plain/i ) {
-            $Param{Template} = $HTMLUtilsObject->ToHTML(
-                String => $Param{Template},
-            );
-        }
-    }
-    else {
-
-        # reformat from html to plain
-        if ( $Param{ContentType} && $Param{ContentType} =~ /text\/html/i ) {
-            $Param{Template} = $HTMLUtilsObject->ToAscii(
-                String => $Param{Template},
-            );
-        }
     }
     return 1;
 }


### PR DESCRIPTION
If you have stored any plaintext (Frontend::RichText = No) templates
in AdminTemplate with `<OTRS*>` tags inside
(i.e. `<OTRS_OWNER_UserFirstname>`) and then switch to
Frontend::RichText = Yes, then all `<OTRS*>` tags will be lost
in rich text editor in AdminTemplate.

This patch solves this problem analogous to AdminAutoResponse.

Related: https://dev.ib.pl/ib/otrs/issues/55
Author-Change-Id: IB#1019597