### PR TITLE
Master frontend - AdminMailAccount delete button confirmation

### DIFF
--- a/Kernel/Modules/AdminMailAccount.pm
+++ b/Kernel/Modules/AdminMailAccount.pm
@@ -76,7 +76,12 @@ sub Run {
         if ( !$Delete ) {
             return $LayoutObject->ErrorScreen();
         }
-        return $LayoutObject->Redirect( OP => 'Action=AdminMailAccount' );
+        return $LayoutObject->Attachment(
+            ContentType => 'text/html',
+            Content     => $Delete,
+            Type        => 'inline',
+            NoCache     => 1,
+        );
     }
 
     # ------------------------------------------------------------ #

--- a/Kernel/Output/HTML/Templates/Standard/AdminMailAccount.tt
+++ b/Kernel/Output/HTML/Templates/Standard/AdminMailAccount.tt
@@ -131,6 +131,13 @@
                     </tbody>
                 </table>
             </div>
+            <div class="Hidden" id="DeleteMailAccountDialogContainer">
+                <div id ="DeleteMailAccountDialog" class="InnerContent GenericInterfaceDialog">
+                    <span class="WarningDialog ">&nbsp;</span>
+                    <p class="Center Warning">[% Translate("Do you really want to delete this mail account?") | html %]</p>
+                    <div class="SpacingTop"></div>
+                </div>
+            </div>
 [% RenderBlockEnd("OverviewResult") %]
 
 [% RenderBlockStart("OverviewAdd") %]

--- a/Kernel/Output/HTML/Templates/Standard/AdminMailAccount.tt
+++ b/Kernel/Output/HTML/Templates/Standard/AdminMailAccount.tt
@@ -116,7 +116,9 @@
                             <td>[% Data.ChangeTime | Localize("TimeShort") %]</td>
                             <td>[% Data.CreateTime | Localize("TimeShort") %]</td>
                             <td class="Center">
-                                <a class="TrashCan" href="[% Env("Baselink") %]Action=[% Env("Action") %];Subaction=Delete;ID=[% Data.ID | uri %];[% Env("ChallengeTokenParam") | html %]" title="[% Translate("Delete account") | html %]">[% Translate("Delete account") | html %]<i class="fa fa-trash-o"></i></a>
+                                <a class="TrashCan MailAccountDelete" href="#" data-query-string="Action=AdminMailAccount;Subaction=Delete;ID=[% Data.ID | uri %];[% Env("ChallengeTokenParam") | html %]" title="[% Translate("Delete account") | html %]">[% Translate("Delete account") | html %]
+                                    <i class="fa fa-trash-o"></i>
+                                </a>
                             </td>
                             <td>
                                 <a class="AsBlock" href="[% Env("Baselink") %]Action=[% Env("Action") %];Subaction=Run;ID=[% Data.ID | uri %];[% Env("ChallengeTokenParam") | html %]">[% Translate("Fetch mail") | html %]</a>

--- a/Kernel/Output/HTML/Templates/Standard/AdminMailAccount.tt
+++ b/Kernel/Output/HTML/Templates/Standard/AdminMailAccount.tt
@@ -133,8 +133,7 @@
             </div>
             <div class="Hidden" id="DeleteMailAccountDialogContainer">
                 <div id ="DeleteMailAccountDialog" class="InnerContent GenericInterfaceDialog">
-                    <span class="WarningDialog ">&nbsp;</span>
-                    <p class="Center Warning">[% Translate("Do you really want to delete this mail account?") | html %]</p>
+                    <p class="Center Spacing">[% Translate("Do you really want to delete this mail account?") | html %]</p>
                     <div class="SpacingTop"></div>
                 </div>
             </div>

--- a/scripts/test/Selenium/Agent/Admin/AdminMailAccount.t
+++ b/scripts/test/Selenium/Agent/Admin/AdminMailAccount.t
@@ -298,7 +298,7 @@ $Selenium->RunTest(
         $Selenium->WaitFor( JavaScript => 'return typeof($) === "function" && $(".Dialog:visible").length === 1;' );
 
         # verify delete dialog message
-        my $DeleteMessage = 'Are you sure you want to delete this mail account?';
+        my $DeleteMessage = 'Do you really want to delete this mail account?';
         $Self->True(
             index( $Selenium->get_page_source(), $DeleteMessage ) > -1,
             "Delete message is found",

--- a/scripts/test/Selenium/Agent/Admin/AdminMailAccount.t
+++ b/scripts/test/Selenium/Agent/Admin/AdminMailAccount.t
@@ -294,18 +294,17 @@ $Selenium->RunTest(
         $Selenium->VerifiedGet("${ScriptAlias}index.pl?Action=AdminMailAccount");
 
         # test mail account delete button
-        my $DBObject = $Kernel::OM->Get('Kernel::System::DB');
-        my $Success  = $DBObject->Prepare(
-            SQL => "SELECT id FROM mail_account WHERE login='$RandomID'",
+        $Selenium->find_element("//a[contains(\@data-query-string, \'Subaction=Delete;ID=$MailAccountID' )]")->click();
+        $Selenium->WaitFor(
+            AlertPresent => 1,
         );
+        $Selenium->accept_alert();
 
-        if ($Success) {
-            my $MailAccountID;
-            while ( my @Row = $DBObject->FetchrowArray() ) {
-                $MailAccountID = $Row[0];
-            }
-            $Selenium->find_element("//a[contains(\@href, \'Subaction=Delete;ID=$MailAccountID' )]")->VerifiedClick();
-        }
+        # check if mail account is deleted
+        $Self->True(
+            index( $Selenium->get_page_source(), $TestMailHost ) == -1,
+            "$TestMailHost is not found on page after deleting",
+        );
 
     }
 

--- a/scripts/test/Selenium/Agent/Admin/AdminMailAccount.t
+++ b/scripts/test/Selenium/Agent/Admin/AdminMailAccount.t
@@ -295,10 +295,17 @@ $Selenium->RunTest(
 
         # test mail account delete button
         $Selenium->find_element("//a[contains(\@data-query-string, \'Subaction=Delete;ID=$MailAccountID' )]")->click();
-        $Selenium->WaitFor(
-            AlertPresent => 1,
+        $Selenium->WaitFor( JavaScript => 'return typeof($) === "function" && $(".Dialog:visible").length === 1;' );
+
+        # verify delete dialog message
+        my $DeleteMessage = 'Are you sure you want to delete this mail account?';
+        $Self->True(
+            index( $Selenium->get_page_source(), $DeleteMessage ) > -1,
+            "Delete message is found",
         );
-        $Selenium->accept_alert();
+
+        # confirm delete action
+        $Selenium->find_element( "#DialogButton1", 'css' )->VerifiedClick();
 
         # check if mail account is deleted
         $Self->True(

--- a/var/httpd/htdocs/js/Core.Agent.Admin.MailAccount.js
+++ b/var/httpd/htdocs/js/Core.Agent.Admin.MailAccount.js
@@ -40,7 +40,7 @@ Core.Agent.Admin = Core.Agent.Admin || {};
                 true,
                 [
                     {
-                        Class: 'CallToAction',
+                        Class: 'CallForAction Primary',
                         Label: Core.Language.Translate("Confirm"),
                         Function: function() {
                             $('.Dialog .InnerContent .Center').text(Core.Language.Translate("Deleting the mail account and its data. This may take a while..."));
@@ -50,12 +50,15 @@ Core.Agent.Admin = Core.Agent.Admin || {};
                                 Core.Config.Get('Baselink'),
                                 MailAccountDelete.data('query-string'),
                                 function() {
-                                    window.location.reload();
+                                   Core.App.InternalRedirect({
+                                       Action: 'AdminMailAccount'
+                                   });
                                 }
                             );
                         }
                     },
                     {
+                        Class: 'CallForAction',
                         Label: Core.Language.Translate("Cancel"),
                         Function: function () {
                             Core.UI.Dialog.CloseDialog($('#DeleteMailAccountDialog'));

--- a/var/httpd/htdocs/js/Core.Agent.Admin.MailAccount.js
+++ b/var/httpd/htdocs/js/Core.Agent.Admin.MailAccount.js
@@ -21,6 +21,41 @@ Core.Agent.Admin = Core.Agent.Admin || {};
  */
  Core.Agent.Admin.MailAccount = (function (TargetNS) {
 
+    /**
+     * @name MailAccountDelete
+     * @memberof Core.Agent.Admin.MailAccount
+     * @function
+     * @description
+     *      Bind event on mail account delete button.
+     */
+    TargetNS.MailAccountDelete = function() {
+        $('.MailAccountDelete').on('click', function () {
+
+            if (window.confirm(Core.Language.Translate("Do you really want to delete this mail account? ALL associated data will be LOST!"))) {
+
+                Core.UI.Dialog.ShowDialog({
+                    Title: Core.Language.Translate("Delete mail account"),
+                    HTML: Core.Language.Translate("Deleting the mail account and its data. This may take a while..."),
+                    Modal: true,
+                    CloseOnClickOutside: false,
+                    CloseOnEscape: false,
+                    PositionTop: '20%',
+                    PositionLeft: 'Center'
+                });
+
+                Core.AJAX.FunctionCall(
+                    Core.Config.Get('Baselink'),
+                    $(this).data('query-string'),
+                    function() {
+                        window.location.reload();
+                    }
+                );
+            }
+
+            return false;
+        });
+    };
+
     /*
     * @name Init
     * @memberof Core.Agent.Admin.MailAccount
@@ -52,6 +87,8 @@ Core.Agent.Admin = Core.Agent.Admin || {};
         }).trigger('change');
 
         Core.UI.Table.InitTableFilter($("#FilterMailAccounts"), $("#MailAccounts"));
+
+        TargetNS.MailAccountDelete();
     };
 
     Core.Init.RegisterNamespace(TargetNS, 'APP_MODULE');

--- a/var/httpd/htdocs/js/Core.Agent.Admin.MailAccount.js
+++ b/var/httpd/htdocs/js/Core.Agent.Admin.MailAccount.js
@@ -32,25 +32,19 @@ Core.Agent.Admin = Core.Agent.Admin || {};
         $('.MailAccountDelete').on('click', function () {
             var MailAccountDelete = $(this);
 
-            Core.UI.Dialog.ShowDialog({
-                Modal: true,
-                Title: Core.Language.Translate("Delete mail account"),
-                HTML: Core.Language.Translate("Are you sure you want to delete this mail account?"),
-                PositionTop: '20%',
-                PositionLeft: 'Center',
-                CloseOnEscape: true,
-                Buttons: [
+            Core.UI.Dialog.ShowContentDialog(
+                $('#DeleteMailAccountDialogContainer'),
+                Core.Language.Translate('Delete this Mail Account'),
+                '240px',
+                'Center',
+                true,
+                [
                     {
-                        Type: 'Submit',
+                        Class: 'Primary',
                         Label: Core.Language.Translate("Confirm"),
                         Function: function() {
-                            Core.UI.Dialog.ShowDialog({
-                                Title: Core.Language.Translate("Delete mail account"),
-                                HTML: Core.Language.Translate("Deleting the mail account and its data. This may take a while..."),
-                                Modal: true,
-                                PositionTop: '20%',
-                                PositionLeft: 'Center'
-                            });
+                            $('.Dialog .InnerContent .Center.Warning').text(Core.Language.Translate("Deleting the mail account and its data. This may take a while..."));
+                            $('.Dialog .Content .ContentFooter').remove();
 
                             Core.AJAX.FunctionCall(
                                 Core.Config.Get('Baselink'),
@@ -62,11 +56,14 @@ Core.Agent.Admin = Core.Agent.Admin || {};
                         }
                     },
                     {
-                        Type: 'Close',
-                        Label: Core.Language.Translate("Cancel")
+                        Class: 'Primary',
+                        Label: Core.Language.Translate("Cancel"),
+                        Function: function () {
+                            Core.UI.Dialog.CloseDialog($('#DeleteMailAccountDialog'));
+                        }
                     }
                 ]
-            });
+            );
             return false;
         });
     };

--- a/var/httpd/htdocs/js/Core.Agent.Admin.MailAccount.js
+++ b/var/httpd/htdocs/js/Core.Agent.Admin.MailAccount.js
@@ -40,10 +40,10 @@ Core.Agent.Admin = Core.Agent.Admin || {};
                 true,
                 [
                     {
-                        Class: 'Primary',
+                        Class: 'CallToAction',
                         Label: Core.Language.Translate("Confirm"),
                         Function: function() {
-                            $('.Dialog .InnerContent .Center.Warning').text(Core.Language.Translate("Deleting the mail account and its data. This may take a while..."));
+                            $('.Dialog .InnerContent .Center').text(Core.Language.Translate("Deleting the mail account and its data. This may take a while..."));
                             $('.Dialog .Content .ContentFooter').remove();
 
                             Core.AJAX.FunctionCall(
@@ -56,7 +56,6 @@ Core.Agent.Admin = Core.Agent.Admin || {};
                         }
                     },
                     {
-                        Class: 'Primary',
                         Label: Core.Language.Translate("Cancel"),
                         Function: function () {
                             Core.UI.Dialog.CloseDialog($('#DeleteMailAccountDialog'));

--- a/var/httpd/htdocs/js/Core.Agent.Admin.MailAccount.js
+++ b/var/httpd/htdocs/js/Core.Agent.Admin.MailAccount.js
@@ -30,28 +30,43 @@ Core.Agent.Admin = Core.Agent.Admin || {};
      */
     TargetNS.MailAccountDelete = function() {
         $('.MailAccountDelete').on('click', function () {
+            var MailAccountDelete = $(this);
 
-            if (window.confirm(Core.Language.Translate("Do you really want to delete this mail account? ALL associated data will be LOST!"))) {
+            Core.UI.Dialog.ShowDialog({
+                Modal: true,
+                Title: Core.Language.Translate("Delete mail account"),
+                HTML: Core.Language.Translate("Are you sure you want to delete this mail account?"),
+                PositionTop: '20%',
+                PositionLeft: 'Center',
+                CloseOnEscape: true,
+                Buttons: [
+                    {
+                        Type: 'Submit',
+                        Label: Core.Language.Translate("Confirm"),
+                        Function: function() {
+                            Core.UI.Dialog.ShowDialog({
+                                Title: Core.Language.Translate("Delete mail account"),
+                                HTML: Core.Language.Translate("Deleting the mail account and its data. This may take a while..."),
+                                Modal: true,
+                                PositionTop: '20%',
+                                PositionLeft: 'Center'
+                            });
 
-                Core.UI.Dialog.ShowDialog({
-                    Title: Core.Language.Translate("Delete mail account"),
-                    HTML: Core.Language.Translate("Deleting the mail account and its data. This may take a while..."),
-                    Modal: true,
-                    CloseOnClickOutside: false,
-                    CloseOnEscape: false,
-                    PositionTop: '20%',
-                    PositionLeft: 'Center'
-                });
-
-                Core.AJAX.FunctionCall(
-                    Core.Config.Get('Baselink'),
-                    $(this).data('query-string'),
-                    function() {
-                        window.location.reload();
+                            Core.AJAX.FunctionCall(
+                                Core.Config.Get('Baselink'),
+                                MailAccountDelete.data('query-string'),
+                                function() {
+                                    window.location.reload();
+                                }
+                            );
+                        }
+                    },
+                    {
+                        Type: 'Close',
+                        Label: Core.Language.Translate("Cancel")
                     }
-                );
-            }
-
+                ]
+            });
             return false;
         });
     };


### PR DESCRIPTION
Hello @mgruner & @zottto ,

Hereby is our proposal for delete confirmation dialog appearance in AdminMailAccount screen. If you agree on this, there is AdminGenericAgent module in which could be used same functionality.

Delete function is appended in Core.Agent.Admin.MailAccount.js. This is similar function which is used for AdminDynamicField delete events, so perhaps we could refactor these functions and place them in some of JS which is loaded in framework.

Selenium test is modified to check for these changes.

Please let me know what do you think about this proposal, and if you have any issues or questions do not hesitate to ask.

Regards,
Sanjin