### PR TITLE
Currently it is impossible to save a 0

### DIFF
--- a/Kernel/Modules/AdminCustomerCompany.pm
+++ b/Kernel/Modules/AdminCustomerCompany.pm
@@ -128,7 +128,7 @@ sub Run {
 
             # check remaining non-dynamic-field mandatory fields
             else {
-                $GetParam{ $Entry->[0] } = $ParamObject->GetParam( Param => $Entry->[0] ) || '';
+                $GetParam{ $Entry->[0] } = $ParamObject->GetParam( Param => $Entry->[0] ) // '';
                 if ( !$GetParam{ $Entry->[0] } && $Entry->[4] ) {
                     $Errors{ $Entry->[0] . 'Invalid' } = 'ServerError';
                 }


### PR DESCRIPTION
This might be ok in stock OTRS, but when you extend your table and you want to save a '0', you can't.
That's why I replaced the or-operator with the defined-or-operator.