### PR TITLE
Master frontend usability - AdminGenericAgent

### DIFF
--- a/Kernel/Modules/AdminGenericAgent.pm
+++ b/Kernel/Modules/AdminGenericAgent.pm
@@ -281,9 +281,18 @@ sub Run {
             );
 
             if ($JobAddResult) {
-                return $LayoutObject->Redirect(
-                    OP => "Action=$Self->{Action}",
-                );
+
+                # if the user would like to continue editing the generic agent job, just redirect to the edit screen
+                if ( $ParamObject->GetParam( Param => 'ContinueAfterSave' ) eq '1' ) {
+                    my $Profile = $Self->{Profile} || '';
+                    return $LayoutObject->Redirect( OP => "Action=$Self->{Action};Subaction=Update;Profile=$Profile" );
+                }
+                else {
+
+                    # otherwise return to overview
+                    return $LayoutObject->Redirect( OP => "Action=$Self->{Action}" );
+                }
+
             }
             else {
                 $Errors{ProfileInvalid}    = 'ServerError';
@@ -413,7 +422,8 @@ sub _MaskUpdate {
             Name => $Self->{Profile},
         );
     }
-    $JobData{Profile} = $Self->{Profile};
+    $JobData{Profile}   = $Self->{Profile};
+    $JobData{Subaction} = $Self->{Subaction};
 
     # get config object
     my $ConfigObject = $Kernel::OM->Get('Kernel::Config');
@@ -1230,6 +1240,8 @@ sub _MaskRun {
         );
     }
     $JobData{Profile} = $Self->{Profile};
+    $Param{Subaction} = $Self->{Subaction};
+    $Param{Profile}   = $Self->{Profile};
 
     # dynamic fields search parameters for ticket search
     my %DynamicFieldSearchParameters;

--- a/Kernel/Output/HTML/Templates/Standard/AdminGenericAgent.tt
+++ b/Kernel/Output/HTML/Templates/Standard/AdminGenericAgent.tt
@@ -8,6 +8,30 @@
 <!-- start form -->
 <div class="MainBox ARIARoleMain LayoutFixedSidebar SidebarFirst">
     <h1>[% Translate("Generic Agent") | html %]</h1>
+
+    [% BreadcrumbPath = [
+            {
+                Name => Translate('Generic Agent'),
+                Link => Env("Action"),
+            },
+        ]
+    %]
+
+    [% SWITCH Data.Subaction %]
+        [% CASE 'Update' %]
+            [% IF Data.Profile %]
+                [% USE EditJob = String(Translate("Edit job")) %]
+                [% BreadcrumbPath.push({ Name => EditJob.append( ': ', Data.Profile ) }) %]
+            [% ELSE %]
+                [% BreadcrumbPath.push({ Name => Translate("Add job"),}) %]
+            [% END %]
+        [% CASE 'Run' %]
+            [% USE RunJob = String(Translate("Run job")) %]
+            [% BreadcrumbPath.push({ Name => RunJob.append( ': ', Data.Profile ) }) %]
+    [% END %]
+
+    [% INCLUDE "Breadcrumb.tt" Path = BreadcrumbPath %]
+
     <div class="SidebarColumn">
 [% RenderBlockStart("ActionList") %]
         <div class="WidgetSimple">
@@ -109,6 +133,9 @@
                     <input type="hidden" name="Subaction" value="UpdateAction"/>
                     <input type="hidden" name="ScheduleLastRun" value="[% Data.ScheduleLastRun | html %]"/>
                     <input type="hidden" name="OldProfile" value="[% Data.Profile | html %]"/>
+                    [% IF Data.Profile %]
+                        <input type="hidden" name="ContinueAfterSave" id="ContinueAfterSave" value=""/>
+                    [% END %]
                     <fieldset class="TableLike">
                         <label for="Profile" class="Mandatory"><span class="Marker">*</span> [% Translate("Job name") | html %]:</label>
                         <div class="Field">
@@ -878,10 +905,16 @@
                 </div>
                 <div class="Content">
                     <fieldset class="TableLike">
-                        <div class="Field SpacingTop">
-                            <button class="Primary CallForAction" type="submit" value="[% Translate("Save") | html %]"><span>[% Translate("Save") |  html %]</span></button>
+                        <div class="Field SpacingTop SaveButtons">
+                            [% IF Data.Profile %]
+                                <button class="CallForAction Primary" id="SubmitAndContinue" type="button" value="[% Translate("Save") | html %]"><span>[% Translate("Save") | html %]</span></button>
+                                [% Translate("or") | html %]
+                                <button class="CallForAction Primary" id="Submit" type="submit" value="[% Translate("Save") | html %]"><span>[% Translate("Save and finish") | html %]</span></button>
+                            [% ELSE %]
+                                <button class="CallForAction Primary" id="Submit" type="submit" value="[% Translate("Save") | html %]"><span>[% Translate("Save") | html %]</span></button>
+                            [% END %]
                             [% Translate("or") | html %]
-                            <a href="[% Env("Baselink") %]Action=[% Env("Action") %]">[% Translate("Cancel") | html %]</a>
+                            <a href="[% Env("Baselink") %]Action=[% Env("Action") %]"><span>[% Translate("Cancel") | html %]</span></a>
                         </div>
                         <div class="Clear"></div>
                     </fieldset>

--- a/Kernel/Output/HTML/Templates/Standard/Breadcrumb.tt
+++ b/Kernel/Output/HTML/Templates/Standard/Breadcrumb.tt
@@ -1,0 +1,23 @@
+# --
+# Copyright (C) 2001-2016 OTRS AG, http://otrs.com/
+# --
+# This software comes with ABSOLUTELY NO WARRANTY. For details, see
+# the enclosed file COPYING for license information (AGPL). If you
+# did not receive this file, see http://www.gnu.org/licenses/agpl.txt.
+# --
+
+<ul class="BreadCrumb">
+    <li>[% Translate("You are here") | html %]:</li>
+    [% FOREACH Item IN Path %]
+        <li>
+
+            <!-- link is not needed if there is only one or for the last item in breadcrumb -->
+            [% IF Item.Link && Path.size() > 1 %]
+                <a href="[% Env('Baselink') %]Action=[% Item.Link %]">[% Item.Name | html %]</a>
+            [% ELSE %]
+                [% Item.Name | html %]
+            [% END %]
+        </li>
+    [% END %]
+</ul>
+<div class="Clear"></div>

--- a/scripts/test/Selenium/Agent/Admin/AdminGenericAgent.t
+++ b/scripts/test/Selenium/Agent/Admin/AdminGenericAgent.t
@@ -126,8 +126,45 @@ $Selenium->RunTest(
         $Selenium->find_element( "table thead tr th", 'css' );
         $Selenium->find_element( "table tbody tr td", 'css' );
 
+        # check breadcrumb on Overview screen
+        $Self->True(
+            $Selenium->find_element( '.BreadCrumb', 'css' ),
+            "Breadcrumb is found on Overview screen.",
+        );
+
         # check add job page
         $Selenium->find_element("//a[contains(\@href, \'Subaction=Update' )]")->VerifiedClick();
+
+        # check breadcrumb on Add job screen
+        my $Count = 0;
+        my $IsLinkedBreadcrumbText;
+        for my $BreadcrumbText ( 'You are here:', 'Generic Agent', 'Add job' ) {
+            $Self->Is(
+                $Selenium->execute_script("return \$(\$('.BreadCrumb li')[$Count]).text().trim()"),
+                $BreadcrumbText,
+                "Breadcrumb text '$BreadcrumbText' is found on screen"
+            );
+
+            $IsLinkedBreadcrumbText =
+                $Selenium->execute_script("return \$(\$('.BreadCrumb li')[$Count]).children('a').length");
+
+            if ( $BreadcrumbText eq 'Generic Agent' ) {
+                $Self->Is(
+                    $IsLinkedBreadcrumbText,
+                    1,
+                    "Breadcrumb text '$BreadcrumbText' is linked"
+                );
+            }
+            else {
+                $Self->Is(
+                    $IsLinkedBreadcrumbText,
+                    0,
+                    "Breadcrumb text '$BreadcrumbText' is not linked"
+                );
+            }
+
+            $Count++;
+        }
 
         my $Element = $Selenium->find_element( "#Profile", 'css' );
         $Element->is_displayed();
@@ -189,6 +226,36 @@ $Selenium->RunTest(
         # edit test job to delete test ticket
         $Selenium->find_element( $GenericAgentJob, 'link_text' )->VerifiedClick();
 
+        # check breadcrumb on Edit job screen
+        $Count = 0;
+        for my $BreadcrumbText ( 'You are here:', 'Generic Agent', 'Edit job: ' . $GenericAgentJob ) {
+            $Self->Is(
+                $Selenium->execute_script("return \$(\$('.BreadCrumb li')[$Count]).text().trim()"),
+                $BreadcrumbText,
+                "Breadcrumb text '$BreadcrumbText' is found on screen"
+            );
+
+            $IsLinkedBreadcrumbText =
+                $Selenium->execute_script("return \$(\$('.BreadCrumb li')[$Count]).children('a').length");
+
+            if ( $BreadcrumbText eq 'Generic Agent' ) {
+                $Self->Is(
+                    $IsLinkedBreadcrumbText,
+                    1,
+                    "Breadcrumb text '$BreadcrumbText' is linked"
+                );
+            }
+            else {
+                $Self->Is(
+                    $IsLinkedBreadcrumbText,
+                    0,
+                    "Breadcrumb text '$BreadcrumbText' is not linked"
+                );
+            }
+
+            $Count++;
+        }
+
         # toggle Execute Ticket Commands widget
         $Selenium->execute_script('$(".WidgetSimple.Collapsed .WidgetAction.Toggle a").click();');
         $Selenium->execute_script("\$('#NewDelete').val('1').trigger('redraw.InputField').trigger('change');");
@@ -215,6 +282,36 @@ $Selenium->RunTest(
 
         # run test job
         $Selenium->find_element("//a[contains(\@href, \'Subaction=Run;Profile=$GenericAgentJob' )]")->VerifiedClick();
+
+        # check breadcrumb on Run job screen
+        $Count = 0;
+        for my $BreadcrumbText ( 'You are here:', 'Generic Agent', 'Run job: ' . $GenericAgentJob ) {
+            $Self->Is(
+                $Selenium->execute_script("return \$(\$('.BreadCrumb li')[$Count]).text().trim()"),
+                $BreadcrumbText,
+                "Breadcrumb text '$BreadcrumbText' is found on screen"
+            );
+
+            $IsLinkedBreadcrumbText =
+                $Selenium->execute_script("return \$(\$('.BreadCrumb li')[$Count]).children('a').length");
+
+            if ( $BreadcrumbText eq 'Generic Agent' ) {
+                $Self->Is(
+                    $IsLinkedBreadcrumbText,
+                    1,
+                    "Breadcrumb text '$BreadcrumbText' is linked"
+                );
+            }
+            else {
+                $Self->Is(
+                    $IsLinkedBreadcrumbText,
+                    0,
+                    "Breadcrumb text '$BreadcrumbText' is not linked"
+                );
+            }
+
+            $Count++;
+        }
 
         # check if test job show expected result
         for my $TicketNumber (@TicketNumbers) {

--- a/var/httpd/htdocs/js/Core.Agent.js
+++ b/var/httpd/htdocs/js/Core.Agent.js
@@ -439,6 +439,23 @@ Core.Agent = (function (TargetNS) {
     }
 
     /**
+     * @private
+     * @name InitSubmitAndContinue
+     * @memberof Core.Agent
+     * @function
+     * @description
+     *      This function initializes the SubmitAndContinue button.
+     */
+    function InitSubmitAndContinue() {
+
+        // bind event on click for #SubmitAndContinue button
+        $('#SubmitAndContinue').on('click', function() {
+            $('#ContinueAfterSave').val(1);
+            $('#Submit').click();
+        });
+    }
+
+    /**
      * @name ReorderNavigationItems
      * @memberof Core.Agent
      * @function
@@ -624,6 +641,8 @@ Core.Agent = (function (TargetNS) {
         Core.App.Responsive.CheckIfTouchDevice();
 
         InitNavigation();
+
+        InitSubmitAndContinue();
     };
 
     /**


### PR DESCRIPTION
Hello @zottto ,

Hereby is added breadcrumb and form action buttons for AdminGenericAgent screens. Used already translatable string 'Add job', 'Edit job' and 'Run job' as last breadcrumb strings. IMO having 'Job Settings' is not quite valid since you can't distinguish when you add or edit job. 

If you disagree on these names or have any issues regaridng this PR please let me know.

Regards,
Sanjin