### PR TITLE
Added button with external URL in AgentTicketZoom ticket menu

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,4 +1,5 @@
 #6.0.0.beta1 2016-??-??
+ - 2016-06-28 Added button with external URL in AgentTicketZoom ticket menu.
  - 2016-06-24 Improved TicketSearch() to return error on a search for inexistent dynamic fields instead of ignoring them, thanks to Moritz Lenz.
  - 2016-06-06 Added checks for length of words in search terms when using search index/StaticDB backend.
  - 2016-06-06 Fixed bug#[12020](http://bugs.otrs.org/show_bug.cgi?id=12020) - Option CaseSensitive has no impact on external customer database.

--- a/Kernel/Config/Files/Ticket.xml
+++ b/Kernel/Config/Files/Ticket.xml
@@ -6630,6 +6630,25 @@
             </Hash>
         </Setting>
     </ConfigItem>
+    <ConfigItem Name="Ticket::Frontend::MenuModule###500-ExternalLink" Required="0" Valid="0">
+        <Description Translatable="1">Shows link to external page in the ticket zoom view of the agent interface. Additional access control to show or not show this link can be done by using Key "Group" and Content like "rw:group1;move_into:group2".</Description>
+        <Group>Ticket</Group>
+        <SubGroup>Frontend::Agent::Ticket::MenuModule</SubGroup>
+        <Setting>
+            <Hash>
+                <Item Key="Module">Kernel::Output::HTML::TicketMenu::Generic</Item>
+                <Item Key="Name" Translatable="1">External Link</Item>
+                <Item Key="Action"></Item>
+                <Item Key="Description" Translatable="1">Open external link!</Item>
+                <Item Key="Link">http://external-application.test/app/index.php?TicketID=[% Data.TicketID %]&amp;queue_id=[% Data.QueueID %]</Item>
+                <Item Key="Target">_blank</Item>
+                <Item Key="PopupType"></Item>
+                <Item Key="ClusterName" Translatable="1"></Item>
+                <Item Key="ClusterPriority"></Item>
+                <Item Key="ExternalLink">1</Item>
+            </Hash>
+        </Setting>
+    </ConfigItem>
     <ConfigItem Name="Ticket::Frontend::OverviewMenuModule###001-Sort" Required="0" Valid="1">
         <Description Translatable="1">Shows a select of ticket attributes to order the queue view ticket list. The possible selections can be configured via 'TicketOverviewMenuSort###SortAttributes'.</Description>
         <Group>Ticket</Group>

--- a/Kernel/Modules/AgentTicketZoom.pm
+++ b/Kernel/Modules/AgentTicketZoom.pm
@@ -1042,11 +1042,18 @@ sub MaskAgentZoom {
 
         # display all items
         for my $Item ( sort keys %ZoomMenuItems ) {
-
-            $LayoutObject->Block(
-                Name => 'TicketMenu',
-                Data => $ZoomMenuItems{$Item},
-            );
+            if ( $ZoomMenuItems{$Item}->{ExternalLink} && $ZoomMenuItems{$Item}->{ExternalLink} == 1 ) {
+                $LayoutObject->Block(
+                    Name => 'TicketMenuExternalLink',
+                    Data => $ZoomMenuItems{$Item},
+                );
+            }
+            else {
+                $LayoutObject->Block(
+                    Name => 'TicketMenu',
+                    Data => $ZoomMenuItems{$Item},
+                );
+            }
 
             if ( $ZoomMenuItems{$Item}->{Type} eq 'Cluster' ) {
 

--- a/Kernel/Output/HTML/Templates/Standard/AgentTicketZoom.tt
+++ b/Kernel/Output/HTML/Templates/Standard/AgentTicketZoom.tt
@@ -218,6 +218,11 @@ $('#[% Data.FormID | html %] select[name=[% Data.PhoneElementID | html %]]').bin
                                 <a href="[% Env("Baselink") %]Action=AgentTicketMove;TicketID=[% Data.TicketID | uri %];" class="AsPopup PopupType_TicketAction" title="[% Translate("Change Queue") | html %]">[% Translate("Queue") | html %]</a>
                             </li>
 [% RenderBlockEnd("MoveForm") %]
+[% RenderBlockStart("TicketMenuExternalLink") %]
+                            <li>
+                                <a href="[% Data.Link | Interpolate %]" class="[% Data.Class | html %]" [% Data.LinkParam %] title="[% Translate(Data.Description) | html %]" target="[% Data.Target %]">[% Translate(Data.Name) | html %]</a>
+                            </li>
+[% RenderBlockEnd("TicketMenuExternalLink") %]
                         </ul>
                         <div class="Clear"></div>
                     </div>


### PR DESCRIPTION
This mod introduces new SysConfig parameter
Ticket::Frontend::MenuModule###500-ExternalLink that allowes one
to put extra link with configurable URL in AgentTicketZoom
ticket menu. URL is configurable using Link option and may
contain templates like

http://external-application.test/app/index.php?TicketID=[% Data.TicketID %]&queue_id=[% Data.QueueID %]

This allowes one to put in AgentTicketZoom menu link
to external application that contains ticket data like
TicketID, QueueID, etc.

Related: https://dev.ib.pl/ib/otrs/issues/80
Related: https://github.com/OTRS/otrs/pull/502
Author-Change-Id: IB#1039489
