### PR TITLE
Blocking external content using CSP

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,4 +1,5 @@
 #6.0.0.beta1 2016-??-??
+ - 2016-09-27 Blocking external content using CSP.
  - 2016-09-21 Fixed bug#[12065](http://bugs.otrs.org/show_bug.cgi?id=12065) - queue and state not mandatory.
  - 2016-09-12 Fixed bug#[11365](http://bugs.otrs.org/show_bug.cgi?id=11365) - ACLs editor shows actions where ACLs does not apply.
  - 2016-09-08 Made possible to define ServiceIDs and SLAIDs as default shown ticket search attributes, thanks to Paweł Bogusławski.

--- a/Kernel/Modules/AgentTicketAttachment.pm
+++ b/Kernel/Modules/AgentTicketAttachment.pm
@@ -164,13 +164,13 @@ sub Run {
         # set filename for inline viewing
         $Data{Filename} = "Ticket-$Article{TicketNumber}-ArticleID-$Article{ArticleID}.html";
 
-        my $LoadExternalImages = $ParamObject->GetParam(
-            Param => 'LoadExternalImages'
+        my $LoadExternalContent = $ParamObject->GetParam(
+            Param => 'LoadExternalContent'
         ) || 0;
 
         # safety check only on customer article
-        if ( !$LoadExternalImages && $Article{SenderType} ne 'customer' ) {
-            $LoadExternalImages = 1;
+        if ( !$LoadExternalContent && $Article{SenderType} ne 'customer' ) {
+            $LoadExternalContent = 1;
         }
 
         # generate base url
@@ -186,10 +186,10 @@ sub Run {
         # reformat rich text document to have correct charset and links to
         # inline documents
         %Data = $LayoutObject->RichTextDocumentServe(
-            Data               => \%Data,
-            URL                => $URL,
-            Attachments        => \%AtmBox,
-            LoadExternalImages => $LoadExternalImages,
+            Data                => \%Data,
+            URL                 => $URL,
+            Attachments         => \%AtmBox,
+            LoadExternalContent => $LoadExternalContent,
         );
 
         # if there is unexpectedly pgp decrypted content in the html email (OE),
@@ -218,7 +218,10 @@ sub Run {
         }
 
         # return html attachment
-        return $LayoutObject->Attachment(%Data);
+        return $LayoutObject->Attachment(
+            %Data,
+            LoadExternalContent => $LoadExternalContent,  # for blocking external content with CSP also
+        );
     }
 
     # download it AttachmentDownloadType is configured

--- a/Kernel/Modules/CustomerTicketAttachment.pm
+++ b/Kernel/Modules/CustomerTicketAttachment.pm
@@ -119,11 +119,11 @@ sub Run {
         $Data{Filename} = "Ticket-$Article{TicketNumber}-ArticleID-$Article{ArticleID}.html";
 
         # safety check only on customer article
-        my $LoadExternalImages = $ParamObject->GetParam(
-            Param => 'LoadExternalImages'
+        my $LoadExternalContent = $ParamObject->GetParam(
+            Param => 'LoadExternalContent'
         ) || 0;
-        if ( !$LoadExternalImages && $Article{SenderType} ne 'customer' ) {
-            $LoadExternalImages = 1;
+        if ( !$LoadExternalContent && $Article{SenderType} ne 'customer' ) {
+            $LoadExternalContent = 1;
         }
 
         # generate base url
@@ -139,14 +139,18 @@ sub Run {
         # reformat rich text document to have correct charset and links to
         # inline documents
         %Data = $LayoutObject->RichTextDocumentServe(
-            Data               => \%Data,
-            URL                => $URL,
-            Attachments        => \%AtmBox,
-            LoadExternalImages => $LoadExternalImages,
+            Data                => \%Data,
+            URL                 => $URL,
+            Attachments         => \%AtmBox,
+            LoadExternalContent => $LoadExternalContent,
         );
 
         # return html attachment
-        return $LayoutObject->Attachment(%Data);
+        return $LayoutObject->Attachment(
+            %Data,
+            LoadExternalContent => $LoadExternalContent,  # for blocking external content with CSP also
+        );
+
     }
 
     # download it AttachmentDownloadType is configured

--- a/Kernel/Output/HTML/Layout.pm
+++ b/Kernel/Output/HTML/Layout.pm
@@ -2466,10 +2466,12 @@ sub ReturnValue {
 returns browser output to display/download a attachment
 
     $HTML = $LayoutObject->Attachment(
-        Type        => 'inline',        # optional, default: attachment, possible: inline|attachment
-        Filename    => 'FileName.png',  # optional
-        ContentType => 'image/png',
-        Content     => $Content,
+        Type                => 'inline',        # optional, default: attachment, possible: inline|attachment
+        Filename            => 'FileName.png',  # optional
+        ContentType         => 'image/png',
+        Content             => $Content,
+        LoadExternalContent => 1,               # optional, 0 - don't allow page to load resources from external sites;
+                                                # 1 (default) - allow allow page to load resources from external sites
     );
 
     or for AJAX html snippets
@@ -2535,6 +2537,15 @@ sub Attachment {
 
     if ( !$ConfigObject->Get('DisableIFrameOriginRestricted') ) {
         $Output .= "X-Frame-Options: SAMEORIGIN\n";
+    }
+
+    # use CSP to disallow external content to be loaded if not explicitly enabled;
+    # don't allow inline scripts but allow inline styles for messages and
+    # blocking info box to look nice; for CSP details see
+    # http://www.html5rocks.com/en/tutorials/security/content-security-policy/
+    # https://www.w3.org/TR/CSP2/#directive-default-src
+    if ( defined $Param{LoadExternalContent} && ( $Param{LoadExternalContent} == 0 ) ) {
+        $Output .= "Content-Security-Policy: default-src 'self'; style-src 'unsafe-inline'\n"; 
     }
 
     if ( $Param{Charset} ) {
@@ -4480,7 +4491,7 @@ but a message will be shown allowing the user to reload the page showing the ext
 
         LoadInlineContent => 0,     # Serve the document including all inline content. WARNING: This might be dangerous.
 
-        LoadExternalImages => 0,    # Load external images? If this is 0, a message will be included if
+        LoadExternalContent => 0,    # Load external images? If this is 0, a message will be included if
                                     # external images were found and removed.
     );
 
@@ -4552,7 +4563,7 @@ sub RichTextDocumentServe {
 
         $Param{Data}->{Content} = $SafetyCheckResult{String};
 
-        if ( !$Param{LoadExternalImages} ) {
+        if ( !$Param{LoadExternalContent} ) {
 
             # Strip out external images, but show a confirmation button to
             #   load them explicitly.

--- a/Kernel/Output/HTML/Templates/Standard/AttachmentBlocker.tt
+++ b/Kernel/Output/HTML/Templates/Standard/AttachmentBlocker.tt
@@ -14,6 +14,6 @@
 <div style="margin: 5px 0; padding: 0px; border: 1px solid #999; border-radius: 2px; -moz-border-radius: 2px; -webkit-border-radius: 2px;">
     <div style="padding: 5px; background-color: #DDD; font-family:Geneva,Helvetica,Arial,sans-serif; font-size: 11px; text-align: center;">
         [% Translate("To protect your privacy, remote content was blocked.") | html %]
-        <a href="[% Env("Baselink") %][% Env("RequestedURL") %];LoadExternalImages=1">[% Translate("Load blocked content.") | html %]</a>
+        <a href="[% Env("Baselink") %][% Env("RequestedURL") %];LoadExternalContent=1">[% Translate("Load blocked content.") | html %]</a>
     </div>
 </div>

--- a/scripts/test/Layout/RichTextDocumentServe.t
+++ b/scripts/test/Layout/RichTextDocumentServe.t
@@ -217,7 +217,7 @@ my @Tests = (
 <div style="margin: 5px 0; padding: 0px; border: 1px solid #999; border-radius: 2px; -moz-border-radius: 2px; -webkit-border-radius: 2px;">
     <div style="padding: 5px; background-color: #DDD; font-family:Geneva,Helvetica,Arial,sans-serif; font-size: 11px; text-align: center;">
         Zum Schutz Ihrer Privatsphäre wurden entfernte Inhalte blockiert.
-        <a href="index.pl?;LoadExternalImages=1;SessionID=123">Blockierte Inhalte laden.</a>
+        <a href="index.pl?;LoadExternalContent=1;SessionID=123">Blockierte Inhalte laden.</a>
     </div>
 </div>
 1',
@@ -236,7 +236,7 @@ my @Tests = (
                 ContentID => '<Untitled%20Attachment>',
             },
         },
-        LoadExternalImages => 1,
+        LoadExternalContent => 1,
         Result             => {
             Content     => '1<img src="http://google.com"/>',
             ContentType => 'text/html; charset="utf-8"',
@@ -266,7 +266,7 @@ EOF
                 ContentID => '<Untitled%20Attachment>',
             },
         },
-        LoadExternalImages => 1,
+        LoadExternalContent => 1,
         Result             => {
             Content => <<EOF,
 <!DOCTYPE html SYSTEM "about:legacy-compat">
@@ -322,7 +322,7 @@ EOF
                 ContentID => '<>',
             },
         },
-        LoadExternalImages => 1,
+        LoadExternalContent => 1,
         Result             => {
             Content     => 'Link <a href="http://test.example" target="_blank">http://test.example</a>',
             ContentType => 'text/html; charset="utf-8"',


### PR DESCRIPTION
OTRS tries to filter external content in HTML e-mails using perl
regexps; this way its difficult to predict and block all HTML/JS/CSS
quirks, i.e. OTRS does not block remote image loading if used
in CSS like this

```
<div style="background:url('http://badspammer.com/tracking/1/TrackRead.aspx?mail_id=1F4CA3DD-24E0-4C14-B631-A7567EAA5D83')"></div>
```

which may allow spammers to notice that their junk was read by receiver.

Using `Content Security Policy` described on
http://www.html5rocks.com/en/tutorials/security/content-security-policy/
seems to be proper way of blocking external content in iframes.
According to https://content-security-policy.com/ it should work fine
in modern browsers (in IE from v12 probably).

This mod adds

```
Content-Security-Policy: default-src 'self'; style-src 'unsafe-inline'
```

HTTP header for iframes with HTML e-mails which forces modern web browsers
to block all external and inline content except inline styling (used often
in html e-mails). CSP header is not added if user explicitly unlocks
external content using link provided by OTRS.

This mod renames also `LoadExternalImages` parameters to `LoadExternalContent`
to better match its purpose and message displayed by OTRS.

In future it may be good idea to drop OTRS own filtering to offload this task
from busy application servers (parsing huge HTML content may cause problems...)
to web browsers.

Related: https://dev.ib.pl/ib/otrs/issues/92
Related: http://www.html5rocks.com/en/tutorials/security/content-security-policy/
Author-Change-Id: IB#1047017
