### PR TITLE
Fixed charset handling in content type of SOAP messages

### DIFF
--- a/Kernel/GenericInterface/Transport/HTTP/SOAP.pm
+++ b/Kernel/GenericInterface/Transport/HTTP/SOAP.pm
@@ -206,7 +206,7 @@ sub ProviderProcessRequest {
 
     # convert charset if necessary
     my $ContentCharset;
-    if ( $ENV{'CONTENT_TYPE'} =~ m{ \A ( .+ ) ;charset= ["']{0,1} ( .+? ) ["']{0,1} \z }xmsi ) {
+    if ( $ENV{'CONTENT_TYPE'} =~ m{ \A ( .+ ) ;charset= ["']{0,1} ( .+? ) ["']{0,1} (;|\z) }xmsi ) {
 
         # remember content type for the response
         $Self->{ContentType} = $1;


### PR DESCRIPTION
Hi,

I encountered a problem regarding the content type of SOAP messages.

When sending SOAP messages with a content type like the following:
`Content-Type: application/soap+xml;charset=UTF-8;action="urn:MyService/MyAction"`

Kernel::System::Encode will throw warnings like this:
`Not supported charset 'utf-8;action="urn:MyService/MyAction', fallback to 'iso-8859-1'!`

The reason is the regex in Kernel::GenericInterface::Transport::HTTP::SOAP which is not prepared for a content type that does not end after the charset information.

Please have a look at my proposal for the regex improvement.

Regards,
   Jens Pfeifer
