### PR TITLE
fix #10448: Unable to filter ticket by 'unchecked' state of dynamic f…

### DIFF
--- a/Kernel/System/DynamicField/Driver/Checkbox.pm
+++ b/Kernel/System/DynamicField/Driver/Checkbox.pm
@@ -766,13 +766,17 @@ sub RandomValueSet {
 sub ObjectMatch {
     my ( $Self, %Param ) = @_;
 
-    my $FieldName = 'DynamicField_' . $Param{DynamicFieldConfig}->{Name};
+    my $FieldName       = 'DynamicField_' . $Param{DynamicFieldConfig}->{Name};
+    my $ObjectAttribute = $Param{ObjectAttributes}->{$FieldName};
 
-    # return false if field is not defined
-    return 0 if ( !defined $Param{ObjectAttributes}->{$FieldName} );
+    # an undefined value is like an unchecked checkbox
+    # and search filters save '-1' for unchecked checkboxes
+    if ( !defined $ObjectAttribute || $ObjectAttribute == 0 ) {
+        $ObjectAttribute = '-1';
+    }
 
     # return false if not match
-    if ( $Param{ObjectAttributes}->{$FieldName} ne $Param{Value} ) {
+    if ( $ObjectAttribute ne $Param{Value} ) {
         return 0;
     }
 


### PR DESCRIPTION
…ield checkbox

Here several things come together:
* You cannot set '0' for dynamic field values via Postmaster filters, the ticket attribute is undef, hence an 'undef' should be treated as an unchecked checkbox
* The filters for event notifications store a value of '-1' for unchecked tests.
* default value for unchecked checkboxes is 0, not -1

So this fix treats 0 and undef equally as unchecked. It sets the check value to -1 to be in line with the value of the filter.