### PR TITLE
Fixed performance issue in PermissionUserGet.

### DIFF
--- a/Kernel/System/Group.pm
+++ b/Kernel/System/Group.pm
@@ -1024,20 +1024,20 @@ sub PermissionUserGet {
         UserID => $Param{UserID},
     );
 
-    return %GroupList if !%RoleList;
+    if ( %RoleList ) {
+        ROLEID:
+        for my $RoleID ( sort keys %RoleList ) {
 
-    ROLEID:
-    for my $RoleID ( sort keys %RoleList ) {
+            next ROLEID if !$RoleID;
 
-        next ROLEID if !$RoleID;
+            # get groups of the role
+            my %RoleGroupList = $Self->PermissionRoleGroupGet(
+                RoleID => $RoleID,
+                Type   => $Param{Type},
+            );
 
-        # get groups of the role
-        my %RoleGroupList = $Self->PermissionRoleGroupGet(
-            RoleID => $RoleID,
-            Type   => $Param{Type},
-        );
-
-        %GroupList = ( %GroupList, %RoleGroupList );
+            %GroupList = ( %GroupList, %RoleGroupList );
+        }
     }
 
     # set cache


### PR DESCRIPTION
Hi there,

currently the PermissionUserGet function of the Group object opens a performance leak for Agents without a role association. If the requested user is not associated to any Role (empty %RoleList) the cache will never get filled with the gathered data. Therefore on each PermissionUserGet call the whole function logic will get executed over and over again. This can lead to high response times in the AgentInterface, namely AgentTicketQueue where the function gets called a lot. We increased the response time by 0,5 sec in any of the SML views with this change.

I removed the return statement and added an if block around the loop.

Let me know if I can clarify any questions.

  Thorsten

PS: A backport for OTRS 5 would be great if possible.