### PR TITLE
Fixed description, improved wording

### DIFF
--- a/Kernel/Config/Files/ProcessManagement.xml
+++ b/Kernel/Config/Files/ProcessManagement.xml
@@ -7,7 +7,7 @@
         <Setting>
             <FrontendModuleReg>
                 <Group>admin</Group>
-                <Description>Admin</Description>
+                <Description Translatable="1">This module is part of the admin area of OTRS.</Description>
                 <Title Translatable="1">Process Management</Title>
                 <NavBarName>Admin</NavBarName>
                 <Loader>
@@ -37,7 +37,7 @@
         <Setting>
             <FrontendModuleReg>
                 <Group>admin</Group>
-                <Description>Admin</Description>
+                <Description Translatable="1">This module is part of the admin area of OTRS.</Description>
                 <Title Translatable="1">Process Management Activity GUI</Title>
                 <Loader>
                     <CSS>Core.Agent.Admin.ProcessManagement.css</CSS>
@@ -55,7 +55,7 @@
         <Setting>
             <FrontendModuleReg>
                 <Group>admin</Group>
-                <Description>Admin</Description>
+                <Description Translatable="1">This module is part of the admin area of OTRS.</Description>
                 <Title Translatable="1">Process Management Activity Dialog GUI</Title>
                 <Loader>
                     <CSS>Core.Agent.Admin.ProcessManagement.css</CSS>
@@ -73,7 +73,7 @@
         <Setting>
             <FrontendModuleReg>
                 <Group>admin</Group>
-                <Description>Admin</Description>
+                <Description Translatable="1">This module is part of the admin area of OTRS.</Description>
                 <Title Translatable="1">Process Management Transition GUI</Title>
                 <Loader>
                     <CSS>Core.Agent.Admin.ProcessManagement.css</CSS>
@@ -89,7 +89,7 @@
         <Setting>
             <FrontendModuleReg>
                 <Group>admin</Group>
-                <Description>Admin</Description>
+                <Description Translatable="1">This module is part of the admin area of OTRS.</Description>
                 <Title Translatable="1">Process Management Transition Action GUI</Title>
                 <Loader>
                     <CSS>Core.Agent.Admin.ProcessManagement.css</CSS>
@@ -105,7 +105,7 @@
         <Setting>
             <FrontendModuleReg>
                 <Group>admin</Group>
-                <Description>Admin</Description>
+                <Description Translatable="1">This module is part of the admin area of OTRS.</Description>
                 <Title Translatable="1">Process Management Path GUI</Title>
                 <Loader>
                     <CSS>Core.Agent.Admin.ProcessManagement.css</CSS>
@@ -354,7 +354,7 @@
         </Setting>
     </ConfigItem>
     <ConfigItem Name="Ticket::Frontend::CustomerTicketProcess###StateType" Required="1" Valid="1">
-        <Description Translatable="1">Determines the next possible ticket states, for process tickets in the agent interface.</Description>
+        <Description Translatable="1">Determines the next possible ticket states, for process tickets in the customer interface.</Description>
         <Group>ProcessManagement</Group>
         <SubGroup>Frontend::Agent::Ticket::ViewProcess</SubGroup>
         <Setting>


### PR DESCRIPTION
Hi @mgruner 
I changed the description of module registrations, as this string is already in the Ticket.xml.
I also fixed a wrong description, the setting is not for agents, but for customers.

Can you also backport this to rel-5_0 and sync with Transifex? Let's give translator a chance to translate the modified strings before the 5.0.13 will be released.
My problem is, that now there is only one translation sync within a release period, when @carlosfrodriguez announces it as a "Prepare for release" commit. With this method OTRS never will be fully translated, as new strings are syncing right before release. If a translator finish them on Transifex, the translated strings will be added only to the next release, not to the current one. So new and modified strings remain untranslated in every OTRS release. Would it be possible to introduce a "string freeze" period? I mean, that Carlos usually closes the code on Thursday, the new tarball is available usually on the next Tuesday. In this few days no commits should be applied, which affect the language files, so Carlos can do an other Transifex sync some days later, but some days before the actual release. Can you discuss my "string freeze" suggestion?
