### PR TITLE
[rel-5_0] Added confirmation for delete buttons

### DIFF
--- a/Kernel/Output/HTML/Templates/Standard/AdminAttachment.tt
+++ b/Kernel/Output/HTML/Templates/Standard/AdminAttachment.tt
@@ -79,7 +79,7 @@
                             <td>[% Data.ChangeTime | Localize("TimeShort") %]</td>
                             <td>[% Data.CreateTime | Localize("TimeShort") %]</td>
                             <td class="Center">
-                                <a class="TrashCan" href="[% Env("Baselink") %]Action=[% Env("Action") %];Subaction=Delete;ID=[% Data.ID | uri %];[% Env("ChallengeTokenParam") | html %]" title="[% Translate("Delete this attachment") | html %]">
+                                <a class="TrashCan AttachmentDelete" href="[% Env("Baselink") %]Action=[% Env("Action") %];Subaction=Delete;ID=[% Data.ID | uri %];[% Env("ChallengeTokenParam") | html %]" title="[% Translate("Delete this attachment") | html %]">
                                     [% Translate("Delete this attachment") | html %]
                                     <i class="fa fa-trash-o"></i>
                                 </a>
@@ -89,6 +89,23 @@
                     </tbody>
                 </table>
             </div>
+
+[% WRAPPER JSOnDocumentComplete %]
+<script type="text/javascript">//<![CDATA[
+$('.AttachmentDelete').bind('click', function (Event) {
+
+    if (window.confirm([% Translate("Do you really want to delete this attachment?") | JSON %])) {
+        window.location = $(this).attr('href');
+    }
+
+    // don't interfere with MasterAction
+    Event.stopPropagation();
+    Event.preventDefault();
+    return false;
+});
+//]]></script>
+[% END %]
+
 [% RenderBlockEnd("OverviewResult") %]
 [% RenderBlockStart("OverviewUpdate") %]
             <div class="Header">

--- a/Kernel/Output/HTML/Templates/Standard/AdminGenericAgent.tt
+++ b/Kernel/Output/HTML/Templates/Standard/AdminGenericAgent.tt
@@ -68,8 +68,9 @@
                             <td>[% Data.ScheduleLastRun | Localize("TimeLong") %]</td>
                             <td>[% Translate(Data.ShownValid) | html %]</td>
                             <td class="Center">
-                                <a href="[% Env("Baselink") %]Action=[% Env("Action") %];Subaction=Delete;Profile=[% Data.Name | uri %];[% Env("ChallengeTokenParam") | html %]" title="[% Translate("Delete this task") | html %]">
-                                    <i class="fa fa-trash-o"></i> [% Translate("Delete") | html %]
+                                <a class="TrashCan TaskDelete" href="[% Env("Baselink") %]Action=[% Env("Action") %];Subaction=Delete;Profile=[% Data.Name | uri %];[% Env("ChallengeTokenParam") | html %]" title="[% Translate("Delete this task") | html %]">
+                                    [% Translate("Delete this task") | html %]
+                                    <i class="fa fa-trash-o"></i>
                                 </a>
                             </td>
                             <td>
@@ -85,6 +86,23 @@
                 </table>
             </div>
         </div>
+
+[% WRAPPER JSOnDocumentComplete %]
+<script type="text/javascript">//<![CDATA[
+$('.TaskDelete').bind('click', function (Event) {
+
+    if (window.confirm([% Translate("Do you really want to delete this task?") | JSON %])) {
+        window.location = $(this).attr('href');
+    }
+
+    // don't interfere with MasterAction
+    Event.stopPropagation();
+    Event.preventDefault();
+    return false;
+});
+//]]></script>
+[% END %]
+
 [% RenderBlockEnd("Overview") %]
 
 

--- a/Kernel/Output/HTML/Templates/Standard/AdminPostMasterFilter.tt
+++ b/Kernel/Output/HTML/Templates/Standard/AdminPostMasterFilter.tt
@@ -82,7 +82,10 @@
                                 <a class="AsBlock" href="[% Env("Baselink") %]Action=[% Env("Action") %];Subaction=Update;Name=[% Data.Name | uri %]">[% Translate(Data.Name) | html %]</a>
                             </td>
                             <td class="Center">
-                                <a href="[% Env("Baselink") %]Action=[% Env("Action") %];Subaction=Delete;Name=[% Data.Name | uri %];[% Env("ChallengeTokenParam") | html %]" title="[% Translate("Delete this filter") | html %]"><i class="fa fa-trash-o"></i> [% Translate("Delete") | html %]</a>
+                                <a class="TrashCan FilterDelete" href="[% Env("Baselink") %]Action=[% Env("Action") %];Subaction=Delete;Name=[% Data.Name | uri %];[% Env("ChallengeTokenParam") | html %]" title="[% Translate("Delete this filter") | html %]">
+                                    [% Translate("Delete this filter") | html %]
+                                    <i class="fa fa-trash-o"></i>
+                                </a>
                             </td>
                         </tr>
 [% RenderBlockEnd("OverviewResultRow") %]
@@ -90,6 +93,23 @@
                 </table>
             </div>
         </div>
+
+[% WRAPPER JSOnDocumentComplete %]
+<script type="text/javascript">//<![CDATA[
+$('.FilterDelete').bind('click', function (Event) {
+
+    if (window.confirm([% Translate("Do you really want to delete this filter?") | JSON %])) {
+        window.location = $(this).attr('href');
+    }
+
+    // don't interfere with MasterAction
+    Event.stopPropagation();
+    Event.preventDefault();
+    return false;
+});
+//]]></script>
+[% END %]
+
 [% RenderBlockEnd("OverviewResult") %]
 
 [% RenderBlockStart("OverviewUpdate") %]

--- a/Kernel/Output/HTML/Templates/Standard/AdminTemplate.tt
+++ b/Kernel/Output/HTML/Templates/Standard/AdminTemplate.tt
@@ -101,7 +101,7 @@
                             <td>[% Data.ChangeTime | Localize("TimeShort") %]</td>
                             <td>[% Data.CreateTime | Localize("TimeShort") %]</td>
                             <td class="Center">
-                                <a class="TrashCan" href="[% Env("Baselink") %]Action=[% Env("Action") %];Subaction=Delete;ID=[% Data.ID | uri %];[% Env("ChallengeTokenParam") | html %]" title="[% Translate("Delete this entry") | html %]">
+                                <a class="TrashCan TemplateDelete" href="[% Env("Baselink") %]Action=[% Env("Action") %];Subaction=Delete;ID=[% Data.ID | uri %];[% Env("ChallengeTokenParam") | html %]" title="[% Translate("Delete this entry") | html %]">
                                     [% Translate("Delete this entry") | html %]
                                     <i class="fa fa-trash-o"></i>
                                 </a>
@@ -115,6 +115,18 @@
 [% WRAPPER JSOnDocumentComplete %]
 <script type="text/javascript">//<![CDATA[
     Core.UI.Table.InitTableFilter($('#Filter'), $('#Templates'));
+
+    $('.TemplateDelete').bind('click', function (Event) {
+
+        if (window.confirm([% Translate("Do you really want to delete this template?") | JSON %])) {
+            window.location = $(this).attr('href');
+        }
+
+        // don't interfere with MasterAction
+        Event.stopPropagation();
+        Event.preventDefault();
+        return false;
+    });
 //]]></script>
 [% END %]
 [% RenderBlockEnd("OverviewResult") %]


### PR DESCRIPTION
Hi @zottto,
I added confirmations for delete buttons, because now these buttons delete items immediately. If a user clicks them accidentally, there is no way to cancel and undo.

@s7design, you are working on JS refactoring in master. Can you also add these confirmations? My solution uses the standard JavaScript confirm dialog, but OTRS has own popup dialog for confirmation (like for deleting a web service).
