### PR TITLE
Services and SLAs enabled by default and label tuning on AgentTicketSearch

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,4 +1,5 @@
 #6.0.0.beta1 2016-??-??
+ - 2016-06-21 Services and SLAs enabled by default and label tuning on AgentTicketSearch.
  - 2016-06-06 Added checks for length of words in search terms when using search index/StaticDB backend.
  - 2016-06-06 Fixed bug#[12020](http://bugs.otrs.org/show_bug.cgi?id=12020) - Option CaseSensitive has no impact on external customer database.
  - 2016-06-03 Improved default procmail config (disabled comsat and added postmaster pipe waiting), thanks to Pawel Boguslawski.

--- a/Kernel/Config/Files/Ticket.xml
+++ b/Kernel/Config/Files/Ticket.xml
@@ -2624,6 +2624,22 @@
             <String></String>
         </Setting>
     </ConfigItem>
+    <ConfigItem Name="Ticket::Frontend::AgentTicketSearch###Defaults###ServiceIDs" Required="0" Valid="0">
+        <Description Translatable="1">Defines the default shown ticket search attribute for ticket search screen.</Description>
+        <Group>Ticket</Group>
+        <SubGroup>Frontend::Agent::Ticket::ViewSearch</SubGroup>
+        <Setting>
+            <Array></Array>
+        </Setting>
+    </ConfigItem>
+    <ConfigItem Name="Ticket::Frontend::AgentTicketSearch###Defaults###SLAIDs" Required="0" Valid="0">
+        <Description Translatable="1">Defines the default shown ticket search attribute for ticket search screen.</Description>
+        <Group>Ticket</Group>
+        <SubGroup>Frontend::Agent::Ticket::ViewSearch</SubGroup>
+        <Setting>
+            <Array></Array>
+        </Setting>
+    </ConfigItem>
     <ConfigItem Name="Frontend::Search###Ticket" Required="0" Valid="1">
         <Description Translatable="1">Search backend router.</Description>
         <Group>Ticket</Group>

--- a/Kernel/Output/HTML/Templates/Standard/AgentTicketSearch.tt
+++ b/Kernel/Output/HTML/Templates/Standard/AgentTicketSearch.tt
@@ -35,10 +35,10 @@
             </div>
         </fieldset>
         <fieldset class="TableLike" id="SearchInsert">
-            <legend><span>[% Translate("Filters in use") | html %]</span></legend>
+            <legend><span>[% Translate("Filters") | html %]</span></legend>
         </fieldset>
         <fieldset class="TableLike">
-            <legend><span>[% Translate("Additional filters") | html %]</span></legend>
+            <legend><span>[% Translate("Settings") | html %]</span></legend>
             <label>[% Translate("Add another attribute") | html %]:</label>
             <div class="Field">
                 [% Data.AttributesStrg %]


### PR DESCRIPTION
This mod adds two new SysConfig parameters...

    Ticket::Frontend::AgentTicketSearch###Defaults###ServiceIDs
    Ticket::Frontend::AgentTicketSearch###Defaults###SLAIDs

...that allows one to enable by default Service and/or SLA filters
on AgentTicketSearch form. It changes two AgentTicketSearch labels
for more suitable names.

Related: https://dev.ib.pl/ib/otrs/issues/77
Author-Change-Id: IB#1011939