### PR TITLE
Master - bug - AdminSession and logging ref() in concat

### DIFF
--- a/Kernel/Modules/AdminSession.pm
+++ b/Kernel/Modules/AdminSession.pm
@@ -97,6 +97,9 @@ sub Run {
                 if ( $Key =~ /Password|Pw/ ) {
                     $Data{$Key} = 'xxxxxxxx';
                 }
+                elsif ( $Key eq 'Config' || $Key eq 'CompanyConfig' ) {
+                    $Data{$Key} = 'HASH of data';
+                }
                 else {
                     $Data{$Key} = $LayoutObject->Ascii2Html( Text => $Data{$Key} );
                 }
@@ -111,9 +114,6 @@ sub Run {
                         SystemTime => $Data{UserSessionStart},
                     );
                     $Data{$Key} = "$TimeStamp / $Age h ";
-                }
-                if ( $Key eq 'Config' || $Key eq 'CompanyConfig' ) {
-                    $Data{$Key} = 'HASH of data';
                 }
                 if ( $Data{$Key} eq ';' ) {
                     $Data{$Key} = '';

--- a/Kernel/Output/HTML/Layout.pm
+++ b/Kernel/Output/HTML/Layout.pm
@@ -1722,7 +1722,7 @@ sub Ascii2Html {
     else {
         $Kernel::OM->Get('Kernel::System::Log')->Log(
             Priority => 'error',
-            Message  => 'Invalid ref "' . ref $Param{Text} . '" of Text param!',
+            Message  => 'Invalid ref "' . ref( $Param{Text} ) . '" of Text param!',
         );
         return '';
     }
@@ -5565,7 +5565,7 @@ sub SetRichTextParameters {
     if ( ref $Param{Data} ne 'HASH' ) {
         $Kernel::OM->Get('Kernel::System::Log')->Log(
             Priority => 'error',
-            Message  => "Need HashRef in Param Data! Got: '" . ref $Param{Data} . "'!",
+            Message  => "Need HashRef in Param Data! Got: '" . ref( $Param{Data} ) . "'!",
         );
         $Self->FatalError();
     }
@@ -5711,7 +5711,7 @@ sub CustomerSetRichTextParameters {
     if ( ref $Param{Data} ne 'HASH' ) {
         $Kernel::OM->Get('Kernel::System::Log')->Log(
             Priority => 'error',
-            Message  => "Need HashRef in Param Data! Got: '" . ref $Param{Data} . "'!",
+            Message  => "Need HashRef in Param Data! Got: '" . ref( $Param{Data} ) . "'!",
         );
         $Self->FatalError();
     }

--- a/Kernel/Output/HTML/Layout/Template.pm
+++ b/Kernel/Output/HTML/Layout/Template.pm
@@ -72,7 +72,7 @@ sub Output {
     if ( ref $Param{Data} ne 'HASH' ) {
         $Kernel::OM->Get('Kernel::System::Log')->Log(
             Priority => 'error',
-            Message  => "Need HashRef in Param Data! Got: '" . ref $Param{Data} . "'!",
+            Message  => "Need HashRef in Param Data! Got: '" . ref( $Param{Data} ) . "'!",
         );
         $Self->FatalError();
     }


### PR DESCRIPTION
Hello @mgruner ,

While working on breadcrumb task for AdminSession found two small bugs. 

Firstly, when you enter to see session for customer, you get this logging error:

![screen shot 2016-09-07 at 11 23 37 am](https://cloud.githubusercontent.com/assets/6348760/18309713/0cbfaa2c-74fb-11e6-8de4-92f13633d402.png)

Tracing steps back found problem on line 101 in AdminSession.pm :

`$Data{$Key} = $LayoutObject->Ascii2Html( Text => $Data{$Key} );`

Specifically only for Config and CompanyConfig keys. These values are hashes and Ascii2Html() function is set to return empty string in such case. Now this had no influence on the remaining of module functionality when on line 115 :

`if ( $Key eq 'Config' || $Key eq 'CompanyConfig' ) {
                    $Data{$Key} = 'HASH of data';
                }`

Data of those keys is set to be 'HASH of data' and this is result we see in detail view of session. Moving this in "elsif" statement prevents Ascii2Html() to handle those keys.

Secondly as you can see from Fred log, log message is not complete. This was caused by ref() in concatenation with other string :

`'Invalid ref "' . ref $Param{Text} . '" of Text param!'`

I searched a bit for the explanation and cause of this issue to no avail. My best guess would be that ref() function is not stopping on ' . ' concat and is taking the rest of the string as param. When expression is placed inside braces problem is solved and log shows whole message.

Please enlighten me regarding second point and let me know if you have any questions.

Regards,
Sanjin  
