### PR TITLE
Configurable shortcut icon

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,4 +1,5 @@
 #6.0.0.beta1 2016-??-??
+ - 2016-08-29 Configurable shortcut icon.
  - 2016-06-07 Added index for searching dynamic field text values.
  - 2016-08-18 Added per-address email loop protection setting (PostmasterMaxEmailsPerAddress), thanks to Moritz Lenz.
  - 2016-08-12 Fixed bug#[12229](http://bugs.otrs.org/show_bug.cgi?id=12229) - Queue is not selectable if the name contains "<" or ">" characters.

--- a/Kernel/Config/Files/Framework.xml
+++ b/Kernel/Config/Files/Framework.xml
@@ -281,6 +281,14 @@
             <String Regex="">Example Company</String>
         </Setting>
     </ConfigItem>
+    <ConfigItem Name="CustomerShortcutIcon" Required="0" Valid="0">
+        <Description Translatable="1">The shortcut icon for the customer interface.</Description>
+        <Group>Framework</Group>
+        <SubGroup>Frontend::Customer</SubGroup>
+        <Setting>
+            <String Regex="">/otrs-web/skins/Agent/default/img/icons/product.ico</String>
+        </Setting>
+    </ConfigItem>
     <ConfigItem Name="CustomerLogo" Required="0" Valid="0">
         <Description Translatable="1">The logo shown in the header of the customer interface. The URL to the image can be a relative URL to the skin image directory, or a full URL to a remote web server.</Description>
         <Group>Framework</Group>
@@ -293,6 +301,14 @@
                 <Item Key="StyleHeight">50px</Item>
                 <Item Key="StyleWidth">135px</Item>
             </Hash>
+        </Setting>
+    </ConfigItem>
+    <ConfigItem Name="AgentShortcutIcon" Required="0" Valid="0">
+        <Description Translatable="1">The shortcut icon for the agent interface. The URL to the icon must be a relative URL to the skin image directory.</Description>
+        <Group>Framework</Group>
+        <SubGroup>Frontend::Agent</SubGroup>
+        <Setting>
+            <String Regex="">/otrs-web/skins/Agent/default/img/icons/product.ico</String>
         </Setting>
     </ConfigItem>
     <ConfigItem Name="AgentLogo" Required="0" Valid="1">

--- a/Kernel/Config/Files/Framework.xml
+++ b/Kernel/Config/Files/Framework.xml
@@ -304,7 +304,7 @@
         </Setting>
     </ConfigItem>
     <ConfigItem Name="AgentShortcutIcon" Required="0" Valid="0">
-        <Description Translatable="1">The shortcut icon for the agent interface. The URL to the icon must be a relative URL to the skin image directory.</Description>
+        <Description Translatable="1">The shortcut icon for the agent interface.</Description>
         <Group>Framework</Group>
         <SubGroup>Frontend::Agent</SubGroup>
         <Setting>

--- a/Kernel/Output/HTML/Templates/Standard/CustomerHTMLHead.tt
+++ b/Kernel/Output/HTML/Templates/Standard/CustomerHTMLHead.tt
@@ -25,7 +25,11 @@
 [% RenderBlockStart("MetaLink") %]
     <link rel="[% Data.Rel | html %]" type="[% Data.Type | html %]" title="[% Data.Title | html %]" href="[% Data.Href %]" />
 [% RenderBlockEnd("MetaLink") %]
+[% IF Config("CustomerShortcutIcon") -%]
+    <link rel="shortcut icon" href="[% Config("CustomerShortcutIcon") %]" type="image/ico" />
+[% ELSE -%]
     <link rel="shortcut icon" href="[% Config("Frontend::ImagePath") %]icons/product.ico" type="image/ico" />
+[% END -%]
     <link rel="apple-touch-icon" href="[% Config("Frontend::ImagePath") %]icons/apple-touch-icon.png" />
 
 [% RenderBlockStart("CommonCSS") %]

--- a/Kernel/Output/HTML/Templates/Standard/HTMLHead.tt
+++ b/Kernel/Output/HTML/Templates/Standard/HTMLHead.tt
@@ -25,7 +25,11 @@
 [% RenderBlockStart("MetaLink") %]
     <link rel="[% Data.Rel | html %]" type="[% Data.Type | html %]" title="[% Data.Title | html %]" href="[% Data.Href %]" />
 [% RenderBlockEnd("MetaLink") %]
+[% IF Config("AgentShortcutIcon") -%]
+    <link rel="shortcut icon" href="[% Config("AgentShortcutIcon") %]" type="image/ico" />
+[% ELSE -%]
     <link rel="shortcut icon" href="[% Config("Frontend::ImagePath") %]icons/product.ico" type="image/ico" />
+[% END -%]
     <link rel="apple-touch-icon" href="[% Config("Frontend::ImagePath") %]icons/apple-touch-icon.png" />
 
 [% RenderBlockStart("CommonCSS") %]

--- a/Kernel/Output/HTML/Templates/Standard/Login.tt
+++ b/Kernel/Output/HTML/Templates/Standard/Login.tt
@@ -15,7 +15,11 @@ X-OTRS-Login: [% Env("Baselink") %]
 <head>
     <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=no" />
     <meta http-equiv="Content-type" content="text/html;charset=utf-8" />
+[% IF Config("AgentShortcutIcon") -%]
+    <link rel="shortcut icon" href="[% Config("AgentShortcutIcon") %]" type="image/ico" />
+[% ELSE -%]
     <link rel="shortcut icon" href="[% Config("Frontend::ImagePath") %]icons/product.ico" type="image/ico" />
+[% END -%]
     <link rel="apple-touch-icon" href="[% Config("Frontend::ImagePath") %]icons/apple-touch-icon.png" />
 
 [% RenderBlockStart("CommonCSS") %]


### PR DESCRIPTION
This mod introduces two new SysConfig parameters
- AgentShortcutIcon
- CustomerShortcutIcon

that allow one to specify shortcut icons to use in otrs agent
and customer panel.

Related: https://dev.ib.pl/ib/otrs/issues/85
Author-Change-Id: IB#1046319
