### PR TITLE
Fixed error Base class package "Kernel::System::EventHandler" is empty

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,4 +1,5 @@
 #6.0.0.beta1 2016-??-??
+ - 2016-07-29 Fixed error Base class package "Kernel::System::EventHandler" is empty.
  - 2016-07-26 Added a new postmaster filter to decrypt and handle encrypted mails.
  - 2016-07-18 Fixed bug#[7860](http://bugs.otrs.org/show_bug.cgi?id=7860) - AgentTicketSearch and Statistics are missing TicketPending option.
  - 2016-07-13 Added a javascript templating mechanism. Use Core.Template.Render() to fill given templates from either files or strings with data.

--- a/Kernel/System/Package.pm
+++ b/Kernel/System/Package.pm
@@ -21,6 +21,7 @@ use Kernel::System::WebUserAgent;
 use Kernel::System::VariableCheck qw(:all);
 use Kernel::Language qw(Translatable);
 
+use Kernel::System::EventHandler;
 use base qw(Kernel::System::EventHandler);
 
 our @ObjectDependencies = (


### PR DESCRIPTION
When running module-tools/DatabaseInstall.pl in Debian 8 - probably after
perl update https://www.debian.org/security/2016/dsa-3628 - an error
occurs

    Base class package "Kernel::System::EventHandler" is empty.
        (Perhaps you need to 'use' the module which defines that package first,
        or make that module available in @INC (@INC contains: /opt/Custom /opt/Kernel/cpan-lib /opt Kernel/cpan-lib [...] .).
     at Kernel/System/Package.pm line 25.
    BEGIN failed--compilation aborted at Kernel/System/Package.pm line 25.
    Compilation failed in require at /opt/module-tools/DatabaseInstall.pl line 54.
    BEGIN failed--compilation aborted at /opt/module-tools/DatabaseInstall.pl line 54.

This mod fixes this issue.

Related: https://dev.ib.pl/ib/otrs/issues/83
Author-Change-Id: IB#1055118