### PR TITLE
Column list validation before saving agent preferences

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,4 +1,5 @@
 #6.0.0.beta1 2016-??-??
+ - 2016-09-28 Column list validation before saving agent preferences.
  - 2016-09-21 Fixed bug#[12065](http://bugs.otrs.org/show_bug.cgi?id=12065) - queue and state not mandatory.
  - 2016-09-12 Fixed bug#[11365](http://bugs.otrs.org/show_bug.cgi?id=11365) - ACLs editor shows actions where ACLs does not apply.
  - 2016-09-08 Made possible to define ServiceIDs and SLAIDs as default shown ticket search attributes, thanks to Paweł Bogusławski.

--- a/Kernel/Output/HTML/Preferences/ColumnFilters.pm
+++ b/Kernel/Output/HTML/Preferences/ColumnFilters.pm
@@ -60,10 +60,23 @@ sub Run {
 
         # pref update db
         if ( !$Kernel::OM->Get('Kernel::Config')->Get('DemoSystem') ) {
+
+            my %Seen;
+            my @ColumnsUnique;
+            COLUMN:
+            for my $Column ( @{ $Param{GetParam}->{$Key} } ) {
+
+                # skip duplicates
+                next COLUMN if $Seen{$Column};
+                $Seen{$Column} = 1;
+
+                push @ColumnsUnique, $Column;
+            }
+
             $Kernel::OM->Get('Kernel::System::User')->SetPreferences(
                 UserID => $Param{UserData}->{UserID},
                 Key    => $Key . '-' . $FilterAction,
-                Value  => $Kernel::OM->Get('Kernel::System::JSON')->Encode( Data => $Param{GetParam}->{$Key} ),
+                Value  => $Kernel::OM->Get('Kernel::System::JSON')->Encode( Data => \@ColumnsUnique ),
             );
         }
     }


### PR DESCRIPTION
It was noticed in OTRS 3.3, that some agents managed to save their column
filter preferences with duplikcated column names i.e.

```
mysql -e 'SELECT * FROM user_preferences where length(preferences_value)>100' otrs
[...]
5       UserFilterColumnsEnabled-AgentTicketQueue       ["TicketNumber","Title","State","Lock","Queue","Owner","Age","Changed","CustomerID","Lock","Queue","CustomerID","TicketNumber", [...], "TicketNumber","Age","Title","State","Lock","Queue","CustomerID"]
```

The whole preference string was over 9kB long (all filled with duplicated
column list as above) and caused apache RAM consumption problems (removing
this record from DB was necessary to avoid out of memory on OTRS
application server). The problem is not reproducible and the cause of
the problem has not been identified (might be some kind of race condition
or web browser bug).

Regardless of cause OTRS should not allow to save duplicated columns
(i.e. to prevent attacks).

This mod adds validation of column list just before saving preferences
- duplicates are removed which should protect OTRS against the problem
  described above.

Related: https://dev.ib.pl/ib/otrs/issues/94
Author-Change-Id: IB#1058144
