### PR TITLE
Whitelisted characters allowed in filenames for security

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,4 +1,5 @@
-#6.0.0.beta1 2016-??-??
+#6.0.0.beta1 2016-??-??  
+ - 2016-09-30 Attachment name validation added.
  - 2016-05-24 Whitelisted characters allowed in filenames for security.
  - 2016-05-04 Added the possiblity to configure the responsible field as mandatory (enabled by default for AgentTicketResponsible, if responsible feature is enabled), thanks to S7.
  - 2016-04-29 Reduced error log noise by reducing the log level of less important messages, thanks to Pawel Boguslawski.

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,4 +1,5 @@
 #6.0.0.beta1 2016-??-??
+ - 2016-05-24 Whitelisted characters allowed in filenames for security.
  - 2016-05-04 Added the possiblity to configure the responsible field as mandatory (enabled by default for AgentTicketResponsible, if responsible feature is enabled), thanks to S7.
  - 2016-04-29 Reduced error log noise by reducing the log level of less important messages, thanks to Pawel Boguslawski.
  - 2016-04-29 Fixed parsing CSV data with quoted values containing newlines, thanks to Pawel Boguslawski.

--- a/Kernel/System/EmailParser.pm
+++ b/Kernel/System/EmailParser.pm
@@ -725,13 +725,16 @@ sub PartsAttachments {
         my ($SubjectString) = $Part->as_string() =~ m/^Subject: ([^\n]*(\n[ \t][^\n]*)*)/m;
         my $Subject = $Self->_DecodeString( String => $SubjectString );
 
-        # cleanup filename
-        $Subject = $Kernel::OM->Get('Kernel::System::Main')->FilenameCleanUp(
-            Filename => $Subject,
-            Type     => 'Attachment',
-        );
+        if ( defined($Subject) && ( length($Subject) > 0 ) ) {
 
-        if ( $Subject eq '' ) {
+            # cleanup filename
+            $Subject = $Kernel::OM->Get('Kernel::System::Main')->FilenameCleanUp(
+                Filename => $Subject,
+                Type     => 'Attachment',
+            );
+        }
+
+        if ( !defined($Subject) || ( length($Subject) == 0 ) ) {
             $Self->{NoFilenamePartCounter}++;
             $Subject = "file-$Self->{NoFilenamePartCounter}";
         }

--- a/Kernel/System/EmailParser.pm
+++ b/Kernel/System/EmailParser.pm
@@ -718,15 +718,19 @@ sub PartsAttachments {
         my ($SubjectString) = $Part->as_string() =~ m/^Subject: ([^\n]*(\n[ \t][^\n]*)*)/m;
         my $Subject = $Self->_DecodeString( String => $SubjectString );
 
-        # trim whitespace
-        $Subject =~ s/^\s+|\n|\s+$//g;
+        # only whitelisted characters allowed in filenames for security
+        $Subject =~ s/[^\w\-+.#_]/_/g;
+
+        # strip dots at the beginning of filenames
+        $Subject =~ s/^\.*//;
+
         if ( length($Subject) > 246 ) {
             $Subject = substr( $Subject, 0, 246 );
         }
 
         if ( $Subject eq '' ) {
             $Self->{NoFilenamePartCounter}++;
-            $Subject = "Unbenannt-$Self->{NoFilenamePartCounter}";
+            $Subject = "file-$Self->{NoFilenamePartCounter}";
         }
         $PartData{Filename} = $Subject . '.eml';
     }

--- a/Kernel/System/EmailParser.pm
+++ b/Kernel/System/EmailParser.pm
@@ -689,6 +689,13 @@ sub PartsAttachments {
             String => $Part->head()->recommended_filename(),
             Encode => 'utf-8',
         );
+
+        # cleanup filename
+        $PartData{Filename} = $Kernel::OM->Get('Kernel::System::Main')->FilenameCleanUp(
+            Filename => $PartData{Filename},
+            Type     => 'Attachment',
+        );
+
         $PartData{ContentDisposition} = $Part->head()->get('Content-Disposition');
         if ( $PartData{ContentDisposition} ) {
             my %Data = $Self->GetContentTypeParams(

--- a/Kernel/System/EmailParser.pm
+++ b/Kernel/System/EmailParser.pm
@@ -718,15 +718,11 @@ sub PartsAttachments {
         my ($SubjectString) = $Part->as_string() =~ m/^Subject: ([^\n]*(\n[ \t][^\n]*)*)/m;
         my $Subject = $Self->_DecodeString( String => $SubjectString );
 
-        # only whitelisted characters allowed in filenames for security
-        $Subject =~ s/[^\w\-+.#_]/_/g;
-
-        # strip dots at the beginning of filenames
-        $Subject =~ s/^\.*//;
-
-        if ( length($Subject) > 246 ) {
-            $Subject = substr( $Subject, 0, 246 );
-        }
+        # cleanup filename
+        $Subject = $Kernel::OM->Get('Kernel::System::Main')->FilenameCleanUp(
+            Filename => $Subject,
+            Type     => 'Attachment',
+        );
 
         if ( $Subject eq '' ) {
             $Self->{NoFilenamePartCounter}++;

--- a/Kernel/System/Main.pm
+++ b/Kernel/System/Main.pm
@@ -237,8 +237,11 @@ sub FilenameCleanUp {
     # replace invalid token for attachment file names
     elsif ( $Type eq 'attachment' ) {
 
-        # replace invalid token like < > ? " : ; | \ / or *
-        $Param{Filename} =~ s/[ <>\?":\\\*\|\/;\[\]]/_/g;
+        # only whitelisted characters allowed in filenames for security
+        $Param{Filename} =~ s/[^\w\-+.#_]/_/g;
+
+        # strip dots at the beginning of filenames
+        $Param{Filename} =~ s/^\.*//;
 
         # replace utf8 and iso
         $Param{Filename} =~ s/(\x{00C3}\x{00A4}|\x{00A4})/ae/g;
@@ -261,8 +264,12 @@ sub FilenameCleanUp {
     }
     else {
 
-        # replace invalid token like [ ] * : ? " < > ; | \ /
-        $Param{Filename} =~ s/[<>\?":\\\*\|\/;\[\]]/_/g;
+        # only whitelisted characters allowed in filenames for security
+        $Param{Filename} =~ s/[^\w\-+.#_]/_/g;
+
+        # strip dots at the beginning of filenames
+        $Param{Filename} =~ s/^\.*//;
+
     }
 
     return $Param{Filename};

--- a/Kernel/System/Main.pm
+++ b/Kernel/System/Main.pm
@@ -233,43 +233,39 @@ sub FilenameCleanUp {
         $Kernel::OM->Get('Kernel::System::Encode')->EncodeOutput( \$Param{Filename} );
         $Param{Filename} = md5_hex( $Param{Filename} );
     }
-
-    # replace invalid token for attachment file names
-    elsif ( $Type eq 'attachment' ) {
-
-        # only whitelisted characters allowed in filenames for security
-        $Param{Filename} =~ s/[^\w\-+.#_]/_/g;
-
-        # strip dots at the beginning of filenames
-        $Param{Filename} =~ s/^\.*//;
-
-        # replace utf8 and iso
-        $Param{Filename} =~ s/(\x{00C3}\x{00A4}|\x{00A4})/ae/g;
-        $Param{Filename} =~ s/(\x{00C3}\x{00B6}|\x{00B6})/oe/g;
-        $Param{Filename} =~ s/(\x{00C3}\x{00BC}|\x{00FC})/ue/g;
-        $Param{Filename} =~ s/(\x{00C3}\x{009F}|\x{00C4})/Ae/g;
-        $Param{Filename} =~ s/(\x{00C3}\x{0096}|\x{0096})/Oe/g;
-        $Param{Filename} =~ s/(\x{00C3}\x{009C}|\x{009C})/Ue/g;
-        $Param{Filename} =~ s/(\x{00C3}\x{009F}|\x{00DF})/ss/g;
-        $Param{Filename} =~ s/-+/-/g;
-
-        # cut the string if too long
-        if ( length( $Param{Filename} ) > 100 ) {
-            my $Ext = '';
-            if ( $Param{Filename} =~ /^.*(\.(...|....))$/ ) {
-                $Ext = $1;
-            }
-            $Param{Filename} = substr( $Param{Filename}, 0, 95 ) . $Ext;
-        }
-    }
     else {
 
-        # only whitelisted characters allowed in filenames for security
+        # trim whitespace
+        $Param{Filename} =~ s/^\s+|\n|\s+$//g;
+
+        # strip leading dots
+        $Param{Filename} =~ s/^\.+//;
+
+        # only whitelisted characters allowed in filename for security
         $Param{Filename} =~ s/[^\w\-+.#_]/_/g;
 
-        # strip dots at the beginning of filenames
-        $Param{Filename} =~ s/^\.*//;
+        # additional cleaup for attachment filename
+        if ( $Type eq 'attachment' ) {
 
+            # replace utf8 and iso
+            $Param{Filename} =~ s/(\x{00C3}\x{00A4}|\x{00A4})/ae/g;
+            $Param{Filename} =~ s/(\x{00C3}\x{00B6}|\x{00B6})/oe/g;
+            $Param{Filename} =~ s/(\x{00C3}\x{00BC}|\x{00FC})/ue/g;
+            $Param{Filename} =~ s/(\x{00C3}\x{009F}|\x{00C4})/Ae/g;
+            $Param{Filename} =~ s/(\x{00C3}\x{0096}|\x{0096})/Oe/g;
+            $Param{Filename} =~ s/(\x{00C3}\x{009C}|\x{009C})/Ue/g;
+            $Param{Filename} =~ s/(\x{00C3}\x{009F}|\x{00DF})/ss/g;
+            $Param{Filename} =~ s/-+/-/g;
+
+            # cut the string if too long
+            if ( length( $Param{Filename} ) > 100 ) {
+                my $Ext = '';
+                if ( $Param{Filename} =~ /^.*(\.(...|....))$/ ) {
+                    $Ext = $1;
+                }
+                $Param{Filename} = substr( $Param{Filename}, 0, 95 ) . $Ext;
+            }
+        }
     }
 
     return $Param{Filename};

--- a/Kernel/System/Ticket/ArticleStorageFS.pm
+++ b/Kernel/System/Ticket/ArticleStorageFS.pm
@@ -354,12 +354,6 @@ sub ArticleWriteAttachment {
     # define path
     $Param{Path} = $Self->{ArticleDataDir} . '/' . $ContentPath . '/' . $Param{ArticleID};
 
-    # strip spaces from filenames
-    $Param{Filename} =~ s/ /_/g;
-
-    # strip dots from filenames
-    $Param{Filename} =~ s/^\.//g;
-
     # get main object
     my $MainObject = $Kernel::OM->Get('Kernel::System::Main');
 

--- a/Kernel/System/Web/Request.pm
+++ b/Kernel/System/Web/Request.pm
@@ -17,6 +17,7 @@ use File::Path qw();
 
 our @ObjectDependencies = (
     'Kernel::Config',
+    'Kernel::System::Main',
     'Kernel::System::CheckItem',
     'Kernel::System::Encode',
 );
@@ -267,6 +268,12 @@ sub GetUploadAll {
     # replace all devices like c: or d: and dirs for IE!
     $NewFileName =~ s/.:\\(.*)/$1/g;
     $NewFileName =~ s/.*\\(.+?)/$1/g;
+
+    # cleanup filename
+    $NewFileName = $Kernel::OM->Get('Kernel::System::Main')->FilenameCleanUp(
+        Filename => $NewFileName,
+        Type     => 'Attachment',
+    );
 
     # return a string
     my $Content;

--- a/scripts/test/EmailParser/FilenameWithNewline.t
+++ b/scripts/test/EmailParser/FilenameWithNewline.t
@@ -42,7 +42,7 @@ $Self->Is(
 
 $Self->Is(
     $Attachments[2]->{'Filename'} || '',
-    'Test testtestt 1231234/34/Testtesttes testes testtesttestt - testtesttes dokumentów/Sprzedaż, testTE [...] [TE#123123123].eml',
+    'Test_testtestt_1231234_34_Testtesttes_testes_testtesttestt_-_testtesttes_dokumentów_Sprzedaż__t.eml',
     "Filename with multiple newlines removed",
 );
 

--- a/scripts/test/EmailParser/NestedMessage.t
+++ b/scripts/test/EmailParser/NestedMessage.t
@@ -38,7 +38,7 @@ $Self->Is(
 
 $Self->Is(
     $Attachments[2]->{Filename} || '',
-    '[Presse-Greenpeace] Morgen wird Greenpeace-Einspruch gegenEmbryonen-Patent verhandelt - NeueDokumentation ueber Patente auf Leben.eml',
+    '_Presse-Greenpeace__Morgen_wird_Greenpeace-Einspruch_gegenEmbryonen-Patent_verhandelt_-_NeueDok.eml',
     "Nested message filename",
 );
 

--- a/scripts/test/Main.t
+++ b/scripts/test/Main.t
@@ -25,7 +25,7 @@ my @Tests = (
     {
         Name         => 'FilenameCleanUp() - Local',
         FilenameOrig => 'me_t o/alal.xml',
-        FilenameNew  => 'me_t o_alal.xml',
+        FilenameNew  => 'me_t_o_alal.xml',
         Type         => 'Local',
     },
     {
@@ -61,8 +61,20 @@ my @Tests = (
     {
         Name         => 'FilenameCleanUp() - Local',
         FilenameOrig => 'me_to/a+lal Grüße 0.xml',
-        FilenameNew  => 'me_to_a+lal Grüße 0.xml',
+        FilenameNew  => 'me_to_a+lal_Grüße_0.xml',
         Type         => 'Local',
+    },
+    {
+        Name         => 'FilenameCleanUp() - leading dots - Local',
+        FilenameOrig => '....test.xml',
+        FilenameNew  => 'test.xml',
+        Type         => 'Local',
+    },
+    {
+        Name         => 'FilenameCleanUp() - leading dots - Attachment',
+        FilenameOrig => '....test.xml',
+        FilenameNew  => 'test.xml',
+        Type         => 'Attachment',
     },
     {
         Name => 'FilenameCleanUp() - Attachment',


### PR DESCRIPTION
OTRS uses bad chars blacklisting in attachment filename creation. Best
practice is to use whitelisting for security (to avoid possible other
bad chars in filenames).

This mod changes OTRS behaviour in this ares - only whitelisted
characters are allowed in filenames.

This mod also moves filename cleanup logic to one place -
the FilenameCleanUp() function - and fixes leading dots removing regexp
(was removing only first leading dot in filename).

Related: https://dev.ib.pl/ib/otrs/issues/59
Related: http://bugs.otrs.org/show_bug.cgi?id=10395
Author-Change-Id: IB#1016067
