### PR TITLE
Master frontend usability - AdminPerformanceLog

### DIFF
--- a/Kernel/Modules/AdminPerformanceLog.pm
+++ b/Kernel/Modules/AdminPerformanceLog.pm
@@ -81,8 +81,9 @@ sub Run {
         my $MaxRequest  = 0;
         my $Slot        = 60;
         my $MinuteSlot  = $ParamObject->GetParam( Param => 'Minute' );
-        my $Interface   = $ParamObject->GetParam( Param => 'Interface' );
-        my $Module      = $ParamObject->GetParam( Param => 'Module' );
+        $Param{Minute} = $MinuteSlot;
+        my $Interface = $ParamObject->GetParam( Param => 'Interface' );
+        my $Module    = $ParamObject->GetParam( Param => 'Module' );
         if ( $MinuteSlot < 31 ) {
             $Slot = 1;
         }

--- a/Kernel/Output/HTML/Templates/Standard/AdminPerformanceLog.tt
+++ b/Kernel/Output/HTML/Templates/Standard/AdminPerformanceLog.tt
@@ -9,6 +9,31 @@
 <div class="MainBox ARIARoleMain LayoutFixedSidebar SidebarFirst">
     <h1>[% Translate("Performance Log") | html %]</h1>
 
+    [% BreadcrumbPath = [
+            {
+                Name => Translate("Performance Log"),
+                Link => Env("Action"),
+            },
+        ]
+    %]
+
+    [% SWITCH Data.Minute %]
+        [% CASE 5 %]
+            [% BreadcrumbPath.push({ Name => Translate("Range (last 5 m)"), }) %]
+        [% CASE 30 %]
+            [% BreadcrumbPath.push({ Name => Translate("Range (last 30 m)"),}) %]
+        [% CASE 60 %]
+            [% BreadcrumbPath.push({ Name => Translate("Range (last 1 h)"),}) %]
+        [% CASE 120 %]
+            [% BreadcrumbPath.push({ Name => Translate("Range (last 2 h)"),}) %]
+        [% CASE 1440 %]
+            [% BreadcrumbPath.push({ Name => Translate("Range (last 1 d)"),}) %]
+        [% CASE 2880 %]
+            [% BreadcrumbPath.push({ Name => Translate("Range (last 2 d)"),}) %]
+    [% END %]
+
+    [% INCLUDE "Breadcrumb.tt" Path = BreadcrumbPath %]
+
     <div class="SidebarColumn">
 [% RenderBlockStart("ActionList") %]
         <div class="WidgetSimple">

--- a/scripts/test/Selenium/Agent/Admin/AdminPerformanceLog.t
+++ b/scripts/test/Selenium/Agent/Admin/AdminPerformanceLog.t
@@ -45,6 +45,21 @@ $Selenium->RunTest(
         # navigate to AdminPerformanceLog screen
         $Selenium->VerifiedGet("${ScriptAlias}index.pl?Action=AdminPerformanceLog");
 
+        # check breadcrumb on Overview screen
+        $Self->True(
+            $Selenium->find_element( '.BreadCrumb', 'css' ),
+            "Breadcrumb is found on Overview screen.",
+        );
+
+        my %RangeBreadcrumb = (
+            5    => 'Range (last 5 m)',
+            30   => 'Range (last 30 m)',
+            60   => 'Range (last 1 h)',
+            120  => 'Range (last 2 h)',
+            1440 => 'Range (last 1 d)',
+            2880 => 'Range (last 2 d)',
+        );
+
         # check for Admin on different range time screens
         for my $Time (
             qw(5 30 60 120 1440 2880)
@@ -58,6 +73,37 @@ $Selenium->RunTest(
             $Selenium->find_element( "table thead tr th", 'css' );
             $Selenium->find_element( "table tbody tr td", 'css' );
             $Selenium->find_element( "div.Progressbar",   'css' )->is_displayed();
+
+            # check breadcrumb on Add screen
+            my $Count = 0;
+            my $IsLinkedBreadcrumbText;
+            for my $BreadcrumbText ( 'You are here:', 'Performance Log', $RangeBreadcrumb{$Time} ) {
+                $Self->Is(
+                    $Selenium->execute_script("return \$('.BreadCrumb li:eq($Count)').text().trim()"),
+                    $BreadcrumbText,
+                    "Breadcrumb text '$BreadcrumbText' is found on screen"
+                );
+
+                $IsLinkedBreadcrumbText =
+                    $Selenium->execute_script("return \$('.BreadCrumb li:eq($Count)').children('a').length");
+
+                if ( $BreadcrumbText eq 'Performance Log' ) {
+                    $Self->Is(
+                        $IsLinkedBreadcrumbText,
+                        1,
+                        "Breadcrumb text '$BreadcrumbText' is linked"
+                    );
+                }
+                else {
+                    $Self->Is(
+                        $IsLinkedBreadcrumbText,
+                        0,
+                        "Breadcrumb text '$BreadcrumbText' is not linked"
+                    );
+                }
+
+                $Count++;
+            }
 
             # click on "Go to overview"
             $Selenium->find_element("//a[contains(\@href, \'Action=AdminPerformanceLog' )]")->VerifiedClick();


### PR DESCRIPTION
Hi @zottto 

Hereby is added breadcrumb for AdminPerformanceLog. The test for is module is updated as well.
We can speak if you would like change breadcrumb item name for:

-            5    => 'Range (last 5 m)',
-            30   => 'Range (last 30 m)',
-            60   => 'Range (last 1 h)',
-            120  => 'Range (last 2 h)',
-            1440 => 'Range (last 1 d)',
-            2880 => 'Range (last 2 d)',

Regards
Zoran