### PR TITLE
Refactoring of lock behavior of AgentTicketProcess.

### DIFF
--- a/Kernel/Modules/AgentTicketProcess.pm
+++ b/Kernel/Modules/AgentTicketProcess.pm
@@ -142,11 +142,6 @@ sub Run {
             # check if it's already locked by somebody else
             if ( $ActivityDialogHashRef->{RequiredLock} ) {
 
-                my $TicketNumber = $TicketObject->TicketNumberLookup(
-                    TicketID => $TicketID,
-                    UserID   => $Self->{UserID},
-                );
-
                 if ( $TicketObject->TicketLockGet( TicketID => $TicketID ) ) {
                     my $AccessOk = $TicketObject->OwnerCheck(
                         TicketID => $TicketID,
@@ -168,30 +163,35 @@ sub Run {
                 }
                 else {
 
+                    # set lock
+                    $TicketObject->TicketLockSet(
+                        TicketID => $TicketID,
+                        Lock     => 'lock',
+                        UserID   => $Self->{UserID},
+                    );
+
+                    # set user id
+                    $TicketObject->TicketOwnerSet(
+                        TicketID  => $TicketID,
+                        UserID    => $Self->{UserID},
+                        NewUserID => $Self->{UserID},
+                    );
+
+                    # reload the parent window to show the updated lock state
+                    $Param{ParentReload} = 1;
+
                     # show lock state link
                     $Param{RenderLocked} = 1;
+
+                    my $TicketNumber = $TicketObject->TicketNumberLookup(
+                        TicketID => $TicketID,
+                        UserID   => $Self->{UserID},
+                    );
 
                     # notify the agent that the ticket was locked
                     push @{ $Param{Notify} }, "$TicketNumber: "
                         . $LayoutObject->{LanguageObject}->Translate("Ticket locked.");
                 }
-
-                # set lock
-                $TicketObject->TicketLockSet(
-                    TicketID => $TicketID,
-                    Lock     => 'lock',
-                    UserID   => $Self->{UserID},
-                );
-
-                # set user id
-                $TicketObject->TicketOwnerSet(
-                    TicketID  => $TicketID,
-                    UserID    => $Self->{UserID},
-                    NewUserID => $Self->{UserID},
-                );
-
-                # reload the parent window to show the updated lock state
-                $Param{ParentReload} = 1;
             }
 
             my $PossibleActivityDialogs = { 1 => $ActivityDialogEntityID };


### PR DESCRIPTION
Hi there,

we noticed a strange behavior when opening an ActivityDialog from the AgentTicketZoom view of a ProcessTicket. Everytime the ActivityDialog pop up opens the parent window (AgentTicketZoom) reloads. (This caused an error that will be handled in another PullRequest).

After some research we found the lines that have been changed in this pull requests. The ticket lock and owner were always set even if the Agent was already the owner and the ticket locked.

Additionally the TicketNumber was only needed in the else case so we've put it right over the line.

  Thorsten

PS: A cherry-pick to OTRS 5 would be nice.