### PR TITLE
Fixed Internal Server Error on attachment removal page reload

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,4 +1,5 @@
 #6.0.0.beta1 2016-??-??
+ - 2016-05-27 Fixed Internal Server Error on attachment removal page reload.
  - 2016-05-04 Added the possiblity to configure the responsible field as mandatory (enabled by default for AgentTicketResponsible, if responsible feature is enabled), thanks to S7.
  - 2016-04-29 Reduced error log noise by reducing the log level of less important messages, thanks to Pawel Boguslawski.
  - 2016-04-29 Fixed parsing CSV data with quoted values containing newlines, thanks to Pawel Boguslawski.

--- a/Kernel/System/Web/UploadCache/DB.pm
+++ b/Kernel/System/Web/UploadCache/DB.pm
@@ -132,6 +132,10 @@ sub FormIDRemoveFile {
     }
 
     my @Index = @{ $Self->FormIDGetAllFilesMeta(%Param) };
+
+    # finish if files have been already removed by other process
+    return if !@Index;
+
     my $ID    = $Param{FileID} - 1;
     $Param{Filename} = $Index[$ID]->{Filename};
 

--- a/Kernel/System/Web/UploadCache/FS.pm
+++ b/Kernel/System/Web/UploadCache/FS.pm
@@ -145,6 +145,10 @@ sub FormIDRemoveFile {
     }
 
     my @Index = @{ $Self->FormIDGetAllFilesMeta(%Param) };
+
+    # finish if files have been already removed by other process
+    return if !@Index;
+
     my $ID    = $Param{FileID} - 1;
     my %File  = %{ $Index[$ID] };
 


### PR DESCRIPTION
If you remove file from message form (i.e. in AgentTicketEmail) and then
refresh page (ignoring web browser warning) OTRS will throw Internal
Server Error and apache error log will contain message similar to

    Can't use an undefined value as a HASH reference at /opt/otrs/Kernel/System/Web/UploadCache/FS.pm line 177.\n

This mod fixes handling such errors in OTRS.

Related: https://dev.ib.pl/ib/otrs/issues/61
Author-Change-Id: IB#1052184