### PR TITLE
Master frontend usability - AdminRegistration

### DIFF
--- a/Kernel/Modules/AdminRegistration.pm
+++ b/Kernel/Modules/AdminRegistration.pm
@@ -33,6 +33,9 @@ sub Run {
     # check if cloud services are disabled
     my $CloudServicesDisabled = $ConfigObject->Get('CloudServices::Disabled') || 0;
 
+    # define parameter for breadcrumb during system registration
+    my $WithoutBreadcrumb;
+
     if ($CloudServicesDisabled) {
 
         my $Output = $LayoutObject->Header( Title => 'Error' );
@@ -57,6 +60,9 @@ sub Run {
         if ( $Self->{Subaction} eq 'Deregister' || $Self->{Subaction} eq 'UpdateNow' ) {
             $Self->{Subaction} = 'OTRSIDValidate';
         }
+
+        # during system registration, don't create breadcrumb item 'Validate OTRS-ID'
+        $WithoutBreadcrumb = 1 if $Self->{Subaction} eq 'OTRSIDValidate';
     }
 
     # get needed objects
@@ -175,7 +181,10 @@ sub Run {
         $Output .= $LayoutObject->NavigationBar();
         $LayoutObject->Block(
             Name => 'Overview',
-            Data => \%Param,
+            Data => {
+                %Param,
+                Subaction => $WithoutBreadcrumb ? '' : $Self->{Subaction},
+            },
         );
 
         my $EntitlementStatus  = 'forbidden';
@@ -254,7 +263,10 @@ sub Run {
         $Output .= $LayoutObject->NavigationBar();
         $LayoutObject->Block(
             Name => 'Overview',
-            Data => \%Param,
+            Data => {
+                %Param,
+                Subaction => $Self->{Subaction},
+            },
         );
 
         $Param{SystemTypeOption} = $LayoutObject->BuildSelection(
@@ -304,7 +316,10 @@ sub Run {
         $Output .= $LayoutObject->NavigationBar();
         $LayoutObject->Block(
             Name => 'Overview',
-            Data => \%Param,
+            Data => {
+                %Param,
+                Subaction => $Self->{Subaction},
+                }
         );
 
         $LayoutObject->Block(
@@ -385,7 +400,10 @@ sub Run {
         $Output .= $LayoutObject->NavigationBar();
         $LayoutObject->Block(
             Name => 'Overview',
-            Data => \%Param,
+            Data => {
+                %Param,
+                Subaction => $Self->{Subaction},
+                }
         );
 
         my %RegistrationData = $RegistrationObject->RegistrationDataGet();
@@ -567,7 +585,10 @@ sub _SentDataOverview {
 
     $LayoutObject->Block(
         Name => 'Overview',
-        Data => \%Param,
+        Data => {
+            %Param,
+            Subaction => 'SentDataOverview',
+            }
     );
 
     $LayoutObject->Block( Name => 'ActionList' );

--- a/Kernel/Output/HTML/Templates/Standard/AdminRegistration.tt
+++ b/Kernel/Output/HTML/Templates/Standard/AdminRegistration.tt
@@ -12,6 +12,30 @@
 <div class="MainBox ARIARoleMain LayoutFixedSidebar SidebarFirst">
     <h1>[% Translate("System Registration Management") | html %]</h1>
 
+    [% BreadcrumbPath = [
+            {
+                Name => Translate('System Registration Management'),
+                Link => Env("Action"),
+            },
+        ]
+    %]
+
+    [% SWITCH Data.Subaction %]
+        [% CASE 'Edit' %]
+            [% BreadcrumbPath.push({ Name => Translate("Edit System Registration"),}) %]
+        [% CASE 'SentDataOverview' %]
+            [% BreadcrumbPath.push({ Name => Translate("System Registration Overview"),}) %]
+        [% CASE 'Register' %]
+            [% BreadcrumbPath.push({ Name => Translate("Register System"),}) %]
+        [% CASE 'OTRSIDValidate' %]
+            [% BreadcrumbPath.push({ Name => Translate("Validate OTRS-ID"),}) %]
+        [% CASE 'Deregister' %]
+            [% BreadcrumbPath.push({ Name => Translate("Deregister System"),}) %]
+    [% END %]
+
+    [% INCLUDE "Breadcrumb.tt" Path = BreadcrumbPath %]
+
+    <div class="Clear"></div>
     <div class="SidebarColumn">
 
 [% RenderBlockStart("ActionList") %]

--- a/scripts/test/Selenium/Agent/Admin/AdminRegistration.t
+++ b/scripts/test/Selenium/Agent/Admin/AdminRegistration.t
@@ -48,6 +48,18 @@ $Selenium->RunTest(
         # navigate to AdminRegistration screen
         $Selenium->VerifiedGet("${ScriptAlias}index.pl?Action=AdminRegistration");
 
+        # check breadcrumb on Overview screen
+        $Self->Is(
+            $Selenium->execute_script("return \$('.BreadCrumb li:eq(0)').text().trim()"),
+            'You are here:',
+            "Breadcrumb text 'You are here:' is found on screen"
+        );
+        $Self->Is(
+            $Selenium->execute_script("return \$('.BreadCrumb li:eq(1)').text().trim()"),
+            'System Registration Management',
+            "Breadcrumb text 'System Registration Management' is found on screen"
+        );
+
         # create test cases with different field values
         my @Tests = (
             {


### PR DESCRIPTION
Hi @zottto 

Hereby is refactored AdminRegistration. Breadcrumb is added. When system is not registered, in Overview screen controller sets up subaction to 'OTRSIDValidate' (parameter for breadcrumb in TT), but our proposal is that breadcrumb 'OTRSIDValidate' might not be drawn in this case.
Selenium test is modified.
Please let me know if you have any suggestion for this PR.

Regards
Zoran