### PR TITLE
Fixed error Can't locate object method "EventHandler"

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,4 +1,5 @@
 #6.0.0.beta1 2016-??-??
+ - 2016-09-28 Fixed error Can't locate object method "EventHandler" in NotifyAgentGroupOfCustomQueue and NotifyAgentGroupOfCustomQueue.
  - 2016-09-21 Fixed bug#[12065](http://bugs.otrs.org/show_bug.cgi?id=12065) - queue and state not mandatory.
  - 2016-09-12 Fixed bug#[11365](http://bugs.otrs.org/show_bug.cgi?id=11365) - ACLs editor shows actions where ACLs does not apply.
  - 2016-09-08 Made possible to define ServiceIDs and SLAIDs as default shown ticket search attributes, thanks to Paweł Bogusławski.

--- a/Kernel/System/GenericAgent/NotifyAgentGroupOfCustomQueue.pm
+++ b/Kernel/System/GenericAgent/NotifyAgentGroupOfCustomQueue.pm
@@ -104,7 +104,7 @@ sub Run {
     }
 
     # trigger notification event
-    $Self->EventHandler(
+    $TicketObject->EventHandler(
         Event => 'Notification' . $EscalationType,
         Data  => {
             TicketID              => $Param{TicketID},

--- a/Kernel/System/GenericAgent/NotifyAgentGroupWithWritePermission.pm
+++ b/Kernel/System/GenericAgent/NotifyAgentGroupWithWritePermission.pm
@@ -105,7 +105,7 @@ sub Run {
     }
 
     # trigger notification event
-    $Self->EventHandler(
+    $TicketObject->EventHandler(
         Event => 'Notification' . $EscalationType,
         Data  => {
             TicketID              => $Param{TicketID},


### PR DESCRIPTION
When OTRS 5/master is configured for sending escalation notifications
using obsolete Kernel/Config/GenericAgent.pm way, notifications are
not sent and errors are fired:

```
Message: Can't locate object method "EventHandler" via package "Kernel::System::GenericAgent::NotifyAgentGroupOfCustomQueue" at /opt/otrs/Kernel/System/GenericAgent/NotifyAgentGroupOfCustomQueue.pm[...]
```

This mod fixes issue as above.

Related: https://dev.ib.pl/ib/otrs/issues/93
Author-Change-Id: IB#1046397
