### PR TITLE
Optimal EnterMode in CKeditor

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,4 +1,5 @@
 #6.0.0.beta1 2016-??-??
+ - 2016-06-08 Optimal EnterMode in CKeditor.
  - 2016-06-06 Fixed bug#[12020](http://bugs.otrs.org/show_bug.cgi?id=12020) - Option CaseSensitive has no impact on external customer database.
  - 2016-06-03 Improved default procmail config (disabled comsat and added postmaster pipe waiting), thanks to Pawel Boguslawski.
  - 2016-06-03 Speed up TicketNewMessageUpdate, thanks to Moritz Lenz.

--- a/Kernel/Config/Files/Framework.xml
+++ b/Kernel/Config/Files/Framework.xml
@@ -461,14 +461,13 @@
         </Setting>
     </ConfigItem>
     <ConfigItem Name="Frontend::RichText::EnterMode" Required="1" Valid="1">
-        <Description Translatable="1"><![CDATA[Sets the behavior of the Enter key in rich text editor (enterMode CKEditor parameter). It also determines other behavior rules of the editor, like whether the <br> element is to be used as a paragraph separator when indenting text. The allowed values are the following constants: P (new <p> paragraphs are created), BR (lines are broken with <br> elements), DIV (new <div> blocks are created).]]></Description>
+        <Description Translatable="1"><![CDATA[Sets the behavior of the Enter key in rich text editor (enterMode CKEditor parameter). It also determines other behavior rules of the editor, like whether the <br> element is to be used as a paragraph separator when indenting text. The allowed values are the following constants: P (new <p> paragraphs are created), BR (lines are broken with <br> elements). After changing this setting adjust accordingly signatures, salutations, message templates, autoresponses and other templates like Ticket::Frontend::ResponseFormat.]]></Description>
         <Group>Framework</Group>
         <SubGroup>Core::Web</SubGroup>
         <Setting>
-            <Option SelectedID="1">
+            <Option SelectedID="2">
                 <Item Key="1">P</Item>
                 <Item Key="2">BR</Item>
-                <Item Key="3">DIV</Item>
             </Option>
         </Setting>
     </ConfigItem>

--- a/Kernel/Config/Files/Framework.xml
+++ b/Kernel/Config/Files/Framework.xml
@@ -460,6 +460,18 @@
             </Option>
         </Setting>
     </ConfigItem>
+    <ConfigItem Name="Frontend::RichText::EnterMode" Required="1" Valid="1">
+        <Description Translatable="1"><![CDATA[Sets the behavior of the Enter key in rich text editor (enterMode CKEditor parameter). It also determines other behavior rules of the editor, like whether the <br> element is to be used as a paragraph separator when indenting text. The allowed values are the following constants: P (new <p> paragraphs are created), BR (lines are broken with <br> elements), DIV (new <div> blocks are created).]]></Description>
+        <Group>Framework</Group>
+        <SubGroup>Core::Web</SubGroup>
+        <Setting>
+            <Option SelectedID="1">
+                <Item Key="1">P</Item>
+                <Item Key="2">BR</Item>
+                <Item Key="3">DIV</Item>
+            </Option>
+        </Setting>
+    </ConfigItem>
     <ConfigItem Name="DisableIFrameOriginRestricted" Required="0" Valid="1">
         <Description Translatable="1">Disable HTTP header "X-Frame-Options: SAMEORIGIN" to allow OTRS to be included as an IFrame in other websites. Disabling this HTTP header can be a security issue! Only disable it, if you know what you are doing!</Description>
         <Group>Framework</Group>

--- a/Kernel/Modules/AgentTicketActionCommon.pm
+++ b/Kernel/Modules/AgentTicketActionCommon.pm
@@ -2646,8 +2646,10 @@ sub _GetQuotedReplyBody {
                 $ResponseFormat
                     .= $LayoutObject->{LanguageObject}->Translate('wrote') . ':';
 
-                $Param{Body} = $ResponseFormat . $Param{Body};
+                my $Separator = ( $ConfigObject->Get('Frontend::RichText::EnterMode') == 2 )
+                    ? '<br/><br/>' : '<p>&nbsp;</p>';
 
+                $Param{Body} = $ResponseFormat . $Param{Body} . $Separator;
             }
             else {
                 $Param{Body} = "<br/>" . $Param{Body};
@@ -2671,8 +2673,14 @@ sub _GetQuotedReplyBody {
                 my $MessageFrom = $LayoutObject->{LanguageObject}->Translate('Message from');
                 my $EndMessage  = $LayoutObject->{LanguageObject}->Translate('End message');
 
-                $Param{Body} = "<br/>---- $MessageFrom $From ---<br/><br/>" . $Param{Body};
-                $Param{Body} .= "<br/>---- $EndMessage ---<br/>";
+                if ( $ConfigObject->Get('Frontend::RichText::EnterMode') == 2 ) {
+                    $Param{Body} = "<br/>---- $MessageFrom $From ---<br/><br/>" . $Param{Body};
+                    $Param{Body} .= "<br/>---- $EndMessage ---<br/><br/>";
+                }
+                else {
+                    $Param{Body} = "<p>---- $MessageFrom $From ---</p>" . $Param{Body};
+                    $Param{Body} .= "<p>---- $EndMessage ---</p><p>&nbsp;</p>";
+                }
             }
         }
     }
@@ -2693,7 +2701,7 @@ sub _GetQuotedReplyBody {
                 $ResponseFormat
                     .= $LayoutObject->{LanguageObject}->Translate('wrote') . ":\n";
 
-                $Param{Body} = $ResponseFormat . $Param{Body};
+                $Param{Body} = $ResponseFormat . $Param{Body} . "\n\n";
             }
             else {
                 $Param{Body} = "\n" . $Param{Body};
@@ -2713,7 +2721,7 @@ sub _GetQuotedReplyBody {
                 my $EndMessage  = $LayoutObject->{LanguageObject}->Translate('End message');
 
                 $Param{Body} = "\n---- $MessageFrom $Param{From} ---\n\n" . $Param{Body};
-                $Param{Body} .= "\n---- $EndMessage ---\n";
+                $Param{Body} .= "\n---- $EndMessage ---\n\n";
             }
         }
     }

--- a/Kernel/Modules/AgentTicketBounce.pm
+++ b/Kernel/Modules/AgentTicketBounce.pm
@@ -232,11 +232,8 @@ sub Run {
 
         # build InformationFormat
         if ( $LayoutObject->{BrowserRichText} ) {
-            $Param{InformationFormat} = "$Param{Salutation}<br/>
-<br/>
-$Param{BounceText}<br/>
-<br/>
-$Param{Signature}";
+            my $Separator = ( $ConfigObject->Get('Frontend::RichText::EnterMode') == 2 ) ? '<br/><br/>' : '';
+            $Param{InformationFormat} = "$Param{Salutation}$Separator$Param{BounceText}$Separator$Param{Signature}";
         }
         else {
             $Param{InformationFormat} = "$Param{Salutation}

--- a/Kernel/Modules/AgentTicketCompose.pm
+++ b/Kernel/Modules/AgentTicketCompose.pm
@@ -1196,8 +1196,11 @@ sub Run {
                 );
                 if ($Quote) {
 
+                    my $Separator = ( $ConfigObject->Get('Frontend::RichText::EnterMode') == 2 )
+                        ? '<br/><br/>' : '<p>&nbsp;</p>';
+
                     # quote text
-                    $Data{Body} = "<blockquote type=\"cite\">$Data{Body}</blockquote>\n";
+                    $Data{Body} = "<blockquote type=\"cite\">$Data{Body}</blockquote>" . $Separator;
 
                     # cleanup not compat. tags
                     $Data{Body} = $LayoutObject->RichTextDocumentCleanup(
@@ -1227,8 +1230,14 @@ sub Run {
                     my $MessageFrom = $LayoutObject->{LanguageObject}->Translate('Message from');
                     my $EndMessage  = $LayoutObject->{LanguageObject}->Translate('End message');
 
-                    $Data{Body} = "<br/>---- $MessageFrom $From ---<br/><br/>" . $Data{Body};
-                    $Data{Body} .= "<br/>---- $EndMessage ---<br/>";
+                    if ( $ConfigObject->Get('Frontend::RichText::EnterMode') == 2 ) {
+                        $Data{Body} = "<br/>---- $MessageFrom $From ---<br/><br/>" . $Data{Body};
+                        $Data{Body} .= "<br/>---- $EndMessage ---<br/>";
+                    }
+                    else {
+                        $Data{Body} = "<p>---- $MessageFrom $From ---</p>" . $Data{Body};
+                        $Data{Body} .= "<p>---- $EndMessage ---</p><p>&nbsp;</p>";
+                    }
                 }
             }
         }

--- a/Kernel/Modules/AgentTicketEmail.pm
+++ b/Kernel/Modules/AgentTicketEmail.pm
@@ -1272,7 +1272,8 @@ sub Run {
         my $MimeType = 'text/plain';
         if ( $LayoutObject->{BrowserRichText} ) {
             $MimeType = 'text/html';
-            $GetParam{Body} .= '<br/><br/>' . $Signature;
+            my $Separator = ( $ConfigObject->Get('Frontend::RichText::EnterMode') == 2 ) ? '<br/><br/>' : '';
+            $GetParam{Body} .= $Separator . $Signature;
 
             # remove unused inline images
             my @NewAttachmentData;

--- a/Kernel/Modules/AgentTicketForward.pm
+++ b/Kernel/Modules/AgentTicketForward.pm
@@ -328,12 +328,27 @@ sub Form {
         my $ForwardedMessageFrom = $LayoutObject->{LanguageObject}->Translate('Forwarded message from');
         my $EndForwardedMessage  = $LayoutObject->{LanguageObject}->Translate('End forwarded message');
 
-        $Data{Body} = "<br/>---- $ForwardedMessageFrom $From ---<br/><br/>" . $Data{Body};
-        $Data{Body} .= "<br/>---- $EndForwardedMessage ---<br/>";
+        my $RichTextEnterMode = $ConfigObject->Get('Frontend::RichText::EnterMode');
+
+        if ( $RichTextEnterMode == 2 ) {
+            $Data{Body} = "<br/>---- $ForwardedMessageFrom $From ---<br/><br/>" . $Data{Body};
+            $Data{Body} .= "<br/>---- $EndForwardedMessage ---<br/>";
+        }
+        else {
+            $Data{Body} = "<p>&nbsp;</p><p>---- $ForwardedMessageFrom $From ---</p>" . $Data{Body};
+            $Data{Body} .= "<p>---- $EndForwardedMessage ---</p><p>&nbsp;</p>";
+        }
+
         $Data{Body} = $Data{Signature} . $Data{Body};
 
         if ( $GetParam{ForwardTemplateID} ) {
-            $Data{Body} = $Data{StdTemplate} . '<br/>' . $Data{Body};
+            my $Separator = ( $RichTextEnterMode == 2 ) ? '<br/>' : '';
+            $Data{Body} = $Data{StdTemplate} . $Separator . $Data{Body};
+        }
+        else {
+            # add leading empty row to speed up message composition
+            my $Separator = ( $RichTextEnterMode == 2 ) ? '<br/><br/>' : '<p>&nbsp;</p>';
+            $Data{Body} = $Separator . $Data{Body}
         }
 
         $Data{ContentType} = 'text/html';
@@ -371,6 +386,11 @@ sub Form {
         if ( $GetParam{ForwardTemplateID} ) {
             $Data{Body} = $Data{StdTemplate} . "\n" . $Data{Body};
         }
+        else {
+            # add leading empty row to speed up message composition
+            $Data{Body} = "\n\n" . $Data{Body};
+        }
+
     }
 
     # get std. attachment object

--- a/Kernel/Modules/AgentTicketMerge.pm
+++ b/Kernel/Modules/AgentTicketMerge.pm
@@ -415,10 +415,11 @@ sub Run {
             my $Body = $LayoutObject->Ascii2RichText(
                 String => $ConfigObject->Get('Ticket::Frontend::MergeText'),
             );
+            my $Separator = ( $ConfigObject->Get('Frontend::RichText::EnterMode') == 2 ) ? '<br/><br/>' : '';
             $Article{Body} = $Salutation
-                . '<br/><br/>'
+                . $Separator
                 . $Body
-                . '<br/><br/>'
+                . $Separator
                 . $Signature;
         }
         else {

--- a/Kernel/Output/HTML/Templates/Standard/CustomerRichTextEditor.tt
+++ b/Kernel/Output/HTML/Templates/Standard/CustomerRichTextEditor.tt
@@ -27,6 +27,8 @@
     ]);
     Core.Config.Set('RichText.PictureUploadAction', "[% Data.RichTextPictureUploadAction | html %]");
 
+    Core.Config.Set('RichText.EnterMode', '[% Config("Frontend::RichText::EnterMode") %]');
+
     Core.UI.RichTextEditor.InitAll();
 //]]></script>
 [% END %]

--- a/Kernel/Output/HTML/Templates/Standard/RichTextEditor.tt
+++ b/Kernel/Output/HTML/Templates/Standard/RichTextEditor.tt
@@ -59,6 +59,8 @@
     }
     Core.Config.Set('RichText.PictureUploadAction', "[% Data.RichTextPictureUploadAction | html %]");
 
+    Core.Config.Set('RichText.EnterMode', '[% Config("Frontend::RichText::EnterMode") %]');
+
     Core.UI.RichTextEditor.InitAll();
 //]]></script>
 [% END %]

--- a/var/httpd/htdocs/js/Core.UI.RichTextEditor.js
+++ b/var/httpd/htdocs/js/Core.UI.RichTextEditor.js
@@ -68,7 +68,8 @@ Core.UI.RichTextEditor = (function (TargetNS) {
         var EditorID = '',
             Editor,
             UserLanguage,
-            UploadURL = '';
+            UploadURL = '',
+            EnterMode;
 
         if (isJQueryObject($EditorArea) && $EditorArea.hasClass('HasCKEInstance')) {
             return false;
@@ -127,6 +128,22 @@ Core.UI.RichTextEditor = (function (TargetNS) {
                     + '=' + Core.Config.Get('SessionID');
         }
 
+        // Get EnterMode from config
+        switch ( Core.Config.Get('RichText.EnterMode') )
+        {
+            case '1':
+                EnterMode = CKEDITOR.ENTER_P;
+                break;
+            case '2':
+                EnterMode = CKEDITOR.ENTER_BR;
+                break;
+            case '3':
+                EnterMode = CKEDITOR.ENTER_DIV;
+                break;
+            default:
+                EnterMode = CKEDITOR.ENTER_P;
+        }
+
         /*eslint-disable camelcase */
         Editor = CKEDITOR.replace(EditorID,
         {
@@ -141,7 +158,7 @@ Core.UI.RichTextEditor = (function (TargetNS) {
             format_tags: 'p;h1;h2;h3;h4;h5;h6;pre',
             fontSize_sizes: '8px;10px;12px;16px;18px;20px;22px;24px;26px;28px;30px;',
             extraAllowedContent: 'div[type]{*}; img[*]; col[width]; style[*]{*}; *[id](*)',
-            enterMode: CKEDITOR.ENTER_BR,
+            enterMode: EnterMode,
             shiftEnterMode: CKEDITOR.ENTER_BR,
             contentsLangDirection: Core.Config.Get('RichText.TextDir', 'ltr'),
             disableNativeSpellChecker: false,

--- a/var/httpd/htdocs/js/Core.UI.RichTextEditor.js
+++ b/var/httpd/htdocs/js/Core.UI.RichTextEditor.js
@@ -131,14 +131,8 @@ Core.UI.RichTextEditor = (function (TargetNS) {
         // Get EnterMode from config
         switch ( Core.Config.Get('RichText.EnterMode') )
         {
-            case '1':
-                EnterMode = CKEDITOR.ENTER_P;
-                break;
             case '2':
                 EnterMode = CKEDITOR.ENTER_BR;
-                break;
-            case '3':
-                EnterMode = CKEDITOR.ENTER_DIV;
                 break;
             default:
                 EnterMode = CKEDITOR.ENTER_P;


### PR DESCRIPTION
OTRS uses non-default value CKEDITOR.ENTER_BR
for CKEDITOR.config.enterMode parameter which is not recommended
by CKEditor authors

http://docs.cksource.com/ckeditor_api/symbols/CKEDITOR.config.html#.enterMode

Using default (and recommended by CKeditor authors) value
CKEDITOR.ENTER_P produces cleaner HTML code and makes increasing/decreasing
idents easier but requires OTRS template adjustments.

This mod introduces new SysConfig parameter Frontend::RichText::EnterMode
which allowes one to set CKEDITOR.config.enterMode to CKEDITOR.ENTER_BR
(default for backward compatibility) and CKEDITOR.ENTER_P (requires manual
template adjustments after change).

When using new default CKEDITOR.ENTER_P one can still break lines
with BR using Shift+Enter.

This mod adds also leading empty row before forwarded message (if template
is not used) and after quoted responses to make it easier to enter manual
text changes.

Fixes: 044f3d8591dab4b6ec147d112d02d2e476958a7b
Related: https://dev.ib.pl/ib/otrs/issues/67
Related: http://docs.cksource.com/ckeditor_api/symbols/CKEDITOR.config.html#.enterMode
Author-Change-Id: IB#1021126
