### PR TITLE
Master frontend usability - AdminCloudServices

### DIFF
--- a/Kernel/Output/HTML/Templates/Standard/AdminCloudServiceSupportDataCollector.tt
+++ b/Kernel/Output/HTML/Templates/Standard/AdminCloudServiceSupportDataCollector.tt
@@ -9,6 +9,19 @@
 <div class="MainBox ARIARoleMain LayoutFixedSidebar SidebarFirst">
     <h1>[% Translate("Cloud Service Management") | html %] » [% Translate("Support Data Collector") | html %]</h1>
 
+    [% BreadcrumbPath = [
+            {
+                Name => Translate('Cloud Service Management'),
+                Link => 'AdminCloudServices',
+            },
+            {
+                Name => Translate('Support data collector'),
+            },
+        ]
+    %]
+
+    [% INCLUDE "Breadcrumb.tt" Path = BreadcrumbPath %]
+
     <div class="SidebarColumn">
 
         <div class="WidgetSimple">
@@ -21,7 +34,7 @@
                         <a href="[% Env("Baselink") %]Action=AdminCloudServices" class="CallForAction Fullsize Center"><span><i class="fa fa-caret-left"></i>[% Translate("Go to overview") | html %]</span></a>
                     </li>
                     <li>
-                        <a href="Action=AdminSupportDataCollector" class="CallForAction Fullsize Center"><span><i class="fa fa-compass"></i>[% Translate("Support data collector") | html %]</span></a>
+                        <a href="[% Env("Baselink") %]Action=AdminSupportDataCollector" class="CallForAction Fullsize Center"><span><i class="fa fa-compass"></i>[% Translate("Support data collector") | html %]</span></a>
                     </li>
                 </ul>
             </div>

--- a/Kernel/Output/HTML/Templates/Standard/AdminCloudServices.tt
+++ b/Kernel/Output/HTML/Templates/Standard/AdminCloudServices.tt
@@ -13,7 +13,7 @@
 
     [% BreadcrumbPath = [
             {
-                Name => 'Admin Cloud Service',
+                Name => Translate('Cloud Service Management'),
                 Link => Env("Action"),
             },
         ]

--- a/Kernel/Output/HTML/Templates/Standard/AdminCloudServices.tt
+++ b/Kernel/Output/HTML/Templates/Standard/AdminCloudServices.tt
@@ -11,6 +11,16 @@
 <div class="MainBox ARIARoleMain LayoutFixedSidebar SidebarFirst">
     <h1>[% Translate("Cloud Service Management") | html %]</h1>
 
+    [% BreadcrumbPath = [
+            {
+                Name => 'Admin Cloud Service',
+                Link => Env("Action"),
+            },
+        ]
+    %]
+
+    [% INCLUDE "Breadcrumb.tt" Path = BreadcrumbPath %]
+
     <div class="SidebarColumn">
         <div class="WidgetSimple">
             <div class="Header">

--- a/Kernel/Output/HTML/Templates/Standard/Breadcrumb.tt
+++ b/Kernel/Output/HTML/Templates/Standard/Breadcrumb.tt
@@ -1,0 +1,23 @@
+# --
+# Copyright (C) 2001-2016 OTRS AG, http://otrs.com/
+# --
+# This software comes with ABSOLUTELY NO WARRANTY. For details, see
+# the enclosed file COPYING for license information (AGPL). If you
+# did not receive this file, see http://www.gnu.org/licenses/agpl.txt.
+# --
+
+<ul class="BreadCrumb">
+    <li>[% Translate("You are here") | html %]:</li>
+    [% FOREACH Item IN Path %]
+        <li>
+
+            <!-- link is not needed if there is only one or for the last item in breadcrumb -->
+            [% IF Item.Link && Path.size() > 1 %]
+                <a href="[% Env('Baselink') %]Action=[% Item.Link %]">[% Item.Name | html %]</a>
+            [% ELSE %]
+                [% Item.Name | html %]
+            [% END %]
+        </li>
+    [% END %]
+</ul>
+<div class="Clear"></div>

--- a/scripts/test/Selenium/Agent/Admin/AdminCloudServices.t
+++ b/scripts/test/Selenium/Agent/Admin/AdminCloudServices.t
@@ -1,0 +1,69 @@
+# --
+# Copyright (C) 2001-2016 OTRS AG, http://otrs.com/
+# --
+# This software comes with ABSOLUTELY NO WARRANTY. For details, see
+# the enclosed file COPYING for license information (AGPL). If you
+# did not receive this file, see http://www.gnu.org/licenses/agpl.txt.
+# --
+
+use strict;
+use warnings;
+use utf8;
+
+use vars (qw($Self));
+use File::Path qw(mkpath rmtree);
+
+# get selenium object
+my $Selenium = $Kernel::OM->Get('Kernel::System::UnitTest::Selenium');
+
+$Selenium->RunTest(
+    sub {
+
+        # get needed objects
+        my $Helper       = $Kernel::OM->Get('Kernel::System::UnitTest::Helper');
+        my $ConfigObject = $Kernel::OM->Get('Kernel::Config');
+
+        # create test user and login
+        my $TestUserLogin = $Helper->TestUserCreate(
+            Groups => ['admin'],
+        ) || die "Did not get test user";
+
+        $Selenium->Login(
+            Type     => 'Agent',
+            User     => $TestUserLogin,
+            Password => $TestUserLogin,
+        );
+
+        # get script alias
+        my $ScriptAlias = $ConfigObject->Get('ScriptAlias');
+
+        # navigate to the AdminCloudServices screen in the test
+        $Selenium->VerifiedGet("${ScriptAlias}index.pl?Action=AdminCloudServices");
+
+        # check available Cloud Services table
+        $Selenium->find_element( "table",             'css' );
+        $Selenium->find_element( "table thead tr th", 'css' );
+        $Selenium->find_element( "table tbody tr td", 'css' );
+
+        # click 'Support data collector' link
+        $Self->True(
+            $Selenium->find_element("//a[contains(\@href, \'Action=AdminCloudServiceSupportDataCollector' )]"),
+            "'Support data collector' link is found on screen.",
+        );
+
+        # click 'Register this system' button
+        $Self->True(
+            $Selenium->find_element("//a[contains(\@href, \'Action=AdminRegistration' )]"),
+            "'Register this system' button is found on screen.",
+        );
+
+        # check breadcrumb on screen
+        $Self->True(
+            $Selenium->find_element( '.BreadCrumb', 'css' ),
+            "Breadcrumb is found on Overview screen.",
+        );
+
+    }
+);
+
+1;

--- a/scripts/test/Selenium/Agent/Admin/AdminCloudServices.t
+++ b/scripts/test/Selenium/Agent/Admin/AdminCloudServices.t
@@ -45,23 +45,29 @@ $Selenium->RunTest(
         $Selenium->find_element( "table thead tr th", 'css' );
         $Selenium->find_element( "table tbody tr td", 'css' );
 
-        # click 'Support data collector' link
+        # check 'Support data collector' link
         $Self->True(
             $Selenium->find_element("//a[contains(\@href, \'Action=AdminCloudServiceSupportDataCollector' )]"),
             "'Support data collector' link is found on screen.",
         );
 
-        # click 'Register this system' button
+        # check 'Register this system' button
         $Self->True(
             $Selenium->find_element("//a[contains(\@href, \'Action=AdminRegistration' )]"),
             "'Register this system' button is found on screen.",
         );
 
         # check breadcrumb on screen
-        $Self->True(
-            $Selenium->find_element( '.BreadCrumb', 'css' ),
-            "Breadcrumb is found on Overview screen.",
-        );
+        my $Count = 0;
+        for my $BreadcrumbText ( 'You are here:', 'Cloud Service Management' ) {
+            $Self->Is(
+                $Selenium->execute_script("return \$(\$('.BreadCrumb li')[$Count]).text().trim()"),
+                $BreadcrumbText,
+                "Breadcrumb text '$BreadcrumbText' is found on screen.",
+            );
+
+            $Count++;
+        }
 
     }
 );

--- a/var/httpd/htdocs/js/Core.Agent.js
+++ b/var/httpd/htdocs/js/Core.Agent.js
@@ -439,6 +439,23 @@ Core.Agent = (function (TargetNS) {
     }
 
     /**
+     * @private
+     * @name InitSubmitAndContinue
+     * @memberof Core.Agent
+     * @function
+     * @description
+     *      This function initializes the SubmitAndContinue button.
+     */
+    function InitSubmitAndContinue() {
+
+        // bind event on click for #SubmitAndContinue button
+        $('#SubmitAndContinue').on('click', function() {
+            $('#ContinueAfterSave').val(1);
+            $('#Submit').click();
+        });
+    }
+
+    /**
      * @name ReorderNavigationItems
      * @memberof Core.Agent
      * @function
@@ -624,6 +641,8 @@ Core.Agent = (function (TargetNS) {
         Core.App.Responsive.CheckIfTouchDevice();
 
         InitNavigation();
+
+        InitSubmitAndContinue();
     };
 
     /**


### PR DESCRIPTION
Hello @zottto ,

Hereby is added breadcrumb for AdminCloudService module. Working on in this module, few questions were raised regarding how we should continue. Please if you could give your input:

- This module is 'somewhat' simple, meaning there is no further action then AdminCloudService screen. For the consistency reason, think we should add also breadcrumb on these type of modules.

- There are few link which are redirecting into other modules (e.g. AdminRegistration, AdminCloudServiceSupportDataCollector and AdminOTRSBusiness). Once any of these links are clicked, and screen is loaded breadcrumb for that module will be initiated. How do you think we should handle breadcrumb path from where we arrived. This will be also more impacting on e.g. AdminUser. We can arrive on this screen from different modules, AdminRoleUser, AdminUserGroup, ect...

Your input on these points is more then welcome.

Regards
Zoran