### PR TITLE
[rel-5_0] Marked login error message as translatable

### DIFF
--- a/Kernel/Output/HTML/Templates/Standard/Login.tt
+++ b/Kernel/Output/HTML/Templates/Standard/Login.tt
@@ -172,7 +172,7 @@ X-OTRS-Login: [% Env("Baselink") %]
 [% RenderBlockStart("LoginBox") %]
             <div id="LoginBox">
                 <p class="[% IF Data.MessageType != 'Logout' %]Error [% END %]Center Spacing">
-                    [% Data.Message | html %]
+                    [% Translate(Data.Message) | html %]
                 </p>
                 <div class="WidgetSimple">
                 [% IF Config("ProductName") %]


### PR DESCRIPTION
Hi @mgruner 
This PR translates the error message of the login screen. Only rel-5_0 is affected, in master it is already fixed with https://github.com/OTRS/otrs/commit/8d9bd97ab54a6fff54e6e13593e08ffbb49e1b3d