### PR TITLE
Master - JS refactoring - part1

### DIFF
--- a/Kernel/Output/HTML/Layout.pm
+++ b/Kernel/Output/HTML/Layout.pm
@@ -1459,9 +1459,31 @@ sub Footer {
     my $Type          = $Param{Type}           || '';
     my $HasDatepicker = $Self->{HasDatepicker} || 0;
 
-    # Generate the minified CSS and JavaScript files and the tags referencing them (see LayoutLoader)
+    # generate the minified CSS and JavaScript files and the tags referencing them (see LayoutLoader)
     $Self->LoaderCreateAgentJSCalls();
     $Self->LoaderCreateJavaScriptTranslationData();
+
+    # get config object
+    my $ConfigObject = $Kernel::OM->Get('Kernel::Config');
+
+    my %JSConfig = (
+        Baselink                 => $Self->{Baselink},
+        CGIHandle                => $Self->{CGIHandle},
+        WebPath                  => $ConfigObject->Get('Frontend::WebPath'),
+        Action                   => $Self->{Action},
+        SessionIDCookie          => $Self->{SessionIDCookie},
+        SessionName              => $Self->{SessionName},
+        SessionID                => $Self->{SessionID},
+        ChallengeToken           => $Self->{UserChallengeToken},
+        CustomerPanelSessionName => $ConfigObject->Get('CustomerPanelSessionName'),
+    );
+
+    for my $Config ( sort keys %JSConfig ) {
+        $Self->AddJSData(
+            Key   => $Config,
+            Value => $JSConfig{$Config},
+        );
+    }
 
     # get datepicker data, if needed in module
     if ($HasDatepicker) {
@@ -1480,8 +1502,6 @@ sub Footer {
             },
         );
     }
-
-    my $ConfigObject = $Kernel::OM->Get('Kernel::Config');
 
     # NewTicketInNewWindow
     if ( $ConfigObject->Get('NewTicketInNewWindow::Enabled') ) {
@@ -1542,7 +1562,7 @@ sub Footer {
     }
 
     # Don't check for business package if the database was not yet configured (in the installer)
-    if ( $Kernel::OM->Get('Kernel::Config')->Get('SecureMode') ) {
+    if ( $ConfigObject->Get('SecureMode') ) {
         $Param{OTRSBusinessIsInstalled} = $Kernel::OM->Get('Kernel::System::OTRSBusiness')->OTRSBusinessIsInstalled();
     }
 
@@ -2441,6 +2461,8 @@ sub Attachment {
         }
     }
 
+    # get config object
+    my $ConfigObject = $Kernel::OM->Get('Kernel::Config');
     # return attachment
     my $Output = 'Content-Disposition: ';
     if ( $Param{Type} ) {
@@ -2448,7 +2470,7 @@ sub Attachment {
         $Output .= '; ';
     }
     else {
-        $Output .= $Kernel::OM->Get('Kernel::Config')->Get('AttachmentDownloadType') || 'attachment';
+        $Output .= $ConfigObject->Get('AttachmentDownloadType') || 'attachment';
         $Output .= '; ';
     }
 
@@ -2472,7 +2494,7 @@ sub Attachment {
     $Output .= "Content-Length: $Param{Size}\n";
     $Output .= "X-UA-Compatible: IE=edge,chrome=1\n";
 
-    if ( !$Kernel::OM->Get('Kernel::Config')->Get('DisableIFrameOriginRestricted') ) {
+    if ( !$ConfigObject->Get('DisableIFrameOriginRestricted') ) {
         $Output .= "X-Frame-Options: SAMEORIGIN\n";
     }
 

--- a/Kernel/Output/HTML/Templates/Standard/FooterJS.tt
+++ b/Kernel/Output/HTML/Templates/Standard/FooterJS.tt
@@ -27,16 +27,6 @@ Core.App.Ready(function () {
 
     Core.Config.AddConfig({
         // config
-        Baselink: '[% Env("Baselink") %]',
-        AjaxDebug: '[% Config("Frontend::AjaxDebug") %]',
-        CGIHandle: '[% Env("CGIHandle") %]',
-        WebPath: '[% Config("Frontend::WebPath") %]',
-        Action: '[% Env("Action") | html %]',
-        SessionIDCookie: '[% Env("SessionIDCookie") | html %]',
-        SessionName: '[% Config("SessionName") %]',
-        SessionID: '[% Env("SessionID") | html %]',
-        ChallengeToken: '[% Env("UserChallengeToken") | html %]',
-        CustomerPanelSessionName: '[% Config("CustomerPanelSessionName") %]',
         Images: '[% Config("Frontend::ImagePath") %]',
         UserLanguage: '[% Env("UserLanguage") | html %]',
         UserID: '[% Env("UserID") | html %]',
@@ -59,9 +49,6 @@ Core.App.Ready(function () {
         SearchFrontend: [% Data.SearchFrontendConfig | JSON %],
 [% RenderBlockEnd("SearchFrontendConfig") %]
         CheckSearchStringsForStopWords: [% Config("Ticket::SearchIndex::WarnOnStopWordUsage") and Config("Ticket::SearchIndexModule") == 'Kernel::System::Ticket::ArticleSearchIndex::StaticDB' ? 1 : 0 %],
-        // translations
-        BrowserListMsg: [% Translate("OTRS runs with a huge lists of browsers, please upgrade to one of these.") | JSON %],
-        BrowserDocumentationMsg: [% Translate("Please see the documentation or ask your admin for further information.") | JSON %],
     });
 
     [% PROCESS JSDataInsert %]


### PR DESCRIPTION
Hi @zottto and @mrcbnsls 

This is first PR for the test where we will refactoring JS code in the framework. As Marc suggested I started with removing global config params from AddConfig call.
There is added AddJSData in Layout Footer method, I think it is OK because these params are used in whole framework. If it is OK I can continue and do the same with other config items in FooterJS. I am planing to check if I can put somewhere else AddJSData if it is not necessary to be globall for all screens ( for example IncludeUnknownTicketCustomers it is used in AgentCustomerInformationCenterSearch and AgentCustomerSearch  but also in Core.Agent.Dashboard.js and Core.Agent.TableFilters.js) Should I put this one also in Layout Footer.

I also removed:
```
        // translations
-        BrowserListMsg: [% Translate("OTRS runs with a huge lists of browsers, please upgrade to one of these.") | JSON %],
-        BrowserDocumentationMsg: [% Translate("Please see the documentation or ask your admin for further information.") | JSON %],
```
These two config are not used anywhere. 

Please let me know if I can improve it or if I on good way at all :)

Regards
Zoran

