### PR TITLE
Fixed "Use of uninitialized value..."

### DIFF
--- a/Kernel/System/Console/Command/Maint/Stats/Generate.pm
+++ b/Kernel/System/Console/Command/Maint/Stats/Generate.pm
@@ -248,7 +248,7 @@ sub Run {
 
         # overwrite the default stats timezone with the given timezone
         my $TimeZone = $Self->GetOption('timezone');
-        if ( length $TimeZone ) {
+        if ( defined $TimeZone ) {
             $GetParam{TimeZone} = $TimeZone;
         }
     }


### PR DESCRIPTION
Happens when called without a TimeZone option parameter.