### PR TITLE
Fixed empty attachment ignoring and hardcoded english file size unit names

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,4 +1,5 @@
 #6.0.0.beta1 2016-??-??
+ - 2016-06-03 Fixed empty attachment ignoring and hardcoced english file size unit names.
  - 2016-05-04 Added the possiblity to configure the responsible field as mandatory (enabled by default for AgentTicketResponsible, if responsible feature is enabled), thanks to S7.
  - 2016-04-29 Reduced error log noise by reducing the log level of less important messages, thanks to Pawel Boguslawski.
  - 2016-04-29 Fixed parsing CSV data with quoted values containing newlines, thanks to Pawel Boguslawski.

--- a/Kernel/GenericInterface/Operation/Ticket/TicketGet.pm
+++ b/Kernel/GenericInterface/Operation/Ticket/TicketGet.pm
@@ -218,7 +218,7 @@ one or more ticket entries in one call.
                                     ContentID          => "",
                                     ContentType        => "application/pdf",
                                     Filename           => "StdAttachment-Test1.pdf",
-                                    Filesize           => "4.6 KBytes",
+                                    Filesize           => "4.6 KB",
                                     FilesizeRaw        => 4722,
                                 },
                                 {

--- a/Kernel/Modules/AdminPackageManager.pm
+++ b/Kernel/Modules/AdminPackageManager.pm
@@ -407,18 +407,18 @@ sub Run {
                     elsif ( $Hash->{Tag} =~ /^(File)$/ ) {
 
                         # add human readable file size
-                        if ( $Hash->{Size} ) {
+                        if ( defined $Hash->{Size} ) {
 
                             # remove meta data in files
                             if ( $Hash->{Size} > ( 1024 * 1024 ) ) {
-                                $Hash->{Size} = sprintf "%.1f MBytes",
+                                $Hash->{Size} = sprintf "%.1f MB",
                                     ( $Hash->{Size} / ( 1024 * 1024 ) );
                             }
                             elsif ( $Hash->{Size} > 1024 ) {
-                                $Hash->{Size} = sprintf "%.1f KBytes", ( ( $Hash->{Size} / 1024 ) );
+                                $Hash->{Size} = sprintf "%.1f KB", ( ( $Hash->{Size} / 1024 ) );
                             }
                             else {
-                                $Hash->{Size} = $Hash->{Size} . ' Bytes';
+                                $Hash->{Size} = $Hash->{Size} . ' B';
                             }
                         }
                         $LayoutObject->Block(
@@ -710,18 +710,18 @@ sub Run {
                     elsif ( $Hash->{Tag} =~ /^(File)$/ ) {
 
                         # add human readable file size
-                        if ( $Hash->{Size} ) {
+                        if ( defined $Hash->{Size} ) {
 
                             # remove meta data in files
                             if ( $Hash->{Size} > ( 1024 * 1024 ) ) {
-                                $Hash->{Size} = sprintf "%.1f MBytes",
+                                $Hash->{Size} = sprintf "%.1f MB",
                                     ( $Hash->{Size} / ( 1024 * 1024 ) );
                             }
                             elsif ( $Hash->{Size} > 1024 ) {
-                                $Hash->{Size} = sprintf "%.1f KBytes", ( ( $Hash->{Size} / 1024 ) );
+                                $Hash->{Size} = sprintf "%.1f KB", ( ( $Hash->{Size} / 1024 ) );
                             }
                             else {
-                                $Hash->{Size} = $Hash->{Size} . ' Bytes';
+                                $Hash->{Size} = $Hash->{Size} . ' B';
                             }
                         }
                         $LayoutObject->Block(

--- a/Kernel/Modules/AdminPackageManager.pm
+++ b/Kernel/Modules/AdminPackageManager.pm
@@ -408,19 +408,11 @@ sub Run {
 
                         # add human readable file size
                         if ( defined $Hash->{Size} ) {
-
-                            # remove meta data in files
-                            if ( $Hash->{Size} > ( 1024 * 1024 ) ) {
-                                $Hash->{Size} = sprintf "%.1f MB",
-                                    ( $Hash->{Size} / ( 1024 * 1024 ) );
-                            }
-                            elsif ( $Hash->{Size} > 1024 ) {
-                                $Hash->{Size} = sprintf "%.1f KB", ( ( $Hash->{Size} / 1024 ) );
-                            }
-                            else {
-                                $Hash->{Size} = $Hash->{Size} . ' B';
-                            }
+                            $Hash->{Size} = $MainObject->HumanReadableDataSize(
+                                Size => $Hash->{Size},
+                            );
                         }
+
                         $LayoutObject->Block(
                             Name => "PackageItemFilelistFile",
                             Data => {
@@ -711,19 +703,11 @@ sub Run {
 
                         # add human readable file size
                         if ( defined $Hash->{Size} ) {
-
-                            # remove meta data in files
-                            if ( $Hash->{Size} > ( 1024 * 1024 ) ) {
-                                $Hash->{Size} = sprintf "%.1f MB",
-                                    ( $Hash->{Size} / ( 1024 * 1024 ) );
-                            }
-                            elsif ( $Hash->{Size} > 1024 ) {
-                                $Hash->{Size} = sprintf "%.1f KB", ( ( $Hash->{Size} / 1024 ) );
-                            }
-                            else {
-                                $Hash->{Size} = $Hash->{Size} . ' B';
-                            }
+                            $Hash->{Size} = $MainObject->HumanReadableDataSize(
+                                Size => $Hash->{Size},
+                            );
                         }
+
                         $LayoutObject->Block(
                             Name => 'PackageItemFilelistFile',
                             Data => {

--- a/Kernel/Modules/AdminPerformanceLog.pm
+++ b/Kernel/Modules/AdminPerformanceLog.pm
@@ -233,7 +233,7 @@ sub Run {
                 $LayoutObject->Block(
                     Name => 'Reset',
                     Data => {
-                        Size => sprintf "%.1f MBytes",
+                        Size => sprintf "%.1f MB",
                         ( $Self->_DatabaseCheck() / ( 1024 * 1024 ) ),
                     },
                 );

--- a/Kernel/System/EmailParser.pm
+++ b/Kernel/System/EmailParser.pm
@@ -452,7 +452,7 @@ sub GetMessageBody {
     my ( $Self, %Param ) = @_;
 
     # check if message body is already there
-    return $Self->{MessageBody} if $Self->{MessageBody};
+    return $Self->{MessageBody} if defined $Self->{MessageBody};
 
     # get encode object
     my $EncodeObject = $Kernel::OM->Get('Kernel::System::Encode');
@@ -667,9 +667,8 @@ sub PartsAttachments {
         if ( !$PartData{Content} ) {
             $Kernel::OM->Get('Kernel::System::Log')->Log(
                 Priority => 'notice',
-                Message  => "Totally empty attachment part ($PartCounter)",
+                Message  => "Empty attachment part ($PartCounter)",
             );
-            return;
         }
     }
 

--- a/Kernel/System/HTMLUtils.pm
+++ b/Kernel/System/HTMLUtils.pm
@@ -889,7 +889,7 @@ sub LinkQuote {
     }
 
     # check ref && return result like called
-    if ($StringScalar) {
+    if (defined $StringScalar) {
         return ${$String};
     }
     return $String;

--- a/Kernel/System/Main.pm
+++ b/Kernel/System/Main.pm
@@ -665,7 +665,7 @@ get a md5 sum of a file or a string
 sub MD5sum {
     my ( $Self, %Param ) = @_;
 
-    if ( !$Param{Filename} && !$Param{String} ) {
+    if ( !$Param{Filename} && !defined( $Param{String} ) ) {
         $Kernel::OM->Get('Kernel::System::Log')->Log(
             Priority => 'error',
             Message  => 'Need Filename or String!',

--- a/Kernel/System/Main.pm
+++ b/Kernel/System/Main.pm
@@ -1027,6 +1027,57 @@ sub GenerateRandomString {
     return $String;
 }
 
+=item HumanReadableDataSize()
+
+Produces human readable data size.
+
+    my $SizeStr = $MainObject->HumanReadableDataSize(
+        Size => 123,  # size in bytes
+    );
+
+=cut
+
+sub HumanReadableDataSize {
+    my ( $Self, %Param ) = @_;
+
+    if ( !defined( $Param{Size} ) ) {
+        $Kernel::OM->Get('Kernel::System::Log')->Log(
+            Priority => 'error',
+            Message  => 'Need Size!',
+        );
+        return;
+    }
+
+    if ( $Param{Size} !~ /^\d+$/ )  {
+        $Kernel::OM->Get('Kernel::System::Log')->Log(
+            Priority => 'error',
+            Message  => 'Size must be integer!',
+        );
+        return;
+    }
+
+    my $SizeStr = '';
+
+    # Use convention descibed on https://en.wikipedia.org/wiki/File_size
+    if ( $Param{Size} > ( 1024 * 1024 * 1024 * 1024 ) ) {
+        $SizeStr = sprintf "%.1f TB", ( $Param{Size} / ( 1024 * 1024 * 1024 * 1024 ) );
+    }
+    elsif ( $Param{Size} > ( 1024 * 1024 * 1024 ) ) {
+        $SizeStr = sprintf "%.1f GB", ( $Param{Size} / ( 1024 * 1024 * 1024 ) );
+    }
+    elsif ( $Param{Size} > ( 1024 * 1024 ) ) {
+        $SizeStr = sprintf "%.1f MB", ( $Param{Size} / ( 1024 * 1024 ) );
+    }
+    elsif ( $Param{Size} > 1024 ) {
+        $SizeStr = sprintf "%.1f KB", ( $Param{Size} / 1024 );
+    }
+    else {
+        $SizeStr = $Param{Size} . ' B';
+    }
+
+    return $SizeStr;
+}
+
 =begin Internal:
 
 =cut

--- a/Kernel/System/Ticket/Article.pm
+++ b/Kernel/System/Ticket/Article.pm
@@ -185,10 +185,9 @@ sub ArticleCreate {
     # get html utils object
     my $HTMLUtilsObject = $Kernel::OM->Get('Kernel::System::HTMLUtils');
 
-    # add 'no body' if there is no body there!
     my @AttachmentConvert;
-    if ( !length $Param{Body} ) {    # allow '0' as body
-        $Param{Body} = 'No body';
+    if ( !defined($Param{Body}) ) {
+        $Param{Body} = '';
     }
 
     # process html article
@@ -3048,7 +3047,7 @@ returns:
         ContentID          => "",
         ContentType        => "application/pdf",
         Filename           => "StdAttachment-Test1.pdf",
-        Filesize           => "4.6 KBytes",
+        Filesize           => "4.6 KB",
         FilesizeRaw        => 4722,
         Disposition        => 'attachment',
     );
@@ -3100,7 +3099,7 @@ returns:
         '1' => {
             ContentAlternative => '',
             ContentID          => '',
-            Filesize           => '4.6 KBytes',
+            Filesize           => '4.6 KB',
             ContentType        => 'application/pdf',
             Filename           => 'StdAttachment-Test1.pdf',
             FilesizeRaw        => 4722,
@@ -3109,7 +3108,7 @@ returns:
         '2' => {
             ContentAlternative => '',
             ContentID          => '',
-            Filesize           => '183 Bytes',
+            Filesize           => '183 B',
             ContentType        => 'text/html; charset="utf-8"',
             Filename           => 'file-2',
             FilesizeRaw        => 183,
@@ -3242,8 +3241,8 @@ sub ArticleAttachmentIndex {
 
                 # check size by tolerance of 1.1 factor (because of charset difs)
                 if (
-                    $BodySize / 1.1 < $AttachmentFilePlain{FilesizeRaw}
-                    && $BodySize * 1.1 > $AttachmentFilePlain{FilesizeRaw}
+                    $BodySize / 1.1 <= $AttachmentFilePlain{FilesizeRaw}
+                    && $BodySize * 1.1 >= $AttachmentFilePlain{FilesizeRaw}
                     )
                 {
                     delete $Attachments{$AttachmentIDPlain};

--- a/Kernel/System/Ticket/ArticleStorageDB.pm
+++ b/Kernel/System/Ticket/ArticleStorageDB.pm
@@ -453,15 +453,9 @@ sub ArticleAttachmentIndexRaw {
         # human readable file size
         my $FileSizeRaw = $Row[2];
         if ( defined $Row[2] ) {
-            if ( $Row[2] > ( 1024 * 1024 ) ) {
-                $Row[2] = sprintf "%.1f MB", ( $Row[2] / ( 1024 * 1024 ) );
-            }
-            elsif ( $Row[2] > 1024 ) {
-                $Row[2] = sprintf "%.1f KB", ( ( $Row[2] / 1024 ) );
-            }
-            else {
-                $Row[2] = $Row[2] . ' B';
-            }
+            $Row[2] = $Kernel::OM->Get('Kernel::System::Main')->HumanReadableDataSize(
+                Size => $Row[2],
+            );
         }
 
         my $Disposition = $Row[5];
@@ -534,16 +528,10 @@ sub ArticleAttachmentIndexRaw {
         next FILENAME if $Filename =~ /\/plain.txt$/;
 
         # human readable file size
-        if (defined $FileSize) {
-            if ( $FileSize > ( 1024 * 1024 ) ) {
-                $FileSize = sprintf "%.1f MB", ( $FileSize / ( 1024 * 1024 ) );
-            }
-            elsif ( $FileSize > 1024 ) {
-                $FileSize = sprintf "%.1f KB", ( ( $FileSize / 1024 ) );
-            }
-            else {
-                $FileSize = $FileSize . ' B';
-            }
+        if ( defined $FileSize ) {
+            $FileSize = $MainObject->HumanReadableDataSize(
+                Size => $FileSize,
+            );
         }
 
         # read content type

--- a/Kernel/System/Ticket/ArticleStorageDB.pm
+++ b/Kernel/System/Ticket/ArticleStorageDB.pm
@@ -265,7 +265,7 @@ sub ArticleWriteAttachment {
     my ( $Self, %Param ) = @_;
 
     # check needed stuff
-    for (qw(Content Filename ContentType ArticleID UserID)) {
+    for (qw(Filename ContentType ArticleID UserID)) {
         if ( !$Param{$_} ) {
             $Kernel::OM->Get('Kernel::System::Log')->Log(
                 Priority => 'error',
@@ -452,15 +452,15 @@ sub ArticleAttachmentIndexRaw {
 
         # human readable file size
         my $FileSizeRaw = $Row[2];
-        if ( $Row[2] ) {
+        if ( defined $Row[2] ) {
             if ( $Row[2] > ( 1024 * 1024 ) ) {
-                $Row[2] = sprintf "%.1f MBytes", ( $Row[2] / ( 1024 * 1024 ) );
+                $Row[2] = sprintf "%.1f MB", ( $Row[2] / ( 1024 * 1024 ) );
             }
             elsif ( $Row[2] > 1024 ) {
-                $Row[2] = sprintf "%.1f KBytes", ( ( $Row[2] / 1024 ) );
+                $Row[2] = sprintf "%.1f KB", ( ( $Row[2] / 1024 ) );
             }
             else {
-                $Row[2] = $Row[2] . ' Bytes';
+                $Row[2] = $Row[2] . ' B';
             }
         }
 
@@ -534,15 +534,15 @@ sub ArticleAttachmentIndexRaw {
         next FILENAME if $Filename =~ /\/plain.txt$/;
 
         # human readable file size
-        if ($FileSize) {
+        if (defined $FileSize) {
             if ( $FileSize > ( 1024 * 1024 ) ) {
-                $FileSize = sprintf "%.1f MBytes", ( $FileSize / ( 1024 * 1024 ) );
+                $FileSize = sprintf "%.1f MB", ( $FileSize / ( 1024 * 1024 ) );
             }
             elsif ( $FileSize > 1024 ) {
-                $FileSize = sprintf "%.1f KBytes", ( ( $FileSize / 1024 ) );
+                $FileSize = sprintf "%.1f KB", ( ( $FileSize / 1024 ) );
             }
             else {
-                $FileSize = $FileSize . ' Bytes';
+                $FileSize = $FileSize . ' B';
             }
         }
 

--- a/Kernel/System/Ticket/ArticleStorageFS.pm
+++ b/Kernel/System/Ticket/ArticleStorageFS.pm
@@ -652,16 +652,10 @@ sub ArticleAttachmentIndexRaw {
         next FILENAME if $Filename =~ /\/plain.txt$/;
 
         # human readable file size
-        if (defined $FileSize) {
-            if ( $FileSize > ( 1024 * 1024 ) ) {
-                $FileSize = sprintf "%.1f MB", ( $FileSize / ( 1024 * 1024 ) );
-            }
-            elsif ( $FileSize > 1024 ) {
-                $FileSize = sprintf "%.1f KB", ( ( $FileSize / 1024 ) );
-            }
-            else {
-                $FileSize = $FileSize . ' B';
-            }
+        if ( defined $FileSize ) {
+            $FileSize = $MainObject->HumanReadableDataSize(
+                Size => $FileSize,
+            );
         }
 
         # read content type
@@ -790,16 +784,10 @@ sub ArticleAttachmentIndexRaw {
 
         # human readable file size
         my $FileSizeRaw = $Row[2];
-        if ( $Row[2] ) {
-            if ( $Row[2] > ( 1024 * 1024 ) ) {
-                $Row[2] = sprintf "%.1f MBytes", ( $Row[2] / ( 1024 * 1024 ) );
-            }
-            elsif ( $Row[2] > 1024 ) {
-                $Row[2] = sprintf "%.1f KBytes", ( ( $Row[2] / 1024 ) );
-            }
-            else {
-                $Row[2] = $Row[2] . ' Bytes';
-            }
+        if ( defined $Row[2] ) {
+            $Row[2] = $MainObject->HumanReadableDataSize(
+                Size => $Row[2],
+            );
         }
 
         my $Disposition = $Row[5];

--- a/Kernel/System/Ticket/ArticleStorageFS.pm
+++ b/Kernel/System/Ticket/ArticleStorageFS.pm
@@ -336,7 +336,7 @@ sub ArticleWriteAttachment {
     my ( $Self, %Param ) = @_;
 
     # check needed stuff
-    for (qw(Content Filename ContentType ArticleID UserID)) {
+    for (qw(Filename ContentType ArticleID UserID)) {
         if ( !$Param{$_} ) {
             $Kernel::OM->Get('Kernel::System::Log')->Log(
                 Priority => 'error',
@@ -652,15 +652,15 @@ sub ArticleAttachmentIndexRaw {
         next FILENAME if $Filename =~ /\/plain.txt$/;
 
         # human readable file size
-        if ($FileSize) {
+        if (defined $FileSize) {
             if ( $FileSize > ( 1024 * 1024 ) ) {
-                $FileSize = sprintf "%.1f MBytes", ( $FileSize / ( 1024 * 1024 ) );
+                $FileSize = sprintf "%.1f MB", ( $FileSize / ( 1024 * 1024 ) );
             }
             elsif ( $FileSize > 1024 ) {
-                $FileSize = sprintf "%.1f KBytes", ( ( $FileSize / 1024 ) );
+                $FileSize = sprintf "%.1f KB", ( ( $FileSize / 1024 ) );
             }
             else {
-                $FileSize = $FileSize . ' Bytes';
+                $FileSize = $FileSize . ' B';
             }
         }
 

--- a/Kernel/System/VirtualFS.pm
+++ b/Kernel/System/VirtualFS.pm
@@ -227,15 +227,14 @@ sub Write {
     # size calculation
     $Param{Preferences}->{FilesizeRaw} = bytes::length( ${ $Param{Content} } );
     my $Filesize = $Param{Preferences}->{FilesizeRaw};
-    if ( $Filesize > ( 1024 * 1024 ) ) {
-        $Filesize = sprintf "%.1f MB", ( $Filesize / ( 1024 * 1024 ) );
+
+    # human readable file size
+    if ( defined $Filesize ) {
+        $Filesize = $Kernel::OM->Get('Kernel::System::Main')->HumanReadableDataSize(
+            Size => $Filesize,
+        );
     }
-    elsif ( $Filesize > 1024 ) {
-        $Filesize = sprintf "%.1f KB", ( $Filesize / 1024 );
-    }
-    else {
-        $Filesize = $Filesize . ' B';
-    }
+
     $Param{Preferences}->{Filesize} = $Filesize;
 
     # insert preferences

--- a/Kernel/System/VirtualFS.pm
+++ b/Kernel/System/VirtualFS.pm
@@ -83,7 +83,7 @@ returns
         Preferences => {
 
             # generated automatically
-            Filesize           => '12.4 KBytes',
+            Filesize           => '12.4 KB',
             FilesizeRaw        => 12345,
 
             # optional
@@ -228,13 +228,13 @@ sub Write {
     $Param{Preferences}->{FilesizeRaw} = bytes::length( ${ $Param{Content} } );
     my $Filesize = $Param{Preferences}->{FilesizeRaw};
     if ( $Filesize > ( 1024 * 1024 ) ) {
-        $Filesize = sprintf "%.1f MBytes", ( $Filesize / ( 1024 * 1024 ) );
+        $Filesize = sprintf "%.1f MB", ( $Filesize / ( 1024 * 1024 ) );
     }
     elsif ( $Filesize > 1024 ) {
-        $Filesize = sprintf "%.1f KBytes", ( $Filesize / 1024 );
+        $Filesize = sprintf "%.1f KB", ( $Filesize / 1024 );
     }
     else {
-        $Filesize = $Filesize . ' Bytes';
+        $Filesize = $Filesize . ' B';
     }
     $Param{Preferences}->{Filesize} = $Filesize;
 

--- a/Kernel/System/Web/Request.pm
+++ b/Kernel/System/Web/Request.pm
@@ -269,14 +269,11 @@ sub GetUploadAll {
     $NewFileName =~ s/.*\\(.+?)/$1/g;
 
     # return a string
-    my $Content;
+    my $Content = '';
     while (<$Upload>) {
         $Content .= $_;
     }
     close $Upload;
-
-    # Check if content is there, IE is always sending file uploads without content.
-    return if !$Content;
 
     my $ContentType = $Self->_GetUploadInfo(
         Filename => $UploadFilenameOrig,

--- a/Kernel/System/Web/UploadCache/DB.pm
+++ b/Kernel/System/Web/UploadCache/DB.pm
@@ -181,15 +181,9 @@ sub FormIDGetAllFilesData {
 
         # human readable file size
         if ( defined $Row[2] ) {
-            if ( $Row[2] > ( 1024 * 1024 ) ) {
-                $Row[2] = sprintf "%.1f MB", ( $Row[2] / ( 1024 * 1024 ) );
-            }
-            elsif ( $Row[2] > 1024 ) {
-                $Row[2] = sprintf "%.1f KB", ( ( $Row[2] / 1024 ) );
-            }
-            else {
-                $Row[2] = $Row[2] . ' B';
-            }
+            $Row[2] = $Kernel::OM->Get('Kernel::System::Main')->HumanReadableDataSize(
+                Size => $Row[2],
+            );
         }
 
         # encode attachment if it's a postgresql backend!!!
@@ -247,15 +241,9 @@ sub FormIDGetAllFilesMeta {
 
         # human readable file size
         if ( defined $Row[2] ) {
-            if ( $Row[2] > ( 1024 * 1024 ) ) {
-                $Row[2] = sprintf "%.1f MB", ( $Row[2] / ( 1024 * 1024 ) );
-            }
-            elsif ( $Row[2] > 1024 ) {
-                $Row[2] = sprintf "%.1f KB", ( ( $Row[2] / 1024 ) );
-            }
-            else {
-                $Row[2] = $Row[2] . ' B';
-            }
+            $Row[2] = $Kernel::OM->Get('Kernel::System::Main')->HumanReadableDataSize(
+                Size => $Row[2],
+            );
         }
 
         # add the info

--- a/Kernel/System/Web/UploadCache/DB.pm
+++ b/Kernel/System/Web/UploadCache/DB.pm
@@ -66,7 +66,7 @@ sub FormIDRemove {
 sub FormIDAddFile {
     my ( $Self, %Param ) = @_;
 
-    for (qw(FormID Filename Content ContentType)) {
+    for (qw(FormID Filename ContentType)) {
         if ( !$Param{$_} ) {
             $Kernel::OM->Get('Kernel::System::Log')->Log(
                 Priority => 'error',
@@ -75,6 +75,8 @@ sub FormIDAddFile {
             return;
         }
     }
+
+    $Param{Content} = '' if !defined( $Param{Content} );
 
     # get file size
     $Param{Filesize} = bytes::length( $Param{Content} );
@@ -178,15 +180,15 @@ sub FormIDGetAllFilesData {
         $Counter++;
 
         # human readable file size
-        if ( $Row[2] ) {
+        if ( defined $Row[2] ) {
             if ( $Row[2] > ( 1024 * 1024 ) ) {
-                $Row[2] = sprintf "%.1f MBytes", ( $Row[2] / ( 1024 * 1024 ) );
+                $Row[2] = sprintf "%.1f MB", ( $Row[2] / ( 1024 * 1024 ) );
             }
             elsif ( $Row[2] > 1024 ) {
-                $Row[2] = sprintf "%.1f KBytes", ( ( $Row[2] / 1024 ) );
+                $Row[2] = sprintf "%.1f KB", ( ( $Row[2] / 1024 ) );
             }
             else {
-                $Row[2] = $Row[2] . ' Bytes';
+                $Row[2] = $Row[2] . ' B';
             }
         }
 
@@ -244,15 +246,15 @@ sub FormIDGetAllFilesMeta {
         $Counter++;
 
         # human readable file size
-        if ( $Row[2] ) {
+        if ( defined $Row[2] ) {
             if ( $Row[2] > ( 1024 * 1024 ) ) {
-                $Row[2] = sprintf "%.1f MBytes", ( $Row[2] / ( 1024 * 1024 ) );
+                $Row[2] = sprintf "%.1f MB", ( $Row[2] / ( 1024 * 1024 ) );
             }
             elsif ( $Row[2] > 1024 ) {
-                $Row[2] = sprintf "%.1f KBytes", ( ( $Row[2] / 1024 ) );
+                $Row[2] = sprintf "%.1f KB", ( ( $Row[2] / 1024 ) );
             }
             else {
-                $Row[2] = $Row[2] . ' Bytes';
+                $Row[2] = $Row[2] . ' B';
             }
         }
 

--- a/Kernel/System/Web/UploadCache/FS.pm
+++ b/Kernel/System/Web/UploadCache/FS.pm
@@ -207,21 +207,16 @@ sub FormIDGetAllFilesData {
         my $FileSize = -s $File;
 
         # human readable file size
-        if (defined $FileSize) {
+        if ( defined $FileSize ) {
 
             # remove meta data in files
             if ( $FileSize > 30 ) {
                 $FileSize = $FileSize - 30
             }
-            if ( $FileSize > 1048576 ) {    # 1024 * 1024
-                $FileSize = sprintf "%.1f MB", ( $FileSize / 1048576 );    # 1024 * 1024
-            }
-            elsif ( $FileSize > 1024 ) {
-                $FileSize = sprintf "%.1f KB", ( ( $FileSize / 1024 ) );
-            }
-            else {
-                $FileSize = $FileSize . ' B';
-            }
+
+            $FileSize = $MainObject->HumanReadableDataSize(
+                Size => $FileSize,
+            );
         }
         my $Content = $MainObject->FileRead(
             Location => $File,
@@ -304,21 +299,16 @@ sub FormIDGetAllFilesMeta {
         my $FileSize = -s $File;
 
         # human readable file size
-        if (defined $FileSize) {
+        if ( defined $FileSize ) {
 
             # remove meta data in files
             if ( $FileSize > 30 ) {
                 $FileSize = $FileSize - 30
             }
-            if ( $FileSize > 1048576 ) {    # 1024 * 1024
-                $FileSize = sprintf "%.1f MB", ( $FileSize / 1048576 );    # 1024 * 1024
-            }
-            elsif ( $FileSize > 1024 ) {
-                $FileSize = sprintf "%.1f KB", ( ( $FileSize / 1024 ) );
-            }
-            else {
-                $FileSize = $FileSize . ' B';
-            }
+
+            $FileSize = $MainObject->HumanReadableDataSize(
+                Size => $FileSize,
+            );
         }
 
         my $ContentType = $MainObject->FileRead(

--- a/Kernel/System/Web/UploadCache/FS.pm
+++ b/Kernel/System/Web/UploadCache/FS.pm
@@ -75,7 +75,7 @@ sub FormIDRemove {
 sub FormIDAddFile {
     my ( $Self, %Param ) = @_;
 
-    for (qw(FormID Filename Content ContentType)) {
+    for (qw(FormID Filename ContentType)) {
         if ( !$Param{$_} ) {
             $Kernel::OM->Get('Kernel::System::Log')->Log(
                 Priority => 'error',
@@ -84,6 +84,8 @@ sub FormIDAddFile {
             return;
         }
     }
+
+    $Param{Content} = '' if !defined($Param{Content});
 
     # create content id
     my $ContentID = $Param{ContentID};
@@ -205,20 +207,20 @@ sub FormIDGetAllFilesData {
         my $FileSize = -s $File;
 
         # human readable file size
-        if ($FileSize) {
+        if (defined $FileSize) {
 
             # remove meta data in files
             if ( $FileSize > 30 ) {
                 $FileSize = $FileSize - 30
             }
             if ( $FileSize > 1048576 ) {    # 1024 * 1024
-                $FileSize = sprintf "%.1f MBytes", ( $FileSize / 1048576 );    # 1024 * 1024
+                $FileSize = sprintf "%.1f MB", ( $FileSize / 1048576 );    # 1024 * 1024
             }
             elsif ( $FileSize > 1024 ) {
-                $FileSize = sprintf "%.1f KBytes", ( ( $FileSize / 1024 ) );
+                $FileSize = sprintf "%.1f KB", ( ( $FileSize / 1024 ) );
             }
             else {
-                $FileSize = $FileSize . ' Bytes';
+                $FileSize = $FileSize . ' B';
             }
         }
         my $Content = $MainObject->FileRead(
@@ -302,20 +304,20 @@ sub FormIDGetAllFilesMeta {
         my $FileSize = -s $File;
 
         # human readable file size
-        if ($FileSize) {
+        if (defined $FileSize) {
 
             # remove meta data in files
             if ( $FileSize > 30 ) {
                 $FileSize = $FileSize - 30
             }
             if ( $FileSize > 1048576 ) {    # 1024 * 1024
-                $FileSize = sprintf "%.1f MBytes", ( $FileSize / 1048576 );    # 1024 * 1024
+                $FileSize = sprintf "%.1f MB", ( $FileSize / 1048576 );    # 1024 * 1024
             }
             elsif ( $FileSize > 1024 ) {
-                $FileSize = sprintf "%.1f KBytes", ( ( $FileSize / 1024 ) );
+                $FileSize = sprintf "%.1f KB", ( ( $FileSize / 1024 ) );
             }
             else {
-                $FileSize = $FileSize . ' Bytes';
+                $FileSize = $FileSize . ' B';
             }
         }
 

--- a/scripts/test/AuthSession.t
+++ b/scripts/test/AuthSession.t
@@ -91,13 +91,13 @@ for my $ModuleFile (@BackendModuleFiles) {
         my $Length = length($LongString);
         my $Size   = $Length;
         if ( $Size > ( 1024 * 1024 ) ) {
-            $Size = sprintf "%.1f MBytes", ( $Size / ( 1024 * 1024 ) );
+            $Size = sprintf "%.1f MB", ( $Size / ( 1024 * 1024 ) );
         }
         elsif ( $Size > 1024 ) {
-            $Size = sprintf "%.1f KBytes", ( ( $Size / 1024 ) );
+            $Size = sprintf "%.1f KB", ( ( $Size / 1024 ) );
         }
         else {
-            $Size = $Size . ' Bytes';
+            $Size = $Size . ' B';
         }
 
         my %NewSessionData = (

--- a/scripts/test/Cache.t
+++ b/scripts/test/Cache.t
@@ -429,13 +429,13 @@ for my $ModuleFile (@BackendModuleFiles) {
             my $Size = length $String1;
 
             if ( $Size > ( 1024 * 1024 ) ) {
-                $Size = sprintf "%.1f MBytes", ( $Size / ( 1024 * 1024 ) );
+                $Size = sprintf "%.1f MB", ( $Size / ( 1024 * 1024 ) );
             }
             elsif ( $Size > 1024 ) {
-                $Size = sprintf "%.1f KBytes", ( ( $Size / 1024 ) );
+                $Size = sprintf "%.1f KB", ( ( $Size / 1024 ) );
             }
             else {
-                $Size = $Size . ' Bytes';
+                $Size = $Size . ' B';
             }
 
             # create key

--- a/scripts/test/DB/XML/Size.t
+++ b/scripts/test/DB/XML/Size.t
@@ -118,13 +118,13 @@ for my $Count ( 1 .. 6 ) {
     my $Size   = $Length;
     my $Key    = 'Some116' . $Count;
     if ( $Size > ( 1024 * 1024 ) ) {
-        $Size = sprintf "%.1f MBytes", ( $Size / ( 1024 * 1024 ) );
+        $Size = sprintf "%.1f MB", ( $Size / ( 1024 * 1024 ) );
     }
     elsif ( $Size > 1024 ) {
-        $Size = sprintf "%.1f KBytes", ( ( $Size / 1024 ) );
+        $Size = sprintf "%.1f KB", ( ( $Size / 1024 ) );
     }
     else {
-        $Size = $Size . ' Bytes';
+        $Size = $Size . ' B';
     }
     $XML = '
         <Insert Table="test_a">
@@ -186,13 +186,13 @@ for my $Count ( 1 .. 6 ) {
     my $Size   = $Length;
     my $Key    = 'Some216' . $Count;
     if ( $Size > ( 1024 * 1024 ) ) {
-        $Size = sprintf "%.1f MBytes", ( $Size / ( 1024 * 1024 ) );
+        $Size = sprintf "%.1f MB", ( $Size / ( 1024 * 1024 ) );
     }
     elsif ( $Size > 1024 ) {
-        $Size = sprintf "%.1f KBytes", ( ( $Size / 1024 ) );
+        $Size = sprintf "%.1f KB", ( ( $Size / 1024 ) );
     }
     else {
-        $Size = $Size . ' Bytes';
+        $Size = $Size . ' B';
     }
 
     # insert
@@ -227,13 +227,13 @@ for my $Count ( 1 .. 19 ) {
     my $Size   = $Length;
     my $Key    = 'Some119' . $Count;
     if ( $Size > ( 1024 * 1024 ) ) {
-        $Size = sprintf "%.1f MBytes", ( $Size / ( 1024 * 1024 ) );
+        $Size = sprintf "%.1f MB", ( $Size / ( 1024 * 1024 ) );
     }
     elsif ( $Size > 1024 ) {
-        $Size = sprintf "%.1f KBytes", ( ( $Size / 1024 ) );
+        $Size = sprintf "%.1f KB", ( ( $Size / 1024 ) );
     }
     else {
-        $Size = $Size . ' Bytes';
+        $Size = $Size . ' B';
     }
 
     # insert

--- a/scripts/test/Main.t
+++ b/scripts/test/Main.t
@@ -680,4 +680,44 @@ $Self->Is(
     'Test output for hex chars in 1000 generated random strings with hex dictionary',
 );
 
+
+# HumanReadableDataSize() tests
+
+my $FileSizeStr;
+
+$FileSizeStr = $MainObject->HumanReadableDataSize( Size => 13 );
+$Self->Is(
+    $FileSizeStr || '',
+    '13 B',
+    'HumanReadableDataSize() - 13',
+);
+
+$FileSizeStr = $MainObject->HumanReadableDataSize( Size => 1536 );
+$Self->Is(
+    $FileSizeStr || '',
+    '1.5 KB',
+    'HumanReadableDataSize() - 1536',
+);
+
+$FileSizeStr = $MainObject->HumanReadableDataSize( Size => 46626123 );
+$Self->Is(
+    $FileSizeStr || '',
+    '44.5 MB',
+    'HumanReadableDataSize() - 46626123',
+);
+
+$FileSizeStr = $MainObject->HumanReadableDataSize( Size => 34508675518 );
+$Self->Is(
+    $FileSizeStr || '',
+    '32.1 GB',
+    'HumanReadableDataSize() - 34458675518',
+);
+
+$FileSizeStr = $MainObject->HumanReadableDataSize( Size => 238870572100000 );
+$Self->Is(
+    $FileSizeStr || '',
+    '217.3 TB',
+    'HumanReadableDataSize() - 238870572100000',
+);
+
 1;

--- a/scripts/test/Ticket/ArticleStorage.t
+++ b/scripts/test/Ticket/ArticleStorage.t
@@ -29,7 +29,7 @@ my $Helper = $Kernel::OM->Get('Kernel::System::UnitTest::Helper');
 
 my $TicketID = $TicketObject->TicketCreate(
     Title        => 'Some Ticket_Title',
-    Queue        => 'Raw',
+    QueueID      => 1,
     Lock         => 'unlock',
     Priority     => '3 normal',
     State        => 'closed successful',
@@ -83,7 +83,7 @@ for my $Backend (qw(DB FS)) {
 
     for my $File (
         qw(Ticket-Article-Test1.xls Ticket-Article-Test1.txt Ticket-Article-Test1.doc
-        Ticket-Article-Test1.png Ticket-Article-Test1.pdf Ticket-Article-Test-utf8-1.txt Ticket-Article-Test-utf8-1.bin)
+        Ticket-Article-Test1.png Ticket-Article-Test1.pdf Ticket-Article-Test-utf8-1.txt Ticket-Article-Test-utf8-1.bin Ticket-Article-Test-empty.txt)
         )
     {
         my $Location = $ConfigObject->Get('Home')
@@ -136,10 +136,6 @@ for my $Backend (qw(DB FS)) {
                 ArticleID => $ArticleID,
                 FileID    => 1,
                 UserID    => 1,
-            );
-            $Self->True(
-                $Data{Content},
-                "$Backend ArticleAttachment() Content - $FileNew",
             );
             $Self->True(
                 $Data{ContentType},
@@ -262,7 +258,7 @@ for my $Backend (qw(DB FS)) {
             'ContentID'          => '',
             'ContentType'        => 'image/png',
             'Filename'           => "$TargetFilename.pdf",
-            'Filesize'           => '3 Bytes',
+            'Filesize'           => '3 B',
             'FilesizeRaw'        => '3',
             'Disposition'        => 'attachment',
         },
@@ -276,7 +272,7 @@ for my $Backend (qw(DB FS)) {
             'ContentID'          => '',
             'ContentType'        => 'image/png',
             'Filename'           => "$TargetFilename-1.pdf",
-            'Filesize'           => '3 Bytes',
+            'Filesize'           => '3 B',
             'FilesizeRaw'        => '3',
             'Disposition'        => 'attachment',
         },


### PR DESCRIPTION
This mod fixes empty attachment handling in incoming e-mail messages
and web uploads and changes hardcoded english file size unit names
to universal symbols.

Related: https://dev.ib.pl/ib/otrs/issues/65
Related: http://bugs.otrs.org/show_bug.cgi?id=10509
Author-Change-Id: IB#1021851
