### PR TITLE
Marked titles as translatable in column names

### DIFF
--- a/Kernel/Output/HTML/Dashboard/TicketGeneric.pm
+++ b/Kernel/Output/HTML/Dashboard/TicketGeneric.pm
@@ -827,7 +827,7 @@ sub Run {
             }
 
             # set title description
-            my $TitleDesc = $OrderBy eq 'Down' ? 'sorted ascending' : 'sorted descending';
+            my $TitleDesc = $OrderBy eq 'Down' ? Translatable('sorted ascending') : Translatable('sorted descending');
             $TitleDesc = $LayoutObject->{LanguageObject}->Translate($TitleDesc);
             $Title .= ', ' . $TitleDesc;
         }
@@ -882,7 +882,7 @@ sub Run {
         if ( $HeaderColumn !~ m{\A DynamicField_}xms ) {
 
             $CSS = '';
-            my $Title = $HeaderColumn;
+            my $Title = $LayoutObject->{LanguageObject}->Translate($HeaderColumn);
 
             if ( $Self->{SortBy} && ( $Self->{SortBy} eq $HeaderColumn ) ) {
                 if ( $Self->{OrderBy} && ( $Self->{OrderBy} eq 'Up' ) ) {
@@ -895,7 +895,7 @@ sub Run {
                 }
 
                 # add title description
-                my $TitleDesc = $OrderBy eq 'Down' ? 'sorted ascending' : 'sorted descending';
+                my $TitleDesc = $OrderBy eq 'Down' ? Translatable('sorted ascending') : Translatable('sorted descending');
                 $TitleDesc = $LayoutObject->{LanguageObject}->Translate($TitleDesc);
                 $Title .= ', ' . $TitleDesc;
             }
@@ -945,7 +945,7 @@ sub Run {
                 next HEADERCOLUMN;
             }
 
-            my $FilterTitle     = $HeaderColumn;
+            my $FilterTitle     = $TranslatedWord;
             my $FilterTitleDesc = Translatable('filter not active');
             if ( $Self->{GetColumnFilterSelect} && $Self->{GetColumnFilterSelect}->{$HeaderColumn} )
             {

--- a/Kernel/Output/HTML/TicketOverview/Small.pm
+++ b/Kernel/Output/HTML/TicketOverview/Small.pm
@@ -655,7 +655,7 @@ sub Run {
                 }
 
                 # set title description
-                my $TitleDesc = $OrderBy eq 'Down' ? 'sorted descending' : 'sorted ascending';
+                my $TitleDesc = $OrderBy eq 'Down' ? Translatable('sorted descending') : Translatable('sorted ascending');
                 $TitleDesc = $LayoutObject->{LanguageObject}->Translate($TitleDesc);
                 $Title .= ', ' . $TitleDesc;
             }
@@ -702,7 +702,7 @@ sub Run {
             );
 
             $CSS = $Column;
-            my $Title = $Column;
+            my $Title = $LayoutObject->{LanguageObject}->Translate($Column);
 
             # output overall block so TicketNumber as well as other columns can be ordered
             $LayoutObject->Block(
@@ -723,7 +723,7 @@ sub Run {
                     }
 
                     # add title description
-                    my $TitleDesc = $OrderBy eq 'Down' ? 'sorted ascending' : 'sorted descending';
+                    my $TitleDesc = $OrderBy eq 'Down' ? Translatable('sorted ascending') : Translatable('sorted descending');
                     $TitleDesc = $LayoutObject->{LanguageObject}->Translate($TitleDesc);
                     $Title .= ', ' . $TitleDesc;
                 }
@@ -748,7 +748,7 @@ sub Run {
                     $TranslatedWord = $LayoutObject->{LanguageObject}->Translate($Column);
                 }
 
-                my $FilterTitle     = $Column;
+                my $FilterTitle     = $TranslatedWord;
                 my $FilterTitleDesc = Translatable('filter not active');
                 if (
                     $Self->{StoredFilters} &&
@@ -906,7 +906,7 @@ sub Run {
                     }
 
                     # add title description
-                    my $TitleDesc = $OrderBy eq 'Down' ? 'sorted ascending' : 'sorted descending';
+                    my $TitleDesc = $OrderBy eq 'Down' ? Translatable('sorted ascending') : Translatable('sorted descending');
                     $TitleDesc = $LayoutObject->{LanguageObject}->Translate($TitleDesc);
                     $Title .= ', ' . $TitleDesc;
                 }
@@ -932,11 +932,11 @@ sub Run {
                     $TranslatedWord = $LayoutObject->{LanguageObject}->Translate($Column);
                 }
 
-                my $FilterTitle     = $Column;
-                my $FilterTitleDesc = 'filter not active';
+                my $FilterTitle     = $TranslatedWord;
+                my $FilterTitleDesc = Translatable('filter not active');
                 if ( $Self->{StoredFilters} && $Self->{StoredFilters}->{ $Column . 'IDs' } ) {
                     $CSS .= ' FilterActive';
-                    $FilterTitleDesc = 'filter active';
+                    $FilterTitleDesc = Translatable('filter active');
                 }
                 $FilterTitleDesc = $LayoutObject->{LanguageObject}->Translate($FilterTitleDesc);
                 $FilterTitle .= ', ' . $FilterTitleDesc;
@@ -1114,7 +1114,7 @@ sub Run {
                         }
 
                         # add title description
-                        my $TitleDesc = $OrderBy eq 'Down' ? 'sorted ascending' : 'sorted descending';
+                        my $TitleDesc = $OrderBy eq 'Down' ? Translatable('sorted ascending') : Translatable('sorted descending');
                         $TitleDesc = $LayoutObject->{LanguageObject}->Translate($TitleDesc);
                         $Title .= ', ' . $TitleDesc;
                     }


### PR DESCRIPTION
Hi @mgruner 
This PR makes translatable the title attributes of the headers of the ticket tables on the dashboard and the headers of ticket small view on status view. These strings are only displayed, if you hover the mouse over the table headers. Now it also translates the sorted and filtered headers.
Rel-5_0 is also affected.