### PR TITLE
Faster new stat add operation

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,4 +1,5 @@
 #6.0.0.beta1 2016-??-??
+ - 2016-05-19 Faster new stat add operation.
  - 2016-05-04 Added the possiblity to configure the responsible field as mandatory (enabled by default for AgentTicketResponsible, if responsible feature is enabled), thanks to S7.
  - 2016-04-29 Reduced error log noise by reducing the log level of less important messages, thanks to Pawel Boguslawski.
  - 2016-04-29 Fixed parsing CSV data with quoted values containing newlines, thanks to Pawel Boguslawski.

--- a/Kernel/System/Stats.pm
+++ b/Kernel/System/Stats.pm
@@ -1004,6 +1004,7 @@ sub GetStaticFiles {
                 my $Data = $Self->StatsGet(
                     StatID => $StatID,
                     UserID => $Param{UserID},
+                    NoObjectAttributes => 1,
                 );
 
                 # check witch one are static statistics


### PR DESCRIPTION
This mod reduces time required to open
Action=AgentStatistics;Subaction=Add screen especially in systems
with many defined stats.

Related: https://dev.ib.pl/ib/otrs/issues/57
Author-Change-Id: IB#1020506