### PR TITLE
Marked strings as translatable

### DIFF
--- a/Kernel/Output/HTML/Statistics/View.pm
+++ b/Kernel/Output/HTML/Statistics/View.pm
@@ -207,8 +207,8 @@ sub StatsParamsWidget {
     if ( $ConfigObject->Get('Stats::ExchangeAxis') ) {
         my $ExchangeAxis = $LayoutObject->BuildSelection(
             Data => {
-                1 => 'Yes',
-                0 => 'No'
+                1 => Translatable('Yes'),
+                0 => Translatable('No')
             },
             Name       => 'ExchangeAxis',
             SelectedID => $LocalGetParam->( Param => 'ExchangeAxis' ) // 0,
@@ -562,12 +562,12 @@ sub StatsParamsWidget {
         }
     }
     my %YesNo = (
-        0 => 'No',
-        1 => 'Yes'
+        0 => Translatable('No'),
+        1 => Translatable('Yes')
     );
     my %ValidInvalid = (
-        0 => 'invalid',
-        1 => 'valid'
+        0 => Translatable('invalid'),
+        1 => Translatable('valid')
     );
     $Stat->{SumRowValue}                = $YesNo{ $Stat->{SumRow} };
     $Stat->{SumColValue}                = $YesNo{ $Stat->{SumCol} };
@@ -620,8 +620,8 @@ sub GeneralSpecificationsWidget {
     for my $Key (qw(Cache ShowAsDashboardWidget SumRow SumCol)) {
         $Frontend{ 'Select' . $Key } = $LayoutObject->BuildSelection(
             Data => {
-                0 => 'No',
-                1 => 'Yes'
+                0 => Translatable('No'),
+                1 => Translatable('Yes')
             },
             SelectedID => $GetParam{$Key} // $Stat->{$Key} || 0,
             Name       => $Key,
@@ -633,7 +633,7 @@ sub GeneralSpecificationsWidget {
     if ( !$Stat->{ObjectBehaviours}->{ProvidesDashboardWidget} ) {
         $Frontend{'SelectShowAsDashboardWidget'} = $LayoutObject->BuildSelection(
             Data => {
-                0 => 'No (not supported)',
+                0 => Translatable('No (not supported)'),
             },
             SelectedID => 0,
             Name       => 'ShowAsDashboardWidget',
@@ -643,8 +643,8 @@ sub GeneralSpecificationsWidget {
 
     $Frontend{SelectValid} = $LayoutObject->BuildSelection(
         Data => {
-            0 => 'invalid',
-            1 => 'valid',
+            0 => Translatable('invalid'),
+            1 => Translatable('valid'),
         },
         SelectedID => $GetParam{Valid} // $Stat->{Valid},
         Name       => 'Valid',
@@ -2448,7 +2448,9 @@ sub _StopWordErrorCheck {
     my $TicketObject = $Kernel::OM->Get('Kernel::System::Ticket');
 
     if ( !%Param ) {
-        $LayoutObject->FatalError( Message => "Got no values to check." );
+        $LayoutObject->FatalError(
+            Message => Translatable('Got no values to check.'),
+        );
     }
 
     my %StopWordsServerErrors;

--- a/Kernel/System/Stats/Dynamic/Ticket.pm
+++ b/Kernel/System/Stats/Dynamic/Ticket.pm
@@ -519,9 +519,9 @@ sub GetObjectAttributes {
             Block            => 'SelectField',
             Translation      => 1,
             Values           => {
-                ArchivedTickets    => 'Archived tickets',
-                NotArchivedTickets => 'Unarchived tickets',
-                AllTickets         => 'All tickets',
+                ArchivedTickets    => Translatable('Archived tickets'),
+                NotArchivedTickets => Translatable('Unarchived tickets'),
+                AllTickets         => Translatable('All tickets'),
             },
         );
 

--- a/Kernel/System/Stats/Dynamic/TicketAccountedTime.pm
+++ b/Kernel/System/Stats/Dynamic/TicketAccountedTime.pm
@@ -450,9 +450,9 @@ sub GetObjectAttributes {
             Block            => 'SelectField',
             Translation      => 1,
             Values           => {
-                ArchivedTickets    => 'Archived tickets',
-                NotArchivedTickets => 'Unarchived tickets',
-                AllTickets         => 'All tickets',
+                ArchivedTickets    => Translatable('Archived tickets'),
+                NotArchivedTickets => Translatable('Unarchived tickets'),
+                AllTickets         => Translatable('All tickets'),
             },
         );
 
@@ -1293,15 +1293,15 @@ sub _KindsOfReporting {
     my $Self = shift;
 
     my %KindsOfReporting = (
-        TotalTime        => 'Total Time',
-        TicketAverage    => 'Ticket Average',
-        TicketMinTime    => 'Ticket Min Time',
-        TicketMaxTime    => 'Ticket Max Time',
-        NumberOfTickets  => 'Number of Tickets',
-        ArticleAverage   => 'Article Average',
-        ArticleMinTime   => 'Article Min Time',
-        ArticleMaxTime   => 'Article Max Time',
-        NumberOfArticles => 'Number of Articles',
+        TotalTime        => Translatable('Total Time'),
+        TicketAverage    => Translatable('Ticket Average'),
+        TicketMinTime    => Translatable('Ticket Min Time'),
+        TicketMaxTime    => Translatable('Ticket Max Time'),
+        NumberOfTickets  => Translatable('Number of Tickets'),
+        ArticleAverage   => Translatable('Article Average'),
+        ArticleMinTime   => Translatable('Article Min Time'),
+        ArticleMaxTime   => Translatable('Article Max Time'),
+        NumberOfArticles => Translatable('Number of Articles'),
     );
     return \%KindsOfReporting;
 }

--- a/Kernel/System/Stats/Dynamic/TicketList.pm
+++ b/Kernel/System/Stats/Dynamic/TicketList.pm
@@ -124,7 +124,7 @@ sub GetObjectAttributes {
         20        => 20,
         50        => 50,
         100       => 100,
-        unlimited => 'unlimited',
+        unlimited => Translatable('unlimited'),
     );
 
     my %TicketAttributes = %{ $Self->_TicketAttributes() };
@@ -152,8 +152,8 @@ sub GetObjectAttributes {
     }
 
     my %SortSequence = (
-        Up   => 'ascending',
-        Down => 'descending',
+        Up   => Translatable('ascending'),
+        Down => Translatable('descending'),
     );
 
     my @ObjectAttributes = (
@@ -627,9 +627,9 @@ sub GetObjectAttributes {
             Block            => 'SelectField',
             Translation      => 1,
             Values           => {
-                ArchivedTickets    => 'Archived tickets',
-                NotArchivedTickets => 'Unarchived tickets',
-                AllTickets         => 'All tickets',
+                ArchivedTickets    => Translatable('Archived tickets'),
+                NotArchivedTickets => Translatable('Unarchived tickets'),
+                AllTickets         => Translatable('All tickets'),
             },
         );
 

--- a/Kernel/System/Stats/Dynamic/TicketSolutionResponseTime.pm
+++ b/Kernel/System/Stats/Dynamic/TicketSolutionResponseTime.pm
@@ -438,9 +438,9 @@ sub GetObjectAttributes {
             Block            => 'SelectField',
             Translation      => 1,
             Values           => {
-                ArchivedTickets    => 'Archived tickets',
-                NotArchivedTickets => 'Unarchived tickets',
-                AllTickets         => 'All tickets',
+                ArchivedTickets    => Translatable('Archived tickets'),
+                NotArchivedTickets => Translatable('Unarchived tickets'),
+                AllTickets         => Translatable('All tickets'),
             },
         );
 
@@ -1307,29 +1307,29 @@ sub _KindsOfReporting {
     my $Self = shift;
 
     my %KindsOfReporting = (
-        SolutionAverageAllOver => 'Solution Average',
-        SolutionMinTimeAllOver => 'Solution Min Time',
-        SolutionMaxTimeAllOver => 'Solution Max Time',
-        NumberOfTicketsAllOver => 'Number of Tickets',
-        SolutionAverage        => 'Solution Average (affected by escalation configuration)',
-        SolutionMinTime        => 'Solution Min Time (affected by escalation configuration)',
-        SolutionMaxTime        => 'Solution Max Time (affected by escalation configuration)',
+        SolutionAverageAllOver => Translatable('Solution Average'),
+        SolutionMinTimeAllOver => Translatable('Solution Min Time'),
+        SolutionMaxTimeAllOver => Translatable('Solution Max Time'),
+        NumberOfTicketsAllOver => Translatable('Number of Tickets'),
+        SolutionAverage        => Translatable('Solution Average (affected by escalation configuration)'),
+        SolutionMinTime        => Translatable('Solution Min Time (affected by escalation configuration)'),
+        SolutionMaxTime        => Translatable('Solution Max Time (affected by escalation configuration)'),
         SolutionWorkingTimeAverage =>
-            'Solution Working Time Average (affected by escalation configuration)',
+            Translatable('Solution Working Time Average (affected by escalation configuration)'),
         SolutionMinWorkingTime =>
-            'Solution Min Working Time (affected by escalation configuration)',
+            Translatable('Solution Min Working Time (affected by escalation configuration)'),
         SolutionMaxWorkingTime =>
-            'Solution Max Working Time (affected by escalation configuration)',
-        ResponseAverage => 'Response Average (affected by escalation configuration)',
-        ResponseMinTime => 'Response Min Time (affected by escalation configuration)',
-        ResponseMaxTime => 'Response Max Time (affected by escalation configuration)',
+            Translatable('Solution Max Working Time (affected by escalation configuration)'),
+        ResponseAverage => Translatable('Response Average (affected by escalation configuration)'),
+        ResponseMinTime => Translatable('Response Min Time (affected by escalation configuration)'),
+        ResponseMaxTime => Translatable('Response Max Time (affected by escalation configuration)'),
         ResponseWorkingTimeAverage =>
-            'Response Working Time Average (affected by escalation configuration)',
+            Translatable('Response Working Time Average (affected by escalation configuration)'),
         ResponseMinWorkingTime =>
-            'Response Min Working Time (affected by escalation configuration)',
+            Translatable('Response Min Working Time (affected by escalation configuration)'),
         ResponseMaxWorkingTime =>
-            'Response Max Working Time (affected by escalation configuration)',
-        NumberOfTickets => 'Number of Tickets (affected by escalation configuration)',
+            Translatable('Response Max Working Time (affected by escalation configuration)'),
+        NumberOfTickets => Translatable('Number of Tickets (affected by escalation configuration)'),
     );
     return \%KindsOfReporting;
 }


### PR DESCRIPTION
Hi @mgruner 
I found some strings related to stats, that are not marked for translation. This can backport into rel-5_0.