### PR TITLE
Optimized user and customer lists generation

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,4 +1,5 @@
 #6.0.0.beta1 2016-??-??
+ - 2016-09-13 Optimized user and customer lists generation.
  - 2016-09-12 Fixed bug#[11365](http://bugs.otrs.org/show_bug.cgi?id=11365) - ACLs editor shows actions where ACLs does not apply.
  - 2016-09-08 Made possible to define ServiceIDs and SLAIDs as default shown ticket search attributes, thanks to Paweł Bogusławski.
  - 2016-09-08 Fixed status passing and redundant TicketGet calls, thanks to Paweł Bogusławski.

--- a/Kernel/Modules/AdminCustomerCompany.pm
+++ b/Kernel/Modules/AdminCustomerCompany.pm
@@ -724,50 +724,35 @@ sub _Overview {
         # get config object
         my $ConfigObject = $Kernel::OM->Get('Kernel::Config');
 
-        # same Limit as $Self->{CustomerCompanyMap}->{'CustomerCompanySearchListLimit'}
-        # smallest Limit from all sources
+        # shown customer limitation in AdminCustomerCompany
         my $Limit = 400;
-        SOURCE:
-        for my $Count ( '', 1 .. 10 ) {
-            next SOURCE if !$ConfigObject->Get("CustomerCompany$Count");
-            my $CustomerUserMap = $ConfigObject->Get("CustomerCompany$Count");
-            next SOURCE if !$CustomerUserMap->{CustomerCompanySearchListLimit};
-            if ( $CustomerUserMap->{CustomerCompanySearchListLimit} < $Limit ) {
-                $Limit = $CustomerUserMap->{CustomerCompanySearchListLimit};
-            }
-        }
 
-        my %ListAllItems = $CustomerCompanyObject->CustomerCompanyList(
+        # search customers with limit (+1 to decide if "more available" must be displayed)
+        # this may actually return ( ($Limit + 1) * # of backends ) number of results; will be
+        # trimmed to $Limit in LISTKEY loop below
+        my %List = $CustomerCompanyObject->CustomerCompanyList(
             Search => $Param{Search},
             Limit  => $Limit + 1,
             Valid  => 0,
         );
 
-        if ( keys %ListAllItems <= $Limit ) {
-            my $ListAllItems = keys %ListAllItems;
+        my $ListSize = keys %List;
+
+        if ( $ListSize <= $Limit ) {
             $LayoutObject->Block(
                 Name => 'OverviewHeader',
                 Data => {
-                    ListAll => $ListAllItems,
+                    ListAll => $ListSize,
                     Limit   => $Limit,
                 },
             );
         }
-
-        my %List = $CustomerCompanyObject->CustomerCompanyList(
-            Search => $Param{Search},
-            Valid  => 0,
-        );
-
-        if ( keys %ListAllItems > $Limit ) {
-            my $ListAllItems   = keys %ListAllItems;
-            my $SearchListSize = keys %List;
-
+        else {
             $LayoutObject->Block(
                 Name => 'OverviewHeader',
                 Data => {
-                    SearchListSize => $SearchListSize,
-                    ListAll        => $ListAllItems,
+                    SearchListSize => $Limit,
+                    ListAll        => $ListSize,
                     Limit          => $Limit,
                 },
             );
@@ -787,7 +772,13 @@ sub _Overview {
 
         # if there are results to show
         if (%List) {
+            my $ListKeyNo = 1;
+
+            LISTKEY:
             for my $ListKey ( sort { $List{$a} cmp $List{$b} } keys %List ) {
+
+                # don't display last customer if beyond limit
+                last LISTKEY if ( $ListKeyNo++ > $Limit );
 
                 my %Data = $CustomerCompanyObject->CustomerCompanyGet( CustomerID => $ListKey );
                 $LayoutObject->Block(

--- a/Kernel/Modules/AdminUser.pm
+++ b/Kernel/Modules/AdminUser.pm
@@ -674,41 +674,34 @@ sub _Overview {
     # ShownUsers limitation in AdminUser
     my $Limit = 400;
 
+    # search users with limit (+1 to decide if "more available" must be displayed);
+    # will be trimmed to $Limit in LISTKEY loop below
     my %List = $UserObject->UserSearch(
-        Search => $Param{Search} . '*',
-        Limit  => $Limit,
-        Valid  => 0,
-    );
-
-    my %ListAllItems = $UserObject->UserSearch(
         Search => $Param{Search} . '*',
         Limit  => $Limit + 1,
         Valid  => 0,
     );
 
-    if ( keys %ListAllItems <= $Limit ) {
-        my $ListAllItems = keys %ListAllItems;
+    my $ListSize = keys %List;
+
+    if ( $ListSize <= $Limit ) {
         $LayoutObject->Block(
             Name => 'OverviewHeader',
             Data => {
-                ListAll => $ListAllItems,
+                ListAll => $ListSize,
                 Limit   => $Limit,
             },
         );
     }
     else {
-        my $ListAllSize    = keys %ListAllItems;
-        my $SearchListSize = keys %List;
-
         $LayoutObject->Block(
             Name => 'OverviewHeader',
             Data => {
-                SearchListSize => $SearchListSize,
-                ListAll        => $ListAllSize,
+                SearchListSize => $Limit,
+                ListAll        => $ListSize,
                 Limit          => $Limit,
             },
         );
-
     }
 
     $LayoutObject->Block(
@@ -731,7 +724,13 @@ sub _Overview {
 
     # if there are results to show
     if (%List) {
+        my $ListKeyNo = 1;
+
+        LISTKEY:
         for my $ListKey ( sort { $List{$a} cmp $List{$b} } keys %List ) {
+
+            # don't diplay last user if beyond limit
+            last LISTKEY if ( $ListKeyNo++ > $Limit );
 
             my %UserData = $UserObject->GetUserData(
                 UserID        => $ListKey,

--- a/Kernel/System/CustomerCompany.pm
+++ b/Kernel/System/CustomerCompany.pm
@@ -337,7 +337,7 @@ get list of customer companies.
 
     my %List = $CustomerCompanyObject->CustomerCompanyList(
         Valid => 0,
-        Limit => 0,     # optional, override configured search result limit (0 means unlimited)
+        Limit => 0,     # optional, if smaller - override configured search result limit (0 means unlimited)
     );
 
     my %List = $CustomerCompanyObject->CustomerCompanyList(

--- a/Kernel/System/CustomerCompany/DB.pm
+++ b/Kernel/System/CustomerCompany/DB.pm
@@ -95,7 +95,12 @@ sub CustomerCompanyList {
         $Valid = 0;
     }
 
+    # use limit specified in function call if specified but do not
+    # go beyond source limit
     my $Limit = $Param{Limit} // $Self->{SearchListLimit};
+    if ( defined $Self->{SearchListLimit} && ( $Limit > $Self->{SearchListLimit} ) ) {
+        $Limit = $Self->{SearchListLimit};
+    }
 
     my $CacheType;
     my $CacheKey;

--- a/Kernel/System/CustomerUser.pm
+++ b/Kernel/System/CustomerUser.pm
@@ -140,7 +140,7 @@ to search users
     my %List = $CustomerUserObject->CustomerSearch(
         Search => '*some*', # also 'hans+huber' possible
         Valid  => 1,        # (optional) default 1
-        Limit  => 100,      # (optional) overrides limit of the config
+        Limit  => 100,      # (optional) if smaller - overrides limit of the config
     );
 
     # username search

--- a/Kernel/System/CustomerUser/DB.pm
+++ b/Kernel/System/CustomerUser/DB.pm
@@ -430,11 +430,18 @@ sub CustomerSearch {
     my @CustomerUserListFieldsDynamicFields
         = grep { exists $Self->{ConfiguredDynamicFieldNames}->{$_} } @{$CustomerUserListFields};
 
+    # use limit specified in function call if specified but do not
+    # go beyond source limit
+    my $Limit = $Param{Limit} // $Self->{UserSearchListLimit};
+    if ( defined $Self->{UserSearchListLimit} && ( $Limit > $Self->{UserSearchListLimit} ) ) {
+        $Limit = $Self->{UserSearchListLimit};
+    }
+
     # get data from customer user table
     return if !$Self->{DBObject}->Prepare(
         SQL   => $SQL,
         Bind  => \@Bind,
-        Limit => $Param{Limit} || $Self->{UserSearchListLimit},
+        Limit => $Limit,
     );
 
     my @CustomerUserData;

--- a/Kernel/System/CustomerUser/LDAP.pm
+++ b/Kernel/System/CustomerUser/LDAP.pm
@@ -463,12 +463,19 @@ sub CustomerSearch {
     # combine needed attrs
     my @Attributes = ( @CustomerUserListFieldsWithoutDynamicFields, $Self->{CustomerKey} );
 
+    # use limit specified in function call if specified but do not
+    # go beyond source limit
+    my $Limit = $Param{Limit} // $Self->{UserSearchListLimit};
+    if ( defined $Self->{UserSearchListLimit} && ( $Limit > $Self->{UserSearchListLimit} ) ) {
+        $Limit = $Self->{UserSearchListLimit};
+    }
+
     # perform user search
     my $Result = $Self->{LDAP}->search(
         base      => $Self->{BaseDN},
         scope     => $Self->{SScope},
         filter    => $Filter,
-        sizelimit => $Param{Limit} || $Self->{UserSearchListLimit},
+        sizelimit => $Limit,
         attrs     => \@Attributes,
     );
 
@@ -599,7 +606,7 @@ sub CustomerSearch {
                 base      => $Self->{GroupDN},
                 scope     => $Self->{SScope},
                 filter    => 'memberUid=' . $Filter2,
-                sizelimit => $Param{Limit} || $Self->{UserSearchListLimit},
+                sizelimit => $Limit,
                 attrs     => ['1.1'],
             );
 

--- a/Kernel/System/User.pm
+++ b/Kernel/System/User.pm
@@ -710,11 +710,18 @@ sub UserSearch {
             . join( ', ', $Kernel::OM->Get('Kernel::System::Valid')->ValidIDsGet() ) . ")";
     }
 
+    # use limit specified in function call if specified but do not
+    # go beyond source limit
+    my $Limit = $Param{Limit} // $Self->{UserSearchListLimit};
+    if ( defined $Self->{UserSearchListLimit} && ( $Limit > $Self->{UserSearchListLimit} ) ) {
+        $Limit = $Self->{UserSearchListLimit};
+    }
+
     # get data
     return if !$DBObject->Prepare(
         SQL   => $SQL,
         Bind  => \@Bind,
-        Limit => $Self->{UserSearchListLimit} || $Param{Limit},
+        Limit => $Limit,
     );
 
     # fetch the result


### PR DESCRIPTION
When searching for users in AdminUser, customer users in AdminCustomerUser
and customer companies in AdminCustomerUser OTRS executes two queries
against all backends: one with limit and second with limit + 1 just
to decide if "more available" should be displayed in list header.

This mod changes this behaviour to execute only one query against each
backend (with limit+1) and trim results to limit which avoids redundant
backend (i.e. DB) queries.

This mod also changes way how limit passed to function call is compared
against limits defined in backend configuration - now the lesser limit
wins which is safer (admin when configuring limit in backend hopes
it won't be exceed; the only exception is Limit = 0 which works
without changes and searches without limits).

This mod also limits number of items returned in functions above to 400
(hardcoded) even if many backends are present (without this mod OTRS
limits display to 400 * # of backends which may produce large web pages
in case of many backends with lots of items).

Related: https://dev.ib.pl/ib/otrs/issues/89
Related: http://bugs.otrs.org/show_bug.cgi?id=7708
Author-Change-Id: IB#1055556