### PR TITLE
Fixed empty attachment links and ugly filesize formatting

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,4 +1,5 @@
 #6.0.0.beta1 2016-??-??
+ - 2016-06-16 Fixed empty attachment links and ugly filesize formatting.
  - 2016-06-06 Added checks for length of words in search terms when using search index/StaticDB backend.
  - 2016-06-06 Fixed bug#[12020](http://bugs.otrs.org/show_bug.cgi?id=12020) - Option CaseSensitive has no impact on external customer database.
  - 2016-06-03 Improved default procmail config (disabled comsat and added postmaster pipe waiting), thanks to Pawel Boguslawski.

--- a/Kernel/Modules/AgentTicketZoom.pm
+++ b/Kernel/Modules/AgentTicketZoom.pm
@@ -2716,15 +2716,18 @@ sub _ArticleItem {
                     Article => \%Article,
                 );
 
-                # check for the display of the filesize
-                if ( $Job eq '2-HTML-Viewer' ) {
-                    $Data{DataFileSize} = ", " . $File{Filesize};
+                if (%Data) {
+                    $LayoutObject->Block(
+                        Name => $Data{Block} || 'ArticleAttachmentRowLink',
+                        Data => {%Data},
+                    );
                 }
-                $LayoutObject->Block(
-                    Name => $Data{Block} || 'ArticleAttachmentRowLink',
-                    Data => {%Data},
-                );
             }
+
+            $LayoutObject->Block(
+                Name => 'ArticleAttachmentRowFilesize',
+                Data => \%File,
+            );
         }
     }
 

--- a/Kernel/Output/HTML/Templates/Standard/AgentTicketZoom.tt
+++ b/Kernel/Output/HTML/Templates/Standard/AgentTicketZoom.tt
@@ -766,10 +766,13 @@ Core.Agent.TicketZoom.TimelineView.Init(TicketID, ListObjects, ArticleID);
                     <p class="Value">
 [% RenderBlockStart("ArticleAttachmentRow") %]
 [% RenderBlockStart("ArticleAttachmentRowLink") %]
-                        <a class="[% Data.Class | html %]" href="[% Data.Link %]" [% Data.Target %] title="[% Translate(Data.Action) | html %]">[% Data.Filename | html %]</a> [% Data.DataFileSize | html %]
+                        <a class="[% Data.Class | html %]" href="[% Data.Link %]" [% Data.Target %] title="[% Translate(Data.Action) | html %]">[% Data.Filename | html %]</a>
 [% RenderBlockEnd("ArticleAttachmentRowLink") %]
+[% RenderBlockStart("ArticleAttachmentRowFilesize") %]
+                        ([% Data.Filesize | html %])
+[% RenderBlockEnd("ArticleAttachmentRowFilesize") %]
 [% RenderBlockStart("ArticleAttachmentRowNoLink") %]
-                        [% Data.Filename | html %], [% Data.Filesize | html %]
+                        [% Data.Filename | html %] ([% Data.Filesize | html %])
 [% RenderBlockEnd("ArticleAttachmentRowNoLink") %]
                         <br />
 [% RenderBlockEnd("ArticleAttachmentRow") %]

--- a/Kernel/Output/HTML/Templates/Standard/CustomerTicketZoom.tt
+++ b/Kernel/Output/HTML/Templates/Standard/CustomerTicketZoom.tt
@@ -128,10 +128,10 @@
                                     <i class="fa fa-paperclip"></i>
                                     <span class="DownloadAttachment" title="[% Data.Filename | html %] - [% Data.Filesize | html %]">
 [% RenderBlockStart("ArticleAttachmentRowLink") %]
-                                        <a href="[% Data.Link %]" [% Data.Target %] title="[% Translate(Data.Action) | html %]">[% Data.Filename | html %]</a>, [% Data.Filesize | html %]
+                                        <a href="[% Data.Link %]" [% Data.Target %] title="[% Translate(Data.Action) | html %]">[% Data.Filename | html %]</a> ([% Data.Filesize | html %])
 [% RenderBlockEnd("ArticleAttachmentRowLink") %]
 [% RenderBlockStart("ArticleAttachmentRowNoLink") %]
-                                        [% Data.Filename | html %], [% Data.Filesize | html %]
+                                        [% Data.Filename | html %] ([% Data.Filesize | html %])
 [% RenderBlockEnd("ArticleAttachmentRowNoLink") %]
                                     </span>
 [% RenderBlockEnd("ArticleAttachmentRow") %]


### PR DESCRIPTION
OTRS adds empty link in HTML code in attachment block in AgentTicketZoom
and CustomerTicketZoom, i.e.:

    <label>Attachment:</label>
    <p class="Value">
        <a class="" href="/otrs/index.pl?Action=AgentTicketAttachment;ArticleID=2;FileID=1" target="AttachmentWindow" title="Download">test1.pdf</a>
        <a class="" href="" title=""></a> , 332.1 KB
        <br>
        <a class="" href="/otrs/index.pl?Action=AgentTicketAttachment;ArticleID=2;FileID=3" target="AttachmentWindow" title="Download">test2.txt</a>
        <a class="" href="" title=""></a> , 6 B
        <br>
    </p>

This disrupts tools like FlashGot when selecting a few attachments
to download in one shot.

Attachment sizes in AgentTicketZoom and CustomerTicketZoom are separated
from filename with ugly " , " while in attachment upload forms there
is nicer formatting like "filename (size)".

This mod fixes both issues.

Related: https://dev.ib.pl/ib/otrs/issues/69
Author-Change-Id: IB#1020949