### PR TITLE
Extended searching for customers and customer users

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,4 +1,5 @@
 #6.0.0.beta1 2016-??-??
+ - 2016-08-11 Extended searching for customers and customer users.
  - 2015-08-01 Updated CPAN module CGI to version 4.32.
  - 2016-07-26 Added a new postmaster filter to decrypt and handle encrypted mails.
  - 2016-07-18 Fixed bug#[7860](http://bugs.otrs.org/show_bug.cgi?id=7860) - AgentTicketSearch and Statistics are missing TicketPending option.

--- a/Kernel/Config/Defaults.pm
+++ b/Kernel/Config/Defaults.pm
@@ -1469,6 +1469,7 @@ via the Preferences button after logging in.
         CustomerUserSearchFields           => [ 'login', 'first_name', 'last_name', 'customer_id' ],
         CustomerUserSearchPrefix           => '*',
         CustomerUserSearchSuffix           => '*',
+        CustomerUserSearchExtended         => 0,   # 0 - normal search (space is part of search phrase), 1 - extended search (space works like +)
         CustomerUserSearchListLimit        => 250,
         CustomerUserPostMasterSearchFields => ['email'],
         CustomerUserNameFields             => [ 'title', 'first_name', 'last_name' ],
@@ -1573,6 +1574,7 @@ via the Preferences button after logging in.
 #        CustomerUserSearchFields => ['uid', 'cn', 'mail'],
 #        CustomerUserSearchPrefix => '',
 #        CustomerUserSearchSuffix => '*',
+#        CustomerUserSearchExtended => 0,   # 0 - normal search (space is part of search phrase), 1 - extended search (space works like +)
 #        CustomerUserSearchListLimit => 250,
 #        CustomerUserPostMasterSearchFields => ['mail'],
 #        CustomerUserNameFields => ['givenname', 'sn'],
@@ -1635,6 +1637,7 @@ via the Preferences button after logging in.
         CustomerCompanySearchFields    => ['customer_id', 'name'],
         CustomerCompanySearchPrefix    => '*',
         CustomerCompanySearchSuffix    => '*',
+        CustomerCompanySearchExtended  => 0,   # 0 - normal search (space is part of search phrase), 1 - extended search (space works like +)
         CustomerCompanySearchListLimit => 250,
         CacheTTL                       => 60 * 60 * 24, # use 0 to turn off cache
 

--- a/Kernel/System/CustomerCompany/DB.pm
+++ b/Kernel/System/CustomerCompany/DB.pm
@@ -47,6 +47,10 @@ sub new {
     if ( !defined( $Self->{SearchSuffix} ) ) {
         $Self->{SearchSuffix} = '*';
     }
+    $Self->{SearchExtended} = $Self->{CustomerCompanyMap}->{'CustomerCompanySearchExtended'};
+    if ( !defined( $Self->{SearchExtended} ) ) {
+        $Self->{SearchExtended} = 0;
+    }
 
     # create cache object, but only if CacheTTL is set in customer config
     if ( $Self->{CustomerCompanyMap}->{CacheTTL} ) {
@@ -155,6 +159,7 @@ sub CustomerCompanyList {
             Value         => $Param{Search},
             SearchPrefix  => $Self->{SearchPrefix},
             SearchSuffix  => $Self->{SearchSuffix},
+            Extended      => $Self->{SearchExtended},
             CaseSensitive => $Self->{CaseSensitive},
             BindMode      => 1,
         );

--- a/Kernel/System/CustomerUser/DB.pm
+++ b/Kernel/System/CustomerUser/DB.pm
@@ -67,6 +67,10 @@ sub new {
     if ( !defined $Self->{SearchSuffix} ) {
         $Self->{SearchSuffix} = '*';
     }
+    $Self->{SearchExtended} = $Self->{CustomerUserMap}->{CustomerUserSearchExtended};
+    if ( !defined $Self->{SearchExtended} ) {
+        $Self->{SearchExtended} = 0;
+    }
 
     # check if CustomerKey is var or int
     ENTRY:
@@ -320,6 +324,7 @@ sub CustomerSearch {
             Value         => $Search,
             SearchPrefix  => $Self->{SearchPrefix},
             SearchSuffix  => $Self->{SearchSuffix},
+            Extended      => $Self->{SearchExtended},
             CaseSensitive => $Self->{CaseSensitive},
             BindMode      => 1,
         );

--- a/Kernel/System/CustomerUser/LDAP.pm
+++ b/Kernel/System/CustomerUser/LDAP.pm
@@ -141,6 +141,10 @@ sub new {
     if ( !defined $Self->{SearchSuffix} ) {
         $Self->{SearchSuffix} = '*';
     }
+    $Self->{SearchExtended} = $Self->{CustomerUserMap}->{CustomerUserSearchExtended};
+    if ( !defined $Self->{SearchExtended} ) {
+        $Self->{SearchExtended} = 0;
+    }
 
     # charset settings
     $Self->{SourceCharset} = $Self->{CustomerUserMap}->{Params}->{SourceCharset} || '';
@@ -378,7 +382,13 @@ sub CustomerSearch {
     if ( $Param{Search} ) {
 
         my $Count = 0;
-        my @Parts = split( /\+/, $Param{Search}, 6 );
+        my @Parts;
+        if ( $Self->{SearchExtended} ) {
+            @Parts = split( /\+|\s/, $Param{Search}, 6 );
+        }
+        else {
+            @Parts = split( /\+/, $Param{Search}, 6 );
+        }
         for my $Part (@Parts) {
 
             $Part = $Self->{SearchPrefix} . $Part . $Self->{SearchSuffix};


### PR DESCRIPTION
OTRS does not allow to search for customer users using first name
and surname separated with space (natural way of searching) -
if one search for "john black", fields specified
in CustomerUserSearchFields will be searched for this whole phrase
individually  and customer user with firstname = John
and surname = Black won't match. To be able to search using
firstname and surname, one need to use "john+black" syntax which
is not obvious.

This mod introduces new parameters for CustomerUser
and CustomerCompany searching maps (to be configured in Config.pm):

```
CustomerUserSearchExtended => 0,   # 0 - normal search (space is part of search phrase), 1 - extended search (space works like +)
CustomerCompanySearchExtended  => 0,   # 0 - normal search (space is part of search phrase), 1 - extended search (space works like +)
```

When set to 1, OTRS treats whitespaces in searched string same
like +; when searching for "john black" all searched fields will
be searched separate for john and black.

Related: https://dev.ib.pl/ib/otrs/issues/84
Author-Change-Id: IB#1055633
