### PR TITLE
Fixed premature end of script headers error when using long URL

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,4 +1,5 @@
 #6.0.0.beta1 2016-??-??
+ - 2016-05-25 Fixed premature end of script headers error when using long URL.
  - 2016-05-04 Added the possiblity to configure the responsible field as mandatory (enabled by default for AgentTicketResponsible, if responsible feature is enabled), thanks to S7.
  - 2016-04-29 Reduced error log noise by reducing the log level of less important messages, thanks to Pawel Boguslawski.
  - 2016-04-29 Fixed parsing CSV data with quoted values containing newlines, thanks to Pawel Boguslawski.

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,4 +1,5 @@
 #6.0.0.beta1 2016-??-??
+ - 2016-06-07 Fixed premature end of script headers error when using long URL.
  - 2016-05-25 Fixed premature end of script headers error when using long URL.
  - 2016-05-04 Added the possiblity to configure the responsible field as mandatory (enabled by default for AgentTicketResponsible, if responsible feature is enabled), thanks to S7.
  - 2016-04-29 Reduced error log noise by reducing the log level of less important messages, thanks to Pawel Boguslawski.

--- a/Kernel/System/Encode.pm
+++ b/Kernel/System/Encode.pm
@@ -62,7 +62,7 @@ sub new {
     if ( !is_interactive() ) {
 
         # encode STDOUT and STDERR
-        $Self->SetIO( \*STDOUT, \*STDERR );
+        $Self->SetO( \*STDOUT, \*STDERR );
     }
     else {
 
@@ -327,15 +327,15 @@ sub EncodeOutput {
     return $What;
 }
 
-=item SetIO()
+=item SetI()
 
-Set array of file handles to utf-8 output.
+Set array of file handles to utf-8 input.
 
-    $EncodeObject->SetIO( \*STDOUT, \*STDERR );
+    $EncodeObject->SetI( $FH );
 
 =cut
 
-sub SetIO {
+sub SetI {
     my ( $Self, @Array ) = @_;
 
     ROW:
@@ -347,6 +347,31 @@ sub SetIO {
         # http://www.perlmonks.org/?node_id=644786
         # http://bugs.otrs.org/show_bug.cgi?id=5158
         binmode( $Row, ':encoding(utf8)' );
+    }
+
+    return;
+}
+
+=item SetO()
+
+Set array of file handles to utf-8 output.
+
+    $EncodeObject->SetO( \*STDOUT, \*STDERR );
+
+=cut
+
+sub SetO {
+    my ( $Self, @Array ) = @_;
+
+    ROW:
+    for my $Row (@Array) {
+        next ROW if !defined $Row;
+        next ROW if ref $Row ne 'GLOB';
+
+        # use :utf8 for outputs to avoid header buffering problems
+        # when using mod_perl
+        # http://bugs.otrs.org/show_bug.cgi?id=12100
+        binmode( $Row, ':utf8' );
     }
 
     return;

--- a/Kernel/System/Log/File.pm
+++ b/Kernel/System/Log/File.pm
@@ -71,7 +71,7 @@ sub Log {
     }
 
     # write log file
-    $Kernel::OM->Get('Kernel::System::Encode')->SetIO($FH);
+    $Kernel::OM->Get('Kernel::System::Encode')->SetO($FH);
 
     print $FH '[' . localtime() . ']';    ## no critic
 

--- a/Kernel/System/Web/InterfaceAgent.pm
+++ b/Kernel/System/Web/InterfaceAgent.pm
@@ -503,27 +503,10 @@ sub Run {
         }
 
         # redirect with new session id
-        my $Result = $Kernel::OM->Get('Kernel::Output::HTML::Layout')->Redirect(
+        print $Kernel::OM->Get('Kernel::Output::HTML::Layout')->Redirect(
             OP    => $Param{RequestedURL},
             Login => 1,
         );
-
-        # "Premature end of script headers" bug occurs when STDOUT uses :encoding(utf8)
-        # and length (headers + \n\n) exceeds 1024 bytes; problem may be connected with
-        # 1024 buffer in Encode::PerlIO and its flushes and mod_perl ParseHeaders; no
-        # such problem with less safe :utf8 - will be used as workaround here;
-        # see also:
-        #    http://bugs.otrs.org/show_bug.cgi?id=12100
-        #    http://search.cpan.org/dist/Encode/lib/Encode/PerlIO.pod
-        #    https://github.com/OTRS/otrs/commit/28996cf88f8a57e70d52fed7ab8963b7f1b4771b
-        my @SplitResult = split("\n\n", $Result);
-        if ( length($SplitResult[0]) > 1022 ) {
-            # replaces :encoding(utf8) with :utf8
-            binmode(*STDOUT, ':pop(encoding):utf8');
-        }
-
-        print $Result;
-
         return 1;
     }
 


### PR DESCRIPTION
If you use mod_perl and you paste the following URL to your web browser
(without active OTRS session)...

    https://[yout otrs domain here]/otrs/index.pl?Action=AgentTicketQueue;QueueID=12;Filter=Unlocked;View=;SortBy=Age;OrderBy=Up;StartWindow=0;StartHit=21;TicketID=111378;TicketID=111647;TicketID=111941;TicketID=111985;TicketID=234056;TicketID=234056;TicketID=234079;TicketID=234178;TicketID=234214;TicketID=234214;TicketID=234255;TicketID=234459;TicketID=234434;TicketID=234428;TicketID=234865;TicketID=234728;TicketID=234786;TicketID=234786;TicketID=234957;TicketID=410006;TicketID=410006;TicketID=410161;TicketID=410199;TicketID=410319;TicketID=410292;TicketID=410581;TicketID=410618;TicketID=410587;TicketID=410907;TicketID=411009;TicketID=411028;TicketID=411184;TicketID=411363;TicketID=411375;TicketID=411354;TicketID=411354;TicketID=411381;TicketID=411426;TicketID=411596

...OTRS will ask you for login and password. After passing correct login
data, OTRS fires "Premature end of script headers: index.pl" error
on redirection.

The problem occurs if HTTP redirection response after login contain
HTTP headers that (all together) are longer than 1024 bytes.
The problem does not occur if you rollback change introduced in
28996cf88f8a57e70d52fed7ab8963b7f1b4771b.

This workaround switches STDOUT from :encoding(utf8) to :utf8 only
for redirection after successfull login.

Fixes: 28996cf88f8a57e70d52fed7ab8963b7f1b4771b
Related: https://dev.ib.pl/ib/otrs/issues/60
Related: http://bugs.otrs.org/show_bug.cgi?id=12100
Author-Change-Id: IB#1052183