### PR TITLE
Master - Fixed code if RichText param is not defined

### DIFF
--- a/Kernel/Output/HTML/Layout.pm
+++ b/Kernel/Output/HTML/Layout.pm
@@ -5576,25 +5576,8 @@ sub SetRichTextParameters {
     my $ConfigObject   = $Kernel::OM->Get('Kernel::Config');
 
     # get needed variables
-    my $ScreenRichTextHeight;
-    my $ScreenRichTextWidth;
-
-    # set variable for 'RichText.Height' property
-    if ( $Param{Data}->{RichTextHeight} > 0 ) {
-        $ScreenRichTextHeight = $Param{Data}->{RichTextHeight};
-    }
-    else {
-        $ScreenRichTextHeight = $ConfigObject->Get("Frontend::RichTextHeight");
-    }
-
-    # set variable for 'RichText.Width' property
-    if ( $Param{Data}->{RichTextWidth} > 0 ) {
-        $ScreenRichTextWidth = $Param{Data}->{RichTextWidth};
-    }
-    else {
-        $ScreenRichTextWidth = $ConfigObject->Get("Frontend::RichTextWidth");
-    }
-
+    my $ScreenRichTextHeight = $Param{Data}->{RichTextHeight} || $ConfigObject->Get("Frontend::RichTextHeight");
+    my $ScreenRichTextWidth  = $Param{Data}->{RichTextWidth}  || $ConfigObject->Get("Frontend::RichTextWidth");
     my $PictureUploadAction = $Param{Data}->{RichTextPictureUploadAction} || '';
     my $TextDir             = $Self->{TextDirection}                      || '';
     my $SpellChecker        = $Self->{BrowserSpellCheckerInline}          || '';


### PR DESCRIPTION
Hi @mgruner 

There is small improvement IMHO. I saw that there is some message in Fred if RichTextWidth and RichTextWidth are not passed in SetRichTextParameters function.
There is our proposal for fixing, if you like that you can merge it in master.

This is log from Fred:
```
[Mon Sep 19 12:58:18 2016] -e: Use of uninitialized value in numeric gt (>) at /opt/otrs//Kernel/Output/HTML/Layout.pm line 5583.
[Mon Sep 19 12:58:18 2016] -e: Use of uninitialized value in numeric gt (>) at /opt/otrs//Kernel/Output/HTML/Layout.pm line 5591.
```

You can reproduce this for example if you edit signature in AdminSignature and similar ones screens.

Regards
Zoran