### PR TITLE
Fixed error log flooding with less important messages

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,4 +1,5 @@
 #6.0.0.beta1 2016-??-??
+ - 2016-06-28 Fixed error log flooding with less important messages.
  - 2016-06-24 Improved TicketSearch() to return error on a search for inexistent dynamic fields instead of ignoring them, thanks to Moritz Lenz.
  - 2016-06-06 Added checks for length of words in search terms when using search index/StaticDB backend.
  - 2016-06-06 Fixed bug#[12020](http://bugs.otrs.org/show_bug.cgi?id=12020) - Option CaseSensitive has no impact on external customer database.

--- a/Kernel/System/CustomerUser/LDAP.pm
+++ b/Kernel/System/CustomerUser/LDAP.pm
@@ -676,10 +676,23 @@ sub CustomerIDList {
 
     # log ldap errors
     if ( $Result->code() ) {
-        $Kernel::OM->Get('Kernel::System::Log')->Log(
-            Priority => 'error',
-            Message  => $Result->error(),
-        );
+
+        if ( $Result->code() == 4 ) {
+
+            # Result code 4 (LDAP_SIZELIMIT_EXCEEDED) is normal if there
+            # are more items in LDAP than search limit defined in OTRS or
+            # in LDAP server. Avoid spamming logs with such errors.
+            $Kernel::OM->Get('Kernel::System::Log')->Log(
+                Priority => 'debug',
+                Message  => 'LDAP size limit exceeded (' . $Result->error() . ').',
+            );
+        }
+        else {
+            $Kernel::OM->Get('Kernel::System::Log')->Log(
+                Priority => 'error',
+                Message  => 'Search failed! ' . $Result->error(),
+            );
+        }
     }
 
     my %Users;


### PR DESCRIPTION
This mod changes LDAP search limit message priority from
error to debug in CustomerIDList() like in
fd25ea3ec4e949a543fac441354c6cabd45c677f.

Fixes: fd25ea3ec4e949a543fac441354c6cabd45c677f
Related: https://dev.ib.pl/ib/otrs/issues/48
Related: https://github.com/OTRS/otrs/pull/1141
Author-Change-Id: IB#1050078