### PR TITLE
Fixed plain e-mails saving with unfolded headers

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,4 +1,5 @@
 #6.0.0.beta1 2016-??-??
+ - 2016-06-16 Fixed plain e-mails saving with unfolded headers.
  - 2016-06-06 Added checks for length of words in search terms when using search index/StaticDB backend.
  - 2016-06-06 Fixed bug#[12020](http://bugs.otrs.org/show_bug.cgi?id=12020) - Option CaseSensitive has no impact on external customer database.
  - 2016-06-03 Improved default procmail config (disabled comsat and added postmaster pipe waiting), thanks to Pawel Boguslawski.

--- a/Kernel/System/EmailParser.pm
+++ b/Kernel/System/EmailParser.pm
@@ -96,6 +96,9 @@ sub new {
             $Param{Email} = \@Content;
         }
 
+        # save copy of unmodified message
+        $Self->{OrigEmail} = join('', @{$Param{Email}});
+
         # create Mail::Internet object
         $Self->{Email} = Mail::Internet->new( $Param{Email} );
 
@@ -138,6 +141,20 @@ sub GetPlainEmail {
     my $Self = shift;
 
     return $Self->{Email}->as_string();
+}
+
+=item GetPlainOrigEmail()
+
+To get back an original email as a string (plain email).
+
+    my $Email = $ParserObject->GetPlainOrigEmail();
+
+=cut
+
+sub GetPlainOrigEmail {
+    my $Self = shift;
+
+    return $Self->{OrigEmail};
 }
 
 =item GetParam()

--- a/Kernel/System/PostMaster/FollowUp.pm
+++ b/Kernel/System/PostMaster/FollowUp.pm
@@ -408,7 +408,7 @@ sub Run {
     # write plain email to the storage
     $TicketObject->ArticleWritePlain(
         ArticleID => $ArticleID,
-        Email     => $Self->{ParserObject}->GetPlainEmail(),
+        Email     => $Self->{ParserObject}->GetPlainOrigEmail(),
         UserID    => $Param{InmailUserID},
     );
 

--- a/Kernel/System/PostMaster/NewTicket.pm
+++ b/Kernel/System/PostMaster/NewTicket.pm
@@ -575,7 +575,7 @@ sub Run {
     # write plain email to the storage
     $TicketObject->ArticleWritePlain(
         ArticleID => $ArticleID,
-        Email     => $Self->{ParserObject}->GetPlainEmail(),
+        Email     => $Self->{ParserObject}->GetPlainOrigEmail(),
         UserID    => $Param{InmailUserID},
     );
 

--- a/Kernel/System/PostMaster/Reject.pm
+++ b/Kernel/System/PostMaster/Reject.pm
@@ -99,7 +99,7 @@ sub Run {
     # write plain email to the storage
     $TicketObject->ArticleWritePlain(
         ArticleID => $ArticleID,
-        Email     => $Self->{ParserObject}->GetPlainEmail(),
+        Email     => $Self->{ParserObject}->GetPlainOrigEmail(),
         UserID    => $Param{InmailUserID},
     );
 


### PR DESCRIPTION
OTRS stores plain copy of every e-mail in plain.txt file with headers
unfolded (i.e. Received header is saved as one line even if in original
message it was multiline). This copy should keep original message
formatting, without unfolding (i.e. for debugging purposes and not
to mess up linebreaks if message arrive with DOS line endings).

Related: https://dev.ib.pl/ib/otrs/issues/70
Author-Change-Id: IB#1022256
