### PR TITLE
Fixed handling hidden files and filter quotation fixes

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,4 +1,5 @@
 #6.0.0.beta1 2016-??-??
+ - 2016-10-05 Fixed handling hidden files and filter quotation fixes.
  - 2016-09-21 Fixed bug#[12065](http://bugs.otrs.org/show_bug.cgi?id=12065) - queue and state not mandatory.
  - 2016-09-12 Fixed bug#[11365](http://bugs.otrs.org/show_bug.cgi?id=11365) - ACLs editor shows actions where ACLs does not apply.
  - 2016-09-08 Made possible to define ServiceIDs and SLAIDs as default shown ticket search attributes, thanks to Paweł Bogusławski.

--- a/Kernel/System/SupportDataCollector.pm
+++ b/Kernel/System/SupportDataCollector.pm
@@ -120,14 +120,14 @@ sub Collect {
     # Look for all plug-ins in the FS
     my @PluginFiles = $Kernel::OM->Get('Kernel::System::Main')->DirectoryRead(
         Directory => dirname(__FILE__) . "/SupportDataCollector/Plugin",
-        Filter    => "*.pm",
+        Filter    => '*.pm',
         Recursive => 1,
     );
 
     # Look for all asynchronous plug-ins in the FS
     my @PluginAsynchronousFiles = $Kernel::OM->Get('Kernel::System::Main')->DirectoryRead(
         Directory => dirname(__FILE__) . "/SupportDataCollector/PluginAsynchronous",
-        Filter    => "*.pm",
+        Filter    => '*.pm',
         Recursive => 1,
     );
 
@@ -353,7 +353,7 @@ sub CollectAsynchronous {
     # Look for all plug-ins in the FS
     my @PluginFiles = $Kernel::OM->Get('Kernel::System::Main')->DirectoryRead(
         Directory => dirname(__FILE__) . "/SupportDataCollector/PluginAsynchronous",
-        Filter    => "*.pm",
+        Filter    => '*.pm',
         Recursive => 1,
     );
 
@@ -401,7 +401,7 @@ sub CleanupAsynchronous {
     # Look for all plug-ins in the FS
     my @PluginFiles = $Kernel::OM->Get('Kernel::System::Main')->DirectoryRead(
         Directory => dirname(__FILE__) . "/SupportDataCollector/PluginAsynchronous",
-        Filter    => "*.pm",
+        Filter    => '*.pm',
         Recursive => 1,
     );
 

--- a/Kernel/System/SysConfig.pm
+++ b/Kernel/System/SysConfig.pm
@@ -1627,7 +1627,7 @@ sub _Init {
     # load xml config files
     my @Files = $MainObject->DirectoryRead(
         Directory => $Directory,
-        Filter    => "*.xml",
+        Filter    => '*.xml',
     );
 
     # get the md5 representing the current configuration state

--- a/Kernel/System/Ticket/ArticleStorageDB.pm
+++ b/Kernel/System/Ticket/ArticleStorageDB.pm
@@ -203,8 +203,9 @@ sub ArticleDeleteAttachment {
     if ( -e $Path ) {
 
         my @List = $Kernel::OM->Get('Kernel::System::Main')->DirectoryRead(
-            Directory => $Path,
-            Filter    => "*",
+            Directory     => $Path,
+            Filter        => '*',
+            IncludeHidden => 1,
         );
 
         for my $File (@List) {
@@ -516,9 +517,10 @@ sub ArticleAttachmentIndexRaw {
 
     # try fs (if there is no index in fs)
     my @List = $MainObject->DirectoryRead(
-        Directory => "$Self->{ArticleDataDir}/$Param{ContentPath}/$Param{ArticleID}",
-        Filter    => "*",
-        Silent    => 1,
+        Directory     => "$Self->{ArticleDataDir}/$Param{ContentPath}/$Param{ArticleID}",
+        Filter        => '*',
+        IncludeHidden => 1,
+        Silent        => 1,
     );
 
     FILENAME:
@@ -739,9 +741,10 @@ sub ArticleAttachment {
     my $MainObject = $Kernel::OM->Get('Kernel::System::Main');
 
     my @List = $MainObject->DirectoryRead(
-        Directory => "$Self->{ArticleDataDir}/$ContentPath/$Param{ArticleID}",
-        Filter    => "*",
-        Silent    => 1,
+        Directory     => "$Self->{ArticleDataDir}/$ContentPath/$Param{ArticleID}",
+        Filter        => '*',
+        IncludeHidden => 1,
+        Silent        => 1,
     );
 
     if (@List) {

--- a/Kernel/System/Ticket/ArticleStorageFS.pm
+++ b/Kernel/System/Ticket/ArticleStorageFS.pm
@@ -234,8 +234,9 @@ sub ArticleDeleteAttachment {
     if ( -e $Path ) {
 
         my @List = $Kernel::OM->Get('Kernel::System::Main')->DirectoryRead(
-            Directory => $Path,
-            Filter    => "*",
+            Directory     => $Path,
+            Filter        => '*',
+            IncludeHidden => 1,
         );
 
         for my $File (@List) {
@@ -630,9 +631,10 @@ sub ArticleAttachmentIndexRaw {
 
     # try fs
     my @List = $MainObject->DirectoryRead(
-        Directory => "$Self->{ArticleDataDir}/$ContentPath/$Param{ArticleID}",
-        Filter    => "*",
-        Silent    => 1,
+        Directory     => "$Self->{ArticleDataDir}/$ContentPath/$Param{ArticleID}",
+        Filter        => '*',
+        IncludeHidden => 1,
+        Silent        => 1,
     );
 
     FILENAME:
@@ -896,9 +898,10 @@ sub ArticleAttachment {
     my $MainObject = $Kernel::OM->Get('Kernel::System::Main');
 
     my @List = $MainObject->DirectoryRead(
-        Directory => "$Self->{ArticleDataDir}/$ContentPath/$Param{ArticleID}",
-        Filter    => "*",
-        Silent    => 1,
+        Directory     => "$Self->{ArticleDataDir}/$ContentPath/$Param{ArticleID}",
+        Filter        => '*',
+        IncludeHidden => 1,
+        Silent        => 1,
     );
 
     if (@List) {

--- a/Kernel/System/UnitTest/Helper.pm
+++ b/Kernel/System/UnitTest/Helper.pm
@@ -658,7 +658,7 @@ sub ConfigSettingCleanup {
     my $Home  = $Kernel::OM->Get('Kernel::Config')->Get('Home');
     my @Files = $Kernel::OM->Get('Kernel::System::Main')->DirectoryRead(
         Directory => "$Home/Kernel/Config/Files",
-        Filter    => "ZZZZUnitTest*.pm",
+        Filter    => 'ZZZZUnitTest*.pm',
     );
     for my $File (@Files) {
         $Kernel::OM->Get('Kernel::System::Main')->FileDelete(

--- a/Kernel/System/Web/UploadCache/FS.pm
+++ b/Kernel/System/Web/UploadCache/FS.pm
@@ -62,7 +62,7 @@ sub FormIDRemove {
 
     my @List = $MainObject->DirectoryRead(
         Directory => $Directory,
-        Filter    => "*",
+        Filter    => '*',
     );
 
     my @Data;
@@ -232,7 +232,7 @@ sub FormIDGetAllFilesData {
 
     my @List = $MainObject->DirectoryRead(
         Directory => $Directory,
-        Filter    => "*",
+        Filter    => '*',
     );
 
     my $Counter = 0;
@@ -337,7 +337,7 @@ sub FormIDGetAllFilesMeta {
 
     my @List = $MainObject->DirectoryRead(
         Directory => $Directory,
-        Filter    => "*",
+        Filter    => '*',
     );
 
     my $Counter = 0;
@@ -442,7 +442,7 @@ sub FormIDCleanUp {
         if ( $RetentionTime > $SubdirTime ) {
             my @Sublist = $MainObject->DirectoryRead(
                 Directory => $Subdir,
-                Filter    => "*",
+                Filter    => '*',
             );
 
             for my $File (@Sublist) {

--- a/scripts/test/Config/Defaults.t
+++ b/scripts/test/Config/Defaults.t
@@ -29,7 +29,7 @@ and cause wrong test failures.
 my $Directory   = $Kernel::OM->Get('Kernel::Config')->Get('Home') . "/Kernel/Config/Files/";
 my @ConfigFiles = $Kernel::OM->Get('Kernel::System::Main')->DirectoryRead(
     Directory => $Directory,
-    Filter    => "*.xml",
+    Filter    => '*.xml',
 );
 
 my %AllowedConfigFiles = (


### PR DESCRIPTION
If mail with attachment headers like...

    Content-Type: text/plain; charset=UTF-8;
     name="../../../uploads/578_jpg_org.txt"
    Content-Transfer-Encoding: base64
    Content-Disposition: attachment;
     filename="../../../uploads/578_jpg_org.txt"

...arrives to OTRS, attachment file

    _.._.._uploads_578_jpg_org.txt

is created in article dir. This file is not present in the ticket
attachment list. When generic agent tries to remove ticket, this
file is not removed and error deleting article dir occurs like this:

    Can't remove: [...]2016/10/05/4: Directory not empty!

Problem does not occur if mod described in https://dev.ib.pl/ib/otrs/issues/59
is applied (this removes periods from filename prefixes using secured
FilenameCleanUp() function).

This mod fixes problem described above and contains minor quotation
changes in DirectoryRead calls.

Related: https://dev.ib.pl/ib/otrs/issues/96
Author-Change-Id: IB#1039611