### PR TITLE
Authentication Module Selector Patch

### DIFF
--- a/Kernel/System/Auth.pm
+++ b/Kernel/System/Auth.pm
@@ -67,11 +67,42 @@ sub new {
 
         next COUNT if !$GenericModule;
 
+        my $EnableBackend = 1; # Enable backend by default
+        
+        # Get configuration of backend
+        my $EnableBackendByHost = $ConfigObject->Get("AuthModule::EnableByHost$Count");
+        
+        # Defined?
+        if ( $EnableBackendByHost && $ENV{HTTP_HOST}) {
+            
+            if ( ref $EnableBackendByHost ne 'ARRAY' ) {
+                # Only one host specified, so create a reference to single element list
+                $EnableBackendByHost = [ $EnableBackendByHost ];
+            }
+            
+            $EnableBackend = 0; # Filtering regexp defined - disable backend
+            
+            REGEXP:
+            for my $RegExp ( @{$EnableBackendByHost} ) {
+    
+                # skip if empty regexp
+                next REGEXP if !$RegExp;
+    
+                # check if regexp is matching
+                if ( $ENV{HTTP_HOST} =~ /$RegExp/i ) {
+                    $EnableBackend = 1;
+                    last REGEXP; # Host matched, no need to check others
+                }
+            }
+        }
         if ( !$MainObject->Require($GenericModule) ) {
             $MainObject->Die("Can't load backend module $GenericModule! $@");
         }
 
         $Self->{"AuthBackend$Count"} = $GenericModule->new( Count => $Count );
+        
+        # Mark enabled or not for PreAuth filtering
+        $Self->{"AuthBackend$Count"}->{Enabled} = $EnableBackend;
     }
 
     # load 2factor auth modules
@@ -123,7 +154,10 @@ Get module options. Currently there is just one option, "PreAuth".
 sub GetOption {
     my ( $Self, %Param ) = @_;
 
-    return $Self->{AuthBackend}->GetOption(%Param);
+    # Find first enabled backend
+    for my $Count ( '', 1..10 ) {
+        return $Self->{"AuthBackend$Count"}->GetOption(%Param) if $Self->{"AuthBackend$Count"}->{Enabled};
+    }
 }
 
 =item Auth()
@@ -153,6 +187,9 @@ sub Auth {
 
         # return on no config setting
         next COUNT if !$Self->{"AuthBackend$Count"};
+
+        # check if enabled
+        next COUNT if !$Self->{"AuthBackend$Count"}->{Enabled};
 
         # check auth backend
         $User = $Self->{"AuthBackend$Count"}->Auth(%Param);

--- a/Kernel/System/Auth.pm
+++ b/Kernel/System/Auth.pm
@@ -67,31 +67,32 @@ sub new {
 
         next COUNT if !$GenericModule;
 
-        my $EnableBackend = 1; # Enable backend by default
-        
+        my $EnableBackend = 1;    # Enable backend by default
+
         # Get configuration of backend
         my $EnableBackendByHost = $ConfigObject->Get("AuthModule::EnableByHost$Count");
-        
+
         # Defined?
-        if ( $EnableBackendByHost && $ENV{HTTP_HOST}) {
-            
+        if ( $EnableBackendByHost && $ENV{HTTP_HOST} ) {
+
             if ( ref $EnableBackendByHost ne 'ARRAY' ) {
+
                 # Only one host specified, so create a reference to single element list
-                $EnableBackendByHost = [ $EnableBackendByHost ];
+                $EnableBackendByHost = [$EnableBackendByHost];
             }
-            
-            $EnableBackend = 0; # Filtering regexp defined - disable backend
-            
+
+            $EnableBackend = 0;    # Filtering regexp defined - disable backend
+
             REGEXP:
             for my $RegExp ( @{$EnableBackendByHost} ) {
-    
+
                 # skip if empty regexp
                 next REGEXP if !$RegExp;
-    
+
                 # check if regexp is matching
                 if ( $ENV{HTTP_HOST} =~ /$RegExp/i ) {
                     $EnableBackend = 1;
-                    last REGEXP; # Host matched, no need to check others
+                    last REGEXP;    # Host matched, no need to check others
                 }
             }
         }
@@ -100,7 +101,7 @@ sub new {
         }
 
         $Self->{"AuthBackend$Count"} = $GenericModule->new( Count => $Count );
-        
+
         # Mark enabled or not for PreAuth filtering
         $Self->{"AuthBackend$Count"}->{Enabled} = $EnableBackend;
     }
@@ -155,7 +156,7 @@ sub GetOption {
     my ( $Self, %Param ) = @_;
 
     # Find first enabled backend
-    for my $Count ( '', 1..10 ) {
+    for my $Count ( '', 1 .. 10 ) {
         return $Self->{"AuthBackend$Count"}->GetOption(%Param) if $Self->{"AuthBackend$Count"}->{Enabled};
     }
 }

--- a/Kernel/System/CustomerAuth.pm
+++ b/Kernel/System/CustomerAuth.pm
@@ -63,10 +63,42 @@ sub new {
         my $GenericModule = $ConfigObject->Get("Customer::AuthModule$Count");
         next SOURCE if !$GenericModule;
 
+        my $EnableBackend = 1; # Enable backend by default
+        
+        # Get configuration of backend
+        my $EnableBackendByHost = $ConfigObject->Get("Customer::AuthModule::EnableByHost$Count");
+        
+        # Defined?
+        if ( $EnableBackendByHost && $ENV{HTTP_HOST}) {
+            
+            if ( ref $EnableBackendByHost ne 'ARRAY' ) {
+                # Only one host specified, so create a reference to single element list
+                $EnableBackendByHost = [ $EnableBackendByHost ];
+            }
+            
+            $EnableBackend = 0; # Filtering regexp defined - disable backend
+            
+            REGEXP:
+            for my $RegExp ( @{$EnableBackendByHost} ) {
+    
+                # skip if empty regexp
+                next REGEXP if !$RegExp;
+    
+                # check if regexp is matching
+                if ( $ENV{HTTP_HOST} =~ /$RegExp/i ) {
+                    $EnableBackend = 1;
+                    last REGEXP; # Host matched, no need to check others
+                }
+            }
+        }
+        
         if ( !$MainObject->Require($GenericModule) ) {
             $MainObject->Die("Can't load backend module $GenericModule! $@");
         }
         $Self->{"Backend$Count"} = $GenericModule->new( %{$Self}, Count => $Count );
+
+        # Mark enabled or not for PreAuth filtering
+        $Self->{"Backend$Count"}->{Enabled} = $EnableBackend;
     }
 
     # load 2factor auth modules
@@ -100,7 +132,10 @@ Get module options. Currently there is just one option, "PreAuth".
 sub GetOption {
     my ( $Self, %Param ) = @_;
 
-    return $Self->{Backend}->GetOption(%Param);
+    # Find first enabled backend
+    for my $Count ( '', 1..10 ) {
+        return $Self->{"Backend$Count"}->GetOption(%Param) if $Self->{"Backend$Count"}->{Enabled};
+    }
 }
 
 =item Auth()
@@ -130,6 +165,9 @@ sub Auth {
 
         # next on no config setting
         next COUNT if !$Self->{"Backend$_"};
+
+        # check if enabled
+        next COUNT if !$Self->{"Backend$_"}->{Enabled};
 
         # check auth backend
         $User = $Self->{"Backend$_"}->Auth(%Param);

--- a/Kernel/System/CustomerAuth.pm
+++ b/Kernel/System/CustomerAuth.pm
@@ -63,35 +63,36 @@ sub new {
         my $GenericModule = $ConfigObject->Get("Customer::AuthModule$Count");
         next SOURCE if !$GenericModule;
 
-        my $EnableBackend = 1; # Enable backend by default
-        
+        my $EnableBackend = 1;    # Enable backend by default
+
         # Get configuration of backend
         my $EnableBackendByHost = $ConfigObject->Get("Customer::AuthModule::EnableByHost$Count");
-        
+
         # Defined?
-        if ( $EnableBackendByHost && $ENV{HTTP_HOST}) {
-            
+        if ( $EnableBackendByHost && $ENV{HTTP_HOST} ) {
+
             if ( ref $EnableBackendByHost ne 'ARRAY' ) {
+
                 # Only one host specified, so create a reference to single element list
-                $EnableBackendByHost = [ $EnableBackendByHost ];
+                $EnableBackendByHost = [$EnableBackendByHost];
             }
-            
-            $EnableBackend = 0; # Filtering regexp defined - disable backend
-            
+
+            $EnableBackend = 0;    # Filtering regexp defined - disable backend
+
             REGEXP:
             for my $RegExp ( @{$EnableBackendByHost} ) {
-    
+
                 # skip if empty regexp
                 next REGEXP if !$RegExp;
-    
+
                 # check if regexp is matching
                 if ( $ENV{HTTP_HOST} =~ /$RegExp/i ) {
                     $EnableBackend = 1;
-                    last REGEXP; # Host matched, no need to check others
+                    last REGEXP;    # Host matched, no need to check others
                 }
             }
         }
-        
+
         if ( !$MainObject->Require($GenericModule) ) {
             $MainObject->Die("Can't load backend module $GenericModule! $@");
         }
@@ -133,7 +134,7 @@ sub GetOption {
     my ( $Self, %Param ) = @_;
 
     # Find first enabled backend
-    for my $Count ( '', 1..10 ) {
+    for my $Count ( '', 1 .. 10 ) {
         return $Self->{"Backend$Count"}->GetOption(%Param) if $Self->{"Backend$Count"}->{Enabled};
     }
 }


### PR DESCRIPTION
This patch adds ability for administrators to selectively choose authentication modules based on FQDN specified in URL. This works mostly the same as host based skins. The main purpose of this modification is to allow mixed authentication (Form and HTTP Basic/Kerberos) on a single web server deployment, which is not possible in the original OTRS Framework.