### PR TITLE
Fixed bug #12306 - SOAP won't use certificates

### DIFF
--- a/Kernel/GenericInterface/Transport/HTTP/SOAP.pm
+++ b/Kernel/GenericInterface/Transport/HTTP/SOAP.pm
@@ -562,7 +562,7 @@ sub RequesterPerformRequest {
             # force Net::SSL instead of IO::Socket::SSL, otherwise GI can't connect to certificate
             # authentication restricted servers, see https://metacpan.org/pod/Net::HTTPS#ENVIRONMENT
             # Fix for bug #12306
-            $ENV{PERL_NET_HTTPS_SSL_SOCKET_CLASS} = 'Net::SSL';
+            $ENV{PERL_NET_HTTPS_SSL_SOCKET_CLASS} = 'Net::SSL';                   ## no critic
 
             $ENV{HTTPS_PKCS12_FILE}     = $Config->{SSL}->{SSLP12Certificate};    ## no critic
             $ENV{HTTPS_PKCS12_PASSWORD} = $Config->{SSL}->{SSLP12Password};       ## no critic

--- a/Kernel/GenericInterface/Transport/HTTP/SOAP.pm
+++ b/Kernel/GenericInterface/Transport/HTTP/SOAP.pm
@@ -560,15 +560,9 @@ sub RequesterPerformRequest {
         {
 
             # force Net::SSL instead of IO::Socket::SSL, otherwise GI can't connect to certificate
-            # authentication restricted servers
-            my $SSLModule = 'Net::SSL';
-            if ( !$Kernel::OM->Get('Kernel::System::Main')->Require($SSLModule) ) {
-                return {
-                    Success      => 0,
-                    ErrorMessage => "The Perl module \"$SSLModule\" needed to manage SSL"
-                        . " connections with certificates is missing!",
-                };
-            }
+            # authentication restricted servers, see https://metacpan.org/pod/Net::HTTPS#ENVIRONMENT
+            # Fix for bug #12306
+            $ENV{PERL_NET_HTTPS_SSL_SOCKET_CLASS} = 'Net::SSL';
 
             $ENV{HTTPS_PKCS12_FILE}     = $Config->{SSL}->{SSLP12Certificate};    ## no critic
             $ENV{HTTPS_PKCS12_PASSWORD} = $Config->{SSL}->{SSLP12Password};       ## no critic


### PR DESCRIPTION
This fixes the bug described here: http://bugs.otrs.org/show_bug.cgi?id=12306