### PR TITLE
Disabled warnings on internal unicode chacter printing

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,4 +1,5 @@
 #6.0.0.beta1 2016-??-??
+ - 2016-10-10 Disabled warnings on internal unicode chacter printing.
  - 2016-09-21 Fixed bug#[12065](http://bugs.otrs.org/show_bug.cgi?id=12065) - queue and state not mandatory.
  - 2016-09-12 Fixed bug#[11365](http://bugs.otrs.org/show_bug.cgi?id=11365) - ACLs editor shows actions where ACLs does not apply.
  - 2016-09-08 Made possible to define ServiceIDs and SLAIDs as default shown ticket search attributes, thanks to Paweł Bogusławski.

--- a/Kernel/Output/HTML/Layout.pm
+++ b/Kernel/Output/HTML/Layout.pm
@@ -1688,6 +1688,10 @@ sub Print {
         binmode STDOUT, ':bytes';
     }
 
+    # disable perl warnings in case of printing unicode private chars
+    # see https://rt.perl.org/Public/Bug/Display.html?id=121226
+    no warnings 'nonchar';
+
     print ${ $Param{Output} };
 
     return 1;


### PR DESCRIPTION
OTRS throws warning

```
Unicode non-character U+FFFF is illegal for open interchange at [...]Kernel/Output/HTML/Layout.pm [...]
```

to apache error log on displaying article containing unicode 0xFFFF
character (i.e. content comming from UTF-8 e-mail with character 0xFFFF).

Problem with such warnings in perl was discussed on
https://rt.perl.org/Public/Bug/Display.html?id=121226

OTRS should not pollute apache logs with such warnings if allows
such private chars to leak from e-mails to web browser.

This mod disables such warnings in OTRS on printing articles
to web browser.

Related: https://dev.ib.pl/ib/otrs/issues/97
Related: https://rt.perl.org/Public/Bug/Display.html?id=121226
Author-Change-Id: IB#1036717
