### PR TITLE
Master frontend - AdminAttachment delete button confirmation

### DIFF
--- a/Kernel/Modules/AdminAttachment.pm
+++ b/Kernel/Modules/AdminAttachment.pm
@@ -228,7 +228,12 @@ sub Run {
             return $LayoutObject->ErrorScreen();
         }
 
-        return $LayoutObject->Redirect( OP => "Action=$Self->{Action}" );
+        return $LayoutObject->Attachment(
+            ContentType => 'text/html',
+            Content     => $Delete,
+            Type        => 'inline',
+            NoCache     => 1,
+        );
     }
 
     # ------------------------------------------------------------ #

--- a/Kernel/Output/HTML/Templates/Standard/AdminAttachment.tt
+++ b/Kernel/Output/HTML/Templates/Standard/AdminAttachment.tt
@@ -108,7 +108,7 @@
                             <td>[% Data.ChangeTime | Localize("TimeShort") %]</td>
                             <td>[% Data.CreateTime | Localize("TimeShort") %]</td>
                             <td class="Center">
-                                <a class="TrashCan" href="[% Env("Baselink") %]Action=[% Env("Action") %];Subaction=Delete;ID=[% Data.ID | uri %];[% Env("ChallengeTokenParam") | html %]" title="[% Translate("Delete this attachment") | html %]">
+                                <a class="TrashCan AttachmentDelete" href="#" data-query-string="Action=AdminAttachment;Subaction=Delete;ID=[% Data.ID | uri %];[% Env("ChallengeTokenParam") | html %]" title="[% Translate("Delete this attachment") | html %]">
                                     [% Translate("Delete this attachment") | html %]
                                     <i class="fa fa-trash-o"></i>
                                 </a>
@@ -120,6 +120,12 @@
                         </tr>
                     </tbody>
                 </table>
+            </div>
+            <div class="Hidden" id="DeleteAttachmentDialogContainer">
+                <div id ="DeleteAttachmentDialog" class="InnerContent GenericInterfaceDialog">
+                    <p class="Center Spacing">[% Translate("Do you really want to delete this attachment?") | html %]</p>
+                    <div class="SpacingTop"></div>
+                </div>
             </div>
 [% RenderBlockEnd("OverviewResult") %]
 [% RenderBlockStart("OverviewUpdate") %]

--- a/var/httpd/htdocs/js/Core.Agent.Admin.Attachment.js
+++ b/var/httpd/htdocs/js/Core.Agent.Admin.Attachment.js
@@ -31,11 +31,55 @@ Core.Agent.Admin = Core.Agent.Admin || {};
     TargetNS.Init = function () {
         Core.UI.Table.InitTableFilter($("#FilterAttachments"), $("#Attachments"));
 
-        // bind click function to remove button
-        $('#Attachments a.TrashCan').on('click', function () {
-            if (window.confirm(Core.Language.Translate('Do you really want to delete this attachment?'))) {
-                return true;
-            }
+        // delete attachment
+        TargetNS.AttachmentDelete();
+    };
+
+    /**
+     * @name AttachmentDelete
+     * @memberof Core.Agent.Admin.Attachment
+     * @function
+     * @description
+     *      This function deletes attachment on buton click.
+     */
+    TargetNS.AttachmentDelete = function () {
+        $('.AttachmentDelete').on('click', function () {
+            var AttachmentDelete = $(this);
+
+            Core.UI.Dialog.ShowContentDialog(
+                $('#DeleteAttachmentDialogContainer'),
+                Core.Language.Translate('Delete this Attachment'),
+                '240px',
+                'Center',
+                true,
+                [
+                    {
+                        Class: 'CallForAction Primary',
+                        Label: Core.Language.Translate("Confirm"),
+                        Function: function() {
+                            $('.Dialog .InnerContent .Center').text(Core.Language.Translate("Deleting the attachment and its data. This may take a while..."));
+                            $('.Dialog .Content .ContentFooter').remove();
+
+                            Core.AJAX.FunctionCall(
+                                Core.Config.Get('Baselink'),
+                                AttachmentDelete.data('query-string'),
+                                function() {
+                                   Core.App.InternalRedirect({
+                                       Action: 'AdminAttachment'
+                                   });
+                                }
+                            );
+                        }
+                    },
+                    {
+                        Class: 'CallForAction',
+                        Label: Core.Language.Translate("Cancel"),
+                        Function: function () {
+                            Core.UI.Dialog.CloseDialog($('#DeleteAttachmentDialog'));
+                        }
+                    }
+                ]
+            );
             return false;
         });
     };


### PR DESCRIPTION
Hi @zottto 

Hereby is added confirmation button dialog for attachment delete in AdminAttachment module. Same logic is used as we did in AdminMailAccount. Selenium test is modified to reflect these changes.
In PR: https://github.com/OTRS/otrs/pull/1448 Balazs Ur added for rel-5_0 with browser confirmation. We will work on other screens as well where delete buttons exists.
Please let me know if you have any suggestions for this PR.

Regards
Zoran
