### PR TITLE
Master frontend usability - AdminRoleGroup

### DIFF
--- a/Kernel/Modules/AdminRoleGroup.pm
+++ b/Kernel/Modules/AdminRoleGroup.pm
@@ -138,7 +138,15 @@ sub Run {
                 UserID     => $Self->{UserID},
             );
         }
-        return $LayoutObject->Redirect( OP => "Action=$Self->{Action}" );
+
+        # if the user would like to continue editing the role-group relation just redirect to the edit screen
+        # otherwise return to relations overview
+        if ( $ParamObject->GetParam( Param => 'ContinueAfterSave' ) eq '1' ) {
+            return $LayoutObject->Redirect( OP => "Action=$Self->{Action};Subaction=Group;ID=$ID" );
+        }
+        else {
+            return $LayoutObject->Redirect( OP => "Action=$Self->{Action}" );
+        }
     }
 
     # ------------------------------------------------------------ #
@@ -178,7 +186,15 @@ sub Run {
                 UserID     => $Self->{UserID},
             );
         }
-        return $LayoutObject->Redirect( OP => "Action=$Self->{Action}" );
+
+        # if the user would like to continue editing the group-role relation just redirect to the edit screen
+        # otherwise return to relations overview
+        if ( $ParamObject->GetParam( Param => 'ContinueAfterSave' ) eq '1' ) {
+            return $LayoutObject->Redirect( OP => "Action=$Self->{Action};Subaction=Role;ID=$ID" );
+        }
+        else {
+            return $LayoutObject->Redirect( OP => "Action=$Self->{Action}" );
+        }
     }
 
     # ------------------------------------------------------------ #
@@ -201,6 +217,17 @@ sub _Change {
     my $Type   = $Param{Type} || 'Role';
     my $NeType = $Type eq 'Group' ? 'Role' : 'Group';
 
+    $Param{BreadcrumbTitle} = $LayoutObject->{LanguageObject}->Translate("Change Group Relations for Role");
+
+    if ( $Type eq 'Group' ) {
+        $Param{BreadcrumbTitle} = $LayoutObject->{LanguageObject}->Translate("Change Role Relations for Group");
+    }
+
+    $LayoutObject->Block(
+        Name => 'Overview',
+        Data => \%Param,
+    );
+
     $LayoutObject->Block(
         Name => 'Change',
         Data => {
@@ -212,8 +239,6 @@ sub _Change {
 
     $LayoutObject->Block( Name => 'ActionList' );
     $LayoutObject->Block( Name => 'ActionOverview' );
-
-    $LayoutObject->Block( Name => "ChangeHeader$NeType" );
 
     # check if there are groups/roles
     if ( !%Data ) {
@@ -295,6 +320,11 @@ sub _Overview {
 
     $LayoutObject->Block(
         Name => 'Overview',
+        Data => {},
+    );
+
+    $LayoutObject->Block(
+        Name => 'OverviewAction',
         Data => {},
     );
 

--- a/Kernel/Output/HTML/Templates/Standard/AdminRoleGroup.tt
+++ b/Kernel/Output/HTML/Templates/Standard/AdminRoleGroup.tt
@@ -10,6 +10,23 @@
 <div class="MainBox ARIARoleMain LayoutFixedSidebar SidebarFirst">
     <h1>[% Translate("Manage Role-Group Relations") | html %]</h1>
 
+    [% BreadcrumbPath = [
+            {
+                Name => Translate('Manage Role-Group Relations'),
+                Link => Env("Action"),
+            },
+        ]
+    %]
+
+    [% IF Data.Type %]
+            [% USE EditTitle = String(Data.BreadcrumbTitle) %]
+            [% BreadcrumbPath.push({ Name => EditTitle.append( " '", Data.Name, "'" ) }) %]
+    [% END %]
+
+    [% INCLUDE "Breadcrumb.tt" Path = BreadcrumbPath %]
+
+    <div class="Clear"></div>
+[% RenderBlockStart("OverviewAction") %]
     <div class="SidebarColumn">
         <div class="WidgetSimple">
             <div class="Header">
@@ -63,12 +80,9 @@
         </div>
     </div>
     <div class="Clear"></div>
-</div>
+[% RenderBlockEnd("OverviewAction") %]
 
-[% RenderBlockEnd("Overview") %]
 [% RenderBlockStart("Change") %]
-<div class="MainBox ARIARoleMain LayoutFixedSidebar SidebarFirst">
-    <h1>[% Translate("Manage Role-Group Relations") | html %]</h1>
     <div class="SidebarColumn">
 
 [% RenderBlockStart("ActionList") %]
@@ -113,12 +127,7 @@
         <div class="WidgetSimple">
             <div class="Header">
                 <h2>
-[% RenderBlockStart("ChangeHeaderRole") %]
-                    [% Translate("Change Role Relations for Group") | html %]
-[% RenderBlockEnd("ChangeHeaderRole") %]
-[% RenderBlockStart("ChangeHeaderGroup") %]
-                    [% Translate("Change Group Relations for Role") | html %]
-[% RenderBlockEnd("ChangeHeaderGroup") %]
+                    [% Data.BreadcrumbTitle | html %]
                     <a href="[% Env("Baselink") %]Action=[% Data.ActionHome | uri %];Subaction=Change;ID=[% Data.ID | uri %]">[% Data.Name | html %]</a>
                 </h2>
             </div>
@@ -127,6 +136,7 @@
                     <input type="hidden" name="Action" value="[% Env("Action") %]"/>
                     <input type="hidden" name="Subaction" value="Change[% Data.Type | html %]"/>
                     <input type="hidden" name="ID" value="[% Data.ID | html %]"/>
+                    <input type="hidden" name="ContinueAfterSave" id="ContinueAfterSave" value=""/>
                     <table class="DataTable VariableWidth" id="UserGroups">
                         <thead>
                             <tr>
@@ -163,7 +173,9 @@
                         </tbody>
                     </table>
                     <div class="Field SpacingTop">
-                        <button class="Primary CallForAction" type="submit" value="[% Translate("Save") | html %]"><span>[% Translate("Save") | html %]</span></button>
+                        <button class="CallForAction Primary" id="SubmitAndContinue" type="button" value="[% Translate("Save") | html %]"><span>[% Translate("Save") | html %]</span></button>
+                        [% Translate("or") | html %]
+                        <button class="CallForAction Primary" id="Submit" type="submit" value="[% Translate("Save") | html %]"><span>[% Translate("Save and finish") | html %]</span></button>
                         [% Translate("or") | html %]
                         <a href="[% Env("Baselink") %]Action=[% Env("Action") %]">[% Translate("Cancel") | html %]</a>
                     </div>
@@ -219,6 +231,6 @@
 
     </div>
     <div class="Clear"></div>
-</div>
-
 [% RenderBlockEnd("Change") %]
+</div>
+[% RenderBlockEnd("Overview") %]

--- a/scripts/test/Selenium/Agent/Admin/AdminRoleGroup.t
+++ b/scripts/test/Selenium/Agent/Admin/AdminRoleGroup.t
@@ -66,6 +66,12 @@ $Selenium->RunTest(
         $Selenium->find_element( "#Roles",  'css' );
         $Selenium->find_element( "#Groups", 'css' );
 
+        # check breadcrumb on Overview screen
+        $Self->True(
+            $Selenium->find_element( '.BreadCrumb', 'css' ),
+            "Breadcrumb is found on Overview screen.",
+        );
+
         $Self->True(
             index( $Selenium->get_page_source(), $RoleName ) > -1,
             "$RoleName role found on page",
@@ -99,6 +105,41 @@ $Selenium->RunTest(
 
         # edit group relations for test role
         $Selenium->find_element( $RoleName, 'link_text' )->VerifiedClick();
+
+        # check breadcrumb on change screen
+        my $Count = 0;
+        my $IsLinkedBreadcrumbText;
+        for my $BreadcrumbText (
+            'You are here:', 'Manage Role-Group Relations',
+            'Change Group Relations for Role \'' . $RoleName . '\''
+            )
+        {
+            $Self->Is(
+                $Selenium->execute_script("return \$('.BreadCrumb li:eq($Count)').text().trim()"),
+                $BreadcrumbText,
+                "Breadcrumb text '$BreadcrumbText' is found on screen"
+            );
+
+            $IsLinkedBreadcrumbText =
+                $Selenium->execute_script("return \$('.BreadCrumb li:eq($Count)').children('a').length");
+
+            if ( $BreadcrumbText eq 'Manage Role-Group Relations' ) {
+                $Self->Is(
+                    $IsLinkedBreadcrumbText,
+                    1,
+                    "Breadcrumb text '$BreadcrumbText' is linked"
+                );
+            }
+            else {
+                $Self->Is(
+                    $IsLinkedBreadcrumbText,
+                    0,
+                    "Breadcrumb text '$BreadcrumbText' is not linked"
+                );
+            }
+
+            $Count++;
+        }
 
         # set permissions
         for my $Permission (qw(ro note owner)) {


### PR DESCRIPTION
Hi @zottto 

Hereby is refactored AdminRoleGroup. 
Blocks 'Overview' and 'Change' are separated and they are created for different screens which means that BreadcrumbPath has to be define for both blocks. Because of that, AdminRoleGroup TT is modified in order to BreadcrumbPath is used only once.
'Save and Finish' is added on the standard way and Selenium test is modified accordingly.
Please let me know if you have any comment for this PR.

Regards
Zoran