### PR TITLE
Used File::Spec to construct paths in restore.pl

### DIFF
--- a/scripts/restore.pl
+++ b/scripts/restore.pl
@@ -23,6 +23,7 @@ use warnings;
 
 # use ../ as lib location
 use File::Basename;
+use File::Spec qw(catfile);
 use FindBin qw($RealBin);
 use lib dirname($RealBin);
 use lib dirname($RealBin) . "/Kernel/cpan-lib";
@@ -60,10 +61,11 @@ elsif ( !-d $Opts{d} ) {
 }
 
 # restore config
-print "Restore $Opts{b}/Config.tar.gz ...\n";
+my $ConfigBackupTar = File::Spec->catfile( $Opts{b}, 'Config.tar.gz' );
+print "Restore $ConfigBackupTar ...\n";
 chdir( $Opts{d} );
-if ( -e "$Opts{b}/Config.tar.gz" ) {
-    system("tar -xzf $Opts{b}/Config.tar.gz");
+if ( -e $ConfigBackupTar ) {
+    system("tar -xzf $ConfigBackupTar");
 }
 
 # create common objects
@@ -145,32 +147,37 @@ my $Home = $Kernel::OM->Get('Kernel::Config')->Get('Home');
 chdir($Home);
 
 # extract application
-if ( -e "$Opts{b}/Application.tar.gz" ) {
-    print "Restore $Opts{b}/Application.tar.gz ...\n";
-    system("tar -xzf $Opts{b}/Application.tar.gz");
+my $ApplicationBackupTar = File::Spec->catfile( $Opts{b}, 'Application.tar.gz' );
+if ( -e $ApplicationBackupTar ) {
+    print "Restore $ApplicationBackupTar ...\n";
+    system("tar -xzf $ApplicationBackupTar");
 }
 
 # extract vardir
-if ( -e "$Opts{b}/VarDir.tar.gz" ) {
-    print "Restore $Opts{b}/VarDir.tar.gz ...\n";
-    system("tar -xzf $Opts{b}/VarDir.tar.gz");
+my $VarDirBackupTar = File::Spec->catfile( $Opts{b}, 'VarDir.tar.gz' );
+if ( -e $VarDirBackupTar ) {
+    print "Restore $VarDirBackupTar ...\n";
+    system("tar -xzf $VarDirBackupTar");
 }
 
 # extract datadir
-if ( -e "$Opts{b}/DataDir.tar.gz" ) {
-    print "Restore $Opts{b}/DataDir.tar.gz ...\n";
-    system("tar -xzf $Opts{b}/DataDir.tar.gz");
+my $DataDirBackupTar = File::Spec->catfile( $Opts{b}, 'DataDir.tar.gz' );
+if ( -e $DataDirBackupTar ) {
+    print "Restore $DataDirBackupTar ...\n";
+    system("tar -xzf $DataDirBackupTar");
 }
 
 # import database
+my $DatabaseBackupGz  = File::Spec->catfile( $Opts{b}, 'DatabaseBackup.sql.gz' );
+my $DatabaseBackupBz2 = File::Spec->catfile( $Opts{b}, 'DatabaseBackup.sql.bz2' );
 if ( $DB =~ m/mysql/i ) {
     print "create $DB\n";
     if ($DatabasePw) {
         $DatabasePw = "-p'$DatabasePw'";
     }
-    if ( -e "$Opts{b}/DatabaseBackup.sql.gz" ) {
+    if ( -e $DatabaseBackupGz ) {
         print "decompresses SQL-file ...\n";
-        system("gunzip $Opts{b}/DatabaseBackup.sql.gz");
+        system("gunzip $DatabaseBackupGz");
         print "cat SQL-file into $DB database\n";
         system(
             "mysql -f -u$DatabaseUser $DatabasePw -h$DatabaseHost $Database < $Opts{b}/DatabaseBackup.sql"
@@ -178,9 +185,9 @@ if ( $DB =~ m/mysql/i ) {
         print "compress SQL-file...\n";
         system("gzip $Opts{b}/DatabaseBackup.sql");
     }
-    elsif ( -e "$Opts{b}/DatabaseBackup.sql.bz2" ) {
+    elsif ( -e $DatabaseBackupBz2 ) {
         print "decompresses SQL-file ...\n";
-        system("bunzip2 $Opts{b}/DatabaseBackup.sql.bz2");
+        system("bunzip2 $DatabaseBackupBz2");
         print "cat SQL-file into $DB database\n";
         system(
             "mysql -f -u$DatabaseUser $DatabasePw -h$DatabaseHost $Database < $Opts{b}/DatabaseBackup.sql"
@@ -194,9 +201,9 @@ else {
         $DatabaseHost = "-h $DatabaseHost"
     }
 
-    if ( -e "$Opts{b}/DatabaseBackup.sql.gz" ) {
+    if ( -e $DatabaseBackupGz ) {
         print "decompresses SQL-file ...\n";
-        system("gunzip $Opts{b}/DatabaseBackup.sql.gz");
+        system("gunzip $DatabaseBackupGz");
 
         # set password via environment variable if there is one
         if ($DatabasePw) {
@@ -209,9 +216,9 @@ else {
         print "compress SQL-file...\n";
         system("gzip $Opts{b}/DatabaseBackup.sql");
     }
-    elsif ( -e "$Opts{b}/DatabaseBackup.sql.bz2" ) {
+    elsif ( -e $DatabaseBackupBz2 ) {
         print "decompresses SQL-file ...\n";
-        system("bunzip2 $Opts{b}/DatabaseBackup.sql.bz2");
+        system("bunzip2 $DatabaseBackupBz2");
 
         # set password via environment variable if there is one
         if ($DatabasePw) {


### PR DESCRIPTION
Use the catfile subroutine from File::Spec to build the paths, instead
of doing "$dir/File.ext". This way, the built paths won't contain double
slashes if the given $dir ends with a slash.

Multiple slashes are a valid separator in Unix-based systems, as far as
I know, but at the very least this is cleaner and the output messages
are less confusing.