### PR TITLE
[ Master Bug 8822 ] - Queue system address settings does not follow the postmaster mail account settings in some cases

### DIFF
--- a/Kernel/Modules/AdminSystemAddress.pm
+++ b/Kernel/Modules/AdminSystemAddress.pm
@@ -91,14 +91,14 @@ sub Run {
         # if no errors occurred
         if ( !%Errors ) {
 
+            my $Success = $SystemAddressObject->SystemAddressUpdate(
+                %GetParam,
+                UserID => $Self->{UserID},
+            );
+
             # update email system address
-            if (
-                $SystemAddressObject->SystemAddressUpdate(
-                    %GetParam,
-                    UserID => $Self->{UserID},
-                )
-                )
-            {
+            if ( $Success ){
+
                 # if the user would like to continue editing system e-mail address, just redirect to the edit screen
                 # otherwise return to overview
                 if (
@@ -114,6 +114,28 @@ sub Run {
                     return $LayoutObject->Redirect( OP => "Action=$Self->{Action}" );
                 }
             }
+            else{
+
+                $Self->_Overview();
+                my $Output = $LayoutObject->Header();
+                $Output .= $LayoutObject->NavigationBar();
+
+                $Output .= $LayoutObject->Notify(
+                    Priority => 'Error',
+                    Info     => Translatable(
+                        'System e-mail address is a parameter in some queue(s) and it should not be changed!'
+                    ),
+                );
+
+                $Output .= $LayoutObject->Output(
+                    TemplateFile => 'AdminSystemAddress',
+                    Data         => \%Param,
+                );
+                $Output .= $LayoutObject->Footer();
+                return $Output;
+
+            }
+
         }
 
         # something has gone wrong

--- a/Kernel/Modules/AdminSystemAddress.pm
+++ b/Kernel/Modules/AdminSystemAddress.pm
@@ -35,6 +35,8 @@ sub Run {
     #create local object
     my $CheckItemObject = Kernel::System::CheckItem->new( %{$Self} );
 
+    my $Notification = $ParamObject->GetParam( Param => 'Notification' ) || '';
+
     # ------------------------------------------------------------ #
     # change
     # ------------------------------------------------------------ #
@@ -45,6 +47,18 @@ sub Run {
         );
         my $Output = $LayoutObject->Header();
         $Output .= $LayoutObject->NavigationBar();
+
+        if ( $Notification && $Notification eq 'Update' ) {
+            $Output .= $LayoutObject->Notify( Info => Translatable('System e-mail address updated!') );
+        }
+        elsif ( $Notification && $Notification eq 'NotPosibleSetInvalid' ) {
+            $Output
+                .= $LayoutObject->Notify(
+                Info =>
+                    Translatable('System e-mail address is a parameter in some queue(s) and it should not be changed!')
+                );
+        }
+
         $Self->_Edit(
             Action => 'Change',
             %Data,
@@ -97,43 +111,17 @@ sub Run {
             );
 
             # update email system address
-            if ( $Success ){
+            my $Notification = $Success ? 'Update' : 'NotPosibleSetInvalid';
 
-                # if the user would like to continue editing system e-mail address, just redirect to the edit screen
-                # otherwise return to overview
-                if (
-                    defined $ParamObject->GetParam( Param => 'ContinueAfterSave' )
-                    && ( $ParamObject->GetParam( Param => 'ContinueAfterSave' ) eq '1' )
-                    )
-                {
-                    return $LayoutObject->Redirect(
-                        OP => "Action=$Self->{Action};Subaction=Change;ID=$GetParam{ID}"
-                    );
-                }
-                else {
-                    return $LayoutObject->Redirect( OP => "Action=$Self->{Action}" );
-                }
+            # if the user would like to continue editing system e-mail address, just redirect to the edit screen
+            # otherwise return to overview
+            if ( $ParamObject->GetParam( Param => 'ContinueAfterSave' ) eq '1' ) {
+                return $LayoutObject->Redirect(
+                    OP => "Action=$Self->{Action};Subaction=Change;ID=$GetParam{ID};Notification=$Notification"
+                );
             }
-            else{
-
-                $Self->_Overview();
-                my $Output = $LayoutObject->Header();
-                $Output .= $LayoutObject->NavigationBar();
-
-                $Output .= $LayoutObject->Notify(
-                    Priority => 'Error',
-                    Info     => Translatable(
-                        'System e-mail address is a parameter in some queue(s) and it should not be changed!'
-                    ),
-                );
-
-                $Output .= $LayoutObject->Output(
-                    TemplateFile => 'AdminSystemAddress',
-                    Data         => \%Param,
-                );
-                $Output .= $LayoutObject->Footer();
-                return $Output;
-
+            else {
+                return $LayoutObject->Redirect( OP => "Action=$Self->{Action};Notification=$Notification" );
             }
 
         }
@@ -256,6 +244,18 @@ sub Run {
 
         my $Output = $LayoutObject->Header();
         $Output .= $LayoutObject->NavigationBar();
+
+        if ( $Notification && $Notification eq 'Update' ) {
+            $Output .= $LayoutObject->Notify( Info => Translatable('System e-mail address updated!') );
+        }
+        elsif ( $Notification && $Notification eq 'NotPosibleSetInvalid' ) {
+            $Output
+                .= $LayoutObject->Notify(
+                Info =>
+                    Translatable('System e-mail address is a parameter in some queue(s) and it should not be changed!')
+                );
+        }
+
         $Output .= $LayoutObject->Output(
             TemplateFile => 'AdminSystemAddress',
             Data         => \%Param,

--- a/scripts/test/Selenium/Agent/Admin/AdminSystemAddress.t
+++ b/scripts/test/Selenium/Agent/Admin/AdminSystemAddress.t
@@ -204,12 +204,12 @@ $Selenium->RunTest(
         # try to set system address ID to invalid
         $Selenium->execute_script("\$('#ValidID').val('2').trigger('redraw.InputField').trigger('change')");
         $Selenium->find_element( "button[value='Save'][type='submit']", 'css' )->VerifiedClick();
+
+        #check is there notification
+        my $Notification = "System e-mail address is a parameter in some queue(s) and it should not be changed!";
         $Self->True(
-            index(
-                $Selenium->get_page_source(),
-                'System e-mail address is a parameter in some queue(s) and it should not be changed!'
-                ) > -1,
-            "'$SysAddRandom' can't be set to invalid because it is parameter in some queue(s)",
+            $Selenium->execute_script("return \$('.MessageBox.Notice p:contains($Notification)').length"),
+            "$Notification - notification is found."
         );
 
         # update queue back to the system address ID = 1


### PR DESCRIPTION
http://bugs.otrs.org/show_bug.cgi?id=8822

Hi @mgruner 

Hereby is fixed this bug, this is only our proposal. Actually, there is updated SystemAddressUpdate and there is not possible to set to invalid SystemAddress which there is as system address for a Queue.

There are updated unit test and Selenium test as well.
Please let me know what do you think about that.

Regards
Zoran
