### PR TITLE
Added option to display number of all customer tickets in AgentTicketZoom

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,4 +1,5 @@
 #6.0.0.beta1 2016-??-??
+ - 2016-08-31 Added option to display number of all customer tickets in AgentTicketZoom.
  - 2016-08-25 Added possibility to send encrypted emails to multiple recipients.
  - 2016-06-07 Added index for searching dynamic field text values.
  - 2016-08-18 Added per-address email loop protection setting (PostmasterMaxEmailsPerAddress), thanks to Moritz Lenz.

--- a/Kernel/Config/Files/Ticket.xml
+++ b/Kernel/Config/Files/Ticket.xml
@@ -1760,6 +1760,17 @@
             </Option>
         </Setting>
     </ConfigItem>
+    <ConfigItem Name="Ticket::Frontend::ZoomCustomerTickets" Required="0" Valid="0">
+        <Description Translatable="1">Displays the number of all tickets with the same CustomerID as current ticket in the ticket zoom view.</Description>
+        <Group>Ticket</Group>
+        <SubGroup>Frontend::Agent::Ticket::ViewZoom</SubGroup>
+        <Setting>
+            <Option SelectedID="0">
+                <Item Key="0" Translatable="1">No</Item>
+                <Item Key="1" Translatable="1">Yes</Item>
+            </Option>
+        </Setting>
+    </ConfigItem>
     <ConfigItem Name="Ticket::Frontend::HistoryOrder" Required="1" Valid="1">
         <Description Translatable="1">Shows the ticket history (reverse ordered) in the agent interface.</Description>
         <Group>Ticket</Group>

--- a/Kernel/Output/HTML/Templates/Standard/AgentTicketZoom/TicketInformation.tt
+++ b/Kernel/Output/HTML/Templates/Standard/AgentTicketZoom/TicketInformation.tt
@@ -107,11 +107,6 @@
                     </fieldset>
 
                     <fieldset class="TableLike FixedLabelSmall Narrow">
-                        <label>[% Translate("CustomerID") | html %]:</label>
-                        <p class="Value">
-                            <a href="[% Config("CustomerDBLink") | Interpolate %]" class="[% Config("CustomerDBLinkClass") %]" [% Config("CustomerDBLinkTarget") %]>[% Data.CustomerID | html %]</a>
-                        </p>
-                        <div class="Clear"></div>
 [% RenderBlockStart("TotalAccountedTime") %]
                         <label>[% Translate("Accounted time") | html %]:</label>
                         <p class="Value">[% Data.TicketTimeUnits %]</p>
@@ -139,6 +134,18 @@
                         <div class="Clear"></div>
 
 [% RenderBlockEnd("Responsible") %]
+                        <label>[% Translate("Customer") | html %]:</label>
+                        <p class="Value">
+                            <a href="[% Config("CustomerDBLink") | Interpolate %]" class="[% Config("CustomerDBLinkClass") %]" [% Config("CustomerDBLinkTarget") %]>[% Data.CustomerID | html %]</a>
+                        </p>
+                        <div class="Clear"></div>
+[% RenderBlockStart("CustomerIDTickets") %]
+                        <label>[% Translate("Customer tickets") | html %]:</label>
+                        <p class="Value">
+                            <a href="[% Env("Baselink") %]Action=AgentTicketSearch;Subaction=Search;CustomerID=[% Data.CustomerID | uri %]">[% Data.CustomerIDTickets %]</a>
+                        </p>
+                        <div class="Clear"></div>
+[% RenderBlockEnd("CustomerIDTickets") %]
                     </fieldset>
 
 [% RenderBlockStart("ProcessData") %]

--- a/Kernel/Output/HTML/TicketZoom/TicketInformation.pm
+++ b/Kernel/Output/HTML/TicketZoom/TicketInformation.pm
@@ -122,6 +122,23 @@ sub Run {
         );
     }
 
+    # show number of tickets with the same customer id if feature is active:
+    if ( $ConfigObject->Get('Ticket::Frontend::ZoomCustomerTickets') ) {
+        $Ticket{CustomerIDTickets} = 1;
+        if ( $Ticket{CustomerID} ) {
+            $Ticket{CustomerIDTickets} = $Kernel::OM->Get('Kernel::System::Ticket')->TicketSearch(
+                CustomerID => $Ticket{CustomerID},
+                Result     => 'COUNT',
+                Permission => 'ro',
+                UserID     => $Self->{UserID},
+            );
+            $LayoutObject->Block(
+                Name => 'CustomerIDTickets',
+                Data => \%Ticket,
+            );
+        }
+    }
+
     # show total accounted time if feature is active:
     if ( $ConfigObject->Get('Ticket::Frontend::AccountTime') ) {
         $Ticket{TicketTimeUnits} = $Kernel::OM->Get('Kernel::System::Ticket')->TicketAccountedTimeGet(%Ticket);

--- a/Kernel/Output/HTML/TicketZoom/TicketInformation.pm
+++ b/Kernel/Output/HTML/TicketZoom/TicketInformation.pm
@@ -23,6 +23,7 @@ sub Run {
 
     my $ConfigObject = $Kernel::OM->Get('Kernel::Config');
     my $LayoutObject = $Kernel::OM->Get('Kernel::Output::HTML::Layout');
+    my $TicketObject = $Kernel::OM->Get('Kernel::System::Ticket');
 
     my %Ticket    = %{ $Param{Ticket} };
     my %AclAction = %{ $Param{AclAction} };
@@ -124,9 +125,8 @@ sub Run {
 
     # show number of tickets with the same customer id if feature is active:
     if ( $ConfigObject->Get('Ticket::Frontend::ZoomCustomerTickets') ) {
-        $Ticket{CustomerIDTickets} = 1;
         if ( $Ticket{CustomerID} ) {
-            $Ticket{CustomerIDTickets} = $Kernel::OM->Get('Kernel::System::Ticket')->TicketSearch(
+            $Ticket{CustomerIDTickets} = $TicketObject->TicketSearch(
                 CustomerID => $Ticket{CustomerID},
                 Result     => 'COUNT',
                 Permission => 'ro',
@@ -141,7 +141,7 @@ sub Run {
 
     # show total accounted time if feature is active:
     if ( $ConfigObject->Get('Ticket::Frontend::AccountTime') ) {
-        $Ticket{TicketTimeUnits} = $Kernel::OM->Get('Kernel::System::Ticket')->TicketAccountedTimeGet(%Ticket);
+        $Ticket{TicketTimeUnits} = $TicketObject->TicketAccountedTimeGet(%Ticket);
         $LayoutObject->Block(
             Name => 'TotalAccountedTime',
             Data => \%Ticket,

--- a/var/httpd/htdocs/skins/Agent/default/css/Core.Form.css
+++ b/var/httpd/htdocs/skins/Agent/default/css/Core.Form.css
@@ -654,14 +654,14 @@ fieldset.TableLike.FixedLabel > .Row > .Value {
  */
 fieldset.TableLike.FixedLabelSmall > label,
 fieldset.TableLike.FixedLabelSmall > .Row > label {
-    width: 100px;
+    width: 120px;
 }
 
 fieldset.TableLike.FixedLabelSmall > .Field,
 fieldset.TableLike.FixedLabelSmall > .Row > .Field,
 fieldset.TableLike.FixedLabelSmall > .Value,
 fieldset.TableLike.FixedLabelSmall > .Row > .Value {
-    margin-left: 100px;
+    margin-left: 120px;
     margin-right: 7px;
     word-wrap: break-word;
 }

--- a/var/httpd/htdocs/skins/Agent/default/css/Core.PageLayout.css
+++ b/var/httpd/htdocs/skins/Agent/default/css/Core.PageLayout.css
@@ -35,7 +35,7 @@
 }
 
 .LayoutFixedSidebar.SidebarLast > .SidebarColumn {
-    width: 270px;
+    width: 290px;
     float: right;
     margin-left: 16px;
     margin-right: 0;


### PR DESCRIPTION
Added option to display number of all customer tickets in AgentTicketZoom

This mod introduces new SysConfig parameter
`Ticket::Frontend::ZoomCustomerTickets` that allows one to put number of
all tickets with the same CustomerID in the Ticket Information box
on AgentTicketZoom. This allows agent to quickly notice if new e-mail
ticket arrived from customer, that sent other tickets in the past.
Number of tickets is displayed as a link to list of all tickets with
the same CustomerID.

This mod also increases sidebar width by 20px and changes technical
"CustomerID" label to simply "Customer" to be compatible with other
labels like `Admin > Customers`.

Related: https://dev.ib.pl/ib/otrs/issues/87
Author-Change-Id: IB#1056300
