### PR TITLE
Change wording for better translation

### DIFF
--- a/Kernel/Output/HTML/Templates/Standard/AdminCustomerCompany.tt
+++ b/Kernel/Output/HTML/Templates/Standard/AdminCustomerCompany.tt
@@ -62,12 +62,11 @@
             <div class="WidgetSimple">
 [% RenderBlockStart("OverviewHeader") %]
                 <div class="Header">
-                    <h2>[% Translate("List") | html %]
+                    <h2>
                         [% IF Data.ListAll && Data.Limit && Data.ListAll > Data.Limit %]
-                            ([% Translate("only") | html %] [% Data.SearchListSize | html %] [% Translate("shown") | html %] -
-                            [% Translate("more available") | html %])
+                            [% Translate("List (only %s shown - more available)", Data.SearchListSize) | html %]
                         [% ELSE %]
-                            ([% Data.ListAll | html %] [% Translate("total") | html %])
+                            [% Translate("List (%s total)", Data.ListAll) | html %]
                         [% END %]
                     </h2>
                 </div>

--- a/Kernel/Output/HTML/Templates/Standard/AdminCustomerUser.tt
+++ b/Kernel/Output/HTML/Templates/Standard/AdminCustomerUser.tt
@@ -74,12 +74,11 @@
         <div class="WidgetSimple">
 [% RenderBlockStart("OverviewHeader") %]
             <div class="Header">
-                <h2>[% Translate("List") | html %]
+                <h2>
                     [% IF Data.ListAll && Data.Limit && Data.ListAll > Data.Limit %]
-                        ([% Translate("only") | html %] [% Data.SearchListSize | html %] [% Translate("shown") | html %] -
-                        [% Translate("more available") | html %])
+                        [% Translate("List (only %s shown - more available)", Data.SearchListSize) | html %]
                     [% ELSE %]
-                        ([% Data.ListAll | html %] [% Translate("total") | html %])
+                        [% Translate("List (%s total)", Data.ListAll) | html %]
                     [% END %]
                 </h2>
             </div>

--- a/Kernel/Output/HTML/Templates/Standard/AdminUser.tt
+++ b/Kernel/Output/HTML/Templates/Standard/AdminUser.tt
@@ -69,12 +69,11 @@
         <div class="WidgetSimple">
 [% RenderBlockStart("OverviewHeader") %]
             <div class="Header">
-                <h2>[% Translate("List") | html %]
+                <h2>
                     [% IF Data.ListAll && Data.Limit && Data.ListAll > Data.Limit %]
-                        ([% Translate("only") | html %] [% Data.SearchListSize | html %] [% Translate("shown") | html %] -
-                        [% Translate("more available") | html %])
+                        [% Translate("List (only %s shown - more available)", Data.SearchListSize) | html %]
                     [% ELSE %]
-                        ([% Data.ListAll | html %] [% Translate("total") | html %])
+                        [% Translate("List (%s total)", Data.ListAll) | html %]
                     [% END %]
                 </h2>
             </div>


### PR DESCRIPTION
Hi @mgruner 
I change these title, because it is impossible to translate word by word. The whole sentence has different word order in Hungarian. Now it is easy to translate.