### PR TITLE
Master frontend usability - AgentStatistics

### DIFF
--- a/Kernel/Modules/AgentStatistics.pm
+++ b/Kernel/Modules/AgentStatistics.pm
@@ -56,9 +56,7 @@ sub Run {
     @{ $Self->{BreadcrumbPath} } = (
         {
             Name =>
-                $LayoutObject->{LanguageObject}->Translate('Statistics') .
-                ' -- ' .
-                $LayoutObject->{LanguageObject}->Translate('Overview'),
+                $LayoutObject->{LanguageObject}->Translate('Statistics Overview'),
             Link => 'AgentStatistics;Subaction=Overview',
         }
     );

--- a/Kernel/Modules/AgentStatistics.pm
+++ b/Kernel/Modules/AgentStatistics.pm
@@ -191,13 +191,13 @@ sub OverviewScreen {
     $Output .= $LayoutObject->NavigationBar();
 
     if ( $Notification && $Notification eq 'Add' ) {
-        $Output .= $LayoutObject->Notify( Info => Translatable('Statistics is added sucessfully!') );
+        $Output .= $LayoutObject->Notify( Info => Translatable('Statistics added sucessfully!') );
     }
     elsif ( $Notification && $Notification eq 'Update' ) {
-        $Output .= $LayoutObject->Notify( Info => Translatable('Statistics is updated sucessfully!') );
+        $Output .= $LayoutObject->Notify( Info => Translatable('Statistics updated sucessfully!') );
     }
     elsif ( $Notification && $Notification eq 'Delete' ) {
-        $Output .= $LayoutObject->Notify( Info => Translatable('Statistics is deleted sucessfully!') );
+        $Output .= $LayoutObject->Notify( Info => Translatable('Statistics deleted sucessfully!') );
     }
 
     $Output .= $LayoutObject->Output(
@@ -378,13 +378,13 @@ sub EditScreen {
     $Output .= $LayoutObject->NavigationBar();
 
     if ( $Notification && $Notification eq 'Add' ) {
-        $Output .= $LayoutObject->Notify( Info => Translatable('Statistics is added sucessfully!') );
+        $Output .= $LayoutObject->Notify( Info => Translatable('Statistics added sucessfully!') );
     }
     elsif ( $Notification && $Notification eq 'Update' ) {
-        $Output .= $LayoutObject->Notify( Info => Translatable('Statistics is updated sucessfully!') );
+        $Output .= $LayoutObject->Notify( Info => Translatable('Statistics updated sucessfully!') );
     }
     elsif ( $Notification && $Notification eq 'Import' ) {
-        $Output .= $LayoutObject->Notify( Info => Translatable('Statistics is imported sucessfully!') );
+        $Output .= $LayoutObject->Notify( Info => Translatable('Statistics imported sucessfully!') );
     }
 
     $Output .= $LayoutObject->Output(
@@ -771,7 +771,7 @@ sub ViewScreen {
     $Output .= $LayoutObject->NavigationBar();
 
     if ( $Notification && $Notification eq 'Add' ) {
-        $Output .= $LayoutObject->Notify( Info => Translatable('Statistics is added sucessfully!') );
+        $Output .= $LayoutObject->Notify( Info => Translatable('Statistics added sucessfully!') );
     }
 
     $Output .= $LayoutObject->Output(

--- a/Kernel/Modules/AgentStatistics.pm
+++ b/Kernel/Modules/AgentStatistics.pm
@@ -52,6 +52,17 @@ sub Run {
 
     my $LayoutObject = $Kernel::OM->Get('Kernel::Output::HTML::Layout');
 
+    # set breadcrumbpath for overview screen and it will be used as base for other screens
+    @{ $Self->{BreadcrumbPath} } = (
+        {
+            Name =>
+                $LayoutObject->{LanguageObject}->Translate('Statistics') .
+                ' -- ' .
+                $LayoutObject->{LanguageObject}->Translate('Overview'),
+            Link => 'AgentStatistics;Subaction=Overview',
+        }
+    );
+
     my $Subaction = $Self->{Subaction};
 
     my %RoSubactions = (
@@ -197,7 +208,8 @@ sub OverviewScreen {
         Data => {
             %Pagination,
             %Param,
-            AccessRw => $Self->{AccessRw},
+            AccessRw       => $Self->{AccessRw},
+            BreadcrumbPath => $Self->{BreadcrumbPath},
         },
         TemplateFile => 'AgentStatisticsOverview',
     );
@@ -218,6 +230,7 @@ sub ImportScreen {
         TemplateFile => 'AgentStatisticsImport',
         Data         => {
             %Errors,
+            BreadcrumbPath => $Self->{BreadcrumbPath},
         },
     );
     $Output .= $LayoutObject->Footer();
@@ -370,6 +383,7 @@ sub EditScreen {
         Data         => {
             %Frontend,
             %{$Stat},
+            BreadcrumbPath => $Self->{BreadcrumbPath},
         },
     );
     $Output .= $LayoutObject->Footer();
@@ -685,10 +699,7 @@ sub EditAction {
         return $LayoutObject->Redirect( OP => $Self->{LastStatsOverview} );
     }
 
-    return $Self->EditScreen(
-        Errors   => \%Errors,
-        GetParam => \%Data,
-    );
+    return $LayoutObject->Redirect( OP => "Action=AgentStatistics;Subaction=Edit;StatID=$Stat->{StatID}" );
 }
 
 sub ViewScreen {
@@ -752,6 +763,7 @@ sub ViewScreen {
             Errors   => \@Errors,
             %Frontend,
             %{$Stat},
+            BreadcrumbPath => $Self->{BreadcrumbPath},
         },
     );
     $Output .= $LayoutObject->Footer();
@@ -816,6 +828,7 @@ sub AddScreen {
         Data         => {
             %Frontend,
             %Errors,
+            BreadcrumbPath => $Self->{BreadcrumbPath},
         },
     );
     $Output .= $LayoutObject->Footer();

--- a/Kernel/Output/HTML/Templates/Standard/AgentStatisticsAdd.tt
+++ b/Kernel/Output/HTML/Templates/Standard/AgentStatisticsAdd.tt
@@ -9,6 +9,10 @@
 <div class="MainBox AriaRoleMain LayoutFixedSidebar SidebarFirst">
     <h1>[% Translate("Statistics » Add") | html %]</h1>
 
+    [% Data.BreadcrumbPath.push({ Name => Translate("Add New Statistic") }) %]
+    [% INCLUDE "Breadcrumb.tt" Path = Data.BreadcrumbPath %]
+
+    <div class="Clear"></div>
     <div class="SidebarColumn">
         <div class="WidgetSimple">
             <div class="Header">

--- a/Kernel/Output/HTML/Templates/Standard/AgentStatisticsAdd.tt
+++ b/Kernel/Output/HTML/Templates/Standard/AgentStatisticsAdd.tt
@@ -21,7 +21,7 @@
             <div class="Content">
                 <ul class="ActionList">
                     <li>
-                        <a href="[% Env("Baselink") %][% Env("LastStatsOverview") %]" class="CallForAction Fullsize Center"><span><i class="fa fa-caret-left"></i>[% Translate("Go to overview") | html %]</span></a>
+                        <a href="[% Env("Baselink") %]Action=[% Env("Action") %];Subaction=Overview" class="CallForAction Fullsize Center"><span><i class="fa fa-caret-left"></i>[% Translate("Go to overview") | html %]</span></a>
                     </li>
                 </ul>
             </div>
@@ -78,7 +78,7 @@
                                 <span>[% Translate("Save") | html %]</span>
                             </button>
                             [% Translate('or') | html %]
-                            <a href="[% Env("Baselink") %][% Env('LastStatsOverview') %]">
+                            <a href="[% Env("Baselink") %]Action=[% Env("Action") %];Subaction=Overview">
                                 [% Translate('Cancel') | html %]
                             </a>
                         </div>

--- a/Kernel/Output/HTML/Templates/Standard/AgentStatisticsAdd.tt
+++ b/Kernel/Output/HTML/Templates/Standard/AgentStatisticsAdd.tt
@@ -7,9 +7,9 @@
 # --
 
 <div class="MainBox AriaRoleMain LayoutFixedSidebar SidebarFirst">
-    <h1>[% Translate("Statistics » Add") | html %]</h1>
+    <h1>[% Translate("Statistics Overview") | html %]</h1>
 
-    [% Data.BreadcrumbPath.push({ Name => Translate("Add New Statistic") }) %]
+    [% Data.BreadcrumbPath.push({ Name => Translate("Add Statistics") }) %]
     [% INCLUDE "Breadcrumb.tt" Path = Data.BreadcrumbPath %]
 
     <div class="Clear"></div>
@@ -35,7 +35,7 @@
 
             <div class="WidgetSimple">
                 <div class="Header">
-                    <h2>[% Translate("Add New Statistic") | html %]</h2>
+                    <h2>[% Translate("Add Statistics") | html %]</h2>
                 </div>
                 <div class="Content BigButtonsContainer">
                     <div class="BigButtons">

--- a/Kernel/Output/HTML/Templates/Standard/AgentStatisticsEdit.tt
+++ b/Kernel/Output/HTML/Templates/Standard/AgentStatisticsEdit.tt
@@ -22,7 +22,7 @@
             <div class="Content">
                 <ul class="ActionList">
                     <li>
-                        <a href="[% Env("Baselink") %][% Env('LastStatsOverview') %]" class="CallForAction Fullsize Center"><span><i class="fa fa-caret-left"></i>[% Translate("Go to overview") | html %]</span></a>
+                        <a href="[% Env("Baselink") %]Action=[% Env("Action") %];Subaction=Overview" class="CallForAction Fullsize Center"><span><i class="fa fa-caret-left"></i>[% Translate("Go to overview") | html %]</span></a>
                     </li>
                     [% IF Data.Valid %]
                     <li>
@@ -83,7 +83,7 @@
                                 <span>[% Translate("Save and finish") | html %]</span>
                             </button>
                             [% Translate('or') | html %]
-                            <a href="[% Env("Baselink") %][% Env('LastStatsOverview') %]">
+                            <a href="[% Env("Baselink") %]Action=[% Env("Action") %];Subaction=Overview">
                                 [% Translate('Cancel') | html %]
                             </a>
                         </div>

--- a/Kernel/Output/HTML/Templates/Standard/AgentStatisticsEdit.tt
+++ b/Kernel/Output/HTML/Templates/Standard/AgentStatisticsEdit.tt
@@ -8,11 +8,9 @@
 
 
 <div class="MainBox AriaRoleMain LayoutFixedSidebar SidebarFirst">
-    <h1>[% Translate("Statistics » Edit %s%s — %s", Config('Stats::StatsHook'), Data.StatNumber, Data.Title) | html %]</h1>
+    <h1>[% Translate("Statistics Overview") | html %]</h1>
 
-    [% USE EditTitle = String(Translate("Edit")) %]
-    [% Data.BreadcrumbPath.push({ Name => EditTitle.append( ' ', Config('Stats::StatsHook'), Data.StatNumber, ' - ', Data.Title ) }) %]
-
+    [% Data.BreadcrumbPath.push({ Name => Translate("Edit %s%s - %s", Config('Stats::StatsHook'), Data.StatNumber, Data.Title) }) %]
     [% INCLUDE "Breadcrumb.tt" Path = Data.BreadcrumbPath %]
 
     <div class="Clear"></div>

--- a/Kernel/Output/HTML/Templates/Standard/AgentStatisticsEdit.tt
+++ b/Kernel/Output/HTML/Templates/Standard/AgentStatisticsEdit.tt
@@ -10,6 +10,12 @@
 <div class="MainBox AriaRoleMain LayoutFixedSidebar SidebarFirst">
     <h1>[% Translate("Statistics » Edit %s%s — %s", Config('Stats::StatsHook'), Data.StatNumber, Data.Title) | html %]</h1>
 
+    [% USE EditTitle = String(Translate("Edit")) %]
+    [% Data.BreadcrumbPath.push({ Name => EditTitle.append( ' ', Config('Stats::StatsHook'), Data.StatNumber, ' - ', Data.Title ) }) %]
+
+    [% INCLUDE "Breadcrumb.tt" Path = Data.BreadcrumbPath %]
+
+    <div class="Clear"></div>
     <div class="SidebarColumn">
         <div class="WidgetSimple">
             <div class="Header">

--- a/Kernel/Output/HTML/Templates/Standard/AgentStatisticsImport.tt
+++ b/Kernel/Output/HTML/Templates/Standard/AgentStatisticsImport.tt
@@ -10,6 +10,10 @@
 <div class="MainBox AriaRoleMain LayoutFixedSidebar SidebarFirst">
     <h1>[% Translate("Statistics » Import") | html %]</h1>
 
+    [% Data.BreadcrumbPath.push({ Name => Translate("Import Statistic Configuration") }) %]
+    [% INCLUDE "Breadcrumb.tt" Path = Data.BreadcrumbPath %]
+
+    <div class="Clear"></div>
     <div class="SidebarColumn">
         <div class="WidgetSimple">
             <div class="Header">

--- a/Kernel/Output/HTML/Templates/Standard/AgentStatisticsImport.tt
+++ b/Kernel/Output/HTML/Templates/Standard/AgentStatisticsImport.tt
@@ -22,7 +22,7 @@
             <div class="Content">
                 <ul class="ActionList">
                     <li>
-                        <a href="[% Env("Baselink") %][% Env('LastStatsOverview') %]" class="CallForAction Fullsize Center"><span><i class="fa fa-caret-left"></i>[% Translate("Go to overview") | html %]</span></a>
+                        <a href="[% Env("Baselink") %]Action=[% Env("Action") %];Subaction=Overview" class="CallForAction Fullsize Center"><span><i class="fa fa-caret-left"></i>[% Translate("Go to overview") | html %]</span></a>
                     </li>
                 </ul>
             </div>
@@ -49,7 +49,7 @@
                         <div class="Field SpacingTop">
                             <button class="Primary CallForAction" accesskey="g" title="[% Translate("Import") | html %] (g)" type="submit" value="[% Translate("Import") | html %]"><span>[% Translate("Import") | html %]</span></button>
                             [% Translate("or") | html %]
-                            <a href="[% Env("Baselink") %][% Env('LastStatsOverview') %]">[% Translate("Cancel") | html %]</a>
+                            <a href="[% Env("Baselink") %]Action=[% Env("Action") %];Subaction=Overview">[% Translate("Cancel") | html %]</a>
                         </div>
                     </fieldset>
 

--- a/Kernel/Output/HTML/Templates/Standard/AgentStatisticsImport.tt
+++ b/Kernel/Output/HTML/Templates/Standard/AgentStatisticsImport.tt
@@ -8,9 +8,9 @@
 
 
 <div class="MainBox AriaRoleMain LayoutFixedSidebar SidebarFirst">
-    <h1>[% Translate("Statistics » Import") | html %]</h1>
+    <h1>[% Translate("Statistics Overview") | html %]</h1>
 
-    [% Data.BreadcrumbPath.push({ Name => Translate("Import Statistic Configuration") }) %]
+    [% Data.BreadcrumbPath.push({ Name => Translate("Import Statistics Configuration") }) %]
     [% INCLUDE "Breadcrumb.tt" Path = Data.BreadcrumbPath %]
 
     <div class="Clear"></div>
@@ -32,7 +32,7 @@
     <div class="ContentColumn">
         <div class="WidgetSimple">
             <div class="Header">
-                <h2>[% Translate("Import Statistic Configuration") | html %]</h2>
+                <h2>[% Translate("Import Statistics Configuration") | html %]</h2>
             </div>
             <div class="Content">
 

--- a/Kernel/Output/HTML/Templates/Standard/AgentStatisticsOverview.tt
+++ b/Kernel/Output/HTML/Templates/Standard/AgentStatisticsOverview.tt
@@ -9,6 +9,9 @@
 <div class="MainBox AriaRoleMain LayoutFixedSidebar SidebarFirst">
     <h1>[% Translate("Statistics » Overview") | html %]</h1>
 
+    [% INCLUDE "Breadcrumb.tt" Path = Data.BreadcrumbPath %]
+
+    <div class="Clear"></div>
     <div class="SidebarColumn">
         <div class="WidgetSimple">
             <div class="Header">

--- a/Kernel/Output/HTML/Templates/Standard/AgentStatisticsOverview.tt
+++ b/Kernel/Output/HTML/Templates/Standard/AgentStatisticsOverview.tt
@@ -7,7 +7,7 @@
 # --
 
 <div class="MainBox AriaRoleMain LayoutFixedSidebar SidebarFirst">
-    <h1>[% Translate("Statistics » Overview") | html %]</h1>
+    <h1>[% Translate("Statistics Overview") | html %]</h1>
 
     [% INCLUDE "Breadcrumb.tt" Path = Data.BreadcrumbPath %]
 

--- a/Kernel/Output/HTML/Templates/Standard/AgentStatisticsView.tt
+++ b/Kernel/Output/HTML/Templates/Standard/AgentStatisticsView.tt
@@ -23,7 +23,7 @@
             <div class="Content">
                 <ul class="ActionList">
                     <li>
-                        <a href="[% Env("Baselink") %][% Env('LastStatsOverview') %]" class="CallForAction Fullsize Center"><span><i class="fa fa-caret-left"></i>[% Translate("Go to overview") | html %]</span></a>
+                        <a href="[% Env("Baselink") %]Action=[% Env("Action") %];Subaction=Overview" class="CallForAction Fullsize Center"><span><i class="fa fa-caret-left"></i>[% Translate("Go to overview") | html %]</span></a>
                     </li>
                     [% IF Data.AccessRw %]
                         <li>
@@ -105,7 +105,7 @@
                                     <span><i class="fa fa-caret-square-o-right"></i> [% Translate("Run now") | html %]</span>
                                 </button>
                                 or
-                                <a href="[% Env("Baselink") %][% Env('LastStatsOverview') %]">Cancel</a>
+                                <a href="[% Env("Baselink") %]Action=[% Env("Action") %];Subaction=Overview">Cancel</a>
                             </div>
                         </fieldset>
 

--- a/Kernel/Output/HTML/Templates/Standard/AgentStatisticsView.tt
+++ b/Kernel/Output/HTML/Templates/Standard/AgentStatisticsView.tt
@@ -11,6 +11,12 @@
 <div class="MainBox AriaRoleMain LayoutFixedSidebar SidebarFirst">
     <h1>[% Translate("Statistics » View %s%s — %s", Config('Stats::StatsHook'), Data.StatNumber, Data.Title) | html %]</h1>
 
+    [% USE EditTitle = String(Translate("View")) %]
+    [% Data.BreadcrumbPath.push({ Name => (EditTitle.append( ' ', Config('Stats::StatsHook'), Data.StatNumber, ' - ', Data.Title )) }) %]
+
+    [% INCLUDE "Breadcrumb.tt" Path = Data.BreadcrumbPath %]
+
+    <div class="Clear"></div>
     <div class="SidebarColumn">
         <div class="WidgetSimple">
             <div class="Header">

--- a/Kernel/Output/HTML/Templates/Standard/AgentStatisticsView.tt
+++ b/Kernel/Output/HTML/Templates/Standard/AgentStatisticsView.tt
@@ -9,11 +9,9 @@
 ## nofilter(TidyAll::Plugin::OTRS::TT::Format)
 
 <div class="MainBox AriaRoleMain LayoutFixedSidebar SidebarFirst">
-    <h1>[% Translate("Statistics » View %s%s — %s", Config('Stats::StatsHook'), Data.StatNumber, Data.Title) | html %]</h1>
+    <h1>[% Translate("Statistics Overview") | html %]</h1>
 
-    [% USE EditTitle = String(Translate("View")) %]
-    [% Data.BreadcrumbPath.push({ Name => (EditTitle.append( ' ', Config('Stats::StatsHook'), Data.StatNumber, ' - ', Data.Title )) }) %]
-
+    [% Data.BreadcrumbPath.push({ Name => Translate("View %s%s - %s", Config('Stats::StatsHook'), Data.StatNumber, Data.Title) }) %]
     [% INCLUDE "Breadcrumb.tt" Path = Data.BreadcrumbPath %]
 
     <div class="Clear"></div>
@@ -38,7 +36,7 @@
 
         <div class="WidgetSimple">
             <div class="Header">
-                <h2>[% Translate("Statistic Information") | html %]</h2>
+                <h2>[% Translate("Statistics Information") | html %]</h2>
             </div>
             <div class="Content">
                 <fieldset class="TableLike FixedLabelSmall">

--- a/scripts/test/Selenium/Agent/AgentStatistics/Add.t
+++ b/scripts/test/Selenium/Agent/AgentStatistics/Add.t
@@ -259,6 +259,13 @@ $Selenium->RunTest(
             );
             $Selenium->find_element("//button[\@value='Save'][\@type='submit']")->VerifiedClick();
 
+            # check if notification exists after adding
+            my $Notification = 'Statistics added sucessfully!';
+            $Self->True(
+                $Selenium->execute_script("return \$('.MessageBox.Notice p:contains($Notification)').length"),
+                "$Notification - notification is found."
+            );
+
             # check X-axis configuration dialog
             $Selenium->find_element( ".EditXAxis", 'css' )->VerifiedClick();
             if ( $StatsData->{Object} ne 'Kernel::System::Stats::Dynamic::TicketList' ) {
@@ -332,6 +339,13 @@ $Selenium->RunTest(
             # save and finish test statistics
             $Selenium->find_element("//button[\@name='SaveAndFinish'][\@type='submit']")->VerifiedClick();
 
+            # check if notification exists after updating
+            $Notification = 'Statistics updated sucessfully!';
+            $Self->True(
+                $Selenium->execute_script("return \$('.MessageBox.Notice p:contains($Notification)').length"),
+                "$Notification - notification is found."
+            );
+
             my $CheckConfirmJS = <<"JAVASCRIPT";
 (function () {
     window.confirm = function (message) {
@@ -374,6 +388,13 @@ JAVASCRIPT
                 index( $Selenium->get_page_source(), "Action=AgentStatistics;Subaction=Edit;StatID=$StatsIDLast" )
                     == -1,
                 "StatsData statistic is deleted - $StatsData->{Title} "
+            );
+
+            # check if notification exists after deletting
+            $Notification = 'Statistics deleted sucessfully!';
+            $Self->True(
+                $Selenium->execute_script("return \$('.MessageBox.Notice p:contains($Notification)').length"),
+                "$Notification - notification is found."
             );
 
         }

--- a/scripts/test/Selenium/Agent/AgentStatistics/Add.t
+++ b/scripts/test/Selenium/Agent/AgentStatistics/Add.t
@@ -111,6 +111,38 @@ $Selenium->RunTest(
         # check add statistics screen
         $Selenium->VerifiedGet("${ScriptAlias}index.pl?Action=AgentStatistics;Subaction=Add");
 
+        # check breadcrumb on Add screen
+        my $Count = 0;
+        my $IsLinkedBreadcrumbText;
+        for my $BreadcrumbText ( 'You are here:', 'Statistics Overview', 'Add Statistics' )
+        {
+            $Self->Is(
+                $Selenium->execute_script("return \$('.BreadCrumb li:eq($Count)').text().trim()"),
+                $BreadcrumbText,
+                "Breadcrumb text '$BreadcrumbText' is found on screen"
+            );
+
+            $IsLinkedBreadcrumbText =
+                $Selenium->execute_script("return \$('.BreadCrumb li:eq($Count)').children('a').length");
+
+            if ( $BreadcrumbText eq 'Statistics Overview' ) {
+                $Self->Is(
+                    $IsLinkedBreadcrumbText,
+                    1,
+                    "Breadcrumb text '$BreadcrumbText' is linked"
+                );
+            }
+            else {
+                $Self->Is(
+                    $IsLinkedBreadcrumbText,
+                    0,
+                    "Breadcrumb text '$BreadcrumbText' is not linked"
+                );
+            }
+
+            $Count++;
+        }
+
         # check link 'DynamicMatrix'
         $Self->True(
             $Selenium->find_element("//a[contains(\@data-statistic-preselection, \'DynamicMatrix\' )]"),
@@ -132,6 +164,12 @@ $Selenium->RunTest(
         # check "Go to overview" button
         $Selenium->find_element("//a[contains(\@href, \'Action=AgentStatistics;Subaction=Overview\' )]")
             ->VerifiedClick();
+
+        # check breadcrumb on Overview screen
+        $Self->True(
+            $Selenium->find_element( '.BreadCrumb', 'css' ),
+            "Breadcrumb is found on Overview screen.",
+        );
 
         my @Tests = (
             {

--- a/scripts/test/Selenium/Agent/AgentStatistics/Import.t
+++ b/scripts/test/Selenium/Agent/AgentStatistics/Import.t
@@ -125,7 +125,7 @@ $Selenium->RunTest(
         # check breadcrumb on Import screen
         my $Count = 0;
         my $IsLinkedBreadcrumbText;
-        for my $BreadcrumbText ( 'You are here:', 'Statistics Overview', 'Import Statistic Configuration' )
+        for my $BreadcrumbText ( 'You are here:', 'Statistics Overview', 'Import Statistics Configuration' )
         {
             $Self->Is(
                 $Selenium->execute_script("return \$('.BreadCrumb li:eq($Count)').text().trim()"),
@@ -160,6 +160,13 @@ $Selenium->RunTest(
         $Selenium->find_element( "#File", 'css' )->send_keys($Location);
 
         $Selenium->find_element("//button[\@value='Import'][\@type='submit']")->VerifiedClick();
+
+        # check if notification exists after importing
+        my $Notification = 'Statistics imported sucessfully!';
+        $Self->True(
+            $Selenium->execute_script("return \$('.MessageBox.Notice p:contains($Notification)').length"),
+            "$Notification - notification is found."
+        );
 
         # create params for import test stats
         my %StatsValues = (

--- a/scripts/test/Selenium/Agent/AgentStatistics/Import.t
+++ b/scripts/test/Selenium/Agent/AgentStatistics/Import.t
@@ -116,11 +116,46 @@ $Selenium->RunTest(
             push @SLAIDs, $SLAID;
         }
 
-        my $ScriptAlias = $Kernel::OM->Get('Kernel::Config')->Get('ScriptAlias');
+        # get config object
+        my $ConfigObject = $Kernel::OM->Get('Kernel::Config');
+
+        my $ScriptAlias = $ConfigObject->Get('ScriptAlias');
         $Selenium->VerifiedGet("${ScriptAlias}index.pl?Action=AgentStatistics;Subaction=Import");
 
+        # check breadcrumb on Import screen
+        my $Count = 0;
+        my $IsLinkedBreadcrumbText;
+        for my $BreadcrumbText ( 'You are here:', 'Statistics Overview', 'Import Statistic Configuration' )
+        {
+            $Self->Is(
+                $Selenium->execute_script("return \$('.BreadCrumb li:eq($Count)').text().trim()"),
+                $BreadcrumbText,
+                "Breadcrumb text '$BreadcrumbText' is found on screen"
+            );
+
+            $IsLinkedBreadcrumbText =
+                $Selenium->execute_script("return \$('.BreadCrumb li:eq($Count)').children('a').length");
+
+            if ( $BreadcrumbText eq 'Statistics Overview' ) {
+                $Self->Is(
+                    $IsLinkedBreadcrumbText,
+                    1,
+                    "Breadcrumb text '$BreadcrumbText' is linked"
+                );
+            }
+            else {
+                $Self->Is(
+                    $IsLinkedBreadcrumbText,
+                    0,
+                    "Breadcrumb text '$BreadcrumbText' is not linked"
+                );
+            }
+
+            $Count++;
+        }
+
         # import test selenium statistic
-        my $Location = $Kernel::OM->Get('Kernel::Config')->Get('Home')
+        my $Location = $ConfigObject->Get('Home')
             . "/scripts/test/sample/Stats/Stats.TicketOverview.de.xml";
         $Selenium->find_element( "#File", 'css' )->send_keys($Location);
 
@@ -155,7 +190,7 @@ $Selenium->RunTest(
             UserID   => 1,
         );
 
-        my $Count       = scalar @{$StatsIDs};
+        $Count = scalar @{$StatsIDs};
         my $StatsIDLast = $StatsIDs->[ $Count - 1 ];
 
         # check for imported stats on overview screen

--- a/scripts/test/Selenium/Agent/AgentStatistics/Run.t
+++ b/scripts/test/Selenium/Agent/AgentStatistics/Run.t
@@ -18,8 +18,9 @@ my $Selenium = $Kernel::OM->Get('Kernel::System::UnitTest::Selenium');
 $Selenium->RunTest(
     sub {
 
-        # get helper object
-        my $Helper = $Kernel::OM->Get('Kernel::System::UnitTest::Helper');
+        # get needed objects
+        my $Helper       = $Kernel::OM->Get('Kernel::System::UnitTest::Helper');
+        my $ConfigObject = $Kernel::OM->Get('Kernel::Config');
 
         # show more stats per page as the default 50
         my $Success = $Helper->ConfigSettingChange(
@@ -39,7 +40,7 @@ $Selenium->RunTest(
             Password => $TestUserLogin,
         );
 
-        my $ScriptAlias = $Kernel::OM->Get('Kernel::Config')->Get('ScriptAlias');
+        my $ScriptAlias = $ConfigObject->Get('ScriptAlias');
         $Selenium->VerifiedGet("${ScriptAlias}index.pl?Action=AgentStatistics;Subaction=Import");
 
         # get test user ID
@@ -48,7 +49,7 @@ $Selenium->RunTest(
         );
 
         # import test selenium statistic
-        my $Location = $Kernel::OM->Get('Kernel::Config')->Get('Home')
+        my $Location = $ConfigObject->Get('Home')
             . "/scripts/test/sample/Stats/Stats.TicketOverview.de.xml";
         $Selenium->find_element( "#File", 'css' )->send_keys($Location);
         $Selenium->find_element("//button[\@value='Import'][\@type='submit']")->VerifiedClick();
@@ -94,6 +95,48 @@ $Selenium->RunTest(
         # go to imported stat to run it
         $Selenium->find_element("//a[contains(\@href, \'Action=AgentStatistics;Subaction=View;StatID=$StatsIDLast\' )]")
             ->VerifiedClick();
+
+        # get stat data
+        my $StatData = $Kernel::OM->Get('Kernel::System::Stats')->StatsGet(
+            StatID => $StatsIDLast,
+            UserID => 1,
+        );
+
+        # check breadcrumb on View screen
+        $Count = 0;
+        my $IsLinkedBreadcrumbText;
+        for my $BreadcrumbText (
+            'You are here:',
+            'Statistics Overview',
+            'View ' . $ConfigObject->Get('Stats::StatsHook') . $StatData->{StatNumber} . ' - ' . $StatsValues{Title}
+            )
+        {
+            $Self->Is(
+                $Selenium->execute_script("return \$('.BreadCrumb li:eq($Count)').text().trim()"),
+                $BreadcrumbText,
+                "Breadcrumb text '$BreadcrumbText' is found on screen"
+            );
+
+            $IsLinkedBreadcrumbText =
+                $Selenium->execute_script("return \$('.BreadCrumb li:eq($Count)').children('a').length");
+
+            if ( $BreadcrumbText eq 'Statistics Overview' ) {
+                $Self->Is(
+                    $IsLinkedBreadcrumbText,
+                    1,
+                    "Breadcrumb text '$BreadcrumbText' is linked"
+                );
+            }
+            else {
+                $Self->Is(
+                    $IsLinkedBreadcrumbText,
+                    0,
+                    "Breadcrumb text '$BreadcrumbText' is not linked"
+                );
+            }
+
+            $Count++;
+        }
 
         # run test statistic
         $Selenium->find_element( "#StartStatistic", 'css' )->VerifiedClick();


### PR DESCRIPTION
Hi @zottto 

Hereby are refactored all screens about AgentStatistics.
Breadcrumb for 'Overview' screen is added in controller and other breadcrumbs are appended on it in TT files. Page titles had breadcrumb pattern and they are replaced with 'Statistics Overview' text.
Selenium tests are modified accordingly. Test for Edit screen is added in Overview.t.
Some text in TT files is not correct and is changed because e.g. 'Statistic' is an adjective and 'Statistics' is a noun.
Please let me know if you have any feedback on this PR.

Regards
Zoran