### PR TITLE
7 Day Stats performance optimizations

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,4 +1,5 @@
 #6.0.0.beta1 2016-??-??
+ - 2016-05-19 7 Day Stats performance optimizations.
  - 2016-05-04 Added the possiblity to configure the responsible field as mandatory (enabled by default for AgentTicketResponsible, if responsible feature is enabled), thanks to S7.
  - 2016-04-29 Reduced error log noise by reducing the log level of less important messages, thanks to Pawel Boguslawski.
  - 2016-04-29 Fixed parsing CSV data with quoted values containing newlines, thanks to Pawel Boguslawski.

--- a/Kernel/Output/HTML/Dashboard/TicketStatsGeneric.pm
+++ b/Kernel/Output/HTML/Dashboard/TicketStatsGeneric.pm
@@ -96,6 +96,9 @@ sub Run {
 
     for my $DaysBack ( 0 .. 6 ) {
 
+        # cache results for 30 min. for todays stats
+        my $CacheTTL = 60 * 30;
+
         my $DateTimeObject = $Kernel::OM->Create(
             'Kernel::System::DateTime',
             ObjectParams => {
@@ -104,6 +107,9 @@ sub Run {
         );
         if ($DaysBack) {
             $DateTimeObject->Subtract( Days => $DaysBack );
+
+            # for past 6 days cache results for 8 days (should not change)
+            $CacheTTL = 60 * 60 * 24 * 8;
         }
         $DateTimeObject->ToOTRSTimeZone();
 
@@ -120,8 +126,8 @@ sub Run {
 
         my $CountCreated = $TicketObject->TicketSearch(
 
-            # cache search result 30 min
-            CacheTTL => 60 * 30,
+            # cache search result
+            CacheTTL => $CacheTTL,
 
             # tickets with create time after ... (ticket newer than this date) (optional)
             TicketCreateTimeNewerDate => $TimeStart,
@@ -143,8 +149,8 @@ sub Run {
 
         my $CountClosed = $TicketObject->TicketSearch(
 
-            # cache search result 30 min
-            CacheTTL => 60 * 30,
+            # cache search result
+            CacheTTL => $CacheTTL,
 
             # tickets with create time after ... (ticket newer than this date) (optional)
             TicketCloseTimeNewerDate => $TimeStart,


### PR DESCRIPTION
OTRS recalculates all data for 7 Day Stats graph every 30 min which
may cause performance problems in bigger systems with lot of ticket
and agents, when graph data expires. Data for past days don't change
so it may be cached for longer time. This mod forces 7 Day Stats
data for past days to be cached for 8 days - only todays data
is cached for 30 min.

This mod adds also hint for MySQL database query optimizer to avoid
its wrong decisions and ticket_history table scans during
7 Day Stats data generation.

Related: https://dev.ib.pl/ib/otrs/issues/58
Author-Change-Id: IB#1020711