### PR TITLE
Fixed performance leak on big systems.

### DIFF
--- a/Kernel/System/Group.pm
+++ b/Kernel/System/Group.pm
@@ -1383,12 +1383,11 @@ sub PermissionUserGroupGet {
 
     return if !%PermissionTypeList;
 
-    # get valid user list
-    my %UserList = $Kernel::OM->Get('Kernel::System::User')->UserList(
-        Type => 'Short',
+    # check if user is valid
+    return if !$Kernel::OM->Get('Kernel::System::User')->GetUserData(
+        UserID => $Param{UserID},
+        Valid  => 1,
     );
-
-    return if !$UserList{ $Param{UserID} };
 
     # get group user data
     my %Permissions = $Self->_DBGroupUserGet(


### PR DESCRIPTION
Hi there,

this is a heavy one. Even though the result is cached its pretty expensive to fetch a UserList (on big systems) and filling a Hash with it for checking if a user is valid. The fetched UserList is used exclusively for checking the validity of the requested UserID. A (cached) GetUserData call is much cheaper.

A backport to OTRS 5 would be great.

  Thorsten