### PR TITLE
Guard against TicketSearch for non-existing dynamic fields

### DIFF
--- a/Kernel/System/Ticket/TicketSearch.pm
+++ b/Kernel/System/Ticket/TicketSearch.pm
@@ -1383,16 +1383,18 @@ sub TicketSearch {
     }
 
     # catch searches for non-existing dynamic fields
+    PARAMS:
     for my $Key ( sort keys %Param ) {
-        if ( $Key =~ /^DynamicField_(.*)$/ && $Param{$Key} ) {
-            my $DynamicFieldName = $1;
-            $Kernel::OM->Get('Kernel::System::Log')->Log(
-                Priority => 'Error',
-                Message  => qq[No such dynamic field "$DynamicFieldName" (or it is inactive)],
-            );
+        next PARAMS if !$Param{$Key};
+        next PARAMS if $Key !~ /^DynamicField_(.*)$/;
 
-            return;
-        }
+        my $DynamicFieldName = $1;
+        $Kernel::OM->Get('Kernel::System::Log')->Log(
+            Priority => 'Error',
+            Message  => qq[No such dynamic field "$DynamicFieldName" (or it is inactive)],
+        );
+
+        return;
     }
 
     # get time object

--- a/Kernel/System/Ticket/TicketSearch.pm
+++ b/Kernel/System/Ticket/TicketSearch.pm
@@ -1383,7 +1383,7 @@ sub TicketSearch {
     }
 
     # catch searches for non-existing dynamic fields
-    for my $Key ( sort %Param ) {
+    for my $Key ( sort keys %Param ) {
         if ( $Key =~ /^DynamicField_(.*)$/ && $Param{$Key} ) {
             my $DynamicFieldName = $1;
             $Kernel::OM->Get('Kernel::System::Log')->Log(

--- a/Kernel/System/Ticket/TicketSearch.pm
+++ b/Kernel/System/Ticket/TicketSearch.pm
@@ -1291,7 +1291,7 @@ sub TicketSearch {
 
     DYNAMIC_FIELD:
     for my $DynamicField ( @{$TicketDynamicFields}, @{$ArticleDynamicFields} ) {
-        my $SearchParam = $Param{ "DynamicField_" . $DynamicField->{Name} };
+        my $SearchParam = delete $Param{ "DynamicField_" . $DynamicField->{Name} };
 
         next DYNAMIC_FIELD if ( !$SearchParam );
         next DYNAMIC_FIELD if ( ref $SearchParam ne 'HASH' );
@@ -1379,6 +1379,19 @@ sub TicketSearch {
             $DynamicFieldJoinTables{ $DynamicField->{Name} } = "dfv$DynamicFieldJoinCounter";
 
             $DynamicFieldJoinCounter++;
+        }
+    }
+
+    # catch searches for non-existing dynamic fields
+    for my $Key ( sort %Param ) {
+        if ( $Key =~ /^DynamicField_(.*)$/ && $Param{$Key} ) {
+            my $DynamicFieldName = $1;
+            $Kernel::OM->Get('Kernel::System::Log')->Log(
+                Priority => 'Error',
+                Message  => qq[No such dynamic field "$DynamicFieldName" (or it is inactive)],
+            );
+
+            return;
         }
     }
 

--- a/scripts/test/Ticket/TicketDynamicFieldSearch.t
+++ b/scripts/test/Ticket/TicketDynamicFieldSearch.t
@@ -803,6 +803,23 @@ $Self->IsDeeply(
     'Search for two values in a same field, match one ticket using an array ',
 );
 
+
+# Check that searching for non-existing dynamic fields is an error
+my $Result = $TicketObject->TicketSearch(
+    Result      => 'COUNT',
+    UserID     => 1,
+    "DynamicField_DFT5_NOSUCHTHING_$RandomID" => {
+        Like => [ 'ticket2_field5', 'ticket4_field5' ],
+    },
+    Permission => 'rw',
+);
+
+$Self->IsDeeply(
+    $Result,
+    undef,
+    'Searching for a non-existing dynamic field is an error',
+);
+
 # cleanup is done by RestoreDatabase.
 
 1;


### PR DESCRIPTION
Previously, such search filter were ignored. This means that
searching for a dynamic field that has been deleted from
or deactivated in the database might return way too many tickets,
putting undue pressure on downstream system.

Includes a test.