### PR TITLE
Fixed escaping values passed to LDAP filters

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,4 +1,5 @@
 #6.0.0.beta1 2016-??-??
+ - 2016-09-30 Fixed escaping values passed to LDAP filters.
  - 2016-09-21 Fixed bug#[12065](http://bugs.otrs.org/show_bug.cgi?id=12065) - queue and state not mandatory.
  - 2016-09-12 Fixed bug#[11365](http://bugs.otrs.org/show_bug.cgi?id=11365) - ACLs editor shows actions where ACLs does not apply.
  - 2016-09-08 Made possible to define ServiceIDs and SLAIDs as default shown ticket search attributes, thanks to Paweł Bogusławski.

--- a/Kernel/System/Auth/LDAP.pm
+++ b/Kernel/System/Auth/LDAP.pm
@@ -12,6 +12,7 @@ use strict;
 use warnings;
 
 use Net::LDAP;
+use Net::LDAP::Util qw(escape_filter_value);
 
 our @ObjectDependencies = (
     'Kernel::Config',
@@ -196,14 +197,8 @@ sub Auth {
         return;
     }
 
-    # user quote
-    my $UserQuote = $Param{User};
-    $UserQuote =~ s/\\/\\\\/g;
-    $UserQuote =~ s/\(/\\(/g;
-    $UserQuote =~ s/\)/\\)/g;
-
     # build filter
-    my $Filter = "($Self->{UID}=$UserQuote)";
+    my $Filter = "($Self->{UID}=" . escape_filter_value($Param{User}) . ')';
 
     # prepare filter
     if ( $Self->{AlwaysFilter} ) {
@@ -250,12 +245,6 @@ sub Auth {
         return;
     }
 
-    # DN quote
-    my $UserDNQuote = $UserDN;
-    $UserDNQuote =~ s/\\/\\\\/g;
-    $UserDNQuote =~ s/\(/\\(/g;
-    $UserDNQuote =~ s/\)/\\)/g;
-
     # check if user need to be in a group!
     if ( $Self->{AccessAttr} && $Self->{GroupDN} ) {
 
@@ -270,10 +259,10 @@ sub Auth {
         # search if we're allowed to
         my $Filter2 = '';
         if ( $Self->{UserAttr} eq 'DN' ) {
-            $Filter2 = "($Self->{AccessAttr}=$UserDNQuote)";
+            $Filter2 = "($Self->{AccessAttr}=" . escape_filter_value($UserDN) . ')';
         }
         else {
-            $Filter2 = "($Self->{AccessAttr}=$UserQuote)";
+            $Filter2 = "($Self->{AccessAttr}=" . escape_filter_value($Param{User}) . ')';
         }
         my $Result2 = $LDAP->search(
             base   => $Self->{GroupDN},

--- a/Kernel/System/Auth/Sync/LDAP.pm
+++ b/Kernel/System/Auth/Sync/LDAP.pm
@@ -12,6 +12,7 @@ use strict;
 use warnings;
 
 use Net::LDAP;
+use Net::LDAP::Util qw(escape_filter_value);
 
 our @ObjectDependencies = (
     'Kernel::Config',
@@ -143,12 +144,8 @@ sub Sync {
         return;
     }
 
-    # user quote
-    my $UserQuote = $Param{User};
-    $UserQuote =~ s{ ( [\\()] ) }{\\$1}xmsg;
-
     # build filter
-    my $Filter = "($Self->{UID}=$UserQuote)";
+    my $Filter = "($Self->{UID}=" . escape_filter_value($Param{User}) . ')';
 
     # prepare filter
     if ( $Self->{AlwaysFilter} ) {
@@ -188,10 +185,6 @@ sub Sync {
         $LDAP->unbind();
         return;
     }
-
-    # DN quote
-    my $UserDNQuote = $UserDN;
-    $UserDNQuote =~ s{ ( [\\()] ) }{\\$1}xmsg;
 
     # get needed objects
     my $UserObject   = $Kernel::OM->Get('Kernel::System::User');
@@ -373,10 +366,10 @@ sub Sync {
             # search if we are allowed to
             my $Filter;
             if ( $Self->{UserAttr} eq 'DN' ) {
-                $Filter = "($Self->{AccessAttr}=$UserDNQuote)";
+                $Filter = "($Self->{AccessAttr}=" . escape_filter_value($UserDN) . ')';
             }
             else {
-                $Filter = "($Self->{AccessAttr}=$UserQuote)";
+                $Filter = "($Self->{AccessAttr}=" . escape_filter_value($Param{User}) . ')';
             }
             my $Result = $LDAP->search(
                 base   => $GroupDN,
@@ -451,7 +444,7 @@ sub Sync {
     if ($UserSyncAttributeGroupsDefinition) {
 
         # build filter
-        my $Filter = "($Self->{UID}=$UserQuote)";
+        my $Filter = "($Self->{UID}=" . escape_filter_value($Param{User}) . ')';
 
         # perform search
         $Result = $LDAP->search(
@@ -592,10 +585,10 @@ sub Sync {
             # search if we're allowed to
             my $Filter;
             if ( $Self->{UserAttr} eq 'DN' ) {
-                $Filter = "($Self->{AccessAttr}=$UserDNQuote)";
+                $Filter = "($Self->{AccessAttr}=" . escape_filter_value($UserDN) . ')';
             }
             else {
-                $Filter = "($Self->{AccessAttr}=$UserQuote)";
+                $Filter = "($Self->{AccessAttr}=" . escape_filter_value($Param{User}) . ')';
             }
             my $Result = $LDAP->search(
                 base   => $GroupDN,
@@ -658,7 +651,7 @@ sub Sync {
     if ($UserSyncAttributeRolesDefinition) {
 
         # build filter
-        my $Filter = "($Self->{UID}=$UserQuote)";
+        my $Filter = "($Self->{UID}=" . escape_filter_value($Param{User}) . ')';
 
         # perform search
         $Result = $LDAP->search(

--- a/Kernel/System/CustomerAuth/LDAP.pm
+++ b/Kernel/System/CustomerAuth/LDAP.pm
@@ -12,6 +12,7 @@ use strict;
 use warnings;
 
 use Net::LDAP;
+use Net::LDAP::Util qw(escape_filter_value);
 
 our @ObjectDependencies = (
     'Kernel::Config',
@@ -194,14 +195,8 @@ sub Auth {
         return;
     }
 
-    # user quote
-    my $UserQuote = $Param{User};
-    $UserQuote =~ s/\\/\\\\/g;
-    $UserQuote =~ s/\(/\\(/g;
-    $UserQuote =~ s/\)/\\)/g;
-
     # build filter
-    my $Filter = "($Self->{UID}=$UserQuote)";
+    my $Filter = "($Self->{UID}=" . escape_filter_value($Param{User}) . ')';
 
     # prepare filter
     if ( $Self->{AlwaysFilter} ) {
@@ -245,12 +240,6 @@ sub Auth {
         return;
     }
 
-    # DN quote
-    my $UserDNQuote = $UserDN;
-    $UserDNQuote =~ s/\\/\\\\/g;
-    $UserDNQuote =~ s/\(/\\(/g;
-    $UserDNQuote =~ s/\)/\\)/g;
-
     # check if user need to be in a group!
     if ( $Self->{AccessAttr} && $Self->{GroupDN} ) {
 
@@ -265,10 +254,10 @@ sub Auth {
         # search if we're allowed to
         my $Filter2 = '';
         if ( $Self->{UserAttr} eq 'DN' ) {
-            $Filter2 = "($Self->{AccessAttr}=$UserDNQuote)";
+            $Filter2 = "($Self->{AccessAttr}=" . escape_filter_value($UserDN) . ')';
         }
         else {
-            $Filter2 = "($Self->{AccessAttr}=$UserQuote)";
+            $Filter2 = "($Self->{AccessAttr}=" . escape_filter_value($Param{User}) . ')';
         }
         my $Result2 = $LDAP->search(
             base   => $Self->{GroupDN},

--- a/Kernel/System/CustomerUser/LDAP.pm
+++ b/Kernel/System/CustomerUser/LDAP.pm
@@ -12,6 +12,7 @@ use strict;
 use warnings;
 
 use Net::LDAP;
+use Net::LDAP::Util qw(escape_filter_value);
 
 use Kernel::System::VariableCheck qw(:all);
 
@@ -226,7 +227,7 @@ sub CustomerName {
     }
 
     # build filter
-    my $Filter = "($Self->{CustomerKey}=$Param{UserLogin})";
+    my $Filter = "($Self->{CustomerKey}=" . escape_filter_value($Param{UserLogin}) . ')';
 
     # prepare filter
     if ( $Self->{AlwaysFilter} ) {
@@ -392,14 +393,26 @@ sub CustomerSearch {
                 @{ $Self->{CustomerUserMap}->{CustomerUserSearchFields} };
 
             if (@CustomerUserSearchFields) {
+
+                # quote LDAP filter value but keep asterisks unenescaped (wildcard)
+                $Part =~ s/\*/encodedasterisk20160930/g;
+                $Part = escape_filter_value($Self->_ConvertTo($Part));
+                $Part =~ s/encodedasterisk20160930/*/g;
+
                 $Filter .= '(|';
                 for my $Field (@CustomerUserSearchFields) {
-                    $Filter .= "($Field=" . $Self->_ConvertTo($Part) . ")";
+                    $Filter .= "($Field=" . $Part . ')';
                 }
                 $Filter .= ')';
             }
             else {
-                $Filter .= "($Self->{CustomerKey}=$Part)";
+
+                # quote LDAP filter value but keep asterisks unescaped (wildcard)
+                $Part =~ s/\*/encodedasterisk20160930/g;
+                $Part = escape_filter_value($Part);
+                $Part =~ s/encodedasterisk20160930/*/g;
+
+                $Filter .= "($Self->{CustomerKey}=" . $Part . ')';
             }
         }
 
@@ -417,16 +430,16 @@ sub CustomerSearch {
         if (@CustomerUserPostMasterSearchFields) {
             $Filter = '(|';
             for my $Field (@CustomerUserPostMasterSearchFields) {
-                $Filter .= "($Field=$Param{PostMasterSearch})";
+                $Filter .= "($Field=" . escape_filter_value($Param{PostMasterSearch}) . ')';
             }
             $Filter .= ')';
         }
     }
     elsif ( $Param{UserLogin} ) {
-        $Filter = "($Self->{CustomerKey}=$Param{UserLogin})";
+        $Filter = "($Self->{CustomerKey}=" . escape_filter_value($Param{UserLogin}) . ')';
     }
     elsif ( $Param{CustomerID} ) {
-        $Filter = "($Self->{CustomerID}=$Param{CustomerID})";
+        $Filter = "($Self->{CustomerID}=" . escape_filter_value($Param{CustomerID}) . ')';
     }
 
     # prepare filter
@@ -598,7 +611,7 @@ sub CustomerSearch {
             my $Result2 = $Self->{LDAP}->search(
                 base      => $Self->{GroupDN},
                 scope     => $Self->{SScope},
-                filter    => 'memberUid=' . $Filter2,
+                filter    => 'memberUid=' . escape_filter_value($Filter2),
                 sizelimit => $Param{Limit} || $Self->{UserSearchListLimit},
                 attrs     => ['1.1'],
             );
@@ -646,6 +659,12 @@ sub CustomerIDList {
         my $SearchFilter = $Self->{SearchPrefix} . $SearchTerm . $Self->{SearchSuffix};
         $SearchFilter =~ s/(\%+)/\%/g;
         $SearchFilter =~ s/(\*+)\*/*/g;
+
+        # quote LDAP filter value but keep asterisks unencoded (wildcard)
+        $SearchFilter =~ s/\*/encodedasterisk20160930/g;
+        $SearchFilter = escape_filter_value($SearchFilter);
+        $SearchFilter =~ s/encodedasterisk20160930/*/g;
+
         $Filter = "($Self->{CustomerID}=$SearchFilter)";
 
     }
@@ -712,7 +731,7 @@ sub CustomerIDList {
             my $Result2 = $Self->{LDAP}->search(
                 base      => $Self->{GroupDN},
                 scope     => $Self->{SScope},
-                filter    => 'memberUid=' . $Filter2,
+                filter    => 'memberUid=' . escape_filter_value($Filter2),
                 sizelimit => $Self->{UserSearchListLimit},
                 attrs     => ['1.1'],
             );
@@ -833,7 +852,7 @@ sub CustomerUserDataGet {
         next ENTRY if $Entry->[5] eq 'dynamic_field';
         push( @Attributes, $Entry->[2] );
     }
-    my $Filter = "($Self->{CustomerKey}=$Param{User})";
+    my $Filter = "($Self->{CustomerKey}=" . escape_filter_value($Param{User}) . ')';
 
     # prepare filter
     if ( $Self->{AlwaysFilter} ) {


### PR DESCRIPTION
OTRS does not escape all special characters in values passed to LDAP
filters. For example, when Active Directory is configured as customer
backend, searching for customer user "()" throws "bad filter"
LDAP error.

Passing unescaped strings may be dangerous (LDAP injections).

This mod introduces escaping values passed to LDAP filters by OTRS
with escape_filter_value from Net::LDAP::Util. Asterisk
in customer searches stays unescaped (acts as wildcard).

Related: https://dev.ib.pl/ib/otrs/issues/95
Related: https://www.praetorian.com/blog/how-to-identify-and-prevent-ldap-injection-part-2
Author-Change-Id: IB#1058224
