### PR TITLE
Per-address loop protection configuration

### DIFF
--- a/Kernel/Config/Files/Ticket.xml
+++ b/Kernel/Config/Files/Ticket.xml
@@ -10059,6 +10059,15 @@
             <String Regex="^[0-9]{1,3}$">40</String>
         </Setting>
     </ConfigItem>
+    <ConfigItem Name="PostmasterMaxEmailsPerAddress" Required="0" Valid="1">
+        <Description Translatable="1">Maximal auto email responses to own email-address a day, configurable by email address (Loop-Protection).</Description>
+        <Group>Ticket</Group>
+        <SubGroup>Core::PostMaster</SubGroup>
+        <Setting>
+            <Hash>
+            </Hash>
+        </Setting>
+    </ConfigItem>
     <ConfigItem Name="PostMasterMaxEmailSize" Required="1" Valid="1">
         <Description Translatable="1">Maximal size in KBytes for mails that can be fetched via POP3/POP3S/IMAP/IMAPS (KBytes).</Description>
         <Group>Ticket</Group>

--- a/Kernel/System/PostMaster/LoopProtection/Common.pm
+++ b/Kernel/System/PostMaster/LoopProtection/Common.pm
@@ -1,0 +1,35 @@
+# --
+# Copyright (C) 2001-2016 OTRS AG, http://otrs.com/
+# --
+# This software comes with ABSOLUTELY NO WARRANTY. For details, see
+# the enclosed file COPYING for license information (AGPL). If you
+# did not receive this file, see http://www.gnu.org/licenses/agpl.txt.
+# --
+package Kernel::System::PostMaster::LoopProtection::Common;
+## nofilter(TidyAll::Plugin::OTRS::Perl::Time)
+
+use strict;
+use warnings;
+use utf8;
+
+our $ObjectManagerDisabled = 1;
+
+sub new {
+    my ( $Type, %Param ) = @_;
+
+    # allocate new hash for object
+    my $Self = {};
+    bless( $Self, $Type );
+
+    # get config options
+    $Self->{PostmasterMaxEmails} = $Kernel::OM->Get('Kernel::Config')->Get('PostmasterMaxEmails') || 40;
+    $Self->{PostmasterMaxEmailsPerAddress} =
+        $Kernel::OM->Get('Kernel::Config')->Get('PostmasterMaxEmailsPerAddress') || {};
+
+    my $DateTimeObject = $Kernel::OM->Create('Kernel::System::DateTime');
+    $Self->{LoopProtectionDate} = $DateTimeObject->Format( Format => '%Y-%m-%d' );
+
+    return $Self;
+}
+
+1;


### PR DESCRIPTION
This allows you to override the default loop protection limit for single
email addresses.

This enables automations that are based on parsing the auto-responder email,
which might otherwise miss some emails that are filtered out by the loop
protection.