### PR TITLE
Marked Attachments popup title as translatable

### DIFF
--- a/var/httpd/htdocs/js/Core.Agent.TicketZoom.js
+++ b/var/httpd/htdocs/js/Core.Agent.TicketZoom.js
@@ -344,7 +344,7 @@ Core.Agent.TicketZoom = (function (TargetNS) {
             var Position;
             if ($(this).attr('rel') && $('#' + $(this).attr('rel')).length) {
                 Position = $(this).offset();
-                Core.UI.Dialog.ShowContentDialog($('#' + $(this).attr('rel'))[0].innerHTML, 'Attachments', Position.top - $(window).scrollTop(), parseInt(Position.left, 10) + 25);
+                Core.UI.Dialog.ShowContentDialog($('#' + $(this).attr('rel'))[0].innerHTML, Core.Language.Translate('Attachments'), Position.top - $(window).scrollTop(), parseInt(Position.left, 10) + 25);
             }
             Event.preventDefault();
             Event.stopPropagation();


### PR DESCRIPTION
Hi @mrcbnsls 
If you click the number showing in an article row (in the last column) that an article has attachments, the title of the pop-up isn't marked for translation.