### PR TITLE
Follow up detection based on Message-ID e-mail header

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,4 +1,5 @@
 #6.0.0.beta1 2016-??-??
+ - 2016-05-18 Added follow up detection based on Message-ID e-mail header.
  - 2016-05-04 Added the possiblity to configure the responsible field as mandatory (enabled by default for AgentTicketResponsible, if responsible feature is enabled), thanks to S7.
  - 2016-04-29 Reduced error log noise by reducing the log level of less important messages, thanks to Pawel Boguslawski.
  - 2016-04-29 Fixed parsing CSV data with quoted values containing newlines, thanks to Pawel Boguslawski.

--- a/Kernel/Config/Files/Ticket.xml
+++ b/Kernel/Config/Files/Ticket.xml
@@ -10437,6 +10437,18 @@ Thanks for your help!
             </Hash>
         </Setting>
     </ConfigItem>
+    <ConfigItem Name="PostMaster::CheckFollowUpModule###0600-MessageID" Required="0" Valid="0">
+        <Description Translatable="1">Executes follow up Message-ID checks in mails that don't have a ticket number in the subject. Incoming message will be treated as ticket X follow up if: (0) Message-ID is not empty (should not be) and (1) there is 1 or more (but not more than MaxArticles if MaxArticles is greater than 0) articles in ticket X with the same Message-ID and (2) no article with the same Message-ID exists in ticket other than X and (3) age difference between oldest Article from (1) and incoming message is not greater than MaxAge seconds if MaxAge greater than 0.</Description>
+        <Group>Ticket</Group>
+        <SubGroup>Core::PostMaster</SubGroup>
+        <Setting>
+            <Hash>
+                <Item Key="Module">Kernel::System::PostMaster::FollowUpCheck::MessageID</Item>
+                <Item Key="MaxAge">604800</Item>
+                <Item Key="MaxArticles">10</Item>
+            </Hash>
+        </Setting>
+    </ConfigItem>
     <ConfigItem Name="SendNoAutoResponseRegExp" Required="1" Valid="1">
         <Description Translatable="1">If this regex matches, no message will be send by the autoresponder.</Description>
         <Group>Ticket</Group>

--- a/Kernel/System/PostMaster/FollowUpCheck/MessageID.pm
+++ b/Kernel/System/PostMaster/FollowUpCheck/MessageID.pm
@@ -1,0 +1,73 @@
+# --
+# Copyright (C) 2016 Informatyka Boguslawski sp. z o.o. sp.k., http://www.ib.pl/
+# --
+# This software comes with ABSOLUTELY NO WARRANTY. For details, see
+# the enclosed file COPYING for license information (AGPL). If you
+# did not receive this file, see http://www.gnu.org/licenses/agpl.txt.
+# --
+
+package Kernel::System::PostMaster::FollowUpCheck::MessageID;
+
+use strict;
+use warnings;
+
+our @ObjectDependencies = (
+    'Kernel::Config',
+    'Kernel::System::Log',
+    'Kernel::System::Ticket',
+);
+
+sub new {
+    my ( $Type, %Param ) = @_;
+
+    # allocate new hash for object
+    my $Self = {};
+    return bless( $Self, $Type );
+}
+
+sub Run {
+    my ( $Self, %Param ) = @_;
+
+    # checking mandatory configuration options
+    for my $Option (qw(MaxAge MaxArticles)) {
+        if ( !defined $Param{JobConfig}->{$Option} && !$Param{JobConfig}->{$Option} ) {
+            $Kernel::OM->Get('Kernel::System::Log')->Log(
+                Priority => 'error',
+                Message  => "Missing configuration for $Option for postmaster MessageID follow-up check module.",
+            );
+            return;
+        }
+    }
+
+    # do ticket lookup using Message-ID; for details see
+    # PostMaster::CheckFollowUpModule###0600-MessageID description in SysConfig
+    if ( $Param{GetParam}->{'Message-ID'} ) {
+        my $TicketObject = $Kernel::OM->Get('Kernel::System::Ticket');
+
+        # get ticket id containing article(s) with given message id
+        my $TicketID = $TicketObject->ArticleGetTicketIDOfMessageID(
+            MessageID   => $Param{GetParam}->{'Message-ID'},
+            MaxAge      => $Param{JobConfig}->{MaxAge},
+            MaxArticles => $Param{JobConfig}->{MaxArticles},
+            Quiet       => $Param{Quiet},
+        );
+
+        if ($TicketID) {
+            my $Tn = $TicketObject->TicketNumberLookup(
+                TicketID => $TicketID,
+            );
+            if ( $Tn && !$Param{Quiet} ) {
+                $Kernel::OM->Get('Kernel::System::Log')->Log(
+                    Priority => 'debug',
+                    Message =>
+                        "CheckFollowUp (Message-ID): yes, it's a follow up ($Tn/$TicketID)",
+                );
+            }
+            return $TicketID;
+        }
+    }
+
+    return;
+}
+
+1;

--- a/Kernel/System/PostMaster/FollowUpCheck/References.pm
+++ b/Kernel/System/PostMaster/FollowUpCheck/References.pm
@@ -41,6 +41,7 @@ sub Run {
         # get ticket id of message id
         my $TicketID = $TicketObject->ArticleGetTicketIDOfMessageID(
             MessageID => "<$Reference>",
+            Quiet => $Param{Quiet},
         );
 
         if ($TicketID) {


### PR DESCRIPTION
OTRS creates separate tickets if one sends same e-mail message to
a few OTRS system addresses (i.e. using multiple OTRS system
addresses in To/Cc/Bcc in the same e-mail message) . It may be
difficult to notice such duplicates in bigger OTRS systems
and same request be processed by different agents.

This mod introduces SysConfig parameter
`PostMaster::CheckFollowUpModule###0600-MessageID`
that allowes OTRS to merge messages with the same Message-ID
into one ticket. To avoid merging too many messages into one
ticket (in case of Message-ID generation problem at sender side)
or merging new messages to very old tickets in case of
Message-ID duplicates in wider time, two module parameters
are provided:

* `MaxAge` - time (in seconds) from the first article with
   given Message-ID creation, after which new messages with
   the same Message-ID won't be merged into the same ticket
   any more,

* `MaxArticles` - number of messages with the same
   Message-ID in OTRS database after which next e-mail messages
   with the same Message-ID won't be merged into the same ticket
   any more.

For example: with MaxAge=604800 and MaxArticles=10 OTRS will merge
into one ticket up to 10 messages with the same Message-ID if all
will arrive in the same week.

Related: https://dev.ib.pl/ib/otrs/issues/56
Author-Change-Id: IB#1051946