### PR TITLE
Allow half time units

### DIFF
--- a/Kernel/GenericInterface/Operation/Ticket/Common.pm
+++ b/Kernel/GenericInterface/Operation/Ticket/Common.pm
@@ -1064,7 +1064,7 @@ sub ValidateTimeUnit {
     return if !$Param{TimeUnit};
 
     # TimeUnit must be possitive
-    return if $Param{TimeUnit} !~ m{\A \d+? \z}xms;
+    return if $Param{TimeUnit} !~ m{\A \d+([.,]\d+)? \z}xms;
 
     return 1;
 }


### PR DESCRIPTION
Changed the regex so the webservice will allow to update/create tickets
with halftime time units (e.g 1.5 or 1,5)  like the web UI does.