### PR TITLE
Fixed error Argument "" isn't numeric in bitwise xor (^) at [...]MatchDBSource.pm

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,4 +1,5 @@
 #6.0.0.beta1 2016-??-??
+ - 2016-09-14 Fixed error Argument "" isn't numeric in bitwise xor (^) at [...]MatchDBSource.pm.
  - 2016-09-12 Fixed bug#[11365](http://bugs.otrs.org/show_bug.cgi?id=11365) - ACLs editor shows actions where ACLs does not apply.
  - 2016-09-08 Made possible to define ServiceIDs and SLAIDs as default shown ticket search attributes, thanks to Paweł Bogusławski.
  - 2016-09-08 Fixed status passing and redundant TicketGet calls, thanks to Paweł Bogusławski.

--- a/Kernel/System/PostMaster/Filter/MatchDBSource.pm
+++ b/Kernel/System/PostMaster/Filter/MatchDBSource.pm
@@ -73,7 +73,7 @@ sub Run {
         }
 
         # match 'Match => ???' stuff
-        my $Matched       = '';
+        my $Matched       = 0;
         my $MatchedNot    = 0;
         my $MatchedResult = '';
         for ( sort keys %Match ) {


### PR DESCRIPTION
When there is postmaster filter defined in OTRS with negated EMAILADDRESS:test@test.com
condition against From header, postmaster throws an error like

    Argument "" isn't numeric in bitwise xor (^) at /opt/otrs/Kernel/System/PostMaster/Filter/MatchDBSource.pm [...]

on every e-mail message import.

This mod fixes this issue.

https://dev.ib.pl/ib/otrs/issues/91
Author-Change-Id: IB#1054236