### PR TITLE
Added sort criteria to TicketSearch call

### DIFF
--- a/Kernel/System/Console/Command/Maint/Ticket/PendingCheck.pm
+++ b/Kernel/System/Console/Command/Maint/Ticket/PendingCheck.pm
@@ -51,6 +51,8 @@ sub Run {
         @TicketIDs = $TicketObject->TicketSearch(
             Result   => 'ARRAY',
             StateIDs => [@PendingAutoStateIDs],
+            SortBy   => ['PendingTime'],
+            OrderBy  => ['Up'],
             UserID   => 1,
         );
 


### PR DESCRIPTION
If more than 10k tickets are in pending states, it might happen that due to missing sort criteria and -order, tickets which should be updated will not experience this update because they're returned at last. The first 10k resulting tickets might be in pending auto states, but their until time is in the future.
