### PR TITLE
Fixed typo in HTML tag

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,4 +1,5 @@
 #6.0.0.beta1 2016-??-??
+ - 2016-09-14 Fixed typo in HTML tag.
  - 2016-09-12 Fixed bug#[11365](http://bugs.otrs.org/show_bug.cgi?id=11365) - ACLs editor shows actions where ACLs does not apply.
  - 2016-09-08 Made possible to define ServiceIDs and SLAIDs as default shown ticket search attributes, thanks to Paweł Bogusławski.
  - 2016-09-08 Fixed status passing and redundant TicketGet calls, thanks to Paweł Bogusławski.

--- a/Kernel/Output/HTML/Templates/Standard/Error.tt
+++ b/Kernel/Output/HTML/Templates/Standard/Error.tt
@@ -50,7 +50,7 @@ Traceback:
                     <p class="SpacingTop">
                         <button type="submit" class="Primary CallForAction" value="[% Translate("Send a bugreport") | html %]"><span>[% Translate("Send a bugreport") | html %]</span></button>
                         &nbsp;[% Translate("or") | html %]&nbsp;
-                        <a href="#" class="CallForAction ReturnToPreviousPage"><span>[% Translate("go back to the previous page") | html %]</spsn></a>
+                        <a href="#" class="CallForAction ReturnToPreviousPage"><span>[% Translate("go back to the previous page") | html %]</span></a>
                     </p>
                 </form>
 


### PR DESCRIPTION
Fixed typo (spsn - span) in Templates/Standard/Error.tt.

Related: https://dev.ib.pl/ib/otrs/issues/90
Author-Change-Id: IB#1054788