### PR TITLE
Master - JS refactoring - PreviewWidget

### DIFF
--- a/Kernel/Output/HTML/Statistics/View.pm
+++ b/Kernel/Output/HTML/Statistics/View.pm
@@ -1107,6 +1107,12 @@ sub PreviewWidget {
         );
     }
 
+    # send data to JS
+    $LayoutObject->AddJSData(
+        Key   => 'PreviewResult',
+        Value => $Frontend{PreviewResult},
+    );
+
     my $Output .= $LayoutObject->Output(
         TemplateFile => 'Statistics/PreviewWidget',
         Data         => {

--- a/Kernel/Output/HTML/Templates/Standard/Statistics/PreviewWidget.tt
+++ b/Kernel/Output/HTML/Templates/Standard/Statistics/PreviewWidget.tt
@@ -138,31 +138,6 @@
                 [% Translate('Please note that the preview uses random data and does not consider data filters.') | html %]
             </span>
         </div>
-        [% WRAPPER JSOnDocumentComplete %]
-        <script type="text/javascript">
-        $('.SwitchPreviewFormat').on('click', function() {
-            var Format = $(this).data('format'),
-                FormatCleaned = Format.replace('::', '');
-            $('.SwitchPreviewFormat').removeClass('Active');
-            $(this).addClass('Active');
-            $('.PreviewContent:visible').hide();
-            $('svg.PreviewContent').empty();
-            $('#PreviewContent' + FormatCleaned).show();
-            if (Format.match(/D3/)) {
-                Core.UI.AdvancedChart.Init(
-                    Format,
-                    [% JSON(Data.PreviewResult) %],
-                    'svg#PreviewContent' + FormatCleaned,
-                    {
-                        HideLegend: true
-                    }
-                );
-            }
-            return false;
-        });
-        $('.SwitchPreviewFormat').first().trigger('click');
-        </script>
-        [% END %]
     [% END %]
 
     <div class="Preview">

--- a/var/httpd/htdocs/js/Core.Agent.Statistics.js
+++ b/var/httpd/htdocs/js/Core.Agent.Statistics.js
@@ -179,9 +179,9 @@ Core.Agent.Statistics = (function (TargetNS) {
        $('.SwitchPreviewFormat').on('click', function() {
             var Format = $(this).data('format'),
                 FormatCleaned = Format.replace('::', ''),
-                PreviewResult = Core.Config.Get('PreviewResult'),StatsPreviewResult = [];
+                StatsPreviewResult;
 
-            StatsPreviewResult = StatsPreviewResult.concat(PreviewResult);
+            StatsPreviewResult = Core.Data.CopyObject(Core.Config.Get('PreviewResult'));
             $('.SwitchPreviewFormat').removeClass('Active');
             $(this).addClass('Active');
             $('.PreviewContent:visible').hide();

--- a/var/httpd/htdocs/js/Core.Agent.Statistics.js
+++ b/var/httpd/htdocs/js/Core.Agent.Statistics.js
@@ -175,6 +175,31 @@ Core.Agent.Statistics = (function (TargetNS) {
 
             return false;
         });
+
+       $('.SwitchPreviewFormat').on('click', function() {
+            var Format = $(this).data('format'),
+                FormatCleaned = Format.replace('::', ''),
+                PreviewResult = Core.Config.Get('PreviewResult'),StatsPreviewResult = [];
+
+            StatsPreviewResult = StatsPreviewResult.concat(PreviewResult);
+            $('.SwitchPreviewFormat').removeClass('Active');
+            $(this).addClass('Active');
+            $('.PreviewContent:visible').hide();
+            $('svg.PreviewContent').empty();
+            $('#PreviewContent' + FormatCleaned).show();
+            if (Format.match(/D3/)) {
+                Core.UI.AdvancedChart.Init(
+                    Format,
+                    StatsPreviewResult,
+                    'svg#PreviewContent' + FormatCleaned,
+                    {
+                        HideLegend: true
+                    }
+                );
+            }
+            return false;
+        });
+        $('.SwitchPreviewFormat').first().trigger('click');
     }
 
     /**

--- a/var/httpd/htdocs/js/Core.UI.AdvancedChart.js
+++ b/var/httpd/htdocs/js/Core.UI.AdvancedChart.js
@@ -124,7 +124,7 @@ Core.UI.AdvancedChart = (function (TargetNS) {
                     return;
                 }
                 // Ignore sum col
-                if (HeadingElement === 'Sum') {
+                if (typeof HeadingElement === 'undefined' ||  HeadingElement === 'Sum') {
                     return;
                 }
 
@@ -395,7 +395,7 @@ Core.UI.AdvancedChart = (function (TargetNS) {
                     return;
                 }
                 // Ignore sum col
-                if (HeadingElement === 'Sum') {
+                if (typeof HeadingElement === 'undefined' ||  HeadingElement === 'Sum') {
                     return;
                 }
 
@@ -552,7 +552,7 @@ Core.UI.AdvancedChart = (function (TargetNS) {
                     return;
                 }
                 // Ignore sum col
-                if (HeadingElement === 'Sum') {
+                if (typeof HeadingElement === 'undefined' ||  HeadingElement === 'Sum') {
                     return;
                 }
 


### PR DESCRIPTION
Hello @zottto ,

Hereby is refactored PreviewWidget in Statistic edit screen. There was in  PreviewResult $('.SwitchPreviewFormat').on('click', function(). It was sent by value Core.UI.AdvancedChart.Init. But now when we send reference to an array, there was a problem because of 
removing the first two elements from RowData
https://github.com/OTRS/otrs/blob/master/var/httpd/htdocs/js/Core.UI.AdvancedChart.js#L94

and I found another problem with this line in DrawStackedAreaChart stats:
https://github.com/OTRS/otrs/blob/master/var/httpd/htdocs/js/Core.UI.AdvancedChart.js#L624

So I add for ignoring Sum column: 
`if (typeof HeadingElement === 'undefined' ||  HeadingElement === 'Sum') {`

It is our proposal for fixing that, we can use also JSON.stringify and JSON.parse to avoid problem with changing data in an array when they are sent by reference.
Please let me know what do you think about all of that.

Regards,
Zoran
