### PR TITLE
[ Master Bug 12313 ] - Fixed spam log error in AdminSysConfig

### DIFF
--- a/Kernel/Modules/AdminSysConfig.pm
+++ b/Kernel/Modules/AdminSysConfig.pm
@@ -1005,7 +1005,7 @@ sub Run {
 
         $LayoutObject->Block( Name => 'OverviewResult' );
 
-        %List = $SysConfigObject->ConfigSubGroupList( Name => $Group );
+        %List = $SysConfigObject->ConfigSubGroupList( Name => $Group ) if $Group;
 
         # if there are any results, they are shown
         if (%List) {


### PR DESCRIPTION
http://bugs.otrs.org/show_bug.cgi?id=12313

Hi @mrcbnsls 

As you suggested I opened the bug and hereby it is fixed. We spoke about that in the PR:
https://github.com/OTRS/otrs/pull/1477


![bug_12313](https://cloud.githubusercontent.com/assets/6348760/18707386/214f491a-7ff6-11e6-8a75-feac6087117a.png)

Regards
Zoran