### PR TITLE
Master - JS refactoring - AgentTicketForward

### DIFF
--- a/Kernel/Config/Files/Ticket.xml
+++ b/Kernel/Config/Files/Ticket.xml
@@ -8909,6 +8909,7 @@
                 <Loader>
                     <JavaScript>Core.Agent.CustomerSearch.js</JavaScript>
                     <JavaScript>Core.Agent.TicketAction.js</JavaScript>
+                    <JavaScript>Core.Agent.TicketForward.js</JavaScript>
                 </Loader>
             </FrontendModuleReg>
         </Setting>

--- a/Kernel/Modules/AgentTicketForward.pm
+++ b/Kernel/Modules/AgentTicketForward.pm
@@ -1696,6 +1696,11 @@ sub _Mask {
         );
     }
 
+    $LayoutObject->AddJSData(
+        Key   => 'DynamicFieldNames',
+        Value => $DynamicFieldNames,
+    );
+
     # create & return output
     return $LayoutObject->Output(
         TemplateFile => 'AgentTicketForward',

--- a/Kernel/Output/HTML/Templates/Standard/AgentTicketForward.tt
+++ b/Kernel/Output/HTML/Templates/Standard/AgentTicketForward.tt
@@ -119,14 +119,6 @@
 [% RenderBlockEnd("MultipleCustomerCounter") %]
                 </div>
                 <div class="Clear"></div>
-[% WRAPPER JSOnDocumentComplete %]
-<script type="text/javascript">//<![CDATA[
-    $('.CustomerTicketRemove').bind('click', function () {
-        Core.Agent.CustomerSearch.RemoveCustomerTicket( $(this) );
-        return false;
-    });
-//]]></script>
-[% END %]
 
                 <label for="CcCustomer">[% Translate("Cc") | html %]:</label>
                 <div class="Field">
@@ -326,16 +318,6 @@
                             [% Data.Filename | html %] ([% Data.Filesize | html %])
                             <button type="button" id="AttachmentDeleteButton[% Data.FileID | html %]" name="AttachmentDeleteButton[% Data.FileID | html %]" value="[% Translate("Delete") | html %]" class="SpacingLeft">[% Translate("Delete") | html %]</button>
                             <input type="hidden" id="AttachmentDelete[% Data.FileID | html %]" name="AttachmentDelete[% Data.FileID | html %]" />
-[% WRAPPER JSOnDocumentComplete %]
-<script type="text/javascript">//<![CDATA[
-    $('#AttachmentDeleteButton[% Data.FileID | html %]').bind('click', function () {
-        var $Form = $('#AttachmentDeleteButton[% Data.FileID | html %]').closest('form');
-        $('#AttachmentDelete[% Data.FileID | html %]').val(1);
-        Core.Form.Validate.DisableValidation($Form);
-        $Form.trigger('submit');
-    });
-//]]></script>
-[% END %]
                         </li>
 [% RenderBlockEnd("Attachment") %]
                         <li>
@@ -343,28 +325,12 @@
                             <input type="hidden" id="AttachmentUpload" name="AttachmentUpload" value="0" />
                         </li>
                     </ul>
-[% WRAPPER JSOnDocumentComplete %]
-<script type="text/javascript">//<![CDATA[
-    $('#FileUpload').bind('change', function () {
-        var $Form = $('#FileUpload').closest('form');
-        Core.Form.Validate.DisableValidation($Form);
-        $Form.find('#AttachmentUpload').val('1').end().submit();
-    });
-//]]></script>
-[% END %]
                 </div>
                 <div class="Clear"></div>
 
                 <label for="ComposeStateID">[% Translate("Next ticket state") | html %]:</label>
                 <div class="Field">
                     [% Data.NextStatesStrg %]
-[% WRAPPER JSOnDocumentComplete %]
-<script type="text/javascript">//<![CDATA[
-    $('#ComposeStateID').bind('change', function (Event) {
-        Core.AJAX.FormUpdate($('#Compose'), 'AJAXUpdate', 'ComposeStateID', [ [% Data.DynamicFieldNamesStrg %] ]);
-    });
-//]]></script>
-[% END %]
                 </div>
                 <div class="Clear"></div>
 
@@ -438,10 +404,3 @@
         </div>
     </div>
 </form>
-
-#Layers
-[% WRAPPER JSOnDocumentComplete %]
-<script type="text/javascript">//<![CDATA[
-    Core.Agent.TicketAction.Init();
-//]]></script>
-[% END %]

--- a/var/httpd/htdocs/js/Core.Agent.TicketForward.js
+++ b/var/httpd/htdocs/js/Core.Agent.TicketForward.js
@@ -1,0 +1,71 @@
+// --
+// Copyright (C) 2001-2016 OTRS AG, http://otrs.com/
+// --
+// This software comes with ABSOLUTELY NO WARRANTY. For details, see
+// the enclosed file COPYING for license information (AGPL). If you
+// did not receive this file, see http://www.gnu.org/licenses/agpl.txt.
+// --
+
+"use strict";
+
+var Core = Core || {};
+Core.Agent = Core.Agent || {};
+
+/**
+ * @namespace Core.Agent.TicketForward
+ * @memberof Core.Agent
+ * @author OTRS AG
+ * @description
+ *      This namespace contains the TicketForward functions.
+ */
+Core.Agent.TicketForward = (function (TargetNS) {
+
+    /**
+     * @name Init
+     * @memberof Core.Agent.TicketForward
+     * @function
+     * @description
+     *      This function initializes the functionality for the TicketForward screen.
+     */
+    TargetNS.Init = function () {
+
+        var $Form,
+            FieldID,
+            DynamicFieldNames = Core.Config.Get('DynamicFieldNames');
+
+        // remove a customer ticket entry
+        $('.CustomerTicketRemove').on('click', function () {
+            Core.Agent.CustomerSearch.RemoveCustomerTicket($(this));
+            return false;
+        });
+
+        // delete attachment
+        $('button[id*=AttachmentDeleteButton]').on('click', function () {
+            $Form = $(this).closest('form');
+            FieldID = $(this).attr('id').split('AttachmentDeleteButton')[1];
+            $('#AttachmentDelete' + FieldID).val(1);
+            Core.Form.Validate.DisableValidation($Form);
+            $Form.trigger('submit');
+        });
+
+        // choose attachment
+        $('#FileUpload').on('change', function () {
+            $Form = $(this).closest('form');
+            Core.Form.Validate.DisableValidation($Form);
+            $Form.find('#AttachmentUpload').val('1').end().submit();
+        });
+
+        // update dynamic fields in form
+        $('#ComposeStateID').on('change', function () {
+            Core.AJAX.FormUpdate($('#Compose'), 'AJAXUpdate', 'ComposeStateID', DynamicFieldNames);
+        });
+
+        // initialize the ticket action popup
+        Core.Agent.TicketAction.Init();
+
+    };
+
+    Core.Init.RegisterNamespace(TargetNS, 'APP_MODULE');
+
+    return TargetNS;
+}(Core.Agent.TicketForward || {}));


### PR DESCRIPTION
Hi @zottto 

Hereby is updated AgentTicketForward module. We moved JS code from TT to the new JS file.
Part of code from AgentTicketForward.tt:

```
<script type="text/javascript">//<![CDATA[
    $('#AttachmentDeleteButton[% Data.FileID | html %]').bind('click', function () {
        var $Form = $('#AttachmentDeleteButton[% Data.FileID | html %]').closest('form');
        $('#AttachmentDelete[% Data.FileID | html %]').val(1);
        Core.Form.Validate.DisableValidation($Form);
        $Form.trigger('submit');
    });
//]]></script>

```
exists too in e.g. AgentTicketActionCommon.tt, AgentTicketCompose.tt etc. When we refactor all of these TT files, we would create one function and call from all appropriate JS files.

Regards
Zoran