### PR TITLE
Configurable bcrypt cost

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,4 +1,5 @@
 #6.0.0.beta1 2016-??-??
+ - 2016-06-23 Configurable bcrypt cost.
  - 2016-06-06 Added checks for length of words in search terms when using search index/StaticDB backend.
  - 2016-06-06 Fixed bug#[12020](http://bugs.otrs.org/show_bug.cgi?id=12020) - Option CaseSensitive has no impact on external customer database.
  - 2016-06-03 Improved default procmail config (disabled comsat and added postmaster pipe waiting), thanks to Pawel Boguslawski.

--- a/Kernel/Config/Files/Framework.xml
+++ b/Kernel/Config/Files/Framework.xml
@@ -8337,6 +8337,14 @@ via the Preferences button after logging in.
             </Option>
         </Setting>
     </ConfigItem>
+    <ConfigItem Name="Customer::AuthModule::DB::bcryptCost" Required="0" Valid="0" ConfigLevel="200">
+        <Description Translatable="1">If "bcrypt" was selected for CryptType, use cost specified here for bcrypt hashing. Currently max. supported cost value is 31.</Description>
+        <Group>Framework</Group>
+        <SubGroup>Frontend::Customer::Auth</SubGroup>
+        <Setting>
+            <String Regex="^[0-9]{1,2}$">12</String>
+        </Setting>
+    </ConfigItem>
     <ConfigItem Name="Customer::AuthModule::DB::Table" Required="1" Valid="1" ConfigLevel="200">
         <Description Translatable="1">If "DB" was selected for Customer::AuthModule, the name of the table where your customer data should be stored must be specified.</Description>
         <Group>Framework</Group>

--- a/Kernel/System/CustomerUser/DB.pm
+++ b/Kernel/System/CustomerUser/DB.pm
@@ -1151,6 +1151,9 @@ sub SetPassword {
     my $Login = $Param{UserLogin};
     my $Pw = $Param{PW} || '';
 
+    # get config object
+    my $ConfigObject = $Kernel::OM->Get('Kernel::Config');
+
     # check ro/rw
     if ( $Self->{ReadOnly} ) {
         $Kernel::OM->Get('Kernel::System::Log')->Log(
@@ -1171,7 +1174,7 @@ sub SetPassword {
     my $CryptedPw = '';
 
     # get crypt type
-    my $CryptType = $Kernel::OM->Get('Kernel::Config')->Get('Customer::AuthModule::DB::CryptType') || 'sha2';
+    my $CryptType = $ConfigObject->Get('Customer::AuthModule::DB::CryptType') || 'sha2';
 
     # get encode object
     my $EncodeObject = $Kernel::OM->Get('Kernel::System::Encode');
@@ -1241,7 +1244,12 @@ sub SetPassword {
             return;
         }
 
-        my $Cost = 9;
+        # get cost from config; use 12 if not configured; don't allow values smaller than 9 for security;
+        # current Crypt::Eksblowfish::Bcrypt limit is 31
+        my $Cost = $ConfigObject->Get('Customer::AuthModule::DB::bcryptCost') // 12;
+        $Cost = 9 if $Cost < 9;
+        $Cost = 31 if $Cost > 31;
+
         my $Salt = $MainObject->GenerateRandomString( Length => 16 );
 
         # remove UTF8 flag, required by Crypt::Eksblowfish::Bcrypt
@@ -1251,7 +1259,7 @@ sub SetPassword {
         my $Octets = Crypt::Eksblowfish::Bcrypt::bcrypt_hash(
             {
                 key_nul => 1,
-                cost    => 9,
+                cost    => $Cost,
                 salt    => $Salt,
             },
             $Pw

--- a/Kernel/System/User.pm
+++ b/Kernel/System/User.pm
@@ -744,6 +744,9 @@ sub SetPassword {
         return;
     }
 
+    # get config object
+    my $ConfigObject = $Kernel::OM->Get('Kernel::Config');
+
     # get old user data
     my %User = $Self->GetUserData( User => $Param{UserLogin} );
     if ( !$User{UserLogin} ) {
@@ -758,7 +761,7 @@ sub SetPassword {
     my $CryptedPw = '';
 
     # get crypt type
-    my $CryptType = $Kernel::OM->Get('Kernel::Config')->Get('AuthModule::DB::CryptType') || 'sha2';
+    my $CryptType = $ConfigObject->Get('AuthModule::DB::CryptType') || 'sha2';
 
     # crypt plain (no crypt at all)
     if ( $CryptType eq 'plain' ) {
@@ -819,7 +822,12 @@ sub SetPassword {
             return;
         }
 
-        my $Cost = 9;
+        # get cost from config; use 12 if not configured; don't allow values smaller than 9 for security;
+        # current Crypt::Eksblowfish::Bcrypt limit is 31
+        my $Cost = $ConfigObject->Get('Customer::AuthModule::DB::bcryptCost') // 12;
+        $Cost = 9 if $Cost < 9;
+        $Cost = 31 if $Cost > 31;
+
         my $Salt = $Kernel::OM->Get('Kernel::System::Main')->GenerateRandomString( Length => 16 );
 
         # remove UTF8 flag, required by Crypt::Eksblowfish::Bcrypt
@@ -829,7 +837,7 @@ sub SetPassword {
         my $Octets = Crypt::Eksblowfish::Bcrypt::bcrypt_hash(
             {
                 key_nul => 1,
-                cost    => 9,
+                cost    => $Cost,
                 salt    => $Salt,
             },
             $Pw


### PR DESCRIPTION
OTRS uses hardcoded bcrypt cost 9. This mod introduces new SysConfig
parameter `AuthModule::DB::bcryptCost` that allowes one to tune bcrypt
cost in range from 9 to 31 (31 seems to be Crypt::Eksblowfish::Bcrypt
limit) and changes default cost from 9 to 12 for better security.

Related: https://dev.ib.pl/ib/otrs/issues/78
Author-Change-Id: IB#1023732
