### PR TITLE
Both types of move possible using MoveType parameter

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,4 +1,5 @@
 #6.0.0.beta1 2016-??-??
+ - 2016-06-29 Both types of move possible using MoveType parameter.
  - 2016-06-24 Improved TicketSearch() to return error on a search for inexistent dynamic fields instead of ignoring them, thanks to Moritz Lenz.
  - 2016-06-06 Added checks for length of words in search terms when using search index/StaticDB backend.
  - 2016-06-06 Fixed bug#[12020](http://bugs.otrs.org/show_bug.cgi?id=12020) - Option CaseSensitive has no impact on external customer database.

--- a/Kernel/Config/Files/Ticket.xml
+++ b/Kernel/Config/Files/Ticket.xml
@@ -5287,13 +5287,14 @@
         </Setting>
     </ConfigItem>
     <ConfigItem Name="Ticket::Frontend::MoveType" Required="1" Valid="1">
-        <Description Translatable="1">Determines if the list of possible queues to move to ticket into should be displayed in a dropdown list or in a new window in the agent interface. If "New Window" is set you can add a move note to the ticket.</Description>
+        <Description Translatable="1">Determines if the list of possible queues to move to ticket into should be displayed in a dropdown list or in a new window in the agent interface or both. If "New window" is set you can add a move note to the ticket.</Description>
         <Group>Ticket</Group>
         <SubGroup>Frontend::Agent::Ticket::ViewMove</SubGroup>
         <Setting>
             <Option SelectedID="form">
-                <Item Key="link" Translatable="1">New Window</Item>
+                <Item Key="link" Translatable="1">New window</Item>
                 <Item Key="form" Translatable="1">Dropdown</Item>
+                <Item Key="linkandform" Translatable="1">Dropdown and new window</Item>
             </Option>
         </Setting>
     </ConfigItem>
@@ -6745,7 +6746,7 @@
             </Hash>
         </Setting>
     </ConfigItem>
-    <ConfigItem Name="Ticket::Frontend::PreMenuModule###445-Move" Required="0" Valid="1">
+    <ConfigItem Name="Ticket::Frontend::PreMenuModule###445-MoveLink" Required="0" Valid="1">
         <Description Translatable="1">Shows a link in the menu to move a ticket in every ticket overview of the agent interface.</Description>
         <Group>Ticket</Group>
         <SubGroup>Frontend::Agent::Ticket::MenuModulePre</SubGroup>
@@ -6755,6 +6756,21 @@
                 <Item Key="Name" Translatable="1">Move</Item>
                 <Item Key="Action">AgentTicketMove</Item>
                 <Item Key="Description" Translatable="1">Change queue!</Item>
+                <Item Key="MoveType">link</Item>
+            </Hash>
+        </Setting>
+    </ConfigItem>
+    <ConfigItem Name="Ticket::Frontend::PreMenuModule###446-MoveForm" Required="0" Valid="1">
+        <Description Translatable="1">Shows a form in the menu to move a ticket in every ticket overview of the agent interface.</Description>
+        <Group>Ticket</Group>
+        <SubGroup>Frontend::Agent::Ticket::MenuModulePre</SubGroup>
+        <Setting>
+            <Hash>
+                <Item Key="Module">Kernel::Output::HTML::TicketMenu::Move</Item>
+                <Item Key="Name">Move</Item>
+                <Item Key="Action">AgentTicketMove</Item>
+                <Item Key="Description" Translatable="1">Change queue!</Item>
+                <Item Key="MoveType">form</Item>
             </Hash>
         </Setting>
     </ConfigItem>
@@ -8800,7 +8816,7 @@
         <Group>Ticket</Group>
         <SubGroup>Frontend::Agent::Ticket::ViewMove</SubGroup>
         <Setting>
-            <String Regex=""></String>
+            <String Regex="" Translatable="1">Queue change</String>
         </Setting>
     </ConfigItem>
     <ConfigItem Name="Ticket::Frontend::AgentTicketMove###Body" Required="0" Valid="1">

--- a/Kernel/Modules/AgentTicketMove.pm
+++ b/Kernel/Modules/AgentTicketMove.pm
@@ -132,7 +132,7 @@ sub Run {
     for my $Parameter (
         qw(Subject Body
         NewUserID NewStateID NewPriorityID
-        OwnerAll NoSubmit DestQueueID DestQueue
+        OwnerAll NoSubmit DestQueueID DestQueue MoveType
         StandardTemplateID CreateArticle
         )
         )
@@ -1069,7 +1069,7 @@ sub Run {
     # only set the dynamic fields if the new window was displayed (link), otherwise if ticket was
     # moved from the dropdown menu (form) in AgentTicketZoom, the value if the dynamic fields will
     # be undefined and it will set to empty in the DB, see bug#8481
-    if ( $ConfigObject->Get('Ticket::Frontend::MoveType') eq 'link' ) {
+    if ( $GetParam{MoveType} ne 'form' ) {
 
         # cycle trough the activated Dynamic Fields for this screen
         DYNAMICFIELD:
@@ -1113,12 +1113,12 @@ sub Run {
     if ( !$AccessNew || $NextScreen eq 'LastScreenOverview' ) {
 
         # Module directly called
-        if ( $ConfigObject->Get('Ticket::Frontend::MoveType') eq 'form' ) {
+        if ( $GetParam{MoveType} eq 'form' ) {
             return $LayoutObject->Redirect( OP => $Self->{LastScreenOverview} );
         }
 
         # Module opened in popup
-        elsif ( $ConfigObject->Get('Ticket::Frontend::MoveType') eq 'link' ) {
+        else {
             return $LayoutObject->PopupClose(
                 URL => ( $Self->{LastScreenOverview} || 'Action=AgentDashboard' ),
             );
@@ -1126,7 +1126,7 @@ sub Run {
     }
 
     # Module directly called
-    if ( $ConfigObject->Get('Ticket::Frontend::MoveType') eq 'form' ) {
+    if ( $GetParam{MoveType} eq 'form' ) {
         return $LayoutObject->Redirect(
             OP => "Action=AgentTicketZoom;TicketID=$Self->{TicketID}"
                 . ( $ArticleID ? ";ArticleID=$ArticleID" : '' ),
@@ -1134,7 +1134,7 @@ sub Run {
     }
 
     # Module opened in popup
-    elsif ( $ConfigObject->Get('Ticket::Frontend::MoveType') eq 'link' ) {
+    else {
         return $LayoutObject->PopupClose(
             URL => "Action=AgentTicketZoom;TicketID=$Self->{TicketID}"
                 . ( $ArticleID ? ";ArticleID=$ArticleID" : '' ),

--- a/Kernel/Modules/AgentTicketZoom.pm
+++ b/Kernel/Modules/AgentTicketZoom.pm
@@ -1068,7 +1068,7 @@ sub MaskAgentZoom {
     }
 
     # get MoveQueuesStrg
-    if ( $ConfigObject->Get('Ticket::Frontend::MoveType') =~ /^form$/i ) {
+    if ( $ConfigObject->Get('Ticket::Frontend::MoveType') =~ /form/i ) {
         $MoveQueues{0} = '- ' . $LayoutObject->{LanguageObject}->Translate('Move') . ' -';
         $Param{MoveQueuesStrg} = $LayoutObject->AgentQueueListOption(
             Name           => 'DestQueueID',
@@ -1091,13 +1091,14 @@ sub MaskAgentZoom {
         );
         $Param{TicketID} = $Ticket{TicketID};
         if ($Access) {
-            if ( $ConfigObject->Get('Ticket::Frontend::MoveType') =~ /^form$/i ) {
+            if ( $ConfigObject->Get('Ticket::Frontend::MoveType') =~ /form/i ) {
                 $LayoutObject->Block(
                     Name => 'MoveLink',
                     Data => { %Param, %AclAction },
                 );
             }
-            else {
+
+            if ( $ConfigObject->Get('Ticket::Frontend::MoveType') =~ /link/i ) {
                 $LayoutObject->Block(
                     Name => 'MoveForm',
                     Data => { %Param, %AclAction },

--- a/Kernel/Output/HTML/Templates/Standard/AgentTicketOverviewMedium.tt
+++ b/Kernel/Output/HTML/Templates/Standard/AgentTicketOverviewMedium.tt
@@ -273,6 +273,7 @@
         <input type="hidden" name="Action" value="AgentTicketMove"/>
         <input type="hidden" name="QueueID" value="[% Data.QueueID | html %]"/>
         <input type="hidden" name="TicketID" value="[% Data.TicketID | html %]"/>
+        <input type="hidden" name="MoveType" value="form"/>
         <label for="DestQueueID" class="InvisibleText">[% Translate("Change queue") | html %]:</label>
         [% Data.MoveQueuesStrg %]
     </form>

--- a/Kernel/Output/HTML/Templates/Standard/AgentTicketOverviewPreview.tt
+++ b/Kernel/Output/HTML/Templates/Standard/AgentTicketOverviewPreview.tt
@@ -330,6 +330,7 @@
         <input type="hidden" name="Action" value="AgentTicketMove"/>
         <input type="hidden" name="QueueID" value="[% Data.QueueID | html %]"/>
         <input type="hidden" name="TicketID" value="[% Data.TicketID | html %]"/>
+        <input type="hidden" name="MoveType" value="form"/>
         <label for="DestQueueID" class="InvisibleText">[% Translate("Change queue") | html %]:</label>
         [% Data.MoveQueuesStrg %]
     </form>

--- a/Kernel/Output/HTML/Templates/Standard/AgentTicketOverviewSmall.tt
+++ b/Kernel/Output/HTML/Templates/Standard/AgentTicketOverviewSmall.tt
@@ -561,6 +561,7 @@ $('.OverviewHeader').off('click').on('click', '.ColumnSettingsTrigger', function
         <input type="hidden" name="Action" value="AgentTicketMove"/>
         <input type="hidden" name="QueueID" value="[% Data.QueueID | html %]"/>
         <input type="hidden" name="TicketID" value="[% Data.TicketID | html %]"/>
+        <input type="hidden" name="MoveType" value="form"/>
         <label for="DestQueueID" class="InvisibleText">[% Translate("Change queue") | html %]:</label>
         [% Data.MoveQueuesStrg %]
     </form>

--- a/Kernel/Output/HTML/Templates/Standard/AgentTicketZoom.tt
+++ b/Kernel/Output/HTML/Templates/Standard/AgentTicketZoom.tt
@@ -195,12 +195,18 @@ $('#[% Data.FormID | html %] select[name=[% Data.PhoneElementID | html %]]').bin
 [% END %]
                             </li>
 [% RenderBlockEnd("TicketMenuPhoneAsDropdown") %]
+[% RenderBlockStart("MoveForm") %]
+                            <li>
+                                <a href="[% Env("Baselink") %]Action=AgentTicketMove;TicketID=[% Data.TicketID | uri %];" class="AsPopup PopupType_TicketAction" title="[% Translate("Change Queue") | html %]">[% Translate("Move") | html %]</a>
+                            </li>
+[% RenderBlockEnd("MoveForm") %]
 [% RenderBlockStart("MoveLink") %]
                             <li class="[% Data.Class | html %]">
                                 <form title="[% Translate("Move ticket to a different queue") | html %]" action="[% Env("CGIHandle") %]" method="post">
                                     <input type="hidden" name="Action" value="AgentTicketMove"/>
                                     <input type="hidden" name="QueueID" value="[% Data.QueueID | html %]"/>
                                     <input type="hidden" name="TicketID" value="[% Data.TicketID | html %]"/>
+                                    <input type="hidden" name="MoveType" value="form"/>
                                     <label for="DestQueueID" class="InvisibleText">[% Translate("Queue") | html %]:</label>
                                     [% Data.MoveQueuesStrg %]
                                 </form>
@@ -213,11 +219,6 @@ $('#[% Data.FormID | html %] select[name=[% Data.PhoneElementID | html %]]').bin
 [% END %]
                             </li>
 [% RenderBlockEnd("MoveLink") %]
-[% RenderBlockStart("MoveForm") %]
-                            <li>
-                                <a href="[% Env("Baselink") %]Action=AgentTicketMove;TicketID=[% Data.TicketID | uri %];" class="AsPopup PopupType_TicketAction" title="[% Translate("Change Queue") | html %]">[% Translate("Queue") | html %]</a>
-                            </li>
-[% RenderBlockEnd("MoveForm") %]
                         </ul>
                         <div class="Clear"></div>
                     </div>

--- a/Kernel/Output/HTML/TicketMenu/Move.pm
+++ b/Kernel/Output/HTML/TicketMenu/Move.pm
@@ -106,28 +106,40 @@ sub Run {
 
     $Param{Link} = 'Action=AgentTicketMove;TicketID=[% Data.TicketID | uri %];';
 
-    if ( $ConfigObject->Get('Ticket::Frontend::MoveType') =~ /^form$/i ) {
-        $Param{Target} = '';
-        $Param{Block}  = 'DocumentMenuItemMoveForm';
+    if ( $Param{Config}->{MoveType} && $Param{Config}->{MoveType} =~ /form/i ) {
 
-        # get layout object
-        my $LayoutObject = $Kernel::OM->Get('Kernel::Output::HTML::Layout');
+        if ( $ConfigObject->Get('Ticket::Frontend::MoveType') =~ /form/i ) {
+            $Param{Target} = '';
+            $Param{Block}  = 'DocumentMenuItemMoveForm';
 
-        # get move queues
-        my %MoveQueues = $TicketObject->MoveList(
-            TicketID => $Param{Ticket}->{TicketID},
-            UserID   => $Self->{UserID},
-            Action   => $LayoutObject->{Action},
-            Type     => 'move_into',
-        );
-        $MoveQueues{0} = '- ' . $LayoutObject->{LanguageObject}->Translate('Move') . ' -';
-        $Param{MoveQueuesStrg} = $LayoutObject->AgentQueueListOption(
-            Name => 'DestQueueID',
-            Data => \%MoveQueues,
-        );
+            # get layout object
+            my $LayoutObject = $Kernel::OM->Get('Kernel::Output::HTML::Layout');
+
+            # get move queues
+            my %MoveQueues = $TicketObject->MoveList(
+                TicketID => $Param{Ticket}->{TicketID},
+                UserID   => $Self->{UserID},
+                Action   => $LayoutObject->{Action},
+                Type     => 'move_into',
+            );
+            $MoveQueues{0} = '- ' . $LayoutObject->{LanguageObject}->Translate('Move') . ' -';
+            $Param{MoveQueuesStrg} = $LayoutObject->AgentQueueListOption(
+                Name => 'DestQueueID',
+                Data => \%MoveQueues,
+            );
+        }
+        else {
+            return;
+        }
     }
-    else {
-        $Param{PopupType} = 'TicketAction';
+
+    if ( $Param{Config}->{MoveType} && $Param{Config}->{MoveType} =~ /link/i ) {
+        if ( $ConfigObject->Get('Ticket::Frontend::MoveType' ) =~ /link/i ) {
+            $Param{PopupType} = 'TicketAction';
+        }
+        else {
+             return;
+        }
     }
 
     # return item


### PR DESCRIPTION
This mod extends `Ticket::Frontend::MoveType` SysConfig parameter
with new value Dropdown and new window that allows one to use
both move operation types (dropdown and dialog) together.

With Dropdown and new window setting agents can easily choose
if they want to move ticket with comment using dialog or
to do just fast move using dropdown.

Related: https://dev.ib.pl/ib/otrs/issues/82
Author-Change-Id: IB#1053415
