### PR TITLE
Master frontend usability - AdminCustomerUserService

### DIFF
--- a/Kernel/Modules/AdminCustomerUserService.pm
+++ b/Kernel/Modules/AdminCustomerUserService.pm
@@ -194,11 +194,20 @@ sub Run {
             );
         }
 
-        # redirect to overview
-        return $LayoutObject->Redirect(
-            OP =>
-                "Action=$Self->{Action};CustomerUserSearch=$Param{CustomerUserSearch}"
-        );
+        # if the user would like to continue editing the customer user allocating just redirect to the edit screen
+        if ( $ParamObject->GetParam( Param => 'ContinueAfterSave' ) eq '1' ) {
+            return $LayoutObject->Redirect(
+                OP =>
+                    "Action=$Self->{Action};Subaction=AllocateCustomerUser;CustomerUserLogin=$Param{CustomerUserLogin};CustomerUserSearch=$Param{CustomerUserSearch}"
+            );
+        }
+        else {
+
+            # otherwise return to relations overview
+            return $LayoutObject->Redirect(
+                OP => "Action=$Self->{Action};CustomerUserSearch=$Param{CustomerUserSearch}"
+            );
+        }
     }
 
     # ------------------------------------------------------------ #
@@ -237,11 +246,21 @@ sub Run {
             );
         }
 
-        # redirect to overview
-        return $LayoutObject->Redirect(
-            OP =>
-                "Action=$Self->{Action};CustomerUserSearch=$Param{CustomerUserSearch}"
-        );
+        # if the user would like to continue editing the customer user allocating just redirect to the edit screen
+        if ( $ParamObject->GetParam( Param => 'ContinueAfterSave' ) eq '1' ) {
+            return $LayoutObject->Redirect(
+                OP =>
+                    "Action=$Self->{Action};Subaction=AllocateService;ServiceID=$Param{ServiceID};CustomerUserSearch=$Param{CustomerUserSearch}"
+            );
+        }
+        else {
+
+            # otherwise return to relations overview
+            return $LayoutObject->Redirect(
+                OP =>
+                    "Action=$Self->{Action};CustomerUserSearch=$Param{CustomerUserSearch}"
+            );
+        }
     }
 
     # ------------------------------------------------------------ #
@@ -335,8 +354,22 @@ sub _Change {
 
     my $LayoutObject = $Kernel::OM->Get('Kernel::Output::HTML::Layout');
 
+    if ( $VisibleType{$NeType} eq 'Customer' ) {
+        $Param{BreadcrumbTitle} = "Allocate Customers to Service";
+    }
+    else {
+        $Param{BreadcrumbTitle} = "Allocate Services to Customer";
+    }
+
     # overview
-    $LayoutObject->Block( Name => 'Overview' );
+    $LayoutObject->Block(
+        Name => 'Overview',
+        Data => {
+            %Param,
+            OverviewLink       => $Self->{Action} . ';CustomerUserSearch=' . $Param{CustomerUserSearch},
+            OverviewLinkAppend => '1',
+        },
+    );
     $LayoutObject->Block( Name => 'ActionList' );
     $LayoutObject->Block(
         Name => 'ActionOverview',
@@ -380,11 +413,10 @@ sub _Change {
             VisibleNeType   => $VisibleType{$NeType},
             SubactionHeader => $Subaction{$Type},
             IDHeaderStrg    => $IDStrg{$Type},
+            Subaction       => $Self->{Subaction},
             %Param,
         },
     );
-
-    $LayoutObject->Block( Name => "AllocateItemHeader$VisibleType{$NeType}" );
 
     my $ColSpan = 2;
 
@@ -482,7 +514,15 @@ sub _Overview {
     my %ServiceData         = %{ $Param{ServiceData} };
 
     my $LayoutObject = $Kernel::OM->Get('Kernel::Output::HTML::Layout');
-    $LayoutObject->Block( Name => 'Overview' );
+
+    # overview
+    $LayoutObject->Block(
+        Name => 'Overview',
+        Data => {
+            %Param,
+            OverviewLinkAppend => '0',
+            }
+    );
     $LayoutObject->Block( Name => 'ActionList' );
 
     # output search block

--- a/Kernel/Modules/AdminCustomerUserService.pm
+++ b/Kernel/Modules/AdminCustomerUserService.pm
@@ -366,8 +366,7 @@ sub _Change {
         Name => 'Overview',
         Data => {
             %Param,
-            OverviewLink       => $Self->{Action} . ';CustomerUserSearch=' . $Param{CustomerUserSearch},
-            OverviewLinkAppend => '1',
+            OverviewLink => $Self->{Action} . ';CustomerUserSearch=' . $Param{CustomerUserSearch},
         },
     );
     $LayoutObject->Block( Name => 'ActionList' );
@@ -520,8 +519,8 @@ sub _Overview {
         Name => 'Overview',
         Data => {
             %Param,
-            OverviewLinkAppend => '0',
-            }
+            OverviewLink => $Self->{Action},
+        },
     );
     $LayoutObject->Block( Name => 'ActionList' );
 

--- a/Kernel/Output/HTML/Templates/Standard/AdminCustomerUserService.tt
+++ b/Kernel/Output/HTML/Templates/Standard/AdminCustomerUserService.tt
@@ -22,7 +22,11 @@
 
     [% IF Data.Type %]
             [% USE EditTitle = String(Translate(Data.BreadcrumbTitle)) %]
-            [% BreadcrumbPath.push({ Name => EditTitle.append( " '", Data.Name, "'" ) }) %]
+            [% IF Data.Name %]
+                [% BreadcrumbPath.push({ Name => EditTitle.append(" '", Data.Name , "'") }) %]
+            [% ELSE %]
+                [% BreadcrumbPath.push({ Name => EditTitle.append("") }) %]
+            [% END %]
     [% END %]
 
     [% INCLUDE "Breadcrumb.tt" Path = BreadcrumbPath %]

--- a/Kernel/Output/HTML/Templates/Standard/AdminCustomerUserService.tt
+++ b/Kernel/Output/HTML/Templates/Standard/AdminCustomerUserService.tt
@@ -12,6 +12,32 @@
         <h1>[% Translate("Manage Customer-Services Relations") | html %]</h1>
     </div>
 
+    [% IF Data.OverviewLinkAppend && Data.OverviewLinkAppend == '1' %]
+        [% BreadcrumbPath = [
+                {
+                    Name => Translate('Manage Customer-Services Relations'),
+                    Link => Data.OverviewLink,
+                },
+            ]
+        %]
+    [% ELSE %]
+        [% BreadcrumbPath = [
+                {
+                    Name => Translate('Manage Customer-Services Relations'),
+                    Link => Env("Action"),
+                },
+            ]
+        %]
+    [% END %]
+
+    [% IF Data.Type %]
+            [% USE EditTitle = String(Translate(Data.BreadcrumbTitle)) %]
+            [% BreadcrumbPath.push({ Name => EditTitle.append( " '", Data.Name, "'" ) }) %]
+    [% END %]
+
+    [% INCLUDE "Breadcrumb.tt" Path = BreadcrumbPath %]
+
+    <div class="Clear"></div>
     <div class="SidebarColumn">
 [% RenderBlockStart("ActionList") %]
         <div class="WidgetSimple">
@@ -119,12 +145,7 @@
 [% RenderBlockStart("AllocateItem") %]
             <div class="Header">
                 <h2>
-[% RenderBlockStart("AllocateItemHeaderService") %]
-                    [% Translate("Allocate Services to Customer") | html %]
-[% RenderBlockEnd("AllocateItemHeaderService") %]
-[% RenderBlockStart("AllocateItemHeaderCustomer") %]
-                    [% Translate("Allocate Customers to Service") | html %]
-[% RenderBlockEnd("AllocateItemHeaderCustomer") %]
+                    [% Translate(Data.BreadcrumbTitle) | html %]
                     <a href="[% Env("Baselink") %]Action=[% Data.ActionHome | uri %];Subaction=[% Data.SubactionHeader | uri %];[% Data.IDHeaderStrg | uri %]=[% Data.ID | uri %]">[% Data.Name | html %]</a>
                 </h2>
             </div>
@@ -134,6 +155,9 @@
                     <input type="hidden" name="Subaction" value="Allocate[% Data.Type | html %]Save"/>
                     <input type="hidden" name="CustomerUserSearch" value="[% Data.CustomerUserSearch | html %]"/>
                     <input type="hidden" name="ID" value="[% Data.ID | html %]"/>
+                    [% IF Data.Subaction == 'AllocateService' OR Data.Subaction == 'AllocateCustomerUser' %]
+                        <input type="hidden" name="ContinueAfterSave" id="ContinueAfterSave" value=""/>
+                    [% END %]
                     <table class="DataTable VariableWidth" id="[% Data.NeType | html %]">
                         <thead>
                             <tr>
@@ -174,7 +198,13 @@
                         </tbody>
                     </table>
                     <div class="Field SpacingTop">
-                        <button class="Primary CallForAction" type="submit" value="[% Translate("Save") | html %]"><span>[% Translate("Save") | html %]</span></button>
+                    [% IF Data.Subaction == 'AllocateService' OR Data.Subaction == 'AllocateCustomerUser' %]
+                        <button class="CallForAction Primary" id="SubmitAndContinue" type="button" value="[% Translate("Save") | html %]"><span>[% Translate("Save") | html %]</span></button>
+                        [% Translate("or") | html %]
+                        <button class="CallForAction Primary" id="Submit" type="submit" value="[% Translate("Save") | html %]"><span>[% Translate("Save and finish") | html %]</span></button>
+                    [% ELSE %]
+                        <button class="CallForAction Primary" id="Submit" type="submit" value="[% Translate("Save") | html %]"><span>[% Translate("Save") | html %]</span></button>
+                    [% END %]
                         [% Translate("or") | html %]
                         <a href="[% Env("Baselink") %]Action=[% Env("Action") %]">[% Translate("Cancel") | html %]</a>
                     </div>

--- a/Kernel/Output/HTML/Templates/Standard/AdminCustomerUserService.tt
+++ b/Kernel/Output/HTML/Templates/Standard/AdminCustomerUserService.tt
@@ -12,23 +12,13 @@
         <h1>[% Translate("Manage Customer-Services Relations") | html %]</h1>
     </div>
 
-    [% IF Data.OverviewLinkAppend && Data.OverviewLinkAppend == '1' %]
-        [% BreadcrumbPath = [
-                {
-                    Name => Translate('Manage Customer-Services Relations'),
-                    Link => Data.OverviewLink,
-                },
-            ]
-        %]
-    [% ELSE %]
-        [% BreadcrumbPath = [
-                {
-                    Name => Translate('Manage Customer-Services Relations'),
-                    Link => Env("Action"),
-                },
-            ]
-        %]
-    [% END %]
+    [% BreadcrumbPath = [
+            {
+                Name => Translate('Manage Customer-Services Relations'),
+                Link => Data.OverviewLink,
+            },
+        ]
+    %]
 
     [% IF Data.Type %]
             [% USE EditTitle = String(Translate(Data.BreadcrumbTitle)) %]

--- a/scripts/test/Selenium/Agent/Admin/AdminCustomerUserService.t
+++ b/scripts/test/Selenium/Agent/Admin/AdminCustomerUserService.t
@@ -112,7 +112,7 @@ $Selenium->RunTest(
         my $IsLinkedBreadcrumbText;
         for my $BreadcrumbText (
             'You are here:', 'Manage Customer-Services Relations',
-            'Allocate Customers to Service \''
+            'Allocate Services to Customer \''
             . $CustomerUserName . ' '
             . $CustomerUserName . ' ('
             . $CustomerUserName . ')\''

--- a/scripts/test/Selenium/Agent/Admin/AdminCustomerUserService.t
+++ b/scripts/test/Selenium/Agent/Admin/AdminCustomerUserService.t
@@ -79,6 +79,12 @@ $Selenium->RunTest(
         $Selenium->find_element( "#Customers",          'css' );
         $Selenium->find_element( "#Service",            'css' );
 
+        # check breadcrumb on Overview screen
+        $Self->True(
+            $Selenium->find_element( '.BreadCrumb', 'css' ),
+            "Breadcrumb is found on Overview screen.",
+        );
+
         # test search filter for CustomerUser
         $Selenium->find_element( "#CustomerUserSearch", 'css' )->clear();
         $Selenium->find_element( "#CustomerUserSearch", 'css' )->send_keys($CustomerUserName);
@@ -100,6 +106,45 @@ $Selenium->RunTest(
 
         # allocate test service to test customer user
         $Selenium->find_element("//a[contains(\@href, \'CustomerUserLogin=$CustomerUserName' )]")->VerifiedClick();
+
+        # check breadcrumb on allocate screen
+        my $Count = 0;
+        my $IsLinkedBreadcrumbText;
+        for my $BreadcrumbText (
+            'You are here:', 'Manage Customer-Services Relations',
+            'Allocate Customers to Service \''
+            . $CustomerUserName . ' '
+            . $CustomerUserName . ' ('
+            . $CustomerUserName . ')\''
+            )
+        {
+            $Self->Is(
+                $Selenium->execute_script("return \$(\$('.BreadCrumb li')[$Count]).text().trim()"),
+                $BreadcrumbText,
+                "Breadcrumb text '$BreadcrumbText' is found on screen"
+            );
+
+            $IsLinkedBreadcrumbText =
+                $Selenium->execute_script("return \$(\$('.BreadCrumb li')[$Count]).children('a').length");
+
+            if ( $BreadcrumbText eq 'Manage Customer-Services Relations' ) {
+                $Self->Is(
+                    $IsLinkedBreadcrumbText,
+                    1,
+                    "Breadcrumb text '$BreadcrumbText' is linked"
+                );
+            }
+            else {
+                $Self->Is(
+                    $IsLinkedBreadcrumbText,
+                    0,
+                    "Breadcrumb text '$BreadcrumbText' is not linked"
+                );
+            }
+
+            $Count++;
+        }
+
         $Selenium->find_element("//input[\@value='$ServiceID']")->VerifiedClick();
         $Selenium->find_element("//button[\@value='Save'][\@type='submit']")->VerifiedClick();
 


### PR DESCRIPTION
Hi @zottto 

Hereby is refactored AdminCustomerUserService. 'First' breadcrumb is added differently because link for 'Manage Customer-Services Relations' depends on screen and search field. If you could confirm that we should use this approach we will update other relevant PRs that have same behaviour.

'Save and finish' button is also added and Selenium test is modified in accordance with changes.
Please let me know if you have any suggestions.

Regards
Zoran