### PR TITLE
Fixed risky status passing and redundant TicketGet calls

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,4 +1,5 @@
 #6.0.0.beta1 2016-??-??
+ - 2016-06-20 Fixed risky status passing and redundant TicketGet calls.
  - 2016-06-06 Added checks for length of words in search terms when using search index/StaticDB backend.
  - 2016-06-06 Fixed bug#[12020](http://bugs.otrs.org/show_bug.cgi?id=12020) - Option CaseSensitive has no impact on external customer database.
  - 2016-06-03 Improved default procmail config (disabled comsat and added postmaster pipe waiting), thanks to Pawel Boguslawski.

--- a/Kernel/System/Ticket.pm
+++ b/Kernel/System/Ticket.pm
@@ -4221,6 +4221,7 @@ sub TicketStateSet {
     # add history
     $Self->HistoryAdd(
         TicketID     => $Param{TicketID},
+        StateID      => $State{ID},
         ArticleID    => $ArticleID,
         QueueID      => $Ticket{QueueID},
         Name         => "\%\%$Ticket{State}\%\%$State{Name}\%\%",
@@ -5638,39 +5639,49 @@ sub HistoryAdd {
         $Param{QueueID} = $Self->TicketQueueID( TicketID => $Param{TicketID} );
     }
 
+    my %Ticket;
+
     # get type
     if ( !$Param{TypeID} ) {
-        my %Ticket = $Self->TicketGet(
-            %Param,
-            DynamicFields => 0,
-        );
+        if ( !%Ticket ) {
+            %Ticket = $Self->TicketGet(
+                %Param,
+                DynamicFields => 0,
+            );
+        }
         $Param{TypeID} = $Ticket{TypeID};
     }
 
     # get owner
     if ( !$Param{OwnerID} ) {
-        my %Ticket = $Self->TicketGet(
-            %Param,
-            DynamicFields => 0,
-        );
+        if ( !%Ticket ) {
+            %Ticket = $Self->TicketGet(
+                %Param,
+                DynamicFields => 0,
+            );
+        }
         $Param{OwnerID} = $Ticket{OwnerID};
     }
 
     # get priority
     if ( !$Param{PriorityID} ) {
-        my %Ticket = $Self->TicketGet(
-            %Param,
-            DynamicFields => 0,
-        );
+        if ( !%Ticket ) {
+            %Ticket = $Self->TicketGet(
+                %Param,
+                DynamicFields => 0,
+            );
+        }
         $Param{PriorityID} = $Ticket{PriorityID};
     }
 
     # get state
     if ( !$Param{StateID} ) {
-        my %Ticket = $Self->TicketGet(
-            %Param,
-            DynamicFields => 0,
-        );
+        if ( !%Ticket ) {
+            %Ticket = $Self->TicketGet(
+                %Param,
+                DynamicFields => 0,
+            );
+        }
         $Param{StateID} = $Ticket{StateID};
     }
 


### PR DESCRIPTION
TicketStateSet() calls HistoryAdd() without specyfing new StateID
as argument which may cause problems in case of cache cleanup
issues. Such arguments should be passed using arguments not
cache to be safer.

HistoryAdd() calls TicketGet() many times which is not necessary.

This mod fixes both issues.

Related: https://dev.ib.pl/ib/otrs/issues/73
Author-Change-Id: IB#1018102