### PR TITLE
Bugfix for multiple notification jobs in one GenericAgent Event.

### DIFF
--- a/Kernel/System/GenericAgent.pm
+++ b/Kernel/System/GenericAgent.pm
@@ -953,6 +953,9 @@ sub _JobRunTicket {
     if ( $Param{Config}->{New}->{SendNoNotification} ) {
         $TicketObject->{SendNoNotification} = 1;
     }
+    else {
+        $TicketObject->{SendNoNotification} = 0;
+    }
 
     # move ticket
     if ( $Param{Config}->{New}->{Queue} ) {


### PR DESCRIPTION
[Line 953](https://github.com/OTRS/otrs/blob/master/Kernel/System/GenericAgent.pm#L953)
is changing TicketObjects' ObjectVariable "SendNoNotification" to 1 if a GenericAgent Job has the configuration option "SendNoNotification".

As long as just one GenericAgent Job gets executed during the lifetime of this TicketObject this is ok.

As soon as Kernel/System/Ticket/Event/GenericAgent's Run [Line 70](https://github.com/OTRS/otrs/blob/master/Kernel/System/Ticket/Event/GenericAgent.pm#L70)
- has two or more GenericAgent Jobs to execute
- first GenericAgent Job has SendNoNotification set to 1

all further GenericAgent Jobs will not send Notifications any more, because the first Job was setting:
```
$TicketObject->{SendNoNotification} = 1;
```
and a following GenericAgent Job even if SendNoNotification in this Job is set to 0 won't change the TicketObjects' ObjectVariable "SendNoNotification" back to 0.

Adding the else block always sets the TicketObjects' SendNoNotification, so Jobs that have the configuration SendNoNotification set to 0 get the chance to work as configured.