### PR TITLE
[ Rel-5_0 Bug 12106 ] - Use of uninitialized value $FirstElementIndex in splice at /var/www/html/otrsnext/Kernel/Output/HTML/Layout

### DIFF
--- a/Kernel/Output/HTML/Layout/Ticket.pm
+++ b/Kernel/Output/HTML/Layout/Ticket.pm
@@ -280,7 +280,7 @@ sub AgentQueueListOption {
         # find index of first element in array @QueueDataArray for displaying in frontend
         # at the top should be element with ' $QueueDataArray[$_]->{Key} = 0' like "- Move -"
         # when such element is found, it is moved at the top
-        my ($FirstElementIndex) = grep $QueueDataArray[$_]->{Key} == 0, 0 .. $#QueueDataArray;
+        my ($FirstElementIndex) = grep $QueueDataArray[$_]->{Key} == 0, 0 .. $#QueueDataArray || 0;
         splice( @QueueDataArray, 0, 0, splice( @QueueDataArray, $FirstElementIndex, 1 ) );
         $Param{Data} = \@QueueDataArray;
 


### PR DESCRIPTION
http://bugs.otrs.org/show_bug.cgi?id=12106

Hello @carlosfrodriguez ,

Hereby is proposal for fixing reporters issue. To be honest, this bug was not reproducible in our different test environments. Value $FirstElementIndex carry value of 0, and perhaps this can cause some different perl version to interpret it as undef value resulting in reporters log warning.

Please let me know if you disagree with this change.

Regards,
Sanjin