### PR TITLE
Fixed errors when processing incomplete session data

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,4 +1,5 @@
 #6.0.0.beta1 2016-??-??
+ - 2016-06-16 Fixed errors when processing incomplete session data.
  - 2016-06-06 Added checks for length of words in search terms when using search index/StaticDB backend.
  - 2016-06-06 Fixed bug#[12020](http://bugs.otrs.org/show_bug.cgi?id=12020) - Option CaseSensitive has no impact on external customer database.
  - 2016-06-03 Improved default procmail config (disabled comsat and added postmaster pipe waiting), thanks to Pawel Boguslawski.

--- a/Kernel/Modules/AdminSession.pm
+++ b/Kernel/Modules/AdminSession.pm
@@ -171,13 +171,15 @@ sub Run {
         for my $SessionID (@List) {
             my $List = '';
             my %Data = $SessionObject->GetSessionIDData( SessionID => $SessionID );
-            $MetaData{"$Data{UserType}Session"}++;
-            if ( !$MetaData{"$Data{UserLogin}"} ) {
-                $MetaData{"$Data{UserType}SessionUniq"}++;
-                $MetaData{"$Data{UserLogin}"} = 1;
+            if ( $Data{UserType} && $Data{UserLogin} ) {
+                $MetaData{"$Data{UserType}Session"}++;
+                if ( !$MetaData{"$Data{UserLogin}"} ) {
+                    $MetaData{"$Data{UserType}SessionUniq"}++;
+                    $MetaData{"$Data{UserLogin}"} = 1;
+                }
             }
 
-            $Data{UserType} = 'Agent' if ( $Data{UserType} ne 'Customer' );
+            $Data{UserType} = 'Agent' if ( !$Data{UserType} || $Data{UserType} ne 'Customer' );
 
             # create blocks
             $LayoutObject->Block(

--- a/Kernel/Modules/AdminSystemMaintenance.pm
+++ b/Kernel/Modules/AdminSystemMaintenance.pm
@@ -535,13 +535,15 @@ sub _ShowEdit {
         for my $SessionID (@List) {
             my $List = '';
             my %Data = $SessionObject->GetSessionIDData( SessionID => $SessionID );
-            $MetaData{"$Data{UserType}Session"}++;
-            if ( !$MetaData{"$Data{UserLogin}"} ) {
-                $MetaData{"$Data{UserType}SessionUniq"}++;
-                $MetaData{"$Data{UserLogin}"} = 1;
+            if ( $Data{UserType} && $Data{UserLogin} ) {
+                $MetaData{"$Data{UserType}Session"}++;
+                if ( !$MetaData{"$Data{UserLogin}"} ) {
+                    $MetaData{"$Data{UserType}SessionUniq"}++;
+                    $MetaData{"$Data{UserLogin}"} = 1;
+                }
             }
 
-            $Data{UserType} = 'Agent' if ( $Data{UserType} ne 'Customer' );
+            $Data{UserType} = 'Agent' if ( !$Data{UserType} || $Data{UserType} ne 'Customer' );
 
             # store data to be used later for showing a users session table
             push @UserSessions, {


### PR DESCRIPTION
OTRS does not check if session data is complete when counting sessions
and may throw errors like

    Use of uninitialized value $Data{"UserType"} in concatenation (.) or string at /opt/otrs//Kernel/Modules/AdminSession.pm line 170.
    Use of uninitialized value $Data{"UserLogin"} in string at /opt/otrs//Kernel/Modules/AdminSession.pm line 171.

Incomplete sessions may occur afters race conditions; i.e. open two
OTRS tabs (same session) and run longer query in one tab (i.e. report
or some other longer stuff like entering AdminSysConfig) and logout
immediately on second tab; after querty finish in the first tab,
session table will contain incomplete session, containing only two
data rows, i.e.:

    SessionID AgG2BEUhx1ZqsbZxobcD4pKIz5LkzKE
    UserLastRequest 1466080902

This patch fixes this issue.

Related: https://dev.ib.pl/ib/otrs/issues/71
Author-Change-Id: IB#1016015