### PR TITLE
Add a missing word at the end of a sentence

### DIFF
--- a/Kernel/Output/HTML/Notification/AgentOTRSBusiness.pm
+++ b/Kernel/Output/HTML/Notification/AgentOTRSBusiness.pm
@@ -121,7 +121,7 @@ sub Run {
     if ( $UpdatesAvailable{OTRSBusinessUpdateAvailable} ) {
 
         my $Text = $LayoutObject->{LanguageObject}->Translate(
-            'An update for your %s is available! Please update at your earliest!',
+            'An update for your %s is available! Please update at your earliest convenience!',
             $OTRSBusinessLabel
         );
         $Output .= $LayoutObject->Notify(

--- a/Kernel/Output/HTML/Templates/Standard/AdminOTRSBusinessInstalled.tt
+++ b/Kernel/Output/HTML/Templates/Standard/AdminOTRSBusinessInstalled.tt
@@ -148,7 +148,7 @@
                     <i class="fa fa-refresh"></i>
                 </div>
                 <p class="Center">
-                    [% Translate('An update for your %s is available! Please update at your earliest!', OTRSBusinessLabel) %]
+                    [% Translate('An update for your %s is available! Please update at your earliest convenience!', OTRSBusinessLabel) %]
                 </p>
                 <div class="Center SpacingTop">
                     <a href="[% Env("Baselink") %]Action=[% Env("Action") %];Subaction=UpdateAction" class="CallForAction Primary"><span><i class="fa fa-refresh"></i> [% Translate('Update %s', OTRSBusinessLabel) %]</span></a>


### PR DESCRIPTION
- While translating strings for OTRS on Transifex, I came across a
  couple of source strings that had typos or missing words. This is
  one I've managed to find in the code to fix. I hope I've fixed it in
  the right places - I have no idea about Perl, I just figured that I
  should fix it in the source rather than every one of the i18n files
  in this repo.