### PR TITLE
Fixed bug in SOAP Username and/or Password handling

### DIFF
--- a/Kernel/GenericInterface/Transport/HTTP/SOAP.pm
+++ b/Kernel/GenericInterface/Transport/HTTP/SOAP.pm
@@ -538,7 +538,7 @@ sub RequesterPerformRequest {
             my $User     = $Config->{Authentication}->{User};
             my $Password = $Config->{Authentication}->{Password};
             if ( IsStringWithData($User) && IsStringWithData($Password) ) {
-                $URL =~ s{ ( http s? :// ) }{$1\Q$User\E:\Q$Password\E@}xmsi;
+                $URL =~ s{ ( http s? :// ) }{$1$User:$Password@}xmsi;
             }
         }
     }


### PR DESCRIPTION
Hi there,

the following commit should fix a possibly security issue:
https://github.com/OTRS/otrs/commit/86dd986fedf5c22f14a68fa86d4b35dd2bc6232f

I'm currently not aware of any issue that should be caused by using the plain string variables configured in the transport config. @carlosfrodriguez do you remember which issue that was? If there is one UnitTests for this would be great.

We had an issue where those line caused a wrong quoting of the char `!` in the password causing "Error in SOAP call: 401 Unauthorized" errors in the GenericInterface log. After removing it everything went as expected.

I'm glad to clarify any questions.

A cherry-pick to OTRS 5 would be great.

  Thorsten
