### PR TITLE
Fixed POD.

### DIFF
--- a/Kernel/System/DynamicField/Backend.pm
+++ b/Kernel/System/DynamicField/Backend.pm
@@ -2526,6 +2526,7 @@ get the list distinct values for a dynamic field from a list of tickets
         ValueB => 'ValueB',
         ValueC => 'ValueC'
     };
+
 =cut
 
 sub ColumnFilterValuesGet {


### PR DESCRIPTION
While customizing and tiding this file the CodePolicy noted that POD blocks always have to end with an empty line.