### PR TITLE
JS Unit test - Core.Form.ErrorTooltips

### DIFF
--- a/var/httpd/htdocs/js/test/Core.Form.ErrorTooltips.UnitTest.html
+++ b/var/httpd/htdocs/js/test/Core.Form.ErrorTooltips.UnitTest.html
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <link rel="stylesheet" href="../thirdparty/qunit-2.0.1/qunit.css" type="text/css"/>
+
+    <title>OTRS &ndash; JavaScript UnitTest Results</title>
+</head>
+<body>
+    <h1 id="qunit-header">OTRS &ndash; JavaScript UnitTest Results</h1>
+    <h2 id="qunit-banner"></h2>
+    <h2 id="qunit-userAgent"></h2>
+    <ol id="qunit-tests"></ol>
+
+
+    <!-- UnitTest code goes here -->
+    <script type="text/javascript" src="../thirdparty/qunit-2.0.1/qunit.js"></script>
+    <!--
+        Now always load library first and then the UnitTest file for it.
+        The UnitTest file is responsible for runnint the tests.
+    -->
+
+    <script type="text/javascript" src="../thirdparty/jquery-2.1.4/jquery.js"></script>
+
+    <script type="text/javascript" src="../Core.Form.ErrorTooltips.js"></script>
+    <script type="text/javascript" src="Core.Form.ErrorTooltips.UnitTest.js"></script>
+    <script type="text/javascript">
+        Core.Form.ErrorTooltips.RunUnitTests();
+    </script>
+</body>
+</html>

--- a/var/httpd/htdocs/js/test/Core.Form.ErrorTooltips.UnitTest.js
+++ b/var/httpd/htdocs/js/test/Core.Form.ErrorTooltips.UnitTest.js
@@ -1,0 +1,76 @@
+// --
+// Copyright (C) 2001-2016 OTRS AG, http://otrs.com/
+// --
+// This software comes with ABSOLUTELY NO WARRANTY. For details, see
+// the enclosed file COPYING for license information (AGPL). If you
+// did not receive this file, see http://www.gnu.org/licenses/agpl.txt.
+// --
+
+"use strict";
+
+var Core = Core || {};
+Core.Form = Core.Form || {};
+
+Core.Form.ErrorTooltips = (function (Namespace) {
+    Namespace.RunUnitTests = function(){
+        QUnit.module('Core.Form.ErrorTooltips');
+        QUnit.test('Core.Form.ErrorTooltip()', function(Assert){
+            var $TestForm = $('<form id="TestForm" class="Validate"></form>'),
+                ErrorTooltipMessage = 'UT Error Tooltip message',
+                ErrorTooltipID = '#OTRS_UI_Tooltips_ErrorTooltip',
+                TestFieldElement;
+
+            Assert.expect(9);
+
+            /*
+             * Create a form container for the test
+             */
+            $TestForm.append('<div class="Field">');
+            $TestForm.append('<input class="Validate_Required" type="text" name="TestField" id="TestField" value=""/>');
+            $TestForm.append('</div>');
+
+            $('body').append($TestForm);
+            TestFieldElement = $('#TestForm').find("input");
+
+            /*
+             * Run the test
+             */
+            // Test ShowToolTip() function
+            Core.Form.ErrorTooltips.ShowTooltip(TestFieldElement, ErrorTooltipMessage);
+            Assert.ok($($(ErrorTooltipID).find('div')[1]).length, 'Found ErrorTooltip on ShowTooltip()');
+            Assert.equal($($(ErrorTooltipID).find('div')[1]).text(), ErrorTooltipMessage, 'ErrorTooltip message is correct');
+
+            // Test HideTooltip() function
+            Core.Form.ErrorTooltips.HideTooltip();
+            Assert.notOk($($(ErrorTooltipID).find('div')[1]).length, 'Not found ErrorTooltip on HideTooltip()');
+
+            // Test InitTooltip() function
+            Core.Form.ErrorTooltips.InitTooltip(TestFieldElement, ErrorTooltipMessage);
+            Assert.notOk($($(ErrorTooltipID).find('div')[1]).length, 'Not found ErrorTooltip on InitTooltip() without focus on the field');
+
+            // Put focus on test field
+            $('#TestField').focus();
+            Assert.ok($($(ErrorTooltipID).find('div')[1]).length, 'Found ErrorTooltip on InitTooltip() with focus on the field');
+            Assert.equal($($(ErrorTooltipID).find('div')[1]).text(), ErrorTooltipMessage, 'ErrorTooltip message is correct');
+
+            // Remove focus from test field
+            $('#TestField').blur();
+            Assert.notOk($($(ErrorTooltipID).find('div')[1]).length, 'Not found ErrorTooltip on InitTooltip() when focus is removed again');
+
+            // Test RemoveTooltip() function
+            Core.Form.ErrorTooltips.RemoveTooltip(TestFieldElement);
+            Assert.notOk($($(ErrorTooltipID).find('div')[1]).length, 'Not found ErrorTooltip on RemoveTooltip() without focus on the field');
+
+            // Put focus on test field
+            $('#TestField').focus();
+            Assert.notOk($($(ErrorTooltipID).find('div')[1]).length, 'Not found ErrorTooltip on RemoveTooltip() with focus on the field');
+
+            /*
+             * Cleanup div container and contents
+             */
+            $('#TestForm').remove();
+        });
+    };
+
+    return Namespace;
+}(Core.Form.ErrorTooltips || {}));

--- a/var/httpd/htdocs/js/test/Core.Form.ErrorTooltips.UnitTest.js
+++ b/var/httpd/htdocs/js/test/Core.Form.ErrorTooltips.UnitTest.js
@@ -37,33 +37,33 @@ Core.Form.ErrorTooltips = (function (Namespace) {
              */
             // Test ShowToolTip() function
             Core.Form.ErrorTooltips.ShowTooltip(TestFieldElement, ErrorTooltipMessage);
-            Assert.ok($($(ErrorTooltipID).find('div')[1]).length, 'Found ErrorTooltip on ShowTooltip()');
-            Assert.equal($($(ErrorTooltipID).find('div')[1]).text(), ErrorTooltipMessage, 'ErrorTooltip message is correct');
+            Assert.ok($(ErrorTooltipID).find('div:eq(1)').length, 'Found ErrorTooltip on ShowTooltip()');
+            Assert.equal($(ErrorTooltipID).find('div:eq(1)').text(), ErrorTooltipMessage, 'ErrorTooltip message is correct');
 
             // Test HideTooltip() function
             Core.Form.ErrorTooltips.HideTooltip();
-            Assert.notOk($($(ErrorTooltipID).find('div')[1]).length, 'Not found ErrorTooltip on HideTooltip()');
+            Assert.notOk($(ErrorTooltipID).find('div:eq(1)').length, 'Not found ErrorTooltip on HideTooltip()');
 
             // Test InitTooltip() function
             Core.Form.ErrorTooltips.InitTooltip(TestFieldElement, ErrorTooltipMessage);
-            Assert.notOk($($(ErrorTooltipID).find('div')[1]).length, 'Not found ErrorTooltip on InitTooltip() without focus on the field');
+            Assert.notOk($(ErrorTooltipID).find('div:eq(1)').length, 'Not found ErrorTooltip on InitTooltip() without focus on the field');
 
             // Put focus on test field
             $('#TestField').focus();
-            Assert.ok($($(ErrorTooltipID).find('div')[1]).length, 'Found ErrorTooltip on InitTooltip() with focus on the field');
-            Assert.equal($($(ErrorTooltipID).find('div')[1]).text(), ErrorTooltipMessage, 'ErrorTooltip message is correct');
+            Assert.ok($(ErrorTooltipID).find('div:eq(1)').length, 'Found ErrorTooltip on InitTooltip() with focus on the field');
+            Assert.equal($(ErrorTooltipID).find('div:eq(1)').text(), ErrorTooltipMessage, 'ErrorTooltip message is correct');
 
             // Remove focus from test field
             $('#TestField').blur();
-            Assert.notOk($($(ErrorTooltipID).find('div')[1]).length, 'Not found ErrorTooltip on InitTooltip() when focus is removed again');
+            Assert.notOk($(ErrorTooltipID).find('div:eq(1)').length, 'Not found ErrorTooltip on InitTooltip() when focus is removed again');
 
             // Test RemoveTooltip() function
             Core.Form.ErrorTooltips.RemoveTooltip(TestFieldElement);
-            Assert.notOk($($(ErrorTooltipID).find('div')[1]).length, 'Not found ErrorTooltip on RemoveTooltip() without focus on the field');
+            Assert.notOk($(ErrorTooltipID).find('div:eq(1)').length, 'Not found ErrorTooltip on RemoveTooltip() without focus on the field');
 
             // Put focus on test field
             $('#TestField').focus();
-            Assert.notOk($($(ErrorTooltipID).find('div')[1]).length, 'Not found ErrorTooltip on RemoveTooltip() with focus on the field');
+            Assert.notOk($(ErrorTooltipID).find('div:eq(1)').length, 'Not found ErrorTooltip on RemoveTooltip() with focus on the field');
 
             /*
              * Cleanup div container and contents


### PR DESCRIPTION
Hello @zottto ,

Hereby is UT for Core.Form.ErrorTooltips.js. Created test to check for JS functions:

- ShowToolTip()
- HideTooltip()
- InitTooltip()
- RemoveTooltip()

Please let me know if you have any additions you would like to see in this UT.

Regards,
Sanjin