### PR TITLE
Product name in messages instead of hardcoded OTRS

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,4 +1,5 @@
 #6.0.0.beta1 2016-??-??
+ - 2016-08-30 Product name in messages instead of hardcoded OTRS.
  - 2016-08-25 Added possibility to send encrypted emails to multiple recipients.
  - 2016-06-07 Added index for searching dynamic field text values.
  - 2016-08-18 Added per-address email loop protection setting (PostmasterMaxEmailsPerAddress), thanks to Moritz Lenz.

--- a/Kernel/Output/HTML/Notification/UIDCheck.pm
+++ b/Kernel/Output/HTML/Notification/UIDCheck.pm
@@ -13,10 +13,9 @@ use base 'Kernel::Output::HTML::Base';
 use strict;
 use warnings;
 
-use Kernel::Language qw(Translatable);
-
 our @ObjectDependencies = (
-    'Kernel::Output::HTML::Layout'
+    'Kernel::Config',
+    'Kernel::Output::HTML::Layout',
 );
 
 sub Run {
@@ -25,6 +24,9 @@ sub Run {
     # return if it's not root@localhost
     return '' if $Self->{UserID} != 1;
 
+    # get the product name
+    my $ProductName = $Kernel::OM->Get('Kernel::Config')->Get('ProductName') || 'OTRS';
+
     # get layout object
     my $LayoutObject = $Kernel::OM->Get('Kernel::Output::HTML::Layout');
 
@@ -32,8 +34,9 @@ sub Run {
     return $LayoutObject->Notify(
         Priority => 'Error',
         Link     => $LayoutObject->{Baselink} . 'Action=AdminUser',
-        Info     => Translatable(
-            'Don\'t use the Superuser account to work with OTRS! Create new Agents and work with these accounts instead.'
+        Info     => $LayoutObject->{LanguageObject}->Translate(
+            'Don\'t use the Superuser account to work with %s! Create new Agents and work with these accounts instead.',
+            $ProductName
         ),
     );
 }

--- a/Kernel/Output/HTML/Templates/Standard/CustomerLogin.tt
+++ b/Kernel/Output/HTML/Templates/Standard/CustomerLogin.tt
@@ -24,7 +24,7 @@
         <h2 class="Center">[% Translate("Browser Warning") | html %]</h2>
         <p>
             [% Translate("The browser you are using is too old.") | html %]
-            [% Translate("OTRS runs with a huge lists of browsers, please upgrade to one of these.") | html %]
+            [% Translate("This software runs with a huge lists of browsers, please upgrade to one of these.") | html %]
             [% Translate("Please see the documentation or ask your admin for further information.") | html %]
         </p>
     </div>

--- a/Kernel/Output/HTML/Templates/Standard/CustomerLogin.tt
+++ b/Kernel/Output/HTML/Templates/Standard/CustomerLogin.tt
@@ -16,7 +16,7 @@
     <div id="NoJavaScript">
         <h2>[% Translate("JavaScript Not Available") | html %]</h2>
         <p>
-            [% Translate("In order to experience OTRS, you'll need to enable JavaScript in your browser.") | html %]
+            [% Translate("In order to experience this software, you'll need to enable JavaScript in your browser.") | html %]
         </p>
     </div>
     </noscript>

--- a/Kernel/Output/HTML/Templates/Standard/Installer.tt
+++ b/Kernel/Output/HTML/Templates/Standard/Installer.tt
@@ -19,7 +19,7 @@
             </div>
             <div class="Content">
                 <p class="SpacingTop Center">
-                    [% Translate("In order to experience OTRS, you'll need to enable JavaScript in your browser.") | html %]
+                    [% Translate("In order to experience this software, you'll need to enable JavaScript in your browser.") | html %]
                 </p>
             </div>
         </div>

--- a/Kernel/Output/HTML/Templates/Standard/Login.tt
+++ b/Kernel/Output/HTML/Templates/Standard/Login.tt
@@ -131,7 +131,7 @@ X-OTRS-Login: [% Env("Baselink") %]
                 <div class="Content">
                     <p class="SpacingTop Center">
                         [% Translate("The browser you are using is too old.") | html %]
-                        [% Translate("OTRS runs with a huge lists of browsers, please upgrade to one of these.") | html %]
+                        [% Translate("This software runs with a huge lists of browsers, please upgrade to one of these.") | html %]
                         [% Translate("Please see the documentation or ask your admin for further information.") | html %]
                     </p>
                 </div>

--- a/Kernel/Output/HTML/Templates/Standard/Login.tt
+++ b/Kernel/Output/HTML/Templates/Standard/Login.tt
@@ -118,7 +118,7 @@ X-OTRS-Login: [% Env("Baselink") %]
                 </div>
                 <div class="Content">
                     <p class="SpacingTop Center">
-                            [% Translate("In order to experience OTRS, you'll need to enable JavaScript in your browser.") | html %]
+                            [% Translate("In order to experience this software, you'll need to enable JavaScript in your browser.") | html %]
                     </p>
                 </div>
             </div>

--- a/var/httpd/htdocs/js/Core.Agent.js
+++ b/var/httpd/htdocs/js/Core.Agent.js
@@ -633,7 +633,7 @@ Core.Agent = (function (TargetNS) {
         if (!TargetNS.SupportedBrowser) {
             alert(Core.Language.Translate('The browser you are using is too old.')
                 + ' '
-                + Core.Language.Translate('OTRS runs with a huge lists of browsers, please upgrade to one of these.')
+                + Core.Language.Translate('This software runs with a huge lists of browsers, please upgrade to one of these.')
                 + ' '
                 + Core.Language.Translate('Please see the documentation or ask your admin for further information.'));
         }

--- a/var/httpd/htdocs/js/Core.Customer.js
+++ b/var/httpd/htdocs/js/Core.Customer.js
@@ -72,7 +72,7 @@ Core.Customer = (function (TargetNS) {
             alert(
                 Core.Language.Translate('The browser you are using is too old.')
                 + ' '
-                + Core.Language.Translate('OTRS runs with a huge lists of browsers, please upgrade to one of these.')
+                + Core.Language.Translate('This software runs with a huge lists of browsers, please upgrade to one of these.')
                 + ' '
                 + Core.Language.Translate('Please see the documentation or ask your admin for further information.')
             );


### PR DESCRIPTION
Product name in messages instead of hardcoded OTRS

This mod changes hardcoded "OTRS" to user-friendly ProductName
as configured in SysConfig; using different system names may
confuse users.

Related: https://dev.ib.pl/ib/otrs/issues/86
Author-Change-Id: IB#1004618
