### PR TITLE
Improved wording

### DIFF
--- a/Kernel/Config/Files/Ticket.xml
+++ b/Kernel/Config/Files/Ticket.xml
@@ -7565,7 +7565,7 @@
                 <Item Key="Module">Kernel::Output::HTML::Preferences::CustomQueue</Item>
                 <Item Key="Column" Translatable="1">Notification Settings</Item>
                 <Item Key="Label" Translatable="1">My Queues</Item>
-                <Item Key="Desc" Translatable="1">Your queue selection of your favorite queues. You also get notified about those queues via email if enabled.</Item>
+                <Item Key="Desc" Translatable="1">Your queue selection of your preferred queues. You also get notified about those queues via email if enabled.</Item>
                 <Item Key="Key" Translatable="1"></Item>
                 <Item Key="Prio">1000</Item>
                 <Item Key="Permission">ro</Item>
@@ -7582,7 +7582,7 @@
                 <Item Key="Module">Kernel::Output::HTML::Preferences::CustomService</Item>
                 <Item Key="Column" Translatable="1">Notification Settings</Item>
                 <Item Key="Label" Translatable="1">My Services</Item>
-                <Item Key="Desc" Translatable="1">Your service selection of your favorite services. You also get notified about those services via email if enabled.</Item>
+                <Item Key="Desc" Translatable="1">Your service selection of your preferred services. You also get notified about those services via email if enabled.</Item>
                 <Item Key="Key" Translatable="1"></Item>
                 <Item Key="Prio">1000</Item>
                 <Item Key="Active">1</Item>


### PR DESCRIPTION
Hi @mgruner,

I think, the word "preferred" is better here in this case. Agents have to select queues, because they work with them, not because they love them.
And there is "preferred" in the caption of OTRS Business Solution chat module, but in the description is still "favorite":
http://otrs.github.io/doc/manual/otrs-business-solution/stable/en/html/otrs-business-solution-features.html#id-1.4.2.4.4
If you apply this modification, can you change this also in OTRS Business Solution?