### PR TITLE
Follow up bug #11877 - Parent connection get lost.

### DIFF
--- a/var/httpd/htdocs/js/Core.UI.Popup.js
+++ b/var/httpd/htdocs/js/Core.UI.Popup.js
@@ -136,11 +136,11 @@ Core.UI.Popup = (function (TargetNS) {
             // Special handling for IE11
             // Because of permission problems, IE11 returns a valid window object
             // but without the needed JS object "Core". window.parent contains that element
-            if (typeof window.opener.Core !== 'undefined') {
-                return window.opener;
+            if ($.browser.msie && parseInt($.browser.version, 10) >= 11 && typeof window.opener.Core !== 'undefined') {
+                return window.parent;
             }
             else {
-                return window.parent;
+                return window.opener;
             }
         }
         else {


### PR DESCRIPTION
Hi there,

we encountered a bug when the parent window of the opened pop up gets reloaded and this takes longer than the timeout hard coded timeout in: https://github.com/OTRS/otrs/blob/15b9ca6783aa5e4ba6e1acc7cf41540459b4bcbe/var/httpd/htdocs/js/Core.UI.Popup.js#L62

Then the wrong handle `window.opener` gets returned instead of the correct `window.parent`.

Since we added this fix especially for the IE 11 I added an additional browser detection condition that covers both cases correctly.

Let me know if I can clarify any questions.

  Thorsten