### PR TITLE
Master - JS refactoring - Modify AdminGenericInterfaceMappingSimple

### DIFF
--- a/Kernel/Output/HTML/Templates/Standard/AdminGenericInterfaceMappingSimple.tt
+++ b/Kernel/Output/HTML/Templates/Standard/AdminGenericInterfaceMappingSimple.tt
@@ -249,22 +249,12 @@
                             <button class="Primary CallForAction" type="submit" value="[% Translate("Save") | html %]"><span>[% Translate("Save") | html %]</span></button>
                             [% Translate("or") | html %]
                             <button class="CallForAction" type="submit" id="SaveAndFinishButton" value="[% Translate("Save and finish") | html %]"><span>[% Translate("Save and finish") | html %]</span></button>
-                            <input type="hidden" name="ReturnToAction" id="ReturnToAction" value="" />
-[% WRAPPER JSOnDocumentComplete %]
-<script type="text/javascript">//<![CDATA[
-$('#SaveAndFinishButton').bind('click', function(){
-    $('#ReturnToAction').val(1);
-});
-//]]></script>
-[% END %]
-
+                            <input type="hidden" name="ReturnToAction" id="ReturnToAction" value="" />s
                             [% Translate("or") | html %]
                             <a href="[% Env("Baselink") %]Action=[% Data.ActionFrontendModule | uri %];Subaction=Change;[% Data.ActionType | uri %]=[% Data.Action | uri %];WebserviceID=[% Data.WebserviceID | uri %]">[% Translate("Cancel") | html %]</a>
                         </div>
-
                     </fieldset>
                     <div class="Clear"></div>
-
                 </form>
             </div>
         </div>

--- a/scripts/test/Selenium/Agent/Admin/AdminGenericInterfaceMappingSimple.t
+++ b/scripts/test/Selenium/Agent/Admin/AdminGenericInterfaceMappingSimple.t
@@ -1,0 +1,239 @@
+# --
+# Copyright (C) 2001-2016 OTRS AG, http://otrs.com/
+# --
+# This software comes with ABSOLUTELY NO WARRANTY. For details, see
+# the enclosed file COPYING for license information (AGPL). If you
+# did not receive this file, see http://www.gnu.org/licenses/agpl.txt.
+# --
+
+use strict;
+use warnings;
+use utf8;
+
+use vars (qw($Self));
+
+use Kernel::GenericInterface::Debugger;
+
+# get selenium object
+my $Selenium = $Kernel::OM->Get('Kernel::System::UnitTest::Selenium');
+
+$Selenium->RunTest(
+    sub {
+
+        # get needed objects
+        my $Helper           = $Kernel::OM->Get('Kernel::System::UnitTest::Helper');
+        my $WebserviceObject = $Kernel::OM->Get('Kernel::System::GenericInterface::Webservice');
+
+        # define needed variable
+        my $RandomID = $Helper->GetRandomID();
+
+        # create test webservice
+        my $WebserviceID = $WebserviceObject->WebserviceAdd(
+            Config => {
+                Debugger => {
+                    DebugThreshold => 'debug',
+                    TestMode       => 1,
+                },
+                Provider => {
+                    Transport => {
+                        Type => '',
+                    },
+                },
+            },
+            Name    => "Selenium $RandomID webservice",
+            ValidID => 1,
+            UserID  => 1,
+        );
+
+        $Self->True(
+            $WebserviceID,
+            "Webservice ID $WebserviceID is created"
+        );
+
+        # create debugger object
+        my $DebuggerObject = Kernel::GenericInterface::Debugger->new(
+            DebuggerConfig => {
+                DebugThreshold => 'debug',
+                TestMode       => 0,
+            },
+            WebserviceID      => $WebserviceID,
+            CommunicationType => 'Provider',
+        );
+
+        $Self->Is(
+            ref $DebuggerObject,
+            'Kernel::GenericInterface::Debugger',
+            'DebuggerObject instantiate correctly',
+        );
+
+        # create test user and login
+        my $TestUserLogin = $Helper->TestUserCreate(
+            Groups => ['admin'],
+        ) || die "Did not get test user";
+
+        $Selenium->Login(
+            Type     => 'Agent',
+            User     => $TestUserLogin,
+            Password => $TestUserLogin,
+        );
+
+        # get script alias
+        my $ScriptAlias = $Kernel::OM->Get('Kernel::Config')->Get('ScriptAlias');
+
+        # navigate to AdminGenericInterfaceWebservice screen
+        $Selenium->VerifiedGet("${ScriptAlias}index.pl?Action=AdminGenericInterfaceWebservice");
+
+        # click on created webservice
+        $Selenium->find_element("//a[contains(\@href, 'WebserviceID=$WebserviceID')]")->VerifiedClick();
+
+        # select 'Ticket::TicketCreate' as option
+        $Selenium->execute_script(
+            "\$('#OperationList').val('Ticket::TicketCreate').trigger('redraw.InputField').trigger('change');");
+
+        # create webservice operation
+        $Selenium->find_element( "#Operation", 'css' )->send_keys('SeleniumOperation');
+
+        # select simple mapping for inbound and outbound data
+        $Selenium->execute_script(
+            "\$('#MappingInbound').val('Simple').trigger('redraw.InputField').trigger('change');");
+        $Selenium->execute_script(
+            "\$('#MappingOutbound').val('Simple').trigger('redraw.InputField').trigger('change');");
+
+        # submit operation
+        $Selenium->find_element("//button[\@value='Save and continue']")->VerifiedClick();
+
+        # click to configure inbound mapping simple
+        $Selenium->find_element("//button[\@id='MappingInboundConfigureButton']")->VerifiedClick();
+
+        # check screen
+        for my $ID (
+            qw(DefaultKeyType_Search DefaultValueType_Search DefaultKeyMapTo DefaultValueMapTo AddKeyMapping)
+            )
+        {
+            my $Element = $Selenium->find_element( "#$ID", 'css' );
+            $Element->is_enabled();
+            $Element->is_displayed();
+        }
+
+        # verify DefaultKeyMapTo and DefaultValueMapTo are hidden with 'Keep (leave unchanged)' DefaultMapTo
+        # and JS will show them when Map to (use provided value as default) is selected
+        for my $DefaultMapTo (qw(DefaultKeyMapTo DefaultValueMapTo)) {
+            $Self->True(
+                $Selenium->execute_script(
+                    "return \$('#$DefaultMapTo').hasClass('Hidden')"
+                ),
+                "Field $DefaultMapTo is hidden"
+            );
+
+            # change default type
+            if ( $DefaultMapTo eq 'DefaultKeyMapTo' ) {
+                $Selenium->execute_script(
+                    "\$('#DefaultKeyType').val('MapTo').trigger('redraw.InputField').trigger('change');");
+            }
+            else {
+                $Selenium->execute_script(
+                    "\$('#DefaultValueType').val('MapTo').trigger('redraw.InputField').trigger('change');");
+            }
+
+            $Self->False(
+                $Selenium->execute_script(
+                    "return \$('#$DefaultMapTo').hasClass('Hidden')"
+                ),
+                "Field $DefaultMapTo is shown"
+            );
+
+            # submit and check client side validation on MapTo fields
+            $Selenium->find_element("//button[\@value='Save']")->click();
+
+            $Self->Is(
+                $Selenium->execute_script(
+                    "return \$('#$DefaultMapTo').hasClass('Error')"
+                ),
+                '1',
+                "Client side validation correctly detected missing input value for field $DefaultMapTo",
+            );
+
+            # input field
+            $Selenium->find_element( "#$DefaultMapTo", 'css' )->send_keys($DefaultMapTo);
+        }
+
+        # add key map
+        $Selenium->find_element( "#AddKeyMapping", 'css' )->click();
+
+        # add value map
+        $Selenium->find_element( "#AddValueMapping1", 'css' )->click();
+
+        # click on 'Save'
+        $Selenium->find_element("//button[\@value='Save']")->click();
+
+        # verify key and value mapping fields and check client side validation
+        for my $MapFields (qw(KeyName1 KeyMapNew1 ValueName1_1 ValueMapNew1_1)) {
+            $Self->Is(
+                $Selenium->execute_script(
+                    "return \$('#$MapFields').hasClass('Error')"
+                ),
+                '1',
+                "Client side validation correctly detected missing input value for field $MapFields",
+            );
+
+            # input checked field
+            my $InputField = $MapFields . $RandomID;
+            $Selenium->find_element( "#$MapFields", 'css' )->send_keys($InputField);
+        }
+
+        # click on 'Save'
+        $Selenium->find_element("//button[\@value='Save']")->VerifiedClick();
+
+        # verify after 'Save' click it is the same screen
+        $Self->True(
+            $Selenium->find_element( "#AddKeyMapping", 'css' ),
+            'After click on Save it is the same screen'
+        );
+
+        # click on 'Save and finish' test JS redirection
+        $Selenium->find_element("//button[\@value='Save and finish']")->VerifiedClick();
+
+        $Self->True(
+            $Selenium->get_current_url() =~ /AdminGenericInterfaceOperationDefault/,
+            'JS redirection is successful to AdminGenericInterfaceOperationDefault screen'
+        );
+
+        # click to configure inbound mapping simple again
+        $Selenium->find_element("//button[\@id='MappingInboundConfigureButton']")->VerifiedClick();
+
+        # verify inputed values
+        my %FieldValues = (
+            DefaultKeyMapTo   => 'DefaultKeyMapTo',
+            DefaultValueMapTo => 'DefaultValueMapTo',
+            KeyName1          => 'KeyName1' . $RandomID,
+            KeyMapNew1        => 'KeyMapNew1' . $RandomID,
+            ValueName1_1      => 'ValueName1_1' . $RandomID,
+            ValueMapNew1_1    => 'ValueMapNew1_1' . $RandomID,
+        );
+
+        for my $CheckField ( sort keys %FieldValues ) {
+            $Self->Is(
+                $Selenium->find_element( "#$CheckField", 'css' )->get_value(),
+                $FieldValues{$CheckField},
+                "Value for field $CheckField is found",
+            );
+        }
+
+        # delete test created webservice
+        my $Success = $WebserviceObject->WebserviceDelete(
+            ID     => $WebserviceID,
+            UserID => 1,
+        );
+        $Self->True(
+            $Success,
+            "Webservice ID $WebserviceID is deleted"
+        );
+
+        # make sure cache is correct
+        $Kernel::OM->Get('Kernel::System::Cache')->CleanUp( Type => 'Webservice' );
+
+    }
+
+);
+
+1;

--- a/var/httpd/htdocs/js/Core.Agent.Admin.GenericInterfaceMapping.js
+++ b/var/httpd/htdocs/js/Core.Agent.Admin.GenericInterfaceMapping.js
@@ -79,6 +79,11 @@ Core.Agent.Admin.GenericInterfaceMapping = (function (TargetNS) {
         //            $(this).parent().remove();
             return false;
         });
+
+        // bind click function to save and finish button
+        $('#SaveAndFinishButton').bind('click', function(){
+            $('#ReturnToAction').val(1);
+        });
     };
 
     /**
@@ -243,9 +248,9 @@ Core.Agent.Admin.GenericInterfaceMapping = (function (TargetNS) {
      * @name RemoveValueMapping
      * @memberof Core.Agent.Admin.GenericInterfaceMapping
      * @function
-     * @param {jQueryObject} Object - JQuery object used to decide if is, or not necessary to hide the input text control for MapTo value.
+     * @param {jQueryObject} Object - JQuery object where the new value mapping is removed.
      * @description
-     *      This function shows or hide the input text control for MapTo value.
+     *      This function removes a new value mapping dialog.
      */
     TargetNS.RemoveValueMapping = function (Object) {
         var ID = Object.attr('id'),

--- a/var/httpd/htdocs/js/Core.Agent.Admin.GenericInterfaceMapping.js
+++ b/var/httpd/htdocs/js/Core.Agent.Admin.GenericInterfaceMapping.js
@@ -64,7 +64,7 @@ Core.Agent.Admin.GenericInterfaceMapping = (function (TargetNS) {
             return false;
         });
 
-        //bind click function to add button
+        // bind click function to add button
         $('.ValueAdd').bind('click', function () {
             TargetNS.AddValueMapping(
                 $(this).closest('fieldset').parent().find('.ValueInsert'),
@@ -73,7 +73,7 @@ Core.Agent.Admin.GenericInterfaceMapping = (function (TargetNS) {
             return false;
         });
 
-        //bind click function to add button
+        // bind click function to remove button
         $('.ValueRemove').bind('click', function () {
             TargetNS.RemoveValueMapping($(this));
         //            $(this).parent().remove();
@@ -128,7 +128,7 @@ Core.Agent.Admin.GenericInterfaceMapping = (function (TargetNS) {
 
             if($(this).hasClass('KeyMapRemove')) {
 
-                // bind click function to add button
+                // bind click function to remove button
                 $(this).bind('click', function () {
                     TargetNS.ShowDeleteDialog($(this).attr('id'));
                     return false;
@@ -218,7 +218,7 @@ Core.Agent.Admin.GenericInterfaceMapping = (function (TargetNS) {
             // add event handler to remove button
             if($(this).hasClass('ValueRemove')) {
 
-                // bind click function to add button
+                // bind click function to remove button
                 $(this).bind('click', function () {
                     // remove row
                     TargetNS.RemoveValueMapping($(this));


### PR DESCRIPTION
Hello @mrcbnsls and @mgruner 

Hereby is uncompleted refactoring for AdminGenericInterfaceMappingSImple. There is one issue i would to consult with you before completing this PR.

In AdminGenericInterfaceMappingSImple.pm in constructor there is value for 
`"$Self->{DeletedString}` =`'_GenericInterface_Mapping_Simple_DeletedString_Dont_Use_It_String_Please';` on line 25. This is changed in commit on July 19, 2011 ( https://github.com/OTRS/otrs/commit/f87b480c5a9c4bc39a16307003e327c90b418d79 ) Where it is removed taking value from config. IMHO there happen a mistakes, since from the looks of it, it was copy pasted value that was in config as a template where agent can modify and see how the config should be used. This parameter is used later in code to mark which string can't be used as values in mapping.

Please, correct me if my findings are wrong. Perhaps there is justified reason why this change happened and how this parameter should be used correctly. I will modify and complete this PR accordingly to your input on how to proceed with this matter.

Additionally, created Selenium test for this module as well. If you have any additional cases you would like to see in it, let me know.

Looking forward to your reply.

Regards,
Sanjin