### PR TITLE
Errors on entering AdminCustomerUser with RunInitialWildcardSearch disabled

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,4 +1,5 @@
 #6.0.0.beta1 2016-??-??
+ - 2016-09-07 Fixed errors on entering AdminCustomerUser with RunInitialWildcardSearch disabled.
  - 2016-08-25 Added possibility to send encrypted emails to multiple recipients.
  - 2016-06-07 Added index for searching dynamic field text values.
  - 2016-08-18 Added per-address email loop protection setting (PostmasterMaxEmailsPerAddress), thanks to Moritz Lenz.

--- a/Kernel/Modules/AdminCustomerCompany.pm
+++ b/Kernel/Modules/AdminCustomerCompany.pm
@@ -718,41 +718,42 @@ sub _Overview {
         );
     }
 
-    # get config object
-    my $ConfigObject = $Kernel::OM->Get('Kernel::Config');
-
-    # same Limit as $Self->{CustomerCompanyMap}->{'CustomerCompanySearchListLimit'}
-    # smallest Limit from all sources
-    my $Limit = 400;
-    SOURCE:
-    for my $Count ( '', 1 .. 10 ) {
-        next SOURCE if !$ConfigObject->Get("CustomerCompany$Count");
-        my $CustomerUserMap = $ConfigObject->Get("CustomerCompany$Count");
-        next SOURCE if !$CustomerUserMap->{CustomerCompanySearchListLimit};
-        if ( $CustomerUserMap->{CustomerCompanySearchListLimit} < $Limit ) {
-            $Limit = $CustomerUserMap->{CustomerCompanySearchListLimit};
-        }
-    }
-
-    my %ListAllItems = $CustomerCompanyObject->CustomerCompanyList(
-        Search => $Param{Search},
-        Limit  => $Limit + 1,
-        Valid  => 0,
-    );
-
-    if ( keys %ListAllItems <= $Limit ) {
-        my $ListAllItems = keys %ListAllItems;
-        $LayoutObject->Block(
-            Name => 'OverviewHeader',
-            Data => {
-                ListAll => $ListAllItems,
-                Limit   => $Limit,
-            },
-        );
-    }
-
     # if there are any registries to search, the table is filled and shown
     if ( $Param{Search} ) {
+
+        # get config object
+        my $ConfigObject = $Kernel::OM->Get('Kernel::Config');
+
+        # same Limit as $Self->{CustomerCompanyMap}->{'CustomerCompanySearchListLimit'}
+        # smallest Limit from all sources
+        my $Limit = 400;
+        SOURCE:
+        for my $Count ( '', 1 .. 10 ) {
+            next SOURCE if !$ConfigObject->Get("CustomerCompany$Count");
+            my $CustomerUserMap = $ConfigObject->Get("CustomerCompany$Count");
+            next SOURCE if !$CustomerUserMap->{CustomerCompanySearchListLimit};
+            if ( $CustomerUserMap->{CustomerCompanySearchListLimit} < $Limit ) {
+                $Limit = $CustomerUserMap->{CustomerCompanySearchListLimit};
+            }
+        }
+
+        my %ListAllItems = $CustomerCompanyObject->CustomerCompanyList(
+            Search => $Param{Search},
+            Limit  => $Limit + 1,
+            Valid  => 0,
+        );
+
+        if ( keys %ListAllItems <= $Limit ) {
+            my $ListAllItems = keys %ListAllItems;
+            $LayoutObject->Block(
+                Name => 'OverviewHeader',
+                Data => {
+                    ListAll => $ListAllItems,
+                    Limit   => $Limit,
+                },
+            );
+        }
+
         my %List = $CustomerCompanyObject->CustomerCompanyList(
             Search => $Param{Search},
             Valid  => 0,

--- a/Kernel/Modules/AdminCustomerUser.pm
+++ b/Kernel/Modules/AdminCustomerUser.pm
@@ -830,43 +830,43 @@ sub _Overview {
         );
     }
 
-    # get config object
-    my $ConfigObject = $Kernel::OM->Get('Kernel::Config');
-
-    # same Limit as $Self->{CustomerUserMap}->{CustomerUserSearchListLimit}
-    # smallest Limit from all sources
-    my $Limit = 400;
-    SOURCE:
-    for my $Count ( '', 1 .. 10 ) {
-        next SOURCE if !$ConfigObject->Get("CustomerUser$Count");
-        my $CustomerUserMap = $ConfigObject->Get("CustomerUser$Count");
-        next SOURCE if !$CustomerUserMap->{CustomerUserSearchListLimit};
-        if ( $CustomerUserMap->{CustomerUserSearchListLimit} < $Limit ) {
-            $Limit = $CustomerUserMap->{CustomerUserSearchListLimit};
-        }
-    }
-
-    my %ListAllItems = $CustomerUserObject->CustomerSearch(
-        Search => $Param{Search},
-        Limit  => $Limit + 1,
-        Valid  => 0,
-    );
-
-    if ( keys %ListAllItems <= $Limit ) {
-        my $ListAllItems = keys %ListAllItems;
-        $LayoutObject->Block(
-            Name => 'OverviewHeader',
-            Data => {
-                ListAll => $ListAllItems,
-                Limit   => $Limit,
-            },
-        );
-    }
-
-    # when there is no data to show, a message is displayed on the table with this colspan
-    my $ColSpan = 6;
-
     if ( $Param{Search} ) {
+
+        # get config object
+        my $ConfigObject = $Kernel::OM->Get('Kernel::Config');
+
+        # when there is no data to show, a message is displayed on the table with this colspan
+        my $ColSpan = 6;
+
+        # same Limit as $Self->{CustomerUserMap}->{CustomerUserSearchListLimit}
+        # smallest Limit from all sources
+        my $Limit = 400;
+        SOURCE:
+        for my $Count ( '', 1 .. 10 ) {
+            next SOURCE if !$ConfigObject->Get("CustomerUser$Count");
+            my $CustomerUserMap = $ConfigObject->Get("CustomerUser$Count");
+            next SOURCE if !$CustomerUserMap->{CustomerUserSearchListLimit};
+            if ( $CustomerUserMap->{CustomerUserSearchListLimit} < $Limit ) {
+                $Limit = $CustomerUserMap->{CustomerUserSearchListLimit};
+            }
+        }
+
+        my %ListAllItems = $CustomerUserObject->CustomerSearch(
+            Search => $Param{Search},
+            Limit  => $Limit + 1,
+            Valid  => 0,
+        );
+
+        if ( keys %ListAllItems <= $Limit ) {
+            my $ListAllItems = keys %ListAllItems;
+            $LayoutObject->Block(
+                Name => 'OverviewHeader',
+                Data => {
+                    ListAll => $ListAllItems,
+                    Limit   => $Limit,
+                },
+            );
+        }
 
         my %List = $CustomerUserObject->CustomerSearch(
             Search => $Param{Search},


### PR DESCRIPTION
When AdminCustomerUser::RunInitialWildcardSearch is disabled (i.e. for
performance reasons) and agent opens AdminCustomerUser (which opens with
empty list) errors like

    Message: Need Search, UserLogin, PostMasterSearch, CustomerIDRaw or CustomerID!

occur in apache error.log (for DB and similar one for LDAP backend if present).

This mod resolves issue as above.

Related: https://dev.ib.pl/ib/otrs/issues/88
Author-Change-Id: IB#1055644