### PR TITLE
Pass Return value to Postmaster post filter

### DIFF
--- a/Kernel/System/PostMaster.pm
+++ b/Kernel/System/PostMaster.pm
@@ -411,6 +411,7 @@ sub Run {
                 TicketID  => $TicketID,
                 GetParam  => $GetParam,
                 JobConfig => $Jobs{$Job},
+                Return    => $Return[0],
             );
 
             if ( !$Run ) {


### PR DESCRIPTION
That way it is far easier to check in a post filter if this runs on a new ticket or on a follow up. This can be quite hard to determine when you have ticket event modules that add notes on ArticleCreate or TicketCreate. The postmaster creates a new ticket the ticket event module runs and now you have two articles in the ticket. Now you have no chance to get to know if the postmaster post filter runs for a mail that created a new ticket