### PR TITLE
Fixed error removing shm for log on OTRS startup

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,4 +1,5 @@
 #6.0.0.beta1 2016-??-??
+ - 2016-06-21 Fixed error removing shm for log on OTRS startup.
  - 2016-06-06 Added checks for length of words in search terms when using search index/StaticDB backend.
  - 2016-06-06 Fixed bug#[12020](http://bugs.otrs.org/show_bug.cgi?id=12020) - Option CaseSensitive has no impact on external customer database.
  - 2016-06-03 Improved default procmail config (disabled comsat and added postmaster pipe waiting), thanks to Pawel Boguslawski.

--- a/Kernel/System/Log.pm
+++ b/Kernel/System/Log.pm
@@ -303,7 +303,7 @@ sub CleanUp {
     # remove the shm
     if ( !shmctl( $Self->{Key}, 0, 0 ) ) {
         $Self->Log(
-            Priority => 'error',
+            Priority => 'notice',
             Message  => "Can't remove shm for log: $!",
         );
         return;


### PR DESCRIPTION
Sometimes during OTRS system startup shm errors occur, i.e.

    Can't remove shm for log: Invalid argument

This may be caused by concurrent OTRS cron jobs execution on
OS startup and races with calling CleanUp() in Log.pm.

This mod changes priority of such messages from error to notice.

Related: https://dev.ib.pl/ib/otrs/issues/76
Author-Change-Id: IB#1023103