### PR TITLE
Added extra informations for ArticleDynamicFieldUpdate event.

### DIFF
--- a/Kernel/System/DynamicField/ObjectType/Article.pm
+++ b/Kernel/System/DynamicField/ObjectType/Article.pm
@@ -124,8 +124,12 @@ sub PostValueSet {
     $TicketObject->EventHandler(
         Event => 'ArticleDynamicFieldUpdate',
         Data  => {
+            FieldName => $Param{DynamicFieldConfig}->{Name},
+            Value     => $Param{Value},
+            OldValue  => $Param{OldValue},
             TicketID  => $Article{TicketID},
             ArticleID => $Param{ObjectID},
+            UserID    => $Param{UserID},
         },
         UserID => $Param{UserID},
     );


### PR DESCRIPTION
New keys in Hash: FieldName, OldValue, Value, UserID

This is very useful when writing events based on 2+ article dynamicfields in one event, since the event will be triggered after each event.