### PR TITLE
Removed superfluous dot from error comment

### DIFF
--- a/Kernel/Modules/AgentLinkObject.pm
+++ b/Kernel/Modules/AgentLinkObject.pm
@@ -108,7 +108,7 @@ sub Run {
     if ( !$Form{SourceObject} || !$Form{SourceKey} ) {
         return $LayoutObject->ErrorScreen(
             Message => Translatable('Need SourceObject and SourceKey!'),
-            Comment => Translatable('Please contact the admin.'),
+            Comment => Translatable('Please contact the administrator.'),
         );
     }
 
@@ -502,7 +502,7 @@ sub Run {
             return $LayoutObject->ErrorScreen(
                 Message => $LayoutObject->{LanguageObject}
                     ->Translate( 'The object %s cannot link with other object!', $Form{SourceObject} ),
-                Comment => Translatable('Please contact the admin.'),
+                Comment => Translatable('Please contact the administrator.'),
             );
         }
 

--- a/Kernel/Modules/AgentTicketActionCommon.pm
+++ b/Kernel/Modules/AgentTicketActionCommon.pm
@@ -81,7 +81,7 @@ sub Run {
     if ( !$Self->{TicketID} ) {
         return $LayoutObject->ErrorScreen(
             Message => Translatable('No TicketID is given!'),
-            Comment => Translatable('Please contact the admin.'),
+            Comment => Translatable('Please contact the administrator.'),
         );
     }
 
@@ -550,7 +550,7 @@ sub Run {
                         Message =>
                             $LayoutObject->{LanguageObject}
                             ->Translate( 'Could not perform validation on field %s!', $DynamicFieldConfig->{Label} ),
-                        Comment => Translatable('Please contact the admin.'),
+                        Comment => Translatable('Please contact the administrator.'),
                     );
                 }
 

--- a/Kernel/Modules/AgentTicketBounce.pm
+++ b/Kernel/Modules/AgentTicketBounce.pm
@@ -41,7 +41,7 @@ sub Run {
         if ( !defined $Self->{$Needed} ) {
             return $LayoutObject->ErrorScreen(
                 Message => $LayoutObject->{LanguageObject}->Translate( '%s is needed!', $Needed ),
-                Comment => Translatable('Please contact your administrator'),
+                Comment => Translatable('Please contact the administrator.'),
             );
         }
     }
@@ -454,7 +454,7 @@ $Param{Signature}";
         if ( !$Bounce ) {
             return $LayoutObject->ErrorScreen(
                 Message => Translatable('Can\'t bounce email!'),
-                Comment => Translatable('Please contact the admin.'),
+                Comment => Translatable('Please contact the administrator.'),
             );
         }
 
@@ -497,7 +497,7 @@ $Param{Signature}";
             if ( !$ArticleID ) {
                 return $LayoutObject->ErrorScreen(
                     Message => Translatable('Can\'t send email!'),
-                    Comment => Translatable('Please contact the admin.'),
+                    Comment => Translatable('Please contact the administrator.'),
                 );
             }
         }
@@ -538,7 +538,7 @@ $Param{Signature}";
     }
     return $LayoutObject->ErrorScreen(
         Message => Translatable('Wrong Subaction!'),
-        Comment => Translatable('Please contact your administrator'),
+        Comment => Translatable('Please contact the administrator.'),
     );
 }
 

--- a/Kernel/Modules/AgentTicketBulk.pm
+++ b/Kernel/Modules/AgentTicketBulk.pm
@@ -45,7 +45,7 @@ sub Run {
         if ( !@TicketIDs ) {
             return $LayoutObject->ErrorScreen(
                 Message => Translatable('Can\'t lock Tickets, no TicketIDs are given!'),
-                Comment => Translatable('Please contact the admin.'),
+                Comment => Translatable('Please contact the administrator.'),
             );
         }
 

--- a/Kernel/Modules/AgentTicketCompose.pm
+++ b/Kernel/Modules/AgentTicketCompose.pm
@@ -47,7 +47,7 @@ sub Run {
     if ( !$Self->{TicketID} ) {
         return $LayoutObject->ErrorScreen(
             Message => Translatable('No TicketID is given!'),
-            Comment => Translatable('Please contact the admin.'),
+            Comment => Translatable('Please contact the administrator.'),
         );
     }
 
@@ -696,7 +696,7 @@ sub Run {
                             'Could not perform validation on field %s!',
                             $DynamicFieldConfig->{Label},
                         ),
-                        Comment => Translatable('Please contact the admin.'),
+                        Comment => Translatable('Please contact the administrator.'),
                     );
                 }
 
@@ -834,7 +834,7 @@ sub Run {
         if ( !$ArticleTypeID ) {
             return $LayoutObject->ErrorScreen(
                 Message => Translatable('Can not determine the ArticleType!'),
-                Comment => Translatable('Please contact the admin.'),
+                Comment => Translatable('Please contact the administrator.'),
             );
         }
 

--- a/Kernel/Modules/AgentTicketCustomer.pm
+++ b/Kernel/Modules/AgentTicketCustomer.pm
@@ -41,7 +41,7 @@ sub Run {
         # error page
         return $LayoutObject->ErrorScreen(
             Message => Translatable('No TicketID is given!'),
-            Comment => Translatable('Please contact the admin.'),
+            Comment => Translatable('Please contact the administrator.'),
         );
     }
 

--- a/Kernel/Modules/AgentTicketEmail.pm
+++ b/Kernel/Modules/AgentTicketEmail.pm
@@ -795,7 +795,7 @@ sub Run {
                         Message =>
                             $LayoutObject->{LanguageObject}
                             ->Translate( 'Could not perform validation on field %s!', $DynamicFieldConfig->{Label} ),
-                        Comment => Translatable('Please contact the admin.'),
+                        Comment => Translatable('Please contact the administrator.'),
                     );
                 }
 
@@ -1806,7 +1806,7 @@ sub Run {
     else {
         return $LayoutObject->ErrorScreen(
             Message => Translatable('No Subaction!'),
-            Comment => Translatable('Please contact your administrator'),
+            Comment => Translatable('Please contact the administrator.'),
         );
     }
 }

--- a/Kernel/Modules/AgentTicketEmailOutbound.pm
+++ b/Kernel/Modules/AgentTicketEmailOutbound.pm
@@ -912,7 +912,7 @@ sub SendEmail {
                 Message =>
                     $LayoutObject->{LanguageObject}
                     ->Translate( 'Could not perform validation on field %s!', $DynamicFieldConfig->{Label} ),
-                Comment => Translatable('Please contact the admin.'),
+                Comment => Translatable('Please contact the administrator.'),
             );
         }
 
@@ -1175,7 +1175,7 @@ sub SendEmail {
     if ( !$ArticleID ) {
 
         return $LayoutObject->ErrorScreen(
-            Comment => Translatable('Please contact the admin.'),
+            Comment => Translatable('Please contact the administrator.'),
         );
     }
 

--- a/Kernel/Modules/AgentTicketForward.pm
+++ b/Kernel/Modules/AgentTicketForward.pm
@@ -761,7 +761,7 @@ sub SendEmail {
                 Message =>
                     $LayoutObject->{LanguageObject}
                     ->Translate( 'Could not perform validation on field %s!', $DynamicFieldConfig->{Label} ),
-                Comment => Translatable('Please contact the admin.'),
+                Comment => Translatable('Please contact the administrator.'),
             );
         }
 
@@ -1007,7 +1007,7 @@ sub SendEmail {
     if ( !$ArticleTypeID ) {
         return $LayoutObject->ErrorScreen(
             Message => Translatable('Can not determine the ArticleType!'),
-            Comment => Translatable('Please contact the admin.'),
+            Comment => Translatable('Please contact the administrator.'),
         );
     }
 
@@ -1035,7 +1035,7 @@ sub SendEmail {
     # error page
     if ( !$ArticleID ) {
         return $LayoutObject->ErrorScreen(
-            Comment => Translatable('Please contact the admin.'),
+            Comment => Translatable('Please contact the administrator.'),
         );
     }
 

--- a/Kernel/Modules/AgentTicketHistory.pm
+++ b/Kernel/Modules/AgentTicketHistory.pm
@@ -38,7 +38,7 @@ sub Run {
         # error page
         return $LayoutObject->ErrorScreen(
             Message => Translatable('Can\'t show history, no TicketID is given!'),
-            Comment => Translatable('Please contact the admin.'),
+            Comment => Translatable('Please contact the administrator.'),
         );
     }
 

--- a/Kernel/Modules/AgentTicketLock.pm
+++ b/Kernel/Modules/AgentTicketLock.pm
@@ -36,7 +36,7 @@ sub Run {
     if ( !$Self->{TicketID} ) {
         return $LayoutObject->ErrorScreen(
             Message => Translatable('Can\'t lock Ticket, no TicketID is given!'),
-            Comment => Translatable('Please contact the admin.'),
+            Comment => Translatable('Please contact the administrator.'),
         );
     }
 

--- a/Kernel/Modules/AgentTicketMerge.pm
+++ b/Kernel/Modules/AgentTicketMerge.pm
@@ -41,7 +41,7 @@ sub Run {
     if ( !$Self->{TicketID} ) {
         return $LayoutObject->ErrorScreen(
             Message => Translatable('No TicketID is given!'),
-            Comment => Translatable('Please contact the admin.'),
+            Comment => Translatable('Please contact the administrator.'),
         );
     }
 

--- a/Kernel/Modules/AgentTicketMove.pm
+++ b/Kernel/Modules/AgentTicketMove.pm
@@ -710,7 +710,7 @@ sub Run {
                             'Could not perform validation on field %s!',
                             $DynamicFieldConfig->{Label},
                         ),
-                        Comment => Translatable('Please contact the admin.'),
+                        Comment => Translatable('Please contact the administrator.'),
                     );
                 }
 

--- a/Kernel/Modules/AgentTicketPhone.pm
+++ b/Kernel/Modules/AgentTicketPhone.pm
@@ -931,7 +931,7 @@ sub Run {
                         Message =>
                             $LayoutObject->{LanguageObject}
                             ->Translate( 'Could not perform validation on field %s!', $DynamicFieldConfig->{Label} ),
-                        Comment => Translatable('Please contact the admin.'),
+                        Comment => Translatable('Please contact the administrator.'),
                     );
                 }
 
@@ -1941,7 +1941,7 @@ sub Run {
     else {
         return $LayoutObject->ErrorScreen(
             Message => Translatable('No Subaction!'),
-            Comment => Translatable('Please contact your administrator'),
+            Comment => Translatable('Please contact the administrator.'),
         );
     }
 }

--- a/Kernel/Modules/AgentTicketPhoneCommon.pm
+++ b/Kernel/Modules/AgentTicketPhoneCommon.pm
@@ -530,7 +530,7 @@ sub Run {
                         Message =>
                             $LayoutObject->{LanguageObject}
                             ->Translate( 'Could not perform validation on field %s!', $DynamicFieldConfig->{Label} ),
-                        Comment => Translatable('Please contact the admin.'),
+                        Comment => Translatable('Please contact the administrator.'),
                     );
                 }
 
@@ -967,7 +967,7 @@ sub Run {
     }
     return $LayoutObject->ErrorScreen(
         Message => Translatable('No Subaction!'),
-        Comment => Translatable('Please contact your administrator'),
+        Comment => Translatable('Please contact the administrator.'),
     );
 }
 

--- a/Kernel/Modules/AgentTicketPlain.pm
+++ b/Kernel/Modules/AgentTicketPlain.pm
@@ -37,7 +37,7 @@ sub Run {
     if ( !$ArticleID ) {
         return $LayoutObject->ErrorScreen(
             Message => Translatable('No ArticleID!'),
-            Comment => Translatable('Please contact your administrator'),
+            Comment => Translatable('Please contact the administrator.'),
         );
     }
 
@@ -66,7 +66,7 @@ sub Run {
             Message => Translatable(
                 'Can\'t read plain article! Maybe there is no plain email in backend! Read backend message.'
             ),
-            Comment => Translatable('Please contact your administrator'),
+            Comment => Translatable('Please contact the administrator.'),
         );
     }
 

--- a/Kernel/Modules/AgentTicketProcess.pm
+++ b/Kernel/Modules/AgentTicketProcess.pm
@@ -88,7 +88,7 @@ sub Run {
                         'Couldn\'t get ActivityDialogEntityID "%s"!',
                         $ActivityDialogEntityID,
                     ),
-                    Comment => Translatable('Please contact the admin.'),
+                    Comment => Translatable('Please contact the administrator.'),
                 );
             }
 
@@ -262,7 +262,7 @@ sub Run {
     if ( !IsHashRefWithData($ProcessList) && !IsHashRefWithData($FollowupProcessList) ) {
         return $LayoutObject->ErrorScreen(
             Message => Translatable('No Process configured!'),
-            Comment => Translatable('Please contact the admin.'),
+            Comment => Translatable('Please contact the administrator.'),
         );
     }
 
@@ -305,7 +305,7 @@ sub Run {
         if ( !IsHashRefWithData($ProcessList) ) {
             return $LayoutObject->ErrorScreen(
                 Message => Translatable('No Process configured!'),
-                Comment => Translatable('Please contact the admin.'),
+                Comment => Translatable('Please contact the administrator.'),
             );
         }
 
@@ -354,7 +354,7 @@ sub Run {
     {
         $LayoutObject->FatalError(
             Message => $LayoutObject->{LanguageObject}->Translate( 'Process %s is invalid!', $ProcessEntityID ),
-            Comment => Translatable('Please contact the admin.'),
+            Comment => Translatable('Please contact the administrator.'),
         );
     }
 
@@ -412,7 +412,7 @@ sub Run {
     }
     return $LayoutObject->ErrorScreen(
         Message => Translatable('Subaction is invalid!'),
-        Comment => Translatable('Please contact the admin.'),
+        Comment => Translatable('Please contact the administrator.'),
     );
 }
 
@@ -880,7 +880,7 @@ sub _GetParam {
                 'Couldn\'t get ActivityDialogEntityID "%s"!',
                 $ActivityDialogEntityID,
             ),
-            Comment => Translatable('Please contact the admin.'),
+            Comment => Translatable('Please contact the administrator.'),
         );
     }
 
@@ -4409,12 +4409,9 @@ sub _StoreActivityDialog {
                 # is not possible to a have an invisible field for this particular value
                 # on agent interface
                 if ( $ActivityDialog->{Fields}{$CurrentField}{Display} == 0 ) {
-
-                    my $InvisibleFieldMessage = Translatable(
-                        'Couldn\'t use CustomerID as an invisible field. Please contact your system administrator!'
-                    );
                     $LayoutObject->FatalError(
-                        Message => $InvisibleFieldMessage,
+                        Message => Translatable('Couldn\'t use CustomerID as an invisible field.'),
+                        Comment => Translatable('Please contact the administrator.'),
                     );
                 }
 
@@ -4658,7 +4655,7 @@ sub _StoreActivityDialog {
                         $Param{ProcessEntityID},
                         $TicketID,
                     ),
-                    Comment => Translatable('Please contact the admin.'),
+                    Comment => Translatable('Please contact the administrator.'),
                 );
             }
 
@@ -4674,7 +4671,7 @@ sub _StoreActivityDialog {
                         'Could not store ActivityDialog, invalid TicketID: %s!',
                         $TicketID,
                     ),
-                    Comment => Translatable('Please contact the admin.'),
+                    Comment => Translatable('Please contact the administrator.'),
                 );
             }
             for my $DynamicFieldConfig (
@@ -4773,7 +4770,7 @@ sub _StoreActivityDialog {
                     $Param{ProcessEntityID},
                     $TicketID,
                 ),
-                Comment => Translatable('Please contact the admin.'),
+                Comment => Translatable('Please contact the administrator.'),
             );
         }
 
@@ -4817,7 +4814,7 @@ sub _StoreActivityDialog {
                     'Missing ActivityEntityID in Ticket %s!',
                     $Ticket{TicketID},
                 ),
-                Comment => Translatable('Please contact the admin.'),
+                Comment => Translatable('Please contact the administrator.'),
             );
         }
 

--- a/Kernel/Modules/AgentTicketZoom.pm
+++ b/Kernel/Modules/AgentTicketZoom.pm
@@ -197,7 +197,7 @@ sub Run {
     if ( !$Self->{TicketID} ) {
         return $LayoutObject->ErrorScreen(
             Message => Translatable('No TicketID is given!'),
-            Comment => Translatable('Please contact the admin.'),
+            Comment => Translatable('Please contact the administrator.'),
         );
     }
 

--- a/Kernel/Modules/CustomerTicketAttachment.pm
+++ b/Kernel/Modules/CustomerTicketAttachment.pm
@@ -39,7 +39,7 @@ sub Run {
         my $Output = $LayoutObject->CustomerHeader( Title => 'Error' );
         $Output .= $LayoutObject->CustomerError(
             Message => Translatable('FileID and ArticleID are needed!'),
-            Comment => Translatable('Please contact your administrator'),
+            Comment => Translatable('Please contact the administrator.'),
         );
         $LogObject->Log(
             Message  => 'FileID and ArticleID are needed!',
@@ -61,7 +61,7 @@ sub Run {
         my $Output = $LayoutObject->CustomerHeader( Title => 'Error' );
         $Output .= $LayoutObject->CustomerError(
             Message => $LayoutObject->{LanguageObject}->Translate( 'No TicketID for ArticleID (%s)!', $ArticleID ),
-            Comment => Translatable('Please contact your administrator'),
+            Comment => Translatable('Please contact the administrator.'),
         );
         $LogObject->Log(
             Message  => "No TicketID for ArticleID ($ArticleID)!",
@@ -91,7 +91,7 @@ sub Run {
         my $Output = $LayoutObject->CustomerHeader( Title => 'Error' );
         $Output .= $LayoutObject->CustomerError(
             Message => $LayoutObject->{LanguageObject}->Translate( 'No such attachment (%s)!', $FileID ),
-            Comment => Translatable('Please contact your administrator'),
+            Comment => Translatable('Please contact the administrator.'),
         );
         $LogObject->Log(
             Message  => "No such attachment ($FileID)! May be an attack!!!",

--- a/Kernel/Modules/CustomerTicketMessage.pm
+++ b/Kernel/Modules/CustomerTicketMessage.pm
@@ -148,7 +148,7 @@ sub Run {
                 $LayoutObject->CustomerFatalError(
                     Message => $LayoutObject->{LanguageObject}
                         ->Translate( 'Check SysConfig setting for %s::QueueDefault.', $Self->{Action} ),
-                    Comment => Translatable('Please contact your administrator'),
+                    Comment => Translatable('Please contact the administrator.'),
                 );
                 return;
             }
@@ -283,7 +283,7 @@ sub Run {
                     Message =>
                         $LayoutObject->{LanguageObject}
                         ->Translate( 'Check SysConfig setting for %s::TicketTypeDefault.', $Self->{Action} ),
-                    Comment => Translatable('Please contact your administrator'),
+                    Comment => Translatable('Please contact the administrator.'),
                 );
                 return;
             }
@@ -399,7 +399,7 @@ sub Run {
                         Message =>
                             $LayoutObject->{LanguageObject}
                             ->Translate( 'Could not perform validation on field %s!', $DynamicFieldConfig->{Label} ),
-                        Comment => Translatable('Please contact your administrator'),
+                        Comment => Translatable('Please contact the administrator.'),
                     );
                     $Output .= $LayoutObject->CustomerFooter();
                     return $Output;
@@ -916,7 +916,7 @@ sub Run {
     else {
         return $LayoutObject->ErrorScreen(
             Message => Translatable('No Subaction!'),
-            Comment => Translatable('Please contact your administrator'),
+            Comment => Translatable('Please contact the administrator.'),
         );
     }
 

--- a/Kernel/Modules/CustomerTicketProcess.pm
+++ b/Kernel/Modules/CustomerTicketProcess.pm
@@ -89,7 +89,7 @@ sub Run {
                 return $LayoutObject->CustomerErrorScreen(
                     Message => $LayoutObject->{LanguageObject}
                         ->Translate( 'Couldn\'t get ActivityDialogEntityID "%s"!', $ActivityDialogEntityID ),
-                    Comment => Translatable('Please contact the admin.'),
+                    Comment => Translatable('Please contact the administrator.'),
                 );
             }
 
@@ -198,7 +198,7 @@ sub Run {
     if ( !IsHashRefWithData($ProcessList) && !IsHashRefWithData($FollowupProcessList) ) {
         return $LayoutObject->CustomerErrorScreen(
             Message => Translatable('No Process configured!'),
-            Comment => Translatable('Please contact the admin.'),
+            Comment => Translatable('Please contact the administrator.'),
         );
     }
 
@@ -233,7 +233,7 @@ sub Run {
         if ( !IsHashRefWithData($ProcessList) ) {
             return $LayoutObject->CustomerErrorScreen(
                 Message => Translatable('No Process configured!'),
-                Comment => Translatable('Please contact the admin.'),
+                Comment => Translatable('Please contact the administrator.'),
             );
         }
 
@@ -281,7 +281,7 @@ sub Run {
     {
         $LayoutObject->CustomerFatalError(
             Message => $LayoutObject->{LanguageObject}->Translate( 'Process %s is invalid!', $ProcessEntityID ),
-            Comment => Translatable('Please contact the admin.'),
+            Comment => Translatable('Please contact the administrator.'),
         );
     }
 
@@ -347,7 +347,7 @@ sub Run {
     }
     return $LayoutObject->CustomerErrorScreen(
         Message => Translatable('Subaction is invalid!'),
-        Comment => Translatable('Please contact the admin.'),
+        Comment => Translatable('Please contact the administrator.'),
     );
 }
 
@@ -765,7 +765,7 @@ sub _GetParam {
         return $LayoutObject->CustomerErrorScreen(
             Message => $LayoutObject->{LanguageObject}
                 ->Translate( 'Couldn\'t get ActivityDialogEntityID "%s"!', $ActivityDialogEntityID ),
-            Comment => Translatable('Please contact the admin.'),
+            Comment => Translatable('Please contact the administrator.'),
         );
     }
 
@@ -3576,7 +3576,7 @@ sub _StoreActivityDialog {
                         'Couldn\'t set ActivityEntityID "%s" on TicketID "%s"!',
                         $Param{ProcessEntityID}, $TicketID
                     ),
-                    Comment => Translatable('Please contact the admin.'),
+                    Comment => Translatable('Please contact the administrator.'),
                 );
             }
 
@@ -3590,7 +3590,7 @@ sub _StoreActivityDialog {
                 $LayoutObject->CustomerFatalError(
                     Message => $LayoutObject->{LanguageObject}
                         ->Translate( 'Could not store ActivityDialog, invalid TicketID: %s!', $TicketID ),
-                    Comment => Translatable('Please contact the admin.'),
+                    Comment => Translatable('Please contact the administrator.'),
                 );
             }
             for my $DynamicFieldConfig (
@@ -3650,7 +3650,7 @@ sub _StoreActivityDialog {
             return $LayoutObject->CustomerErrorScreen(
                 Message => $LayoutObject->{LanguageObject}
                     ->Translate( 'Missing ActivityEntityID in Ticket %s!', $Ticket{TicketID} ),
-                Comment => Translatable('Please contact the admin.'),
+                Comment => Translatable('Please contact the administrator.'),
             );
         }
 

--- a/Kernel/Modules/CustomerTicketZoom.pm
+++ b/Kernel/Modules/CustomerTicketZoom.pm
@@ -507,7 +507,7 @@ sub Run {
                     $Output .= $LayoutObject->CustomerError(
                         Message => $LayoutObject->{LanguageObject}
                             ->Translate( 'Could not perform validation on field %s!', $DynamicFieldConfig->{Label} ),
-                        Comment => Translatable('Please contact your administrator'),
+                        Comment => Translatable('Please contact the administrator.'),
                     );
                     $Output .= $LayoutObject->CustomerFooter();
                     return $Output;

--- a/Kernel/Modules/Installer.pm
+++ b/Kernel/Modules/Installer.pm
@@ -49,7 +49,7 @@ sub Run {
         $LayoutObject->FatalError(
             Message =>
                 $LayoutObject->{LanguageObject}->Translate( 'File "%s/Kernel/Config.pm" not found!', $Self->{Path} ),
-            Comment => Translatable('Please contact the admin.'),
+            Comment => Translatable('Please contact the administrator.'),
         );
     }
 
@@ -58,7 +58,7 @@ sub Run {
     if ( !-d $DirOfSQLFiles ) {
         $LayoutObject->FatalError(
             Message => $LayoutObject->{LanguageObject}->Translate( 'Directory "%s" not found!', $DirOfSQLFiles ),
-            Comment => Translatable('Please contact the admin.'),
+            Comment => Translatable('Please contact the administrator.'),
         );
     }
 
@@ -1040,7 +1040,7 @@ sub Run {
     # else error!
     $LayoutObject->FatalError(
         Message => $LayoutObject->{LanguageObject}->Translate( 'Unknown Subaction %s!', $Self->{Subaction} ),
-        Comment => Translatable('Please contact your administrator'),
+        Comment => Translatable('Please contact the administrator.'),
     );
 }
 

--- a/Kernel/Output/HTML/Notification/DaemonCheck.pm
+++ b/Kernel/Output/HTML/Notification/DaemonCheck.pm
@@ -64,10 +64,10 @@ sub Run {
         $NotificationDetails{LinkClass} = 'DaemonInfo';
     }
 
-    # if user is not admin, add 'Please contact your administrator' to error message
+    # if user is not admin, add 'Please contact the administrator.' to error message
     else {
         $NotificationDetails{Data}
-            .= ' ' . $LayoutObject->{LanguageObject}->Translate("Please contact your administrator!");
+            .= ' ' . $LayoutObject->{LanguageObject}->Translate("Please contact the administrator.");
     }
 
     # show error notification

--- a/Kernel/Output/HTML/Preferences/Password.pm
+++ b/Kernel/Output/HTML/Preferences/Password.pm
@@ -178,7 +178,7 @@ sub Run {
     # check if password is not matching PasswordRegExp
     if ( $Config->{PasswordRegExp} && $Pw !~ /$Config->{PasswordRegExp}/ ) {
         $Self->{Error} = Translatable(
-            'This password is forbidden by the current system configuration. Please contact your admin if you have additional questions.'
+            'This password is forbidden by the current system configuration. Please contact the administrator if you have additional questions.'
         );
         return;
     }

--- a/Kernel/Output/HTML/Templates/Standard/Error.tt
+++ b/Kernel/Output/HTML/Templates/Standard/Error.tt
@@ -18,7 +18,7 @@
                     [% Translate("Error Message") | html %]: <span class="Error">[% Translate(Data.Message) | html %]</span>
                 </h4>
                 <p class="SpacingTop">
-                    [% Translate(Data.Comment) | html %].
+                    [% Translate(Data.Comment) | html %]
                 </p>
 
                 [% IF !Data.OTRSBusinessIsInstalled %]

--- a/Kernel/System/Web/InterfaceAgent.pm
+++ b/Kernel/System/Web/InterfaceAgent.pm
@@ -168,14 +168,14 @@ sub Run {
         my $LayoutObject = $Kernel::OM->Get('Kernel::Output::HTML::Layout');
         if ( !$DBCanConnect ) {
             $LayoutObject->FatalError(
-                Comment => Translatable('Please contact your administrator'),
+                Comment => Translatable('Please contact the administrator.'),
             );
             return;
         }
         if ( $ParamObject->Error() ) {
             $LayoutObject->FatalError(
                 Message => $ParamObject->Error(),
-                Comment => Translatable('Please contact your administrator'),
+                Comment => Translatable('Please contact the administrator.'),
             );
             return;
         }
@@ -570,8 +570,8 @@ sub Run {
         # remove session id
         if ( !$SessionObject->RemoveSessionID( SessionID => $Param{SessionID} ) ) {
             $LayoutObject->FatalError(
-                Message => Translatable('Can`t remove SessionID'),
-                Comment => Translatable('Please contact your administrator'),
+                Message => Translatable('Can`t remove SessionID.'),
+                Comment => Translatable('Please contact the administrator.'),
             );
             return;
         }
@@ -693,7 +693,7 @@ sub Run {
             );
             if ( !$Sent ) {
                 $LayoutObject->FatalError(
-                    Comment => Translatable('Please contact your administrator'),
+                    Comment => Translatable('Please contact the administrator.'),
                 );
                 return;
             }
@@ -753,7 +753,7 @@ sub Run {
 
         if ( !$Sent ) {
             $LayoutObject->FatalError(
-                Comment => Translatable('Please contact your administrator'),
+                Comment => Translatable('Please contact the administrator.'),
             );
             return;
         }
@@ -910,7 +910,7 @@ sub Run {
                     "Module Kernel::Modules::$Param{Action} not registered in Kernel/Config.pm!",
             );
             $Kernel::OM->Get('Kernel::Output::HTML::Layout')->FatalError(
-                Comment => Translatable('Please contact your administrator'),
+                Comment => Translatable('Please contact the administrator.'),
             );
             return;
         }
@@ -1099,7 +1099,7 @@ sub Run {
         },
     );
     $Kernel::OM->Get('Kernel::Output::HTML::Layout')->FatalError(
-        Comment => Translatable('Please contact your administrator'),
+        Comment => Translatable('Please contact the administrator.'),
     );
     return;
 }

--- a/Kernel/System/Web/InterfaceCustomer.pm
+++ b/Kernel/System/Web/InterfaceCustomer.pm
@@ -168,14 +168,14 @@ sub Run {
         my $LayoutObject = $Kernel::OM->Get('Kernel::Output::HTML::Layout');
         if ( !$DBCanConnect ) {
             $LayoutObject->CustomerFatalError(
-                Comment => Translatable('Please contact your administrator'),
+                Comment => Translatable('Please contact the administrator.'),
             );
             return;
         }
         if ( $ParamObject->Error() ) {
             $LayoutObject->CustomerFatalError(
                 Message => $ParamObject->Error(),
-                Comment => Translatable('Please contact your administrator'),
+                Comment => Translatable('Please contact the administrator.'),
             );
             return;
         }
@@ -317,7 +317,7 @@ sub Run {
                 Output => \$LayoutObject->CustomerLogin(
                     Title   => 'Panic!',
                     Message => Translatable(
-                        'Authentication succeeded, but no customer record is found in the customer backend. Please contact your administrator.'
+                        'Authentication succeeded, but no customer record is found in the customer backend. Please contact the administrator.'
                     ),
                     %Param,
                 ),
@@ -514,7 +514,7 @@ sub Run {
         # remove session id
         if ( !$SessionObject->RemoveSessionID( SessionID => $Param{SessionID} ) ) {
             $LayoutObject->CustomerFatalError(
-                Comment => Translatable('Please contact your administrator')
+                Comment => Translatable('Please contact the administrator.')
             );
             return;
         }
@@ -632,7 +632,7 @@ sub Run {
             );
             if ( !$Sent ) {
                 $LayoutObject->FatalError(
-                    Comment => Translatable('Please contact your administrator'),
+                    Comment => Translatable('Please contact the administrator.'),
                 );
                 return;
             }
@@ -678,7 +678,7 @@ sub Run {
             $LayoutObject->Print(
                 Output => \$LayoutObject->CustomerLogin(
                     Title   => 'Login',
-                    Message => Translatable('Reset password unsuccessful. Please contact your administrator'),
+                    Message => Translatable('Reset password unsuccessful. Please contact the administrator.'),
                     User    => $User,
                 ),
             );
@@ -702,7 +702,7 @@ sub Run {
         );
         if ( !$Sent ) {
             $LayoutObject->CustomerFatalError(
-                Comment => Translatable('Please contact your administrator')
+                Comment => Translatable('Please contact the administrator.')
             );
             return;
         }
@@ -1062,7 +1062,7 @@ sub Run {
                     "Module Kernel::Modules::$Param{Action} not registered in Kernel/Config.pm!",
             );
             $LayoutObject->CustomerFatalError(
-                Comment => Translatable('Please contact your administrator'),
+                Comment => Translatable('Please contact the administrator.'),
             );
             return;
         }
@@ -1088,7 +1088,7 @@ sub Run {
                     Message  => 'No Permission to use this frontend action module!'
                 );
                 $LayoutObject->CustomerFatalError(
-                    Comment => Translatable('Please contact your administrator'),
+                    Comment => Translatable('Please contact the administrator.'),
                 );
                 return;
             }
@@ -1127,7 +1127,7 @@ sub Run {
                             Message  => 'No Permission to use this frontend subaction module!'
                         );
                         $LayoutObject->CustomerFatalError(
-                            Comment => Translatable('Please contact your administrator')
+                            Comment => Translatable('Please contact the administrator.')
                         );
                         return;
                     }
@@ -1264,7 +1264,7 @@ sub Run {
     );
     my $LayoutObject = $Kernel::OM->Get('Kernel::Output::HTML::Layout');
     $LayoutObject->CustomerFatalError(
-        Comment => Translatable('Please contact your administrator'),
+        Comment => Translatable('Please contact the administrator.'),
     );
     return;
 }

--- a/Kernel/System/Web/InterfaceInstaller.pm
+++ b/Kernel/System/Web/InterfaceInstaller.pm
@@ -114,7 +114,7 @@ sub Run {
         print $LayoutObject->Error(
             Message => Translatable('SecureMode active!'),
             Comment => Translatable(
-                'If you want to re-run the Installer, disable the SecureMode in the SysConfig'
+                'If you want to re-run the Installer, disable the SecureMode in the SysConfig.'
             ),
         );
         print $LayoutObject->Footer();
@@ -139,7 +139,7 @@ sub Run {
         print $LayoutObject->Header();
         print $LayoutObject->Error(
             Message => $LayoutObject->{LanguageObject}->Translate( 'Action "%s" not found!', $Param{Action} ),
-            Comment => Translatable('Please contact the admin.'),
+            Comment => Translatable('Please contact the administrator.'),
         );
         print $LayoutObject->Footer();
     }

--- a/Kernel/System/Web/InterfacePublic.pm
+++ b/Kernel/System/Web/InterfacePublic.pm
@@ -162,20 +162,20 @@ sub Run {
 
     if ( !$DBCanConnect ) {
         $LayoutObject->CustomerFatalError(
-            Comment => Translatable('Please contact your administrator'),
+            Comment => Translatable('Please contact the administrator.'),
         );
     }
     if ( $ParamObject->Error() ) {
         $LayoutObject->CustomerFatalError(
             Message => $ParamObject->Error(),
-            Comment => Translatable('Please contact your administrator'),
+            Comment => Translatable('Please contact the administrator.'),
         );
     }
 
     # run modules if a version value exists
     if ( !$Kernel::OM->Get('Kernel::System::Main')->Require("Kernel::Modules::$Param{Action}") ) {
         $LayoutObject->CustomerFatalError(
-            Comment => Translatable('Please contact your administrator'),
+            Comment => Translatable('Please contact the administrator.'),
         );
         return 1;
     }
@@ -189,7 +189,7 @@ sub Run {
                 "Module Kernel::Modules::$Param{Action} not registered in Kernel/Config.pm!",
         );
         $LayoutObject->CustomerFatalError(
-            Comment => Translatable('Please contact your administrator'),
+            Comment => Translatable('Please contact the administrator.'),
         );
         return;
     }

--- a/scripts/test/Selenium/Customer/CustomerGroupPermission.t
+++ b/scripts/test/Selenium/Customer/CustomerGroupPermission.t
@@ -123,7 +123,7 @@ $Selenium->RunTest(
         $Selenium->VerifiedGet("${ScriptAlias}customer.pl?Action=CustomerTicketOverview;Subaction=CompanyTickets");
 
         # check for customer user fatal error
-        my $ExpectedMsg = 'Please contact your administrator';
+        my $ExpectedMsg = 'Please contact the administrator.';
         $Self->True(
             index( $Selenium->get_page_source(), $ExpectedMsg ) > -1,
             "Customer fatal error message - found",


### PR DESCRIPTION
Hi @mgruner 
There is a dot at the end of the comments, but it is superfluous, because most of the comments already ending with a punctuation. But not all of them! Here are the results:

`$ grep -rn 'Comment =>' .`

In OTRS framework:
"Please contact the admin."  46 occurrences 
"Please contact your administrator" 36 occurences

In ITSM modules:
"Please contact the admin." 148 occurrences
"Please contact the administrator." 36 occurrences
"Please contact your administrator" 2 occurrences

As you can see, "Please contact the admin." is the most frequent. I think, it would be good to replace "Please contact your administrator" with "Please contact the admin." or "Please contact the administrator." What do you think about this? What is the best comment? Can I make a pull request for this change?

There are also some other comments, but they all have a dot at the end of the sentence. In these cases double dots are shown in the error message. Branch rel-5_0 is also affected.