### PR TITLE
Added index for searching dynamic field text values

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,4 +1,5 @@
 #6.0.0.beta1 2016-??-??
+ - 2016-06-07 Added index for searching dynamic field text values.
  - 2016-06-06 Fixed bug#[12020](http://bugs.otrs.org/show_bug.cgi?id=12020) - Option CaseSensitive has no impact on external customer database.
  - 2016-06-03 Improved default procmail config (disabled comsat and added postmaster pipe waiting), thanks to Pawel Boguslawski.
  - 2016-06-03 Speed up TicketNewMessageUpdate, thanks to Moritz Lenz.

--- a/scripts/DBUpdate-to-6.mysql.sql
+++ b/scripts/DBUpdate-to-6.mysql.sql
@@ -11,3 +11,4 @@ CREATE TABLE dynamic_field_obj_id_name (
     PRIMARY KEY(object_id),
     UNIQUE INDEX dynamic_field_object_name (object_name, object_type)
 );
+CREATE INDEX dynamic_field_value_search_text ON dynamic_field_value (field_id, value_text(150));

--- a/scripts/DBUpdate-to-6.oracle.sql
+++ b/scripts/DBUpdate-to-6.oracle.sql
@@ -39,5 +39,6 @@ BEGIN
 END;
 /
 --;
+CREATE INDEX dynamic_field_value_search_tbc ON dynamic_field_value (field_id, value_text);
 SET DEFINE OFF;
 SET SQLBLANKLINES ON;

--- a/scripts/DBUpdate-to-6.postgresql.sql
+++ b/scripts/DBUpdate-to-6.postgresql.sql
@@ -12,4 +12,5 @@ CREATE TABLE dynamic_field_obj_id_name (
     PRIMARY KEY(object_id),
     CONSTRAINT dynamic_field_object_name UNIQUE (object_name, object_type)
 );
+CREATE INDEX dynamic_field_value_search_text ON dynamic_field_value (field_id, value_text);
 SET standard_conforming_strings TO ON;

--- a/scripts/database/otrs-schema.mysql.sql
+++ b/scripts/database/otrs-schema.mysql.sql
@@ -1253,7 +1253,8 @@ CREATE TABLE dynamic_field_value (
     PRIMARY KEY(id),
     INDEX dynamic_field_value_field_values (object_id, field_id),
     INDEX dynamic_field_value_search_date (field_id, value_date),
-    INDEX dynamic_field_value_search_int (field_id, value_int)
+    INDEX dynamic_field_value_search_int (field_id, value_int),
+    INDEX dynamic_field_value_search_text (field_id, value_text(150))
 );
 # ----------------------------------------------------------
 #  create table dynamic_field

--- a/scripts/database/otrs-schema.oracle.sql
+++ b/scripts/database/otrs-schema.oracle.sql
@@ -2713,6 +2713,7 @@ CREATE INDEX FK_dynamic_field_value_field90 ON dynamic_field_value (field_id);
 CREATE INDEX dynamic_field_value_field_va6e ON dynamic_field_value (object_id, field_id);
 CREATE INDEX dynamic_field_value_search_db3 ON dynamic_field_value (field_id, value_date);
 CREATE INDEX dynamic_field_value_search_int ON dynamic_field_value (field_id, value_int);
+CREATE INDEX dynamic_field_value_search_tbc ON dynamic_field_value (field_id, value_text);
 -- ----------------------------------------------------------
 --  create table dynamic_field
 -- ----------------------------------------------------------

--- a/scripts/database/otrs-schema.postgresql.sql
+++ b/scripts/database/otrs-schema.postgresql.sql
@@ -1256,6 +1256,7 @@ CREATE TABLE dynamic_field_value (
 CREATE INDEX dynamic_field_value_field_values ON dynamic_field_value (object_id, field_id);
 CREATE INDEX dynamic_field_value_search_date ON dynamic_field_value (field_id, value_date);
 CREATE INDEX dynamic_field_value_search_int ON dynamic_field_value (field_id, value_int);
+CREATE INDEX dynamic_field_value_search_text ON dynamic_field_value (field_id, value_text);
 -- ----------------------------------------------------------
 --  create table dynamic_field
 -- ----------------------------------------------------------

--- a/scripts/database/otrs-schema.xml
+++ b/scripts/database/otrs-schema.xml
@@ -1913,6 +1913,10 @@
     <Column Name="value_int" Required="false" Type="BIGINT" />
 
     <!-- search objects with certain field content -->
+    <Index Name="dynamic_field_value_search_text">
+        <IndexColumn Name="field_id"/>
+        <IndexColumn Name="value_text" Size="150"/>
+    </Index>
     <Index Name="dynamic_field_value_search_date">
         <IndexColumn Name="field_id"/>
         <IndexColumn Name="value_date"/>

--- a/scripts/database/update/otrs-upgrade-to-6.xml
+++ b/scripts/database/update/otrs-upgrade-to-6.xml
@@ -11,4 +11,13 @@
             <UniqueColumn Name="object_type"/>
         </Unique>
     </TableCreate>
+
+    <!-- index to speed up searching against dynamic filed text values -->
+    <TableAlter Name="dynamic_field_value">
+        <IndexCreate Name="dynamic_field_value_search_text">
+            <IndexColumn Name="field_id"/>
+            <IndexColumn Name="value_text" Size="150"/>
+        </IndexCreate>
+    </TableAlter>
+
 </database>


### PR DESCRIPTION
Searching text dynamic fields may be slow in bigger OTRS systems
because of lack of indexing on dynamic_field_value.value_text
column.

This mod adds index dynamic_field_value_search_text
to speed up such searches.

Related: https://dev.ib.pl/ib/otrs/issues/66
Related: http://bugs.otrs.org/show_bug.cgi?id=10503
Author-Change-Id: IB#1021541