### PR TITLE
Master - JS and Selenium update - AdminGenericAgent

### DIFF
--- a/scripts/test/Selenium/Agent/Admin/AdminGenericAgent.t
+++ b/scripts/test/Selenium/Agent/Admin/AdminGenericAgent.t
@@ -38,6 +38,12 @@ $Selenium->RunTest(
             Value => 1,
         );
 
+        # disable modernize fields
+        $Helper->ConfigSettingChange(
+            Key   => 'ModernizeFormFields',
+            Value => 0,
+        );
+
         # create test user and login
         my $TestUserLogin = $Helper->TestUserCreate(
             Groups => [ 'admin', 'users' ],
@@ -97,7 +103,7 @@ $Selenium->RunTest(
         );
 
         $Self->True(
-            $DynamicFieldID,
+            $CheckboxDynamicFieldID,
             "Dynamic field $CheckboxDynamicFieldName - ID $CheckboxDynamicFieldID - created",
         );
 
@@ -192,6 +198,91 @@ $Selenium->RunTest(
 
         # Toggle widgets
         $Selenium->execute_script('$(".WidgetSimple.Collapsed .WidgetAction.Toggle a").click();');
+
+        # test AddEvent() JS function
+        $Selenium->find_element( "#AddEvent", 'css' )->click();
+
+        $Self->Is(
+            $Selenium->execute_script(
+                "return \$('#EventsTable tbody tr:eq(1)').length"
+            ),
+            '1',
+            'JS function AddEvent() is success',
+        );
+
+        # try to add same event, test ShowDuplicatedDialog() JS function
+        $Selenium->find_element( "#AddEvent", 'css' )->click();
+
+        # wait for dialog to show up, if necessary
+        $Selenium->WaitFor(
+            JavaScript => 'return typeof($) === "function" && $(".Dialog:visible").length === 1;'
+        );
+
+        # verify dialog message
+        $Self->True(
+            index(
+                $Selenium->get_page_source(),
+                'This event is already attached to the job, Please use a different one.'
+                ) > -1,
+            "Duplicated event dialog message is found",
+        );
+
+        # close dialog
+        $Selenium->find_element( "#DialogButton1", 'css' )->click();
+
+        # wait for dialog to disappear, if necessary
+        $Selenium->WaitFor(
+            JavaScript => 'return typeof($) === "function" && $(".Dialog:visible").length === 0;'
+        );
+
+        # click to delete added event, confirmation dialog will appear
+        $Selenium->execute_script("\$('#EventsTable tbody tr:eq(1) #DeleteEvent').click();");
+
+        # wait for dialog to show up, if necessary
+        $Selenium->WaitFor(
+            JavaScript => 'return typeof($) === "function" && $(".Dialog:visible").length === 1;'
+        );
+
+        # verify confirmation dialog message on delete event
+        $Self->True(
+            index( $Selenium->get_page_source(), 'Do you really want to delete this event trigger?' ) > -1,
+            "Delete event dialog message is found",
+        );
+
+        # confirm delete event
+        $Selenium->find_element( "#DialogButton2", 'css' )->click();
+
+        # wait for dialog to disappear, if necessary
+        $Selenium->WaitFor(
+            JavaScript => 'return typeof($) === "function" && $(".Dialog:visible").length === 0;'
+        );
+
+        # verify delete action event
+        $Self->Is(
+            $Selenium->execute_script(
+                "return \$('#EventsTable tbody tr:eq(1)').length"
+            ),
+            '0',
+            'Added event is deleted',
+        );
+
+        # check AddSelectClearButton() JS function
+        $Selenium->find_element( "#PriorityIDs option[value='1']", 'css' )->click();
+        $Self->True(
+            $Selenium->execute_script(
+                "return \$('#PriorityIDs option:eq(0)').is(':selected')"
+            ),
+            "Priority '1 very low' is selected"
+        );
+
+        # click to clear selection for Priority field and verify action
+        $Selenium->find_element("//a[contains(\@data-select, \'PriorityIDs' )]")->click();
+        $Self->False(
+            $Selenium->execute_script(
+                "return \$('#PriorityIDs option:eq(0)').is(':selected')"
+            ),
+            "Priority '1 very low' is no longer selected - JS is success"
+        );
 
         # create test job
         my $GenericTicketSearch = "*Ticket $RandomID Generic*";
@@ -398,15 +489,18 @@ $Selenium->RunTest(
         $Selenium->find_element("//a[contains(\@href, \'Subaction=Delete;Profile=$GenericAgentJob\' )]")
             ->VerifiedClick();
 
-        # delete created test dynamic field
-        my $Success = $DynamicFieldObject->DynamicFieldDelete(
-            ID     => $DynamicFieldID,
-            UserID => $UserID,
-        );
-        $Self->True(
-            $Success,
-            "Dynamic field - ID $DynamicFieldID - deleted",
-        );
+        # delete created test dynamic fields
+        my $Success;
+        for my $DynamicFieldDelete ( $DynamicFieldID, $CheckboxDynamicFieldID ) {
+            $Success = $DynamicFieldObject->DynamicFieldDelete(
+                ID     => $DynamicFieldDelete,
+                UserID => $UserID,
+            );
+            $Self->True(
+                $Success,
+                "Dynamic field - ID $DynamicFieldDelete - deleted",
+            );
+        }
     },
 
 );

--- a/var/httpd/htdocs/js/Core.Agent.Admin.GenericAgent.js
+++ b/var/httpd/htdocs/js/Core.Agent.Admin.GenericAgent.js
@@ -42,7 +42,7 @@ Core.Agent.Admin.GenericAgent = (function (TargetNS) {
 
             // Only handle select fields with a size > 1, leave all single-dropdown fields untouched
             if (isNaN(Size) || Size <= 1) {
-                return false;
+                return;
             }
 
             // If select field has a tree selection icon already,
@@ -82,25 +82,28 @@ Core.Agent.Admin.GenericAgent = (function (TargetNS) {
      */
     TargetNS.Init = function () {
 
-        $('.DeleteEvent').bind('click', function (Event) {
+        $('.DeleteEvent').on('click', function (Event) {
             TargetNS.ShowDeleteEventDialog(Event, $(this));
             return false;
         });
 
-        $('#AddEvent').bind('click', function (){
+        $('#AddEvent').on('click', function (){
             if ($('#EventType').val() !== null) {
                 TargetNS.AddEvent($('#EventType').val());
                 return;
             }
         });
 
-        $('#EventType').bind('change', function (){
+        $('#EventType').on('change', function (){
             TargetNS.ToggleEventSelect($(this).val());
         });
 
         Core.UI.Table.InitTableFilter($("#FilterGenericAgentJobs"), $("#GenericAgentJobs"));
 
-        AddSelectClearButton();
+        // Add select clear button if ModernizeFormFields is disabled
+        if (parseInt(Core.Config.Get('InputFieldsActivated'), 10) === 0) {
+            AddSelectClearButton();
+        }
     };
 
     /**
@@ -152,7 +155,7 @@ Core.Agent.Admin.GenericAgent = (function (TargetNS) {
         $Clone.find('.EventValue').attr('name', 'EventValues').val(EventName);
 
         // bind delete function
-        $Clone.find('#DeleteEvent').bind('click', function (Event) {
+        $Clone.find('#DeleteEvent').on('click', function (Event) {
             // remove row
             TargetNS.ShowDeleteEventDialog(Event, $(this));
             return false;

--- a/var/httpd/htdocs/js/Core.Agent.Admin.GenericAgent.js
+++ b/var/httpd/htdocs/js/Core.Agent.Admin.GenericAgent.js
@@ -36,13 +36,25 @@ Core.Agent.Admin.GenericAgent = (function (TargetNS) {
         // Loop over all select fields available on the page
         $SelectFields.each(function () {
             var Size = parseInt($(this).attr('size'), 10),
+                ModernizeField = $(this).hasClass('Modernize'),
+                ModernizeActive = parseInt(Core.Config.Get('InputFieldsActivated'), 10),
                 $SelectField = $(this),
                 SelectID = this.id,
                 ButtonHTML = '<a href="#" title="' + Core.Language.Translate('Remove selection') + '" class="GenericAgentClearSelect" data-select="' + SelectID + '"><span>' + Core.Language.Translate('Remove selection') + '</span><i class="fa fa-undo"></i></a>';
 
-            // Only handle select fields with a size > 1, leave all single-dropdown fields untouched
-            if (isNaN(Size) || Size <= 1) {
-                return;
+            if (SelectID.indexOf('DynamicField') !== -1) {
+
+                // Only handle dynamic fields that are not modernized
+                if (ModernizeActive && ModernizeField) {
+                    return;
+                }
+            }
+            else {
+
+                // Only handle select fields with a size > 1, leave all single-dropdown fields untouched
+                if ((ModernizeActive && ModernizeField) || isNaN(Size) || Size <= 1) {
+                    return;
+                }
             }
 
             // If select field has a tree selection icon already,
@@ -100,10 +112,8 @@ Core.Agent.Admin.GenericAgent = (function (TargetNS) {
 
         Core.UI.Table.InitTableFilter($("#FilterGenericAgentJobs"), $("#GenericAgentJobs"));
 
-        // Add select clear button if ModernizeFormFields is disabled
-        if (parseInt(Core.Config.Get('InputFieldsActivated'), 10) === 0) {
-            AddSelectClearButton();
-        }
+        // Add select clear button
+        AddSelectClearButton();
     };
 
     /**

--- a/var/httpd/htdocs/js/Core.Agent.Admin.GenericAgent.js
+++ b/var/httpd/htdocs/js/Core.Agent.Admin.GenericAgent.js
@@ -31,20 +31,21 @@ Core.Agent.Admin.GenericAgent = (function (TargetNS) {
      *      Only select fields with size > 1 are selected (no dropdowns).
      */
     function AddSelectClearButton() {
-        var $SelectFields = $('select');
+        var $SelectFields = $('select'),
+            ModernizeActive = parseInt(Core.Config.Get('InputFieldsActivated'), 10);
 
         // Loop over all select fields available on the page
         $SelectFields.each(function () {
             var Size = parseInt($(this).attr('size'), 10),
                 ModernizeField = $(this).hasClass('Modernize'),
-                ModernizeActive = parseInt(Core.Config.Get('InputFieldsActivated'), 10),
+                DynamicFieldMultiSelectClass = $(this).hasClass('DynamicFieldMultiSelect'),
                 $SelectField = $(this),
                 SelectID = this.id,
                 ButtonHTML = '<a href="#" title="' + Core.Language.Translate('Remove selection') + '" class="GenericAgentClearSelect" data-select="' + SelectID + '"><span>' + Core.Language.Translate('Remove selection') + '</span><i class="fa fa-undo"></i></a>';
 
-            if (SelectID.indexOf('DynamicField') !== -1) {
+            if (DynamicFieldMultiSelectClass) {
 
-                // Only handle dynamic fields that are not modernized
+                // Only handle dynamic fields with class DynamicFieldMultiSelectClass that are not modernized
                 if (ModernizeActive && ModernizeField) {
                     return;
                 }

--- a/var/httpd/htdocs/js/Core.Agent.Admin.GenericAgent.js
+++ b/var/httpd/htdocs/js/Core.Agent.Admin.GenericAgent.js
@@ -43,23 +43,18 @@ Core.Agent.Admin.GenericAgent = (function (TargetNS) {
                 SelectID = this.id,
                 ButtonHTML = '<a href="#" title="' + Core.Language.Translate('Remove selection') + '" class="GenericAgentClearSelect" data-select="' + SelectID + '"><span>' + Core.Language.Translate('Remove selection') + '</span><i class="fa fa-undo"></i></a>';
 
-            if (DynamicFieldMultiSelectClass) {
-
-                // Only handle dynamic fields with class DynamicFieldMultiSelectClass that are not modernized
-                if (ModernizeActive && ModernizeField) {
-                    return;
-                }
+            // Only handle fields without class Modernize when modernized is disabled
+            if (ModernizeActive && ModernizeField) {
+                return;
             }
-            else {
 
-                // Only handle select fields with a size > 1, leave all single-dropdown fields untouched
-                if ((ModernizeActive && ModernizeField) || isNaN(Size) || Size <= 1) {
-                    return;
-                }
+            // Only handle select fields with a size > 1 and without class DynamicFieldMultiSelect
+            if (!DynamicFieldMultiSelectClass && isNaN(Size) || Size <= 1) {
+                return;
             }
 
             // If select field has a tree selection icon already,
-            // // we want to insert the new code after that element
+            // we want to insert the new code after that element
             if ($SelectField.next('a.ShowTreeSelection').length) {
                 $SelectField = $SelectField.next('a.ShowTreeSelection');
             }


### PR DESCRIPTION
Hello @zottto ,

Hereby is update for AdminGenricAgent JS function AddSelectClearButton(). This function was not working as it is suppose to. 

`// Only handle select fields with a size > 1, leave all single-dropdown fields untouched
  if (isNaN(Size) || Size <= 1) {
      return false;
 }`

This was causing .each() to leave event propagation on first field that satisfy condition. In this case it was validity field. Removed 'false', this now work as it is expected. Additionally included condition that this function only trigger if 'Modernize' fields are disabled. IMO there is no need for it with modernize fields, since there is option to deselect all values from the field.

Improved Selenium test to check for AddEvent(), ShowDuplicatedDialog(), ShowDeleteEventDialog() and AddSelectClearButton() JS functions. Additionally test was not clearing all dynamic fields that were created, fixed it as well.

Please let me know if you disagree with these changes.

Regards,
Sanjin
