### PR TITLE
Fixed error Undefined value as a SCALAR reference at UploadCache/FS.pm

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,4 +1,5 @@
 #6.0.0.beta1 2016-??-??
+ - 2016-06-02 Fixed error Undefined value as a SCALAR reference at UploadCache/FS.pm.
  - 2016-05-04 Added the possiblity to configure the responsible field as mandatory (enabled by default for AgentTicketResponsible, if responsible feature is enabled), thanks to S7.
  - 2016-04-29 Reduced error log noise by reducing the log level of less important messages, thanks to Pawel Boguslawski.
  - 2016-04-29 Fixed parsing CSV data with quoted values containing newlines, thanks to Pawel Boguslawski.

--- a/Kernel/System/Web/UploadCache/FS.pm
+++ b/Kernel/System/Web/UploadCache/FS.pm
@@ -248,6 +248,7 @@ sub FormIDGetAllFilesData {
             Location => "$File.Disposition",
             Mode     => 'binmode',                                             # optional - binmode|utf8
         );
+        next FILE if !$Disposition;
 
         # strip filename
         $File =~ s/^.*\/$Param{FormID}\.(.+?)$/$1/;
@@ -340,6 +341,7 @@ sub FormIDGetAllFilesMeta {
             Location => "$File.Disposition",
             Mode     => 'binmode',                                             # optional - binmode|utf8
         );
+        next FILE if !$Disposition;
 
         # strip filename
         $File =~ s/^.*\/$Param{FormID}\.(.+?)$/$1/;


### PR DESCRIPTION
OTRS may throw

    Can't use an undefined value as a SCALAR reference at [...]UploadCache/FS.pm[...]

error to apache error log if two HTTP requests call same OTRS action
(i.e. web browser failure). This patch resolves this issue.

Related: https://dev.ib.pl/ib/otrs/issues/64
Author-Change-Id: IB#1052439