### PR TITLE
Fixed unnecessary merge errors when link already exists

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,4 +1,5 @@
 #6.0.0.beta1 2016-??-??
+ - 2016-06-21 Fixed unnecessary merge errors when link already exists.
  - 2016-06-06 Added checks for length of words in search terms when using search index/StaticDB backend.
  - 2016-06-06 Fixed bug#[12020](http://bugs.otrs.org/show_bug.cgi?id=12020) - Option CaseSensitive has no impact on external customer database.
  - 2016-06-03 Improved default procmail config (disabled comsat and added postmaster pipe waiting), thanks to Pawel Boguslawski.

--- a/Kernel/System/LinkObject.pm
+++ b/Kernel/System/LinkObject.pm
@@ -315,13 +315,14 @@ sub PossibleLinkList {
 add a new link between two elements
 
     $True = $LinkObject->LinkAdd(
-        SourceObject => 'Ticket',
-        SourceKey    => '321',
-        TargetObject => 'FAQ',
-        TargetKey    => '5',
-        Type         => 'ParentChild',
-        State        => 'Valid',
-        UserID       => 1,
+        SourceObject   => 'Ticket',
+        SourceKey      => '321',
+        TargetObject   => 'FAQ',
+        TargetKey      => '5',
+        Type           => 'ParentChild',
+        State          => 'Valid',
+        UserID         => 1,
+        NoticeIfExists => 1, # optional; notice not error if link exists
     );
 
 =cut
@@ -436,8 +437,11 @@ sub LinkAdd {
         if ( $Existing{StateID} ne $StateID ) {
 
             $Kernel::OM->Get('Kernel::System::Log')->Log(
-                Priority => 'error',
-                Message  => "Link already exists between these two objects "
+                Priority => $Param{NoticeIfExists} ? 'notice' : 'error',
+                Message  => "Cannot create a '$Param{Type}' link between "
+                    . "$Param{SourceObject} $Param{SourceKey} and "
+                    . "$Param{TargetObject} $Param{TargetKey}! "
+                    . "Link already exists between these two objects "
                     . "with a different state id '$Existing{StateID}'!",
             );
             return;
@@ -454,8 +458,11 @@ sub LinkAdd {
 
         # log error
         $Kernel::OM->Get('Kernel::System::Log')->Log(
-            Priority => 'error',
-            Message  => 'Link already exists between these two objects in opposite direction!',
+            Priority => $Param{NoticeIfExists} ? 'notice' : 'error',
+            Message  => "Cannot create a '$Param{Type}' link between "
+                . "$Param{SourceObject} $Param{SourceKey} and "
+                . "$Param{TargetObject} $Param{TargetKey}! "
+                . 'Link already exists between these two objects in opposite direction!',
         );
         return;
     }
@@ -494,8 +501,11 @@ sub LinkAdd {
 
             # existing link type is in a type group with the new link
             $Kernel::OM->Get('Kernel::System::Log')->Log(
-                Priority => 'error',
-                Message  => 'Another Link already exists within the same type group!',
+                Priority => $Param{NoticeIfExists} ? 'notice' : 'error',
+                Message  => "Cannot create a '$Param{Type}' link between "
+                    . "$Param{SourceObject} $Param{SourceKey} and "
+                    . "$Param{TargetObject} $Param{TargetKey}! "
+                    . 'Another Link already exists within the same type group!',
             );
 
             return;

--- a/Kernel/System/Ticket.pm
+++ b/Kernel/System/Ticket.pm
@@ -6102,13 +6102,14 @@ sub TicketMerge {
 
     # link tickets
     $Kernel::OM->Get('Kernel::System::LinkObject')->LinkAdd(
-        SourceObject => 'Ticket',
-        SourceKey    => $Param{MainTicketID},
-        TargetObject => 'Ticket',
-        TargetKey    => $Param{MergeTicketID},
-        Type         => 'ParentChild',
-        State        => 'Valid',
-        UserID       => $Param{UserID},
+        SourceObject   => 'Ticket',
+        SourceKey      => $Param{MainTicketID},
+        TargetObject   => 'Ticket',
+        TargetKey      => $Param{MergeTicketID},
+        Type           => 'ParentChild',
+        State          => 'Valid',
+        UserID         => $Param{UserID},
+        NoticeIfExists => 1,
     );
 
     # get the list of all merged states


### PR DESCRIPTION
OTRS throws error messages like

    Link already exists between these two objects in opposite direction
    Another Link already exists within the same type group!

when merging tickets with existing links between it.

This mod changes such message priority from error to notice.

Related: https://dev.ib.pl/ib/otrs/issues/75
Author-Change-Id: IB#1016061