### PR TITLE
Master frontend usability - AdminAttachment

### DIFF
--- a/Kernel/Modules/AdminAttachment.pm
+++ b/Kernel/Modules/AdminAttachment.pm
@@ -91,16 +91,34 @@ sub Run {
                 UserID => $Self->{UserID},
             );
             if ($Update) {
-                $Self->_Overview();
-                my $Output = $LayoutObject->Header();
-                $Output .= $LayoutObject->NavigationBar();
-                $Output .= $LayoutObject->Notify( Info => Translatable('Attachment updated!') );
-                $Output .= $LayoutObject->Output(
-                    TemplateFile => 'AdminAttachment',
-                    Data         => \%Param,
-                );
-                $Output .= $LayoutObject->Footer();
-                return $Output;
+                if ( $ParamObject->GetParam( Param => 'ContinueAfterSave' ) eq '1' ) {
+
+                    # if the user would like to continue editing the attachment, just redirect to the edit screen
+                    my $ID = $ParamObject->GetParam( Param => 'ID' ) || '';
+                    my %Data = $StdAttachmentObject->StdAttachmentGet(
+                        ID => $ID,
+                    );
+
+                    my $Output = $LayoutObject->Header();
+                    $Output .= $LayoutObject->NavigationBar();
+                    $Output .= $LayoutObject->Notify( Info => Translatable('Attachment updated!') );
+                    $Self->_Edit(
+                        Action => 'Change',
+                        %Data,
+                    );
+
+                    $Output .= $LayoutObject->Output(
+                        TemplateFile => 'AdminAttachment',
+                        Data         => \%Param,
+                    );
+                    $Output .= $LayoutObject->Footer();
+                    return $Output;
+                }
+                else {
+
+                    # otherwise return to overview
+                    return $LayoutObject->Redirect( OP => "Action=$Self->{Action}" );
+                }
             }
         }
 
@@ -310,16 +328,6 @@ sub _Edit {
             %{ $Param{Errors} },
         },
     );
-
-    # shows header
-    if ( $Param{Action} eq 'Change' ) {
-        $LayoutObject->Block( Name => 'HeaderEdit' );
-        $LayoutObject->Block( Name => 'ContenLabelEdit' );
-    }
-    else {
-        $LayoutObject->Block( Name => 'HeaderAdd' );
-        $LayoutObject->Block( Name => 'ContenLabelAdd' );
-    }
 
     return 1;
 }

--- a/Kernel/Modules/AdminAttachment.pm
+++ b/Kernel/Modules/AdminAttachment.pm
@@ -91,28 +91,11 @@ sub Run {
                 UserID => $Self->{UserID},
             );
             if ($Update) {
+
+                # if the user would like to continue editing the attachment, just redirect to the edit screen
                 if ( $ParamObject->GetParam( Param => 'ContinueAfterSave' ) eq '1' ) {
-
-                    # if the user would like to continue editing the attachment, just redirect to the edit screen
                     my $ID = $ParamObject->GetParam( Param => 'ID' ) || '';
-                    my %Data = $StdAttachmentObject->StdAttachmentGet(
-                        ID => $ID,
-                    );
-
-                    my $Output = $LayoutObject->Header();
-                    $Output .= $LayoutObject->NavigationBar();
-                    $Output .= $LayoutObject->Notify( Info => Translatable('Attachment updated!') );
-                    $Self->_Edit(
-                        Action => 'Change',
-                        %Data,
-                    );
-
-                    $Output .= $LayoutObject->Output(
-                        TemplateFile => 'AdminAttachment',
-                        Data         => \%Param,
-                    );
-                    $Output .= $LayoutObject->Footer();
-                    return $Output;
+                    return $LayoutObject->Redirect( OP => "Action=$Self->{Action};Subaction=Change;ID=$ID" );
                 }
                 else {
 

--- a/Kernel/Output/HTML/Templates/Standard/AdminAttachment.tt
+++ b/Kernel/Output/HTML/Templates/Standard/AdminAttachment.tt
@@ -9,21 +9,22 @@
 [% RenderBlockStart("Overview") %]
 <div class="MainBox ARIARoleMain LayoutFixedSidebar SidebarFirst">
     <h1>[% Translate("Attachment Management") | html %]</h1>
-    <ul class="BreadCrumb">
-        <li>[% Translate("You are here") | html %]:</li>
-        <li>
-            <a href="[% Env("Baselink") %]Action=[% Env("Action") %]">[% Translate("Admin Attachment") | html %]</a>
-        </li>
-        <li>
-        [% IF Data.Action &&  Data.Action == 'Add' %]
-            [% Translate("Add New Attacment") | html %]
-        [% ELSIF Data.Action && Data.Action == 'Change' %]
-            [% Data.Name | html %]
-        [% END %]
-        </li>
-    </ul>
-
-    <div class="Clear"></div>
+    [% IF Data.Action &&  Data.Action == 'Add' %]
+        [%  ItemName = Translate("Add New Attachment") | html %]
+    [% ELSIF Data.Action && Data.Action == 'Change' %]
+        [% ItemName = Data.Name | html %]
+    [% END %]
+    [% INCLUDE "Breadcrumb.tt"
+        Path = [
+            {
+                Name => 'Admin Attachment',
+                Link => Env("Action"),
+            },
+            {
+                Name => ItemName,
+            },
+        ]
+    %]
     <div class="SidebarColumn">
 
 [% RenderBlockStart("ActionList") %]

--- a/Kernel/Output/HTML/Templates/Standard/AdminAttachment.tt
+++ b/Kernel/Output/HTML/Templates/Standard/AdminAttachment.tt
@@ -9,7 +9,21 @@
 [% RenderBlockStart("Overview") %]
 <div class="MainBox ARIARoleMain LayoutFixedSidebar SidebarFirst">
     <h1>[% Translate("Attachment Management") | html %]</h1>
+    <ul class="BreadCrumb">
+        <li>[% Translate("You are here") | html %]:</li>
+        <li>
+            <a href="[% Env("Baselink") %]Action=[% Env("Action") %]">[% Translate("Admin Attachment") | html %]</a>
+        </li>
+        <li>
+        [% IF Data.Action &&  Data.Action == 'Add' %]
+            [% Translate("Add New Attacment") | html %]
+        [% ELSIF Data.Action && Data.Action == 'Change' %]
+            [% Data.Name | html %]
+        [% END %]
+        </li>
+    </ul>
 
+    <div class="Clear"></div>
     <div class="SidebarColumn">
 
 [% RenderBlockStart("ActionList") %]
@@ -27,7 +41,7 @@
 [% RenderBlockStart("ActionAdd") %]
                     <li>
                         <a class="CallForAction Fullsize Center" href="[% Env("Baselink") %]Action=[% Env("Action") %];Subaction=Add">
-                            <span><i class="fa fa-plus-square"></i>[% Translate("Add attachment") | html %]</span>
+                            <span><i class="fa fa-plus-square"></i>[% Translate("Add Attachment") | html %]</span>
                         </a>
                     </li>
 [% RenderBlockEnd("ActionAdd") %]
@@ -106,12 +120,12 @@
 [% RenderBlockEnd("OverviewResult") %]
 [% RenderBlockStart("OverviewUpdate") %]
             <div class="Header">
-[% RenderBlockStart("HeaderAdd") %]
-                <h2>[% Translate("Add Attachment") | html %]</h2>
-[% RenderBlockEnd("HeaderAdd") %]
-[% RenderBlockStart("HeaderEdit") %]
-                <h2>[% Translate("Edit Attachment") | html %]</h2>
-[% RenderBlockEnd("HeaderEdit") %]
+                [% IF Data.Action == 'Add' %]
+                    <h2>[% Translate("Add Attachment") | html %]</h2>
+                [% ELSE %]
+                    <h2>[% Translate("Edit Attachment") | html %]</h2>
+                [% END %]
+
             </div>
             <div class="Content">
 
@@ -119,6 +133,9 @@
                     <input type="hidden" name="Action" value="[% Env("Action") %]"/>
                     <input type="hidden" name="Subaction" value="[% Data.Action | uri %]Action"/>
                     <input type="hidden" name="ID" value="[% Data.ID | html %]"/>
+                    [% IF Data.Action == 'Change' %]
+                        <input type="hidden" name="ContinueAfterSave" id="ContinueAfterSave" value=""/>
+                    [% END %]
 
                     <fieldset class="TableLike">
                         <label class="Mandatory" for="Name"><span class="Marker">*</span> [% Translate("Name") | html %]:</label>
@@ -133,12 +150,11 @@
                         </div>
                         <div class="Clear"></div>
 
-[% RenderBlockStart("ContenLabelAdd") %]
-                        <label class="Mandatory" for="FileUpload"><span class="Marker">*</span> [% Translate("Attachment") | html %]:</label>
-[% RenderBlockEnd("ContenLabelAdd") %]
-[% RenderBlockStart("ContenLabelEdit") %]
-                        <label for="FileUpload">[% Translate("Attachment") | html %]:</label>
-[% RenderBlockEnd("ContenLabelEdit") %]
+                        [% IF Data.Action == 'Add' %]
+                            <label class="Mandatory" for="FileUpload"><span class="Marker">*</span> [% Translate("Attachment") | html %]:</label>
+                        [% ELSE %]
+                            <label for="FileUpload">[% Translate("Attachment") | html %]:</label>
+                        [% END %]
                         <div class="Field">
                             <input name="FileUpload" id="FileUpload" type="file" class="W50pc [% Data.ValidateContent | html %] [% Data.FileUploadInvalid | html %]"/>
                             <div id="FileUploadError" class="TooltipErrorMessage">
@@ -168,10 +184,21 @@
                         </div>
                         <div class="Clear"></div>
 
-                        <div class="Field SpacingTop">
-                            <button class="Primary CallForAction" type="submit" value="[% Translate("Save") | html %]"><span>[% Translate("Save") | html %]</span></button>
-                            [% Translate("or") | html %]
-                            <a href="[% Env("Baselink") %]Action=[% Env("Action") %]">[% Translate("Cancel") | html %]</a>
+                        <div class="Content">
+                            <fieldset class="TableLike">
+                                <div class="Field SpacingTop SaveButtons">
+                                    [% IF Data.Action == 'Change' %]
+                                        <button class="CallForAction Primary" id="SubmitAndContinue" type="button" value="[% Translate("Save") | html %]"><span>[% Translate("Save") | html %]</span></button>
+                                        [% Translate("or") | html %]
+                                        <button class="CallForAction Primary" id="Submit" type="submit" value="[% Translate("Save") | html %]"><span>[% Translate("Save and finish") | html %]</span></button>
+                                    [% ELSE %]
+                                        <button class="CallForAction Primary" id="Submit" type="submit" value="[% Translate("Save") | html %]"><span>[% Translate("Save") | html %]</span></button>
+                                    [% END %]
+                                    [% Translate("or") | html %]
+                                    <a href="[% Env("Baselink") %]Action=[% Env("Action") %]"><span>[% Translate("Cancel") | html %]</span></a>
+                                </div>
+                                <div class="Clear"></div>
+                            </fieldset>
                         </div>
                         <div class="Clear"></div>
                     </fieldset>

--- a/Kernel/Output/HTML/Templates/Standard/AdminAttachment.tt
+++ b/Kernel/Output/HTML/Templates/Standard/AdminAttachment.tt
@@ -9,41 +9,24 @@
 [% RenderBlockStart("Overview") %]
 <div class="MainBox ARIARoleMain LayoutFixedSidebar SidebarFirst">
     <h1>[% Translate("Attachment Management") | html %]</h1>
-    [% IF Data.Action &&  Data.Action == 'Add' %]
-        [%
-            BreadcrumbPath = [
-                {
-                    Name => 'Admin Attachment',
-                    Link => Env("Action"),
-                },
-                {
-                    Name => Translate("Add New Attachment"),
-                },
-            ]
-        %]
-    [% ELSIF Data.Action && Data.Action == 'Change' %]
-        [%
-            BreadcrumbPath = [
-                {
-                    Name => 'Admin Attachment',
-                    Link => Env("Action"),
-                },
-                {
-                    Name => ItemName,
-                },
-            ]
-        %]
-    [% ELSE %]
-        [%
-            BreadcrumbPath = [
-                {
-                    Name => 'Admin Attachment',
-                },
-            ]
-        %]
+
+    [% BreadcrumbPath = [
+            {
+                Name => 'Admin Attachment',
+                Link => Env("Action"),
+            },
+        ]
+    %]
+
+    [% SWITCH Data.Action %]
+    [%   CASE 'Add' %]
+           [% BreadcrumbPath.push({ Name => Translate("Add New Attachment"),}) %]
+    [%   CASE 'Change' %]
+           [% BreadcrumbPath.push({ Name => Data.Name }) %]
     [% END %]
 
     [% INCLUDE "Breadcrumb.tt" Path = BreadcrumbPath %]
+
     <div class="SidebarColumn">
 
 [% RenderBlockStart("ActionList") %]

--- a/Kernel/Output/HTML/Templates/Standard/AdminAttachment.tt
+++ b/Kernel/Output/HTML/Templates/Standard/AdminAttachment.tt
@@ -12,17 +12,18 @@
 
     [% BreadcrumbPath = [
             {
-                Name => 'Admin Attachment',
+                Name => Translate('Attachment Management'),
                 Link => Env("Action"),
             },
         ]
     %]
 
     [% SWITCH Data.Action %]
-    [%   CASE 'Add' %]
-           [% BreadcrumbPath.push({ Name => Translate("Add New Attachment"),}) %]
-    [%   CASE 'Change' %]
-           [% BreadcrumbPath.push({ Name => Data.Name }) %]
+        [% CASE 'Add' %]
+            [% BreadcrumbPath.push({ Name => Translate("Add Attachment"),}) %]
+        [% CASE 'Change' %]
+            [% USE EditTitle = String(Translate("Edit Attachment")) %]
+            [% BreadcrumbPath.push({ Name => EditTitle.append( ': ', Data.Name ) }) %]
     [% END %]
 
     [% INCLUDE "Breadcrumb.tt" Path = BreadcrumbPath %]

--- a/Kernel/Output/HTML/Templates/Standard/AdminAttachment.tt
+++ b/Kernel/Output/HTML/Templates/Standard/AdminAttachment.tt
@@ -10,21 +10,40 @@
 <div class="MainBox ARIARoleMain LayoutFixedSidebar SidebarFirst">
     <h1>[% Translate("Attachment Management") | html %]</h1>
     [% IF Data.Action &&  Data.Action == 'Add' %]
-        [%  ItemName = Translate("Add New Attachment") | html %]
+        [%
+            BreadcrumbPath = [
+                {
+                    Name => 'Admin Attachment',
+                    Link => Env("Action"),
+                },
+                {
+                    Name => Translate("Add New Attachment"),
+                },
+            ]
+        %]
     [% ELSIF Data.Action && Data.Action == 'Change' %]
-        [% ItemName = Data.Name | html %]
+        [%
+            BreadcrumbPath = [
+                {
+                    Name => 'Admin Attachment',
+                    Link => Env("Action"),
+                },
+                {
+                    Name => ItemName,
+                },
+            ]
+        %]
+    [% ELSE %]
+        [%
+            BreadcrumbPath = [
+                {
+                    Name => 'Admin Attachment',
+                },
+            ]
+        %]
     [% END %]
-    [% INCLUDE "Breadcrumb.tt"
-        Path = [
-            {
-                Name => 'Admin Attachment',
-                Link => Env("Action"),
-            },
-            {
-                Name => ItemName,
-            },
-        ]
-    %]
+
+    [% INCLUDE "Breadcrumb.tt" Path = BreadcrumbPath %]
     <div class="SidebarColumn">
 
 [% RenderBlockStart("ActionList") %]

--- a/Kernel/Output/HTML/Templates/Standard/Breadcrumb.tt
+++ b/Kernel/Output/HTML/Templates/Standard/Breadcrumb.tt
@@ -1,0 +1,21 @@
+# --
+# Copyright (C) 2001-2016 OTRS AG, http://otrs.com/
+# --
+# This software comes with ABSOLUTELY NO WARRANTY. For details, see
+# the enclosed file COPYING for license information (AGPL). If you
+# did not receive this file, see http://www.gnu.org/licenses/agpl.txt.
+# --
+
+<ul class="BreadCrumb">
+    <li>[% Translate("You are here") | html %]:</li>
+    [% FOREACH Item IN Path %]
+        <li>
+            [% IF Item.Link %]
+                <a href="[% Env('Baselink') %]Action=[% Item.Link %]">[% Translate(Item.Name) | html %]</a>
+            [% ELSE %]
+                [% Translate(Item.Name) | html %]
+            [% END %]
+        </li>
+    [% END %]
+</ul>
+<div class="Clear"></div>

--- a/Kernel/Output/HTML/Templates/Standard/Breadcrumb.tt
+++ b/Kernel/Output/HTML/Templates/Standard/Breadcrumb.tt
@@ -9,14 +9,13 @@
 <ul class="BreadCrumb">
     <li>[% Translate("You are here") | html %]:</li>
     [% FOREACH Item IN Path %]
-        [% NEXT IF Item.Name == undef %]
         <li>
 
             <!-- link is not needed if there is only one or for the last item in breadcrumb -->
             [% IF Item.Link && Path.size() > 1 %]
-                <a href="[% Env('Baselink') %]Action=[% Item.Link %]">[% Translate(Item.Name) | html %]</a>
+                <a href="[% Env('Baselink') %]Action=[% Item.Link %]">[% Item.Name | html %]</a>
             [% ELSE %]
-                [% Translate(Item.Name) | html %]
+                [% Item.Name | html %]
             [% END %]
         </li>
     [% END %]

--- a/Kernel/Output/HTML/Templates/Standard/Breadcrumb.tt
+++ b/Kernel/Output/HTML/Templates/Standard/Breadcrumb.tt
@@ -9,8 +9,11 @@
 <ul class="BreadCrumb">
     <li>[% Translate("You are here") | html %]:</li>
     [% FOREACH Item IN Path %]
+        [% NEXT IF Item.Name == undef %]
         <li>
-            [% IF Item.Link %]
+
+            <!-- link is not needed if there is only one or for the last item in breadcrumb -->
+            [% IF Item.Link && Path.size() > 1 %]
                 <a href="[% Env('Baselink') %]Action=[% Item.Link %]">[% Translate(Item.Name) | html %]</a>
             [% ELSE %]
                 [% Translate(Item.Name) | html %]

--- a/scripts/test/Selenium/Agent/Admin/AdminAttachment.t
+++ b/scripts/test/Selenium/Agent/Admin/AdminAttachment.t
@@ -26,6 +26,8 @@ $Selenium->RunTest(
         # get needed variables
         my $Home = $ConfigObject->Get('Home');
         my %Attachments;
+        my $Count;
+        my $IsLinkedBreadcrumbText;
 
         # create test user and login
         my $TestUserLogin = $Helper->TestUserCreate(
@@ -49,7 +51,7 @@ $Selenium->RunTest(
         $Selenium->find_element( "table thead tr th", 'css' );
         $Selenium->find_element( "table tbody tr td", 'css' );
 
-        # check breadcrumb on Add screen
+        # check breadcrumb on Overview screen
         $Self->True(
             $Selenium->find_element( '.BreadCrumb', 'css' ),
             "Breadcrumb is found on Overview screen.",
@@ -62,20 +64,34 @@ $Selenium->RunTest(
             $Selenium->find_element("//a[contains(\@href, \'Action=AdminAttachment;Subaction=Add' )]")->VerifiedClick();
 
             # check breadcrumb on Add screen
-            $Self->True(
-                $Selenium->find_element( '.BreadCrumb', 'css' ),
-                "Breadcrumb is found on Add screen.",
-            );
+            $Count = 0;
+            for my $BreadcrumbText ( 'You are here:', 'Attachment Management', 'Add Attachment' ) {
+                $Self->Is(
+                    $Selenium->execute_script("return \$(\$('.BreadCrumb li')[$Count]).text().trim()"),
+                    $BreadcrumbText,
+                    "Breadcrumb text '$BreadcrumbText' is found on screen"
+                );
 
-            $Self->True(
-                $Selenium->execute_script("return \$('li>a:contains(Admin Attachment)').length"),
-                "Breadcrumb previus item is found on Add screen - link to Admin Attacment screen.",
-            );
+                $IsLinkedBreadcrumbText =
+                    $Selenium->execute_script("return \$(\$('.BreadCrumb li')[$Count]).children('a').length");
 
-            $Self->True(
-                $Selenium->execute_script("return \$('li:contains(Add New Attacment)').length"),
-                "Breadcrumb last item is found on Add screen.",
-            );
+                if ( $BreadcrumbText eq 'Attachment Management' ) {
+                    $Self->Is(
+                        $IsLinkedBreadcrumbText,
+                        1,
+                        "Breadcrumb text '$BreadcrumbText' is linked"
+                    );
+                }
+                else {
+                    $Self->Is(
+                        $IsLinkedBreadcrumbText,
+                        0,
+                        "Breadcrumb text '$BreadcrumbText' is not linked"
+                    );
+                }
+
+                $Count++;
+            }
 
             # check form action
             $Self->True(
@@ -94,7 +110,7 @@ $Selenium->RunTest(
             $Selenium->find_element( "#FileUpload", 'css' )->send_keys($Location);
             $Selenium->find_element( "#Name",       'css' )->VerifiedSubmit();
 
-            # check if standard attachment show on AdminAttacnment screen
+            # check if standard attachment show on AdminAttachment screen
             $Self->True(
                 index( $Selenium->get_page_source(), $AttachmentName ) > -1,
                 "Attachment $AttachmentName is found on page",
@@ -107,20 +123,34 @@ $Selenium->RunTest(
             $Selenium->find_element( $AttachmentName, 'link_text' )->VerifiedClick();
 
             # check breadcrumb on Edit screen
-            $Self->True(
-                $Selenium->find_element( '.BreadCrumb', 'css' ),
-                "Breadcrumb is found on Edit screen.",
-            );
+            $Count = 0;
+            for my $BreadcrumbText ( 'You are here:', 'Attachment Management', 'Edit Attachment: ' . $AttachmentName ) {
+                $Self->Is(
+                    $Selenium->execute_script("return \$(\$('.BreadCrumb li')[$Count]).text().trim()"),
+                    $BreadcrumbText,
+                    "Breadcrumb text '$BreadcrumbText' is found on screen"
+                );
 
-            $Self->True(
-                $Selenium->execute_script("return \$('li>a:contains(Admin Attachment)').length"),
-                "Breadcrumb previus item is found on Edit screen - link to Admin Attacment screen.",
-            );
+                $IsLinkedBreadcrumbText =
+                    $Selenium->execute_script("return \$(\$('.BreadCrumb li')[$Count]).children('a').length");
 
-            $Self->True(
-                $Selenium->execute_script("return \$('li:contains($AttachmentName)').length"),
-                "Breadcrumb last item is found on Edit screen.",
-            );
+                if ( $BreadcrumbText eq 'Attachment Management' ) {
+                    $Self->Is(
+                        $IsLinkedBreadcrumbText,
+                        1,
+                        "Breadcrumb text '$BreadcrumbText' is linked"
+                    );
+                }
+                else {
+                    $Self->Is(
+                        $IsLinkedBreadcrumbText,
+                        0,
+                        "Breadcrumb text '$BreadcrumbText' is not linked"
+                    );
+                }
+
+                $Count++;
+            }
 
             # check form actions
             for my $Action (qw(Submit SubmitAndContinue)) {

--- a/scripts/test/Selenium/Agent/Admin/AdminAttachment.t
+++ b/scripts/test/Selenium/Agent/Admin/AdminAttachment.t
@@ -49,11 +49,39 @@ $Selenium->RunTest(
         $Selenium->find_element( "table thead tr th", 'css' );
         $Selenium->find_element( "table tbody tr td", 'css' );
 
+        # check breadcrumb on Add screen
+        $Self->True(
+            $Selenium->find_element( '.BreadCrumb', 'css' ),
+            "Breadcrumb is found on Overview screen.",
+        );
+
         # create test standard attachments
         for my $File (qw(xls txt doc png pdf)) {
 
             # click 'add new attachment' link
             $Selenium->find_element("//a[contains(\@href, \'Action=AdminAttachment;Subaction=Add' )]")->VerifiedClick();
+
+            # check breadcrumb on Add screen
+            $Self->True(
+                $Selenium->find_element( '.BreadCrumb', 'css' ),
+                "Breadcrumb is found on Add screen.",
+            );
+
+            $Self->True(
+                $Selenium->execute_script("return \$('li>a:contains(Admin Attachment)').length"),
+                "Breadcrumb previus item is found on Add screen - link to Admin Attacment screen.",
+            );
+
+            $Self->True(
+                $Selenium->execute_script("return \$('li:contains(Add New Attacment)').length"),
+                "Breadcrumb last item is found on Add screen.",
+            );
+
+            # check form action
+            $Self->True(
+                $Selenium->find_element( '#Submit', 'css' ),
+                "Submit is found on Add screen.",
+            );
 
             # file checks
             my $Location = $Home . "/scripts/test/sample/StdAttachment/StdAttachment-Test1.$File";
@@ -77,6 +105,30 @@ $Selenium->RunTest(
 
             # go to new standard attachment again and edit
             $Selenium->find_element( $AttachmentName, 'link_text' )->VerifiedClick();
+
+            # check breadcrumb on Edit screen
+            $Self->True(
+                $Selenium->find_element( '.BreadCrumb', 'css' ),
+                "Breadcrumb is found on Edit screen.",
+            );
+
+            $Self->True(
+                $Selenium->execute_script("return \$('li>a:contains(Admin Attachment)').length"),
+                "Breadcrumb previus item is found on Edit screen - link to Admin Attacment screen.",
+            );
+
+            $Self->True(
+                $Selenium->execute_script("return \$('li:contains($AttachmentName)').length"),
+                "Breadcrumb last item is found on Edit screen.",
+            );
+
+            # check form actions
+            for my $Action (qw(Submit SubmitAndContinue)) {
+                $Self->True(
+                    $Selenium->find_element( "#$Action", 'css' ),
+                    "$Action is found on Edit screen.",
+                );
+            }
 
             $Selenium->execute_script("\$('#ValidID').val('2').trigger('redraw.InputField').trigger('change');");
             $Selenium->find_element( "#Comment", 'css' )->send_keys('Selenium test attachment');

--- a/var/httpd/htdocs/js/Core.Agent.Admin.Attachment.js
+++ b/var/httpd/htdocs/js/Core.Agent.Admin.Attachment.js
@@ -38,11 +38,6 @@ Core.Agent.Admin = Core.Agent.Admin || {};
             }
             return false;
         });
-
-        $('#SubmitAndContinue').on('click', function() {
-            $('#ContinueAfterSave').val(1);
-            $('#Submit').click();
-        });
     };
 
     Core.Init.RegisterNamespace(TargetNS, 'APP_MODULE');

--- a/var/httpd/htdocs/js/Core.Agent.Admin.Attachment.js
+++ b/var/httpd/htdocs/js/Core.Agent.Admin.Attachment.js
@@ -38,6 +38,11 @@ Core.Agent.Admin = Core.Agent.Admin || {};
             }
             return false;
         });
+
+        $('#SubmitAndContinue').on('click', function() {
+            $('#ContinueAfterSave').val(1);
+            $('#Submit').click();
+        });
     };
 
     Core.Init.RegisterNamespace(TargetNS, 'APP_MODULE');

--- a/var/httpd/htdocs/js/Core.Agent.js
+++ b/var/httpd/htdocs/js/Core.Agent.js
@@ -624,6 +624,12 @@ Core.Agent = (function (TargetNS) {
         Core.App.Responsive.CheckIfTouchDevice();
 
         InitNavigation();
+
+        // bind event on click for #SubmitAndContinue button
+        $('#SubmitAndContinue').on('click', function() {
+            $('#ContinueAfterSave').val(1);
+            $('#Submit').click();
+        });
     };
 
     /**

--- a/var/httpd/htdocs/js/Core.Agent.js
+++ b/var/httpd/htdocs/js/Core.Agent.js
@@ -439,6 +439,23 @@ Core.Agent = (function (TargetNS) {
     }
 
     /**
+     * @private
+     * @name InitSubmitAndContinue
+     * @memberof Core.Agent
+     * @function
+     * @description
+     *      This function initializes the SubmitAndContinue button.
+     */
+    function InitSubmitAndContinue() {
+
+        // bind event on click for #SubmitAndContinue button
+        $('#SubmitAndContinue').on('click', function() {
+            $('#ContinueAfterSave').val(1);
+            $('#Submit').click();
+        });
+    }
+
+    /**
      * @name ReorderNavigationItems
      * @memberof Core.Agent
      * @function
@@ -625,11 +642,7 @@ Core.Agent = (function (TargetNS) {
 
         InitNavigation();
 
-        // bind event on click for #SubmitAndContinue button
-        $('#SubmitAndContinue').on('click', function() {
-            $('#ContinueAfterSave').val(1);
-            $('#Submit').click();
-        });
+        InitSubmitAndContinue();
     };
 
     /**


### PR DESCRIPTION
Hi @zottto,

Hereby we started refactoring  frontend usability. There is added breadcrumb link for AdminAttachment screens (Overview, Add, Edit). As you can see I changed code a little bit. This is first PR and would like to see with this PR how deep we should go with this task. 
For example I removed block which are not necessary, because IF directives are enough for selecting HTML element in TT module. I am not sure if you like such approach. In any case I will be able to provide solution that is the best one. In this moment it is only our proposal.

You can see that I did not use simple redirect in ContinueAfterSave action as it has been done in AdminProcessManagement and similar modules. I wanted to add Notify - Attachment updated!

There is also extended Selenium test with new test ceases for form actions: 

- 'Save' and 'Save and finish'
- breadcrumb links 
Would you like extending  Selenium tests.

We have some opened task about refactoring JS and JS unit test, whit this PR I would like provide solution for new task in order you have time to give us feedback and after that we will be able to continue refactoring other modules on the same way.

Regards
Zoran