### PR TITLE
Fixed hiding attachments with Content-ID found anywhere in the messag…

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,4 +1,5 @@
 #6.0.0.beta1 2016-??-??
+ - 2016-06-10 Fixed hiding attachments with Content-ID found anywhere in the message body.
  - 2016-06-06 Added checks for length of words in search terms when using search index/StaticDB backend.
  - 2016-06-06 Fixed bug#[12020](http://bugs.otrs.org/show_bug.cgi?id=12020) - Option CaseSensitive has no impact on external customer database.
  - 2016-06-03 Improved default procmail config (disabled comsat and added postmaster pipe waiting), thanks to Pawel Boguslawski.

--- a/Kernel/Output/HTML/Layout.pm
+++ b/Kernel/Output/HTML/Layout.pm
@@ -4517,71 +4517,39 @@ sub RichTextDocumentServe {
         $SessionID = ';' . $Self->{SessionName} . '=' . $Self->{SessionID};
     }
 
-    # replace inline images in content with runtime url to images
+    # replace inline images (defined with Content-ID or Content-Location)
+    # in content with runtime url to images
     my $AttachmentLink = $Self->{Baselink} . $Param{URL};
-    $Param{Data}->{Content} =~ s{
-        (=|"|')cid:(.*?)("|'|>|\/>|\s)
-    }
-    {
-        my $Start= $1;
-        my $ContentID = $2;
-        my $End = $3;
-
-        # improve html quality
-        if ( $Start ne '"' && $Start ne '\'' ) {
-            $Start .= '"';
-        }
-        if ( $End ne '"' && $End ne '\'' ) {
-            $End = '"' . $End;
-        }
-
-        # find matching attachment and replace it with runtime url to image
-        ATTACHMENT_ID:
-        for my $AttachmentID (  sort keys %{ $Param{Attachments} }) {
-            next ATTACHMENT_ID if lc $Param{Attachments}->{$AttachmentID}->{ContentID} ne lc "<$ContentID>";
-            $ContentID = $AttachmentLink . $AttachmentID . $SessionID;
-            last ATTACHMENT_ID;
-        }
-
-        # return new runtime url
-        $Start . $ContentID . $End;
-    }egxi;
-
-    # bug #5053
-    # inline images using Content-Location as identifier instead of Content-ID even RFC2557
-    # http://www.ietf.org/rfc/rfc2557.txt
-
-    # find matching attachment and replace it with runtlime url to image
-    ATTACHMENT:
+    ATTACHMENTID:
     for my $AttachmentID ( sort keys %{ $Param{Attachments} } ) {
-        next ATTACHMENT if !$Param{Attachments}->{$AttachmentID}->{ContentID};
+        next ATTACHMENTID if !$Param{Attachments}->{$AttachmentID}->{ContentID};
 
         # content id cleanup
         $Param{Attachments}->{$AttachmentID}->{ContentID} =~ s/^<//;
         $Param{Attachments}->{$AttachmentID}->{ContentID} =~ s/>$//;
 
-        next ATTACHMENT if !$Param{Attachments}->{$AttachmentID}->{ContentID};
+        next ATTACHMENTID if !$Param{Attachments}->{$AttachmentID}->{ContentID};
 
         $Param{Data}->{Content} =~ s{
-        (=|"|')(\Q$Param{Attachments}->{$AttachmentID}->{ContentID}\E)("|'|>|\/>|\s)
-    }
-    {
-        my $Start= $1;
-        my $ContentID = $2;
-        my $End = $3;
-
-        # improve html quality
-        if ( $Start ne '"' && $Start ne '\'' ) {
-            $Start .= '"';
+        (\ssrc\s*=\s*)(["']{0,1})(cid:){0,1}(\Q$Param{Attachments}->{$AttachmentID}->{ContentID}\E)("|'|>|\/>|\s)
         }
-        if ( $End ne '"' && $End ne '\'' ) {
-            $End = '"' . $End;
-        }
+        {
+            my $PartSrc = $1;
+            my $PartOpenQuot;
+            my $PartContentID = $4;
+            my $PartEnd = $5;
 
-        # return new runtime url
-        $ContentID = $AttachmentLink . $AttachmentID . $SessionID;
-        $Start . $ContentID . $End;
-    }egxi;
+            # improve html quality
+            if ( $PartEnd ne '"' && $PartEnd ne '\'' ) {
+                $PartEnd = '"' . $PartEnd;
+                $PartOpenQuot = '"';
+            }
+            $PartOpenQuot = $PartEnd if !$PartOpenQuot;
+
+            # return new runtime url
+            $PartContentID = $AttachmentLink . $AttachmentID . ';' . $SessionID;
+            $PartSrc . $PartOpenQuot . $PartContentID . $PartEnd;
+        }egxi;
     }
 
     return %{ $Param{Data} };

--- a/Kernel/System/Ticket/Article.pm
+++ b/Kernel/System/Ticket/Article.pm
@@ -3183,17 +3183,17 @@ sub ArticleAttachmentIndex {
                     UserID    => $Param{UserID},
                 );
 
-                ATTACHMENT:
+                ATTACHMENTID:
                 for my $AttachmentID ( sort keys %Attachments ) {
                     my %File = %{ $Attachments{$AttachmentID} };
-                    next ATTACHMENT if !$File{ContentID};
+                    next ATTACHMENTID if !$File{ContentID};
 
                     # content id cleanup
                     $File{ContentID} =~ s/^<//;
                     $File{ContentID} =~ s/>$//;
                     if (
                         $File{ContentID}
-                        && $Attachment{Content} =~ /\Q$File{ContentID}\E/i
+                        && $Attachment{Content} =~ /(\ssrc\s*=\s*)(["']{0,1})(cid:){0,1}(\Q$File{ContentID}\E)("|'|>|\/>|\s)/i
                         && $File{Disposition} eq 'inline'
                         )
                     {

--- a/scripts/test/sample/PostMaster/PostMaster-Test24.box
+++ b/scripts/test/sample/PostMaster/PostMaster-Test24.box
@@ -1,0 +1,29 @@
+Date: Wed, 16 Apr 2016 12:00:00 +0200
+From: test <test@host.test>
+To: test <test@host.test>
+Subject: test
+Message-ID: <testmsg1@host.test>
+MIME-Version: 1.0
+Content-Type: multipart/related; boundary="testpart1"
+
+--testpart1
+Content-Type: text/html; charset="iso-8859-2"
+Content-Disposition: inline
+Content-Transfer-Encoding: quoted-printable
+
+test pic: <img id=3D"testcid1" src=3D"http://www.h=
+ost.test/test.png" alt=3D"" width=3D"10" height=3D"10" />
+
+--testpart1
+Content-Type: image/png;
+ name="test.png"
+Content-Transfer-Encoding: base64
+Content-ID: <testcid1>
+Content-Disposition: inline;
+ filename="test.png"
+
+iVBORw0KGgoAAAANSUhEUgAAAAoAAAAKAQMAAAC3/F3+AAAABlBMVEX///8AAABVwtN+AAAA
+CXBIWXMAAAsTAAALEwEAmpwYAAAAB3RJTUUH3gQYFBgEGpRZowAAAB1pVFh0Q29tbWVudAAA
+AAAAQ3JlYXRlZCB3aXRoIEdJTVBkLmUHAAAAEklEQVQI12NggAEWBgY+MIkEAAGUABckedJ2
+AAAAAElFTkSuQmCC
+--testpart1--


### PR DESCRIPTION
…e body

When displaying HTML messages OTRS hides inline attachments
that have Content-ID somewhere in HTML message body,
not checking if Content-ID is in src attribute. This may cause some
poorly attached inline attachments to be hidden in OTRS while
standard MTA show it as attachment.

This mod fixes this issue and removes redundant replace operations.

Related: https://dev.ib.pl/ib/otrs/issues/68
Author-Change-Id: IB#1052680