### PR TITLE
Fixed uninitialized counters after TicketSearch calls without permissions

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,4 +1,5 @@
 #6.0.0.beta1 2016-??-??
+ - 2016-06-17 Fixed uninitialized counters after TicketSearch calls without permissions.
  - 2016-06-06 Added checks for length of words in search terms when using search index/StaticDB backend.
  - 2016-06-06 Fixed bug#[12020](http://bugs.otrs.org/show_bug.cgi?id=12020) - Option CaseSensitive has no impact on external customer database.
  - 2016-06-03 Improved default procmail config (disabled comsat and added postmaster pipe waiting), thanks to Pawel Boguslawski.

--- a/Kernel/Modules/AgentTicketLockedView.pm
+++ b/Kernel/Modules/AgentTicketLockedView.pm
@@ -330,7 +330,7 @@ sub Run {
             %{ $Filters{$Filter}->{Search} },
             %ColumnFilter,
             Result => 'COUNT',
-        );
+        ) || 0;
 
         $NavBarFilter{ $Filters{$Filter}->{Prio} } = {
             Count  => $Count,

--- a/Kernel/Modules/AgentTicketQueue.pm
+++ b/Kernel/Modules/AgentTicketQueue.pm
@@ -381,7 +381,7 @@ sub Run {
                 %{ $Filters{$FilterColumn}->{Search} },
                 %ColumnFilter,
                 Result => 'COUNT',
-            );
+            ) || 0;
         }
 
         if ( $FilterColumn eq $Filter ) {

--- a/Kernel/Modules/AgentTicketResponsibleView.pm
+++ b/Kernel/Modules/AgentTicketResponsibleView.pm
@@ -362,7 +362,7 @@ sub Run {
             %{ $Filters{$FilterColumn}->{Search} },
             %ColumnFilter,
             Result => 'COUNT',
-        );
+        ) || 0;
 
         # prepare count for new article tickets
         if ( $FilterColumn eq 'New' ) {
@@ -370,7 +370,7 @@ sub Run {
                 %{ $Filters{All}->{Search} },
                 %ColumnFilter,
                 Result => 'COUNT',
-            );
+            ) || 0;
             $Count = $CountAll - $Count;
         }
 

--- a/Kernel/Modules/AgentTicketService.pm
+++ b/Kernel/Modules/AgentTicketService.pm
@@ -405,7 +405,7 @@ sub Run {
                 %{ $Filters{$FilterColumn}->{Search} },
                 %ColumnFilter,
                 Result => 'COUNT',
-            );
+            ) || 0;
         }
 
         if ( $FilterColumn eq $Filter ) {
@@ -476,7 +476,7 @@ sub Run {
             Permission => $Permission,
             UserID     => $Self->{UserID},
             Result     => 'COUNT',
-        );
+        ) || 0;
     }
 
     # add the count for the custom services
@@ -500,7 +500,7 @@ sub Run {
             Permission => $Permission,
             UserID     => $Self->{UserID},
             Result     => 'COUNT',
-        );
+        ) || 0;
 
         next SERVICEID if !$Count;
 

--- a/Kernel/Modules/AgentTicketStatusView.pm
+++ b/Kernel/Modules/AgentTicketStatusView.pm
@@ -238,7 +238,7 @@ sub Run {
             %{ $Filters{$Filter}->{Search} },
             %ColumnFilter,
             Result => 'COUNT',
-        );
+        ) || 0;
     }
 
     my $View = $ParamObject->GetParam( Param => 'View' ) || '';
@@ -294,7 +294,7 @@ sub Run {
             %{ $Filters{$Filter}->{Search} },
             %ColumnFilter,
             Result => 'COUNT',
-        );
+        ) || 0;
         if ( $Count > $Limit ) {
             $Count = $Limit;
         }

--- a/Kernel/Modules/AgentTicketWatchView.pm
+++ b/Kernel/Modules/AgentTicketWatchView.pm
@@ -396,7 +396,7 @@ sub Run {
             %{ $Filters{$FilterColumn}->{Search} },
             %ColumnFilter,
             Result => 'COUNT',
-        );
+        ) || 0;
 
         # prepare count for new article tickets
         if ( $FilterColumn eq 'New' ) {
@@ -404,7 +404,7 @@ sub Run {
                 %{ $Filters{All}->{Search} },
                 %ColumnFilter,
                 Result => 'COUNT',
-            );
+            ) || 0;
             $Count = $CountAll - $Count;
         }
 

--- a/Kernel/Modules/CustomerTicketOverview.pm
+++ b/Kernel/Modules/CustomerTicketOverview.pm
@@ -188,7 +188,7 @@ sub Run {
             %{ $Filters{ $Self->{Subaction} }->{$Filter}->{Search} },
             %SearchInArchive,
             Result => 'COUNT',
-        );
+        ) || 0;
 
         my $ClassA = '';
         if ( $Filter eq $FilterCurrent ) {

--- a/Kernel/Output/HTML/Dashboard/CustomerIDStatus.pm
+++ b/Kernel/Output/HTML/Dashboard/CustomerIDStatus.pm
@@ -68,7 +68,7 @@ sub Run {
         Permission                       => $Self->{Config}->{Permission},
         UserID                           => $Self->{UserID},
         CacheTTL                         => $Self->{Config}->{CacheTTLLocal} * 60,
-    );
+    ) || 0;
 
     # get layout object
     my $LayoutObject = $Kernel::OM->Get('Kernel::Output::HTML::Layout');
@@ -89,7 +89,7 @@ sub Run {
         Permission    => $Self->{Config}->{Permission},
         UserID        => $Self->{UserID},
         CacheTTL      => $Self->{Config}->{CacheTTLLocal} * 60,
-    );
+    ) || 0;
 
     $LayoutObject->Block(
         Name => 'ContentSmallCustomerIDStatusOpenTickets',
@@ -107,7 +107,7 @@ sub Run {
         Permission    => $Self->{Config}->{Permission},
         UserID        => $Self->{UserID},
         CacheTTL      => $Self->{Config}->{CacheTTLLocal} * 60,
-    );
+    ) || 0;
 
     $LayoutObject->Block(
         Name => 'ContentSmallCustomerIDStatusClosedTickets',
@@ -124,7 +124,7 @@ sub Run {
         Permission    => $Self->{Config}->{Permission},
         UserID        => $Self->{UserID},
         CacheTTL      => $Self->{Config}->{CacheTTLLocal} * 60,
-    );
+    ) || 0;
 
     $LayoutObject->Block(
         Name => 'ContentSmallCustomerIDStatusAllTickets',
@@ -143,7 +143,7 @@ sub Run {
             Permission    => $Self->{Config}->{Permission},
             UserID        => $Self->{UserID},
             CacheTTL      => $Self->{Config}->{CacheTTLLocal} * 60,
-        );
+        ) || 0;
 
         $LayoutObject->Block(
             Name => 'ContentSmallCustomerIDStatusArchivedTickets',

--- a/Kernel/Output/HTML/Dashboard/CustomerUserList.pm
+++ b/Kernel/Output/HTML/Dashboard/CustomerUserList.pm
@@ -300,7 +300,7 @@ sub Run {
             Permission           => $Self->{Config}->{Permission},
             UserID               => $Self->{UserID},
             CacheTTL             => $Self->{Config}->{CacheTTLLocal} * 60,
-        );
+        ) || 0;
 
         my $CustomerKeySQL = $Kernel::OM->Get('Kernel::System::DB')->QueryStringEscape( QueryString => $CustomerKey );
 
@@ -321,7 +321,7 @@ sub Run {
             Permission           => $Self->{Config}->{Permission},
             UserID               => $Self->{UserID},
             CacheTTL             => $Self->{Config}->{CacheTTLLocal} * 60,
-        );
+        ) || 0;
 
         $LayoutObject->Block(
             Name => 'ContentLargeCustomerUserListRowCustomerUserTicketsClosed',

--- a/Kernel/Output/HTML/Dashboard/TicketGeneric.pm
+++ b/Kernel/Output/HTML/Dashboard/TicketGeneric.pm
@@ -650,7 +650,7 @@ sub Run {
                     %{ $TicketSearchSummary{$Type} },
                     %{ $Self->{ColumnFilter} },
                     %ColumnFilter,
-                );
+                ) || 0;
             }
         }
     }

--- a/Kernel/Output/HTML/Dashboard/TicketQueueOverview.pm
+++ b/Kernel/Output/HTML/Dashboard/TicketQueueOverview.pm
@@ -142,7 +142,7 @@ sub Run {
                 Result => 'COUNT',
                 Queues => [ $Queues{$QueueID} ],
                 States => [ $ConfiguredStates{$StateOrderID} ],
-            );
+            ) || 0;
             push @Results, $QueueTotal;
         }
 

--- a/Kernel/Output/HTML/Dashboard/TicketStatsGeneric.pm
+++ b/Kernel/Output/HTML/Dashboard/TicketStatsGeneric.pm
@@ -141,7 +141,7 @@ sub Run {
             # search with user permissions
             Permission => $Self->{Config}->{Permission} || 'ro',
             UserID => $Self->{UserID},
-        );
+        ) || 0;
         if ( $CountCreated && $CountCreated > $Max ) {
             $Max = $CountCreated;
         }
@@ -164,7 +164,7 @@ sub Run {
             # search with user permissions
             Permission => $Self->{Config}->{Permission} || 'ro',
             UserID => $Self->{UserID},
-        );
+        ) || 0;
         if ( $CountClosed && $CountClosed > $Max ) {
             $Max = $CountClosed;
         }

--- a/Kernel/Output/HTML/ToolBar/TicketLocked.pm
+++ b/Kernel/Output/HTML/ToolBar/TicketLocked.pm
@@ -45,7 +45,7 @@ sub Run {
         OwnerIDs   => [ $Self->{UserID} ],
         UserID     => 1,
         Permission => 'ro',
-    );
+    ) || 0;
     my $CountNew = $TicketObject->TicketSearch(
         Result     => 'COUNT',
         Locks      => [ 'lock', 'tmp_lock' ],
@@ -56,7 +56,7 @@ sub Run {
         TicketFlagUserID => $Self->{UserID},
         UserID           => 1,
         Permission       => 'ro',
-    );
+    ) || 0;
     $CountNew = $Count - $CountNew;
     my $CountReached = $TicketObject->TicketSearch(
         Result                        => 'COUNT',
@@ -66,7 +66,7 @@ sub Run {
         OwnerIDs                      => [ $Self->{UserID} ],
         UserID                        => 1,
         Permission                    => 'ro',
-    );
+    ) || 0;
 
     my $Class        = $Param{Config}->{CssClass};
     my $ClassNew     = $Param{Config}->{CssClassNew};

--- a/Kernel/Output/HTML/ToolBar/TicketResponsible.pm
+++ b/Kernel/Output/HTML/ToolBar/TicketResponsible.pm
@@ -48,7 +48,7 @@ sub Run {
         ResponsibleIDs => [ $Self->{UserID} ],
         UserID         => 1,
         Permission     => 'ro',
-    );
+    ) || 0;
     my $CountNew = $TicketObject->TicketSearch(
         Result         => 'COUNT',
         StateType      => 'Open',
@@ -59,7 +59,7 @@ sub Run {
         TicketFlagUserID => $Self->{UserID},
         UserID           => 1,
         Permission       => 'ro',
-    );
+    ) || 0;
     $CountNew = $Count - $CountNew;
 
     my $CountReached = $TicketObject->TicketSearch(
@@ -69,7 +69,7 @@ sub Run {
         TicketPendingTimeOlderMinutes => 1,
         UserID                        => 1,
         Permission                    => 'ro',
-    );
+    ) || 0;
 
     my $Class        = $Param{Config}->{CssClass};
     my $ClassNew     = $Param{Config}->{CssClassNew};

--- a/Kernel/Output/HTML/ToolBar/TicketService.pm
+++ b/Kernel/Output/HTML/ToolBar/TicketService.pm
@@ -72,7 +72,7 @@ sub Run {
         LockIDs    => \@ViewableLockIDs,
         UserID     => $Self->{UserID},
         Permission => 'ro',
-    );
+    ) || 0;
 
     my $Class = $Param{Config}->{CssClass};
     my $Icon  = $Param{Config}->{Icon};

--- a/Kernel/Output/HTML/ToolBar/TicketWatcher.pm
+++ b/Kernel/Output/HTML/ToolBar/TicketWatcher.pm
@@ -74,7 +74,7 @@ sub Run {
         WatchUserIDs => [ $Self->{UserID} ],
         UserID       => 1,
         Permission   => 'ro',
-    );
+    ) || 0;
     my $CountNew = $TicketObject->TicketSearch(
         Result       => 'COUNT',
         WatchUserIDs => [ $Self->{UserID} ],
@@ -84,7 +84,7 @@ sub Run {
         TicketFlagUserID => $Self->{UserID},
         UserID           => 1,
         Permission       => 'ro',
-    );
+    ) || 0;
     $CountNew = $Count - $CountNew;
 
     my $CountReached = $TicketObject->TicketSearch(
@@ -94,7 +94,7 @@ sub Run {
         TicketPendingTimeOlderMinutes => 1,
         UserID                        => 1,
         Permission                    => 'ro',
-    );
+    ) || 0;
 
     my $Class        = $Param{Config}->{CssClass};
     my $ClassNew     = $Param{Config}->{CssClassNew};

--- a/Kernel/System/Stats/Dynamic/Ticket.pm
+++ b/Kernel/System/Stats/Dynamic/Ticket.pm
@@ -758,7 +758,7 @@ sub GetStatElement {
         Permission => 'ro',
         Limit      => 100_000_000,
         %Param,
-    );
+    ) || 0;
 }
 
 sub ExportWrapper {

--- a/Kernel/System/SupportDataCollector/Plugin/OTRS/Ticket/OpenTickets.pm
+++ b/Kernel/System/SupportDataCollector/Plugin/OTRS/Ticket/OpenTickets.pm
@@ -31,7 +31,7 @@ sub Run {
         StateType  => 'Open',
         UserID     => 1,
         Permission => 'ro',
-    );
+    ) || 0;
 
     if ( $OpenTickets > 8000 ) {
         $Self->AddResultWarning(


### PR DESCRIPTION
When agent without permissions (no groups associated) opens
AgentTicketStatusView, OTRS throws to apache error log many messages
similar to

    Use of uninitialized value $ViewableTicketCount in numeric gt (>) at [...]Kernel/Modules/AgentTicketStatusView.pm line 286.

This mod fixes such issues by setting return value to 0 if TicketSearch()
called with Result => 'COUNT' returns undef (i.e. agent has no permissions
to any queues in system); this is similar solution to one found in
AdminGenericAgent.pm.

Related: https://dev.ib.pl/ib/otrs/issues/72
Author-Change-Id: IB#1019544