### PR TITLE
Master - JS refactoring - LinkObject

### DIFF
--- a/Kernel/Output/HTML/Layout/LinkObject.pm
+++ b/Kernel/Output/HTML/Layout/LinkObject.pm
@@ -334,6 +334,12 @@ sub LinkObjectTableCreateComplex {
                 $SourceObjectData = "<input type='hidden' name='$Block->{ObjectName}' value='$Block->{ObjectID}' />";
             }
 
+            # send data to JS
+            $LayoutObject->AddJSData(
+                Key   => 'LinkObjectName',
+                Value => $Block->{Blockname},
+            );
+
             $LayoutObject->Block(
                 Name => 'ContentLargePreferences',
                 Data => {
@@ -344,6 +350,12 @@ sub LinkObjectTableCreateComplex {
             my %Preferences = $Self->ComplexTablePreferencesGet(
                 Config  => $Config->{ $Block->{Blockname} },
                 PrefKey => "LinkObject::ComplexTable-" . $Block->{Blockname},
+            );
+
+            # send data to JS
+            $LayoutObject->AddJSData(
+                Key   => 'LinkObjectPreferences',
+                Value => \%Preferences,
             );
 
             $LayoutObject->Block(

--- a/Kernel/Output/HTML/Templates/Standard/LinkObject.tt
+++ b/Kernel/Output/HTML/Templates/Standard/LinkObject.tt
@@ -22,16 +22,6 @@
 <a class="AsBlock LinkObjectLink" href="[% Data.Link %]" title="[% Data.Title | html %]" >[% Data.Content | truncate(Data.MaxLength) | html %]</a>
 [% RenderBlockEnd("Link") %]
 
-[% WRAPPER JSOnDocumentComplete %]
-<script type="text/javascript">//<![CDATA[
-// Make sure that (only!) from a popup window, links are always opened in a new tab of the main window.
-if (Core.UI.Popup.CurrentIsPopupWindow()) {
-    $('a.LinkObjectLink').attr('target', '_blank');
-}
-//]]></script>
-[% END %]
-
-
 [% RenderBlockStart("TimeLong") %]
 [% Data.Content | Localize("TimeLong") %]
 [% RenderBlockEnd("TimeLong") %]
@@ -81,14 +71,6 @@ if (Core.UI.Popup.CurrentIsPopupWindow()) {
                         <i class="fa fa-cog"></i>
                     </a>
                 </div>
-[% WRAPPER JSOnDocumentComplete %]
-<script type="text/javascript">//<![CDATA[
-// register click on settings button
-Core.UI.RegisterToggleTwoContainer($('#linkobject-' + Core.App.EscapeSelector('[% Data.Name | html %]') + '-toggle'),
-    $('#linkobject-' + Core.App.EscapeSelector('[% Data.Name | html %]') + '-setting'),
-    $('#' + Core.App.EscapeSelector('[% Data.Name | html %]')));
-//]]></script>
-[% END %]
 [% RenderBlockEnd("ContentLargePreferences") %]
             <div class="Clear"></div>
         </div>
@@ -146,19 +128,6 @@ Core.UI.RegisterToggleTwoContainer($('#linkobject-' + Core.App.EscapeSelector('[
                         </div>
                     </div>
                     <div class="Clear"></div>
-[% WRAPPER JSOnDocumentComplete %]
-<script type="text/javascript">//<![CDATA[
-// Update preferences and load linked table via AJAX
-Core.Agent.LinkObject.RegisterUpdatePreferences($('#linkobject-' + Core.App.EscapeSelector('[% Data.Name | html %]') + '_submit'),
-    "Widget" + Core.App.EscapeSelector('[% Data.Name | html %]'),
-    $('#linkobject-' + Core.App.EscapeSelector('[% Data.NameForm | html %]') + '_setting_form'));
-
-// toggle two containers when user press Cancel
-Core.UI.RegisterToggleTwoContainer($('#linkobject-' + Core.App.EscapeSelector('[% Data.Name | html %]') + '_cancel'),
-    $('#linkobject-' + Core.App.EscapeSelector('[% Data.Name | html %]') + '-setting'),
-    $('#' + Core.App.EscapeSelector('[% Data.Name | html %]')));
-//]]></script>
-[% END %]
 
 [% RenderBlockEnd("ContentLargePreferencesItemAllocationList") %]
 [% RenderBlockStart("ContentLargePreferencesItemRawHTML") %]
@@ -224,12 +193,3 @@ Core.UI.RegisterToggleTwoContainer($('#linkobject-' + Core.App.EscapeSelector('[
 [% RenderBlockEnd("TableComplexBlock") %]
 
 [% RenderBlockEnd("TableComplex") %]
-
-[% WRAPPER JSOnDocumentComplete %]
-<script type="text/javascript">//<![CDATA[
-    $('.SelectAll').bind('click', function () {
-        var Status = $(this).prop('checked');
-        $(this).closest('.WidgetSimple').find('table input[type=checkbox]').prop('checked', Status);
-    });
-//]]></script>
-[% END %]

--- a/var/httpd/htdocs/js/Core.Agent.LinkObject.SearchForm.js
+++ b/var/httpd/htdocs/js/Core.Agent.LinkObject.SearchForm.js
@@ -30,7 +30,8 @@ Core.Agent.LinkObject.SearchForm = (function (TargetNS) {
     TargetNS.Init = function () {
 
         var SearchValueFlag,
-            TemporaryLink = Core.Config.Get('TemporaryLink');
+            TemporaryLink = Core.Config.Get('TemporaryLink'),
+            Status;
 
         if (typeof TemporaryLink !== 'undefined' && parseInt(TemporaryLink, 10) === 1) {
             $('#LinkAddCloseLink, #LinkDeleteCloseLink').on('click', function () {
@@ -74,6 +75,22 @@ Core.Agent.LinkObject.SearchForm = (function (TargetNS) {
                alert(Core.Language.Translate("Please enter at least one search value or * to find anything."));
                return false;
             }
+        });
+
+        // Make sure that (only!) from a popup window, links are always opened in a new tab of the main window.
+        if (Core.UI.Popup.CurrentIsPopupWindow()) {
+            $('a.LinkObjectLink').attr('target', '_blank');
+        }
+
+        // event for 'Select All' checkbox
+        $('.SelectAll').on('click', function () {
+            Status = $(this).prop('checked');
+            $(this).closest('.WidgetSimple').find('table input[type=checkbox]').prop('checked', Status);
+        });
+
+        // event for checkboxes
+        $('input[type="checkbox"][name="LinkTargetKeys"]').on('click', function () {
+            Core.Form.SelectAllCheckboxes($(this), $(this).closest('.WidgetSimple').find('.SelectAll'));
         });
     };
 

--- a/var/httpd/htdocs/js/Core.Agent.LinkObject.js
+++ b/var/httpd/htdocs/js/Core.Agent.LinkObject.js
@@ -44,7 +44,50 @@ Core.Agent.LinkObject = (function (TargetNS) {
         }
     };
 
-    Core.Agent.TableFilters.SetAllocationList();
+    /**
+     * @name Init
+     * @memberof Core.Agent.LinkObject
+     * @function
+     * @description
+     *      This function initializes module functionality.
+     */
+    TargetNS.Init = function () {
+
+        var Name = Core.Config.Get('LinkObjectName');
+        var Preferences = Core.Config.Get('LinkObjectPreferences');
+
+        // events for link object complex table
+        if (typeof Name !== 'undefined') {
+
+            // initialize allocation list
+            if (typeof Preferences !== 'undefined') {
+                Core.Agent.TableFilters.SetAllocationList();
+            }
+
+            // Update preferences and load linked table via AJAX
+            TargetNS.RegisterUpdatePreferences(
+                $('#linkobject-' + Core.App.EscapeSelector(Name) + '_submit'),
+                'Widget' + Core.App.EscapeSelector(Name),
+                $('#linkobject-' + Core.App.EscapeSelector(Name) + '_setting_form')
+            );
+
+            // register click on settings button
+            Core.UI.RegisterToggleTwoContainer(
+                $('#linkobject-' + Core.App.EscapeSelector(Name) + '-toggle'),
+                $('#linkobject-' + Core.App.EscapeSelector(Name) + '-setting'),
+                $('#' + Core.App.EscapeSelector(Name))
+            );
+
+            // toggle two containers when user press Cancel
+            Core.UI.RegisterToggleTwoContainer(
+                $('#linkobject-' + Core.App.EscapeSelector(Name) + '_cancel'),
+                $('#linkobject-' + Core.App.EscapeSelector(Name) + '-setting'),
+                $('#' + Core.App.EscapeSelector(Name))
+            );
+        }
+    };
+
+    Core.Init.RegisterNamespace(TargetNS, 'APP_MODULE');
 
     return TargetNS;
 }(Core.Agent.LinkObject || {}));


### PR DESCRIPTION
Hi @zottto 

Hereby is refactored LinkObject.tt. Part of JS code for 'Simple' table is moved to Core.Agent.LinkObject.SearchForms.js and part for 'Complex' table is moved to Core.Agent.LinkObject.js because 'Complex' view mode has to be set and some JS and CSS files have to be included in SysConfig.
Everything is ok when complex table is shown for AgentTicketZoom screen, but there were errors when we tried to make the same situation in AgentLinkObject screen (function Core.Agent.TableFilters.SetAllocationList reported error because columns data arrays are not defined).
Please let me know if you have any suggestion for this PR.

Regards
Zoran