### PR TITLE
Fixed bug #12110 - ACL Queue limitation not working in CustomerTicketProcess

### DIFF
--- a/Kernel/Modules/CustomerTicketProcess.pm
+++ b/Kernel/Modules/CustomerTicketProcess.pm
@@ -4422,10 +4422,10 @@ sub _GetQueues {
         if ( $ConfigObject->Get('Ticket::Frontend::NewQueueSelectionType') eq 'Queue' ) {
             %Queues = $Kernel::OM->Get('Kernel::System::Ticket')->MoveList(
                 %Param,
-                Type    => 'create',
-                Action  => $Self->{Action},
-                QueueID => $Self->{QueueID},
-                UserID  => $ConfigObject->Get('CustomerPanelUserID'),
+                Type           => 'create',
+                Action         => $Self->{Action},
+                QueueID        => $Self->{QueueID},
+                CustomerUserID => $Self->{UserID},
             );
         }
         else {


### PR DESCRIPTION
See [bug #12110](http://bugs.otrs.org/show_bug.cgi?id=12110) for further information.