### PR TITLE
Error on initial agent login from LDAP

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,4 +1,5 @@
 #6.0.0.beta1 2016-??-??
+ - 2016-06-20 Error on initial agent login from LDAP.
  - 2016-06-06 Added checks for length of words in search terms when using search index/StaticDB backend.
  - 2016-06-06 Fixed bug#[12020](http://bugs.otrs.org/show_bug.cgi?id=12020) - Option CaseSensitive has no impact on external customer database.
  - 2016-06-03 Improved default procmail config (disabled comsat and added postmaster pipe waiting), thanks to Pawel Boguslawski.

--- a/Kernel/System/Auth/Sync/LDAP.pm
+++ b/Kernel/System/Auth/Sync/LDAP.pm
@@ -198,7 +198,10 @@ sub Sync {
     my $ConfigObject = $Kernel::OM->Get('Kernel::Config');
 
     # get current user id
-    my $UserID = $UserObject->UserLookup( UserLogin => $Param{User} );
+    my $UserID = $UserObject->UserLookup(
+        UserLogin       => $Param{User},
+        DisableWarnings => 1,
+    );
 
     # system permissions
     my %PermissionsEmpty =

--- a/Kernel/System/User.pm
+++ b/Kernel/System/User.pm
@@ -878,7 +878,8 @@ user login or id lookup
     );
 
     my $UserID = $UserObject->UserLookup(
-        UserLogin => 'some_user_login',
+        UserLogin       => 'some_user_login',
+        DisableWarnings => 1,         # optional
     );
 
 =cut
@@ -925,10 +926,12 @@ sub UserLookup {
         }
 
         if ( !$ID ) {
-            $Kernel::OM->Get('Kernel::System::Log')->Log(
-                Priority => 'error',
-                Message  => "No UserID found for '$Param{UserLogin}'!",
-            );
+            if ( !$Param{DisableWarnings} ) {
+                $Kernel::OM->Get('Kernel::System::Log')->Log(
+                    Priority => 'error',
+                    Message  => "No UserID found for '$Param{UserLogin}'!",
+                );
+            }
             return;
         }
 
@@ -968,10 +971,12 @@ sub UserLookup {
         }
 
         if ( !$Login ) {
-            $Kernel::OM->Get('Kernel::System::Log')->Log(
-                Priority => 'error',
-                Message  => "No UserLogin found for '$Param{UserID}'!",
-            );
+            if ( !$Param{DisableWarnings} ) {
+                $Kernel::OM->Get('Kernel::System::Log')->Log(
+                    Priority => 'error',
+                    Message  => "No UserLogin found for '$Param{UserID}'!",
+                );
+            }
             return;
         }
 


### PR DESCRIPTION
OTRS throws error like

    No UserID found for 'login_here'!

when agent defined in LDAP loggs in for the first time.

This mod removes this unnecessary error message.

Related: https://dev.ib.pl/ib/otrs/issues/74
Author-Change-Id: IB#1016084