### PR TITLE
TicketSearch: Allow filtering for non-empty dynamic fields

### DIFF
--- a/Kernel/GenericInterface/Operation/Ticket/TicketSearch.pm
+++ b/Kernel/GenericInterface/Operation/Ticket/TicketSearch.pm
@@ -138,6 +138,7 @@ perform TicketSearch Operation. This will return a Ticket ID list.
         #       values in an operator with OR.
         #   You can also pass more than one argument to an operator: ['value1', 'value2']
         DynamicField_FieldNameX => {
+            Empty             => 1,                       # will return dynamic fields without a value (default: 0)
             Equals            => 123,
             Like              => 'value*',                # "equals" operator with wildcard support
             GreaterThan       => '2001-01-01 01:01:01',
@@ -392,7 +393,7 @@ sub _GetParams {
 
     # get array params
     for my $Item (
-        qw(TicketNumber Title
+        qw(TicketNumber TicketID Title
         StateIDs StateTypeIDs QueueIDs PriorityIDs OwnerIDs
         CreatedUserIDs WatchUserIDs ResponsibleIDs
         TypeIDs ServiceIDs SLAIDs LockIDs Queues Types States

--- a/Kernel/System/DynamicField/Driver/BaseDateTime.pm
+++ b/Kernel/System/DynamicField/Driver/BaseDateTime.pm
@@ -126,7 +126,11 @@ sub SearchSQLGet {
         SmallerThanEquals => '<=',
     );
 
-    if ( !$Operators{ $Param{Operator} } ) {
+    if ( $Param{Operator} eq 'Empty' ) {
+        my $SQL = " $Param{TableAlias}.value_date IS NULL ";
+        return $SQL;
+    }
+    elsif ( !$Operators{ $Param{Operator} } ) {
         $Kernel::OM->Get('Kernel::System::Log')->Log(
             'Priority' => 'error',
             'Message'  => "Unsupported Operator $Param{Operator}",

--- a/Kernel/System/DynamicField/Driver/BaseDateTime.pm
+++ b/Kernel/System/DynamicField/Driver/BaseDateTime.pm
@@ -127,8 +127,12 @@ sub SearchSQLGet {
     );
 
     if ( $Param{Operator} eq 'Empty' ) {
-        my $SQL = " $Param{TableAlias}.value_date IS NULL ";
-        return $SQL;
+        if ($Param{SearchTerm} ) {
+            return " $Param{TableAlias}.value_date IS NULL ";
+        }
+        else {
+            return " $Param{TableAlias}.value_date IS NOT NULL ";
+        }
     }
     elsif ( !$Operators{ $Param{Operator} } ) {
         $Kernel::OM->Get('Kernel::System::Log')->Log(

--- a/Kernel/System/DynamicField/Driver/BaseSelect.pm
+++ b/Kernel/System/DynamicField/Driver/BaseSelect.pm
@@ -113,7 +113,7 @@ sub SearchSQLGet {
     );
 
     if ( $Param{Operator} eq 'Empty' ) {
-        my $SQL = " $Param{TableAlias}.value_text IS NULL ";
+        my $SQL = " $Param{TableAlias}.value_text IS NULL OR $Param{TableAlias}.value_text = '' ";
         return $SQL;
     }
     elsif ( !$Operators{ $Param{Operator} } ) {

--- a/Kernel/System/DynamicField/Driver/BaseSelect.pm
+++ b/Kernel/System/DynamicField/Driver/BaseSelect.pm
@@ -112,7 +112,11 @@ sub SearchSQLGet {
         SmallerThanEquals => '<=',
     );
 
-    if ( !$Operators{ $Param{Operator} } ) {
+    if ( $Param{Operator} eq 'Empty' ) {
+        my $SQL = " $Param{TableAlias}.value_text IS NULL ";
+        return $SQL;
+    }
+    elsif ( !$Operators{ $Param{Operator} } ) {
         $Kernel::OM->Get('Kernel::System::Log')->Log(
             'Priority' => 'error',
             'Message'  => "Unsupported Operator $Param{Operator}",

--- a/Kernel/System/DynamicField/Driver/BaseSelect.pm
+++ b/Kernel/System/DynamicField/Driver/BaseSelect.pm
@@ -113,8 +113,12 @@ sub SearchSQLGet {
     );
 
     if ( $Param{Operator} eq 'Empty' ) {
-        my $SQL = " $Param{TableAlias}.value_text IS NULL OR $Param{TableAlias}.value_text = '' ";
-        return $SQL;
+        if ( $Param{SearchTerm} ) {
+            return " $Param{TableAlias}.value_text IS NULL OR $Param{TableAlias}.value_text = '' ";
+        }
+        else {
+            return " $Param{TableAlias}.value_text <> '' ";
+        }
     }
     elsif ( !$Operators{ $Param{Operator} } ) {
         $Kernel::OM->Get('Kernel::System::Log')->Log(

--- a/Kernel/System/DynamicField/Driver/BaseText.pm
+++ b/Kernel/System/DynamicField/Driver/BaseText.pm
@@ -126,7 +126,11 @@ sub SearchSQLGet {
         SmallerThanEquals => '<=',
     );
 
-    if ( !$Operators{ $Param{Operator} } ) {
+    if ( $Param{Operator} eq 'Empty' ) {
+        my $SQL = " $Param{TableAlias}.value_text IS NULL ";
+        return $SQL;
+    }
+    elsif ( !$Operators{ $Param{Operator} } ) {
         $Kernel::OM->Get('Kernel::System::Log')->Log(
             'Priority' => 'error',
             'Message'  => "Unsupported Operator $Param{Operator}",

--- a/Kernel/System/DynamicField/Driver/BaseText.pm
+++ b/Kernel/System/DynamicField/Driver/BaseText.pm
@@ -127,8 +127,12 @@ sub SearchSQLGet {
     );
 
     if ( $Param{Operator} eq 'Empty' ) {
-        my $SQL = " $Param{TableAlias}.value_text IS NULL ";
-        return $SQL;
+        if ( $Param{SearchTerm} ) {
+            return " $Param{TableAlias}.value_text IS NULL ";
+        }
+        else {
+            return " $Param{TableAlias}.value_text <> '' ";
+        }
     }
     elsif ( !$Operators{ $Param{Operator} } ) {
         $Kernel::OM->Get('Kernel::System::Log')->Log(

--- a/Kernel/System/DynamicField/Driver/Checkbox.pm
+++ b/Kernel/System/DynamicField/Driver/Checkbox.pm
@@ -187,7 +187,7 @@ sub SearchSQLGet {
     );
 
     if ( $Param{Operator} eq 'Empty' ) {
-        my $SQL = " ($Param{TableAlias}.value_int IS NULL OR $Param{TableAlias}.value_int = 0) ";
+        my $SQL = " $Param{TableAlias}.value_int IS NULL ";
         return $SQL;
     }
     elsif ( !$Operators{ $Param{Operator} } ) {

--- a/Kernel/System/DynamicField/Driver/Checkbox.pm
+++ b/Kernel/System/DynamicField/Driver/Checkbox.pm
@@ -186,7 +186,11 @@ sub SearchSQLGet {
         Equals => '=',
     );
 
-    if ( !$Operators{ $Param{Operator} } ) {
+    if ( $Param{Operator} eq 'Empty' ) {
+        my $SQL = " ($Param{TableAlias}.value_int IS NULL OR $Param{TableAlias}.value_int = 0) ";
+        return $SQL;
+    }
+    elsif ( !$Operators{ $Param{Operator} } ) {
         $Kernel::OM->Get('Kernel::System::Log')->Log(
             'Priority' => 'error',
             'Message'  => "Unsupported Operator $Param{Operator}",

--- a/Kernel/System/DynamicField/Driver/Checkbox.pm
+++ b/Kernel/System/DynamicField/Driver/Checkbox.pm
@@ -187,8 +187,12 @@ sub SearchSQLGet {
     );
 
     if ( $Param{Operator} eq 'Empty' ) {
-        my $SQL = " $Param{TableAlias}.value_int IS NULL ";
-        return $SQL;
+        if ( $Param{SearchTerm} ) {
+            return " $Param{TableAlias}.value_int IS NULL ";
+        }
+        else {
+            return " $Param{TableAlias}.value_int IS NOT NULL ";
+        }
     }
     elsif ( !$Operators{ $Param{Operator} } ) {
         $Kernel::OM->Get('Kernel::System::Log')->Log(

--- a/Kernel/System/DynamicField/Driver/Date.pm
+++ b/Kernel/System/DynamicField/Driver/Date.pm
@@ -221,7 +221,11 @@ sub SearchSQLGet {
         SmallerThanEquals => '<=',
     );
 
-    if ( !$Operators{ $Param{Operator} } ) {
+    if ( $Param{Operator} eq 'Empty' ) {
+        my $SQL = " $Param{TableAlias}.value_date IS NULL ";
+        return $SQL;
+    }
+    elsif ( !$Operators{ $Param{Operator} } ) {
         $Kernel::OM->Get('Kernel::System::Log')->Log(
             'Priority' => 'error',
             'Message'  => "Unsupported Operator $Param{Operator}",

--- a/Kernel/System/DynamicField/Driver/Date.pm
+++ b/Kernel/System/DynamicField/Driver/Date.pm
@@ -222,8 +222,12 @@ sub SearchSQLGet {
     );
 
     if ( $Param{Operator} eq 'Empty' ) {
-        my $SQL = " $Param{TableAlias}.value_date IS NULL ";
-        return $SQL;
+        if ( $Param{SearchTerm} ) {
+            return " $Param{TableAlias}.value_date IS NULL ";
+        }
+        else {
+            return " $Param{TableAlias}.value_date IS NOT NULL ";
+        }
     }
     elsif ( !$Operators{ $Param{Operator} } ) {
         $Kernel::OM->Get('Kernel::System::Log')->Log(

--- a/Kernel/System/Ticket/TicketSearch.pm
+++ b/Kernel/System/Ticket/TicketSearch.pm
@@ -125,6 +125,7 @@ To find tickets in your system.
         #       values in an operator with OR.
         #   You can also pass more than one argument to an operator: ['value1', 'value2']
         DynamicField_FieldNameX => {
+            Empty             => 1,                       # will return dynamic fields without a value (default: 0)
             Equals            => 123,
             Like              => 'value*',                # "equals" operator with wildcard support
             GreaterThan       => '2001-01-01 01:01:01',
@@ -1291,6 +1292,8 @@ sub TicketSearch {
 
     DYNAMIC_FIELD:
     for my $DynamicField ( @{$TicketDynamicFields}, @{$ArticleDynamicFields} ) {
+        my $DynamicFieldsEmpty    = 0;
+        my $DynamicFieldsStandard = 0;
         my $SearchParam = delete $Param{ "DynamicField_" . $DynamicField->{Name} };
 
         next DYNAMIC_FIELD if ( !$SearchParam );
@@ -1315,34 +1318,50 @@ sub TicketSearch {
                 # check search attribute, we do not need to search for *
                 next TEXT if $Text =~ /^\%{1,3}$/;
 
-                # validate data type
-                my $ValidateSuccess = $DynamicFieldBackendObject->ValueValidate(
-                    DynamicFieldConfig => $DynamicField,
-                    Value              => $Text,
-                    UserID             => $Param{UserID} || 1,
-                );
-                if ( !$ValidateSuccess ) {
-                    $Kernel::OM->Get('Kernel::System::Log')->Log(
-                        Priority => 'error',
-                        Message =>
-                            "Search not executed due to invalid value '"
-                            . $Text
-                            . "' on field '"
-                            . $DynamicField->{Name}
-                            . "'!",
+                # skip validation for empty values
+                if ( $Operator ne 'Empty' ) {
+
+                    # validate data type
+                    my $ValidateSuccess = $DynamicFieldBackendObject->ValueValidate(
+                        DynamicFieldConfig => $DynamicField,
+                        Value              => $Text,
+                        UserID             => $Param{UserID} || 1,
                     );
-                    return;
+                    if ( !$ValidateSuccess ) {
+                        $Kernel::OM->Get('Kernel::System::Log')->Log(
+                            Priority => 'error',
+                            Message =>
+                                "Search not executed due to invalid value '"
+                                . $Text
+                                . "' on field '"
+                                . $DynamicField->{Name}
+                                . "'!",
+                        );
+                        return;
+                    }
                 }
 
                 if ($Counter) {
                     $SQLExtSub .= ' OR ';
                 }
-                $SQLExtSub .= $DynamicFieldBackendObject->SearchSQLGet(
-                    DynamicFieldConfig => $DynamicField,
-                    TableAlias         => "dfv$DynamicFieldJoinCounter",
-                    Operator           => $Operator,
-                    SearchTerm         => $Text,
-                );
+                if ( $Operator eq 'Empty' ) {
+                    $SQLExtSub .= $DynamicFieldBackendObject->SearchSQLGet(
+                        DynamicFieldConfig => $DynamicField,
+                        TableAlias         => "dfvEmpty$DynamicFieldJoinCounter",
+                        Operator           => $Operator,
+                        SearchTerm         => $Text,
+                    );
+                    $DynamicFieldsEmpty = 1;
+                }
+                else {
+                    $SQLExtSub .= $DynamicFieldBackendObject->SearchSQLGet(
+                        DynamicFieldConfig => $DynamicField,
+                        TableAlias         => "dfv$DynamicFieldJoinCounter",
+                        Operator           => $Operator,
+                        SearchTerm         => $Text,
+                    );
+                    $DynamicFieldsStandard = 1;
+                }
 
                 $Counter++;
             }
@@ -1358,10 +1377,18 @@ sub TicketSearch {
             if ( $DynamicField->{ObjectType} eq 'Ticket' ) {
 
                 # Join the table for this dynamic field
-                $SQLFrom .= "INNER JOIN dynamic_field_value dfv$DynamicFieldJoinCounter
-                    ON (st.id = dfv$DynamicFieldJoinCounter.object_id
-                        AND dfv$DynamicFieldJoinCounter.field_id = " .
-                    $DBObject->Quote( $DynamicField->{ID}, 'Integer' ) . ") ";
+                if ($DynamicFieldsStandard) {
+                    $SQLFrom .= "INNER JOIN dynamic_field_value dfv$DynamicFieldJoinCounter
+                        ON (st.id = dfv$DynamicFieldJoinCounter.object_id
+                            AND dfv$DynamicFieldJoinCounter.field_id = " .
+                        $DBObject->Quote( $DynamicField->{ID}, 'Integer' ) . ") ";
+                }
+                if ($DynamicFieldsEmpty) {
+                    $SQLFrom .= "LEFT JOIN dynamic_field_value dfvEmpty$DynamicFieldJoinCounter
+                        ON (st.id = dfvEmpty$DynamicFieldJoinCounter.object_id
+                            AND dfvEmpty$DynamicFieldJoinCounter.field_id = " .
+                        $DBObject->Quote( $DynamicField->{ID}, 'Integer' ) . ") ";
+                }
             }
             elsif ( $DynamicField->{ObjectType} eq 'Article' ) {
                 if ( !$ArticleJoinSQL ) {
@@ -1369,10 +1396,18 @@ sub TicketSearch {
                     $SQLFrom .= $ArticleJoinSQL;
                 }
 
-                $SQLFrom .= "INNER JOIN dynamic_field_value dfv$DynamicFieldJoinCounter
-                    ON (art.id = dfv$DynamicFieldJoinCounter.object_id
-                        AND dfv$DynamicFieldJoinCounter.field_id = " .
-                    $DBObject->Quote( $DynamicField->{ID}, 'Integer' ) . ") ";
+                if ($DynamicFieldsStandard) {
+                    $SQLFrom .= "INNER JOIN dynamic_field_value dfv$DynamicFieldJoinCounter
+                        ON (art.id = dfv$DynamicFieldJoinCounter.object_id
+                            AND dfv$DynamicFieldJoinCounter.field_id = " .
+                        $DBObject->Quote( $DynamicField->{ID}, 'Integer' ) . ") ";
+                }
+                if ($DynamicFieldsEmpty) {
+                    $SQLFrom .= "LEFT JOIN dynamic_field_value dfvEmpty$DynamicFieldJoinCounter
+                        ON (art.id = dfvEmpty$DynamicFieldJoinCounter.object_id
+                            AND dfvEmpty$DynamicFieldJoinCounter.field_id = " .
+                        $DBObject->Quote( $DynamicField->{ID}, 'Integer' ) . ") ";
+                }
 
             }
 

--- a/Kernel/System/Ticket/TicketSearch.pm
+++ b/Kernel/System/Ticket/TicketSearch.pm
@@ -125,7 +125,8 @@ To find tickets in your system.
         #       values in an operator with OR.
         #   You can also pass more than one argument to an operator: ['value1', 'value2']
         DynamicField_FieldNameX => {
-            Empty             => 1,                       # will return dynamic fields without a value (default: 0)
+            Empty             => 1,                       # will return dynamic fields without a value
+                                                          # set to 0 to invert the condition
             Equals            => 123,
             Like              => 'value*',                # "equals" operator with wildcard support
             GreaterThan       => '2001-01-01 01:01:01',

--- a/development/webservices/GenericTicketConnectorSOAP.wsdl
+++ b/development/webservices/GenericTicketConnectorSOAP.wsdl
@@ -2094,8 +2094,13 @@ WARNING: This WSDL file is for Development and Test purposes ONLY!
         <xsd:sequence>
             <xsd:choice minOccurs="1" maxOccurs="1">
                 <xsd:annotation>
-                    <xsd:documentation>Equals, Like, GreaterThan, GreaterThanEquals, SmallerThan or SmallerThanEquals is mandatory</xsd:documentation>
+                    <xsd:documentation>Empty, Equals, Like, GreaterThan, GreaterThanEquals, SmallerThan or SmallerThanEquals is mandatory</xsd:documentation>
                 </xsd:annotation>
+                <xsd:element
+                    name="Empty"
+                    type="xsd:string"
+                    minOccurs="0" maxOccurs="1">
+                </xsd:element>
                 <xsd:element
                     name="Equals"
                     type="xsd:string"

--- a/scripts/test/DynamicField/SearchSQLGet.t
+++ b/scripts/test/DynamicField/SearchSQLGet.t
@@ -296,7 +296,7 @@ my @Tests = (
             },
         },
         ExpectedResult => {
-            Empty             => " (dfv.value_int IS NULL OR dfv.value_int = 0) ",
+            Empty             => " dfv.value_int IS NULL ",
             Equals            => " dfv.value_int = 123 ",
             GreaterThan       => undef,
             GreaterThanEquals => undef,
@@ -321,7 +321,7 @@ my @Tests = (
             },
         },
         ExpectedResult => {
-            Empty            => " dfv.value_text IS NULL ",
+            Empty            => " dfv.value_text IS NULL OR dfv.value_text = '' ",
             Equals            => " dfv.value_text = 'Foo' ",
             GreaterThan       => " dfv.value_text > 'Foo' ",
             GreaterThanEquals => " dfv.value_text >= 'Foo' ",
@@ -348,7 +348,7 @@ my @Tests = (
             },
         },
         ExpectedResult => {
-            Empty             => " dfv.value_text IS NULL ",
+            Empty             => " dfv.value_text IS NULL OR dfv.value_text = '' ",
             Equals            => " dfv.value_text = 'Foo' ",
             GreaterThan       => " dfv.value_text > 'Foo' ",
             GreaterThanEquals => " dfv.value_text >= 'Foo' ",

--- a/scripts/test/DynamicField/SearchSQLGet.t
+++ b/scripts/test/DynamicField/SearchSQLGet.t
@@ -209,6 +209,7 @@ my @Tests = (
             DynamicFieldConfig => $DynamicFieldConfigs{Text},
             TableAlias         => 'dfv',
             TestOperators      => {
+                Empty             => 1,
                 Equals            => 'Foo',
                 GreaterThan       => 'Foo',
                 GreaterThanEquals => 'Foo',
@@ -218,6 +219,7 @@ my @Tests = (
             },
         },
         ExpectedResult => {
+            Empty            => " dfv.value_text IS NULL ",
             Equals            => " dfv.value_text = 'Foo' ",
             GreaterThan       => " dfv.value_text > 'Foo' ",
             GreaterThanEquals => " dfv.value_text >= 'Foo' ",
@@ -234,6 +236,7 @@ my @Tests = (
             DynamicFieldConfig => $DynamicFieldConfigs{TextArea},
             TableAlias         => 'dfv',
             TestOperators      => {
+                Empty             => 1,
                 Equals            => 'Foo',
                 GreaterThan       => 'Foo',
                 GreaterThanEquals => 'Foo',
@@ -243,6 +246,7 @@ my @Tests = (
             },
         },
         ExpectedResult => {
+            Empty             => " dfv.value_text IS NULL ",
             Equals            => " dfv.value_text = 'Foo' ",
             GreaterThan       => " dfv.value_text > 'Foo' ",
             GreaterThanEquals => " dfv.value_text >= 'Foo' ",
@@ -282,6 +286,7 @@ my @Tests = (
             DynamicFieldConfig => $DynamicFieldConfigs{Checkbox},
             TableAlias         => 'dfv',
             TestOperators      => {
+                Empty             => 1,
                 Equals            => 123,
                 GreaterThan       => 123,
                 GreaterThanEquals => 123,
@@ -291,6 +296,7 @@ my @Tests = (
             },
         },
         ExpectedResult => {
+            Empty             => " (dfv.value_int IS NULL OR dfv.value_int = 0) ",
             Equals            => " dfv.value_int = 123 ",
             GreaterThan       => undef,
             GreaterThanEquals => undef,
@@ -305,6 +311,7 @@ my @Tests = (
             DynamicFieldConfig => $DynamicFieldConfigs{Dropdown},
             TableAlias         => 'dfv',
             TestOperators      => {
+                Empty             => 1,
                 Equals            => 'Foo',
                 GreaterThan       => 'Foo',
                 GreaterThanEquals => 'Foo',
@@ -314,6 +321,7 @@ my @Tests = (
             },
         },
         ExpectedResult => {
+            Empty            => " dfv.value_text IS NULL ",
             Equals            => " dfv.value_text = 'Foo' ",
             GreaterThan       => " dfv.value_text > 'Foo' ",
             GreaterThanEquals => " dfv.value_text >= 'Foo' ",
@@ -330,6 +338,7 @@ my @Tests = (
             DynamicFieldConfig => $DynamicFieldConfigs{Multiselect},
             TableAlias         => 'dfv',
             TestOperators      => {
+                Empty             => 1,
                 Equals            => 'Foo',
                 GreaterThan       => 'Foo',
                 GreaterThanEquals => 'Foo',
@@ -339,6 +348,7 @@ my @Tests = (
             },
         },
         ExpectedResult => {
+            Empty             => " dfv.value_text IS NULL ",
             Equals            => " dfv.value_text = 'Foo' ",
             GreaterThan       => " dfv.value_text > 'Foo' ",
             GreaterThanEquals => " dfv.value_text >= 'Foo' ",
@@ -355,6 +365,7 @@ my @Tests = (
             DynamicFieldConfig => $DynamicFieldConfigs{DateTime},
             TableAlias         => 'dfv',
             TestOperators      => {
+                Empty             => 1,
                 Equals            => 'Foo',
                 GreaterThan       => 'Foo',
                 GreaterThanEquals => 'Foo',
@@ -364,6 +375,7 @@ my @Tests = (
             },
         },
         ExpectedResult => {
+            Empty            => " dfv.value_date IS NULL ",
             Equals            => " dfv.value_date = 'Foo' ",
             GreaterThan       => " dfv.value_date > 'Foo' ",
             GreaterThanEquals => " dfv.value_date >= 'Foo' ",
@@ -378,6 +390,7 @@ my @Tests = (
             DynamicFieldConfig => $DynamicFieldConfigs{Date},
             TableAlias         => 'dfv',
             TestOperators      => {
+                Empty             => 1,
                 Equals            => 'Foo',
                 GreaterThan       => 'Foo',
                 GreaterThanEquals => 'Foo',
@@ -387,6 +400,7 @@ my @Tests = (
             },
         },
         ExpectedResult => {
+            Empty             => " dfv.value_date IS NULL ",
             Equals            => " dfv.value_date = 'Foo' ",
             GreaterThan       => " dfv.value_date > 'Foo' ",
             GreaterThanEquals => " dfv.value_date >= 'Foo' ",

--- a/scripts/test/DynamicField/SearchSQLGet.t
+++ b/scripts/test/DynamicField/SearchSQLGet.t
@@ -258,6 +258,19 @@ my @Tests = (
         },
     },
     {
+        Name   => 'TextArea Not Empty',
+        Config => {
+            DynamicFieldConfig => $DynamicFieldConfigs{TextArea},
+            TableAlias         => 'dfv',
+            TestOperators      => {
+                Empty             => 0,
+            },
+        },
+        ExpectedResult => {
+            Empty             => " dfv.value_text <> '' ",
+        },
+    },
+    {
         Name   => 'Checkbox Wrong Data',
         Config => {
             DynamicFieldConfig => $DynamicFieldConfigs{Checkbox},
@@ -306,6 +319,19 @@ my @Tests = (
         },
     },
     {
+        Name   => 'Checkbox Not Empty',
+        Config => {
+            DynamicFieldConfig => $DynamicFieldConfigs{Checkbox},
+            TableAlias         => 'dfv',
+            TestOperators      => {
+                Empty             => 0,
+            },
+        },
+        ExpectedResult => {
+            Empty             => " dfv.value_int IS NOT NULL ",
+        },
+    },
+    {
         Name   => 'Dropdown',
         Config => {
             DynamicFieldConfig => $DynamicFieldConfigs{Dropdown},
@@ -330,6 +356,19 @@ my @Tests = (
             },
             SmallerThan       => " dfv.value_text < 'Foo' ",
             SmallerThanEquals => " dfv.value_text <= 'Foo' ",
+        },
+    },
+    {
+        Name   => 'Dropdown Not Empty',
+        Config => {
+            DynamicFieldConfig => $DynamicFieldConfigs{Dropdown},
+            TableAlias         => 'dfv',
+            TestOperators      => {
+                Empty             => 0,
+            },
+        },
+        ExpectedResult => {
+            Empty            => " dfv.value_text <> '' ",
         },
     },
     {
@@ -360,6 +399,19 @@ my @Tests = (
         },
     },
     {
+        Name   => 'Multiselect Not Empty',
+        Config => {
+            DynamicFieldConfig => $DynamicFieldConfigs{Multiselect},
+            TableAlias         => 'dfv',
+            TestOperators      => {
+                Empty             => 0,
+            },
+        },
+        ExpectedResult => {
+            Empty             => " dfv.value_text <> '' ",
+        },
+    },
+    {
         Name   => 'DateTime',
         Config => {
             DynamicFieldConfig => $DynamicFieldConfigs{DateTime},
@@ -382,6 +434,19 @@ my @Tests = (
             Like              => undef,
             SmallerThan       => " dfv.value_date < 'Foo' ",
             SmallerThanEquals => " dfv.value_date <= 'Foo' ",
+        },
+    },
+    {
+        Name   => 'DateTime Not Empty',
+        Config => {
+            DynamicFieldConfig => $DynamicFieldConfigs{DateTime},
+            TableAlias         => 'dfv',
+            TestOperators      => {
+                Empty             => 0,
+            },
+        },
+        ExpectedResult => {
+            Empty            => " dfv.value_date IS NOT NULL ",
         },
     },
     {
@@ -408,6 +473,19 @@ my @Tests = (
             SmallerThan       => " dfv.value_date < 'Foo' ",
             SmallerThanEquals => " dfv.value_date <= 'Foo' ",
         },
+    },
+    {
+        Name   => 'Date',
+        Config => {
+            DynamicFieldConfig => $DynamicFieldConfigs{Date},
+            TableAlias         => 'dfv',
+            TestOperators      => {
+                Empty             => 0,
+            },
+        },
+        ExpectedResult => {
+            Empty             => " dfv.value_date IS NOT NULL ",
+        }
     },
 );
 

--- a/scripts/test/GenericInterface/Operation/Ticket/TicketSearch.t
+++ b/scripts/test/GenericInterface/Operation/Ticket/TicketSearch.t
@@ -1468,13 +1468,13 @@ my @Tests = (
         },
         ExpectedReturnLocalData => {
             Data => {
-                TicketID => [ $TicketID1, $TicketID3, $TicketID4 ],
+                TicketID => [ $TicketID3, $TicketID4 ],
             },
             Success => 1
         },
         ExpectedReturnRemoteData => {
             Data => {
-                TicketID => [ $TicketID1, $TicketID3, $TicketID4, ],
+                TicketID => [ $TicketID3, $TicketID4 ],
             },
             Success => 1,
         },

--- a/scripts/test/GenericInterface/Operation/Ticket/TicketSearch.t
+++ b/scripts/test/GenericInterface/Operation/Ticket/TicketSearch.t
@@ -1380,6 +1380,140 @@ my @Tests = (
         },
         Operation => 'TicketSearch',
     },
+    {
+        Name           => "Test Operator 'Empty' DFT1 - DF " . $TestCounter++,
+        SuccessRequest => 1,
+        RequestData    => {
+            TicketID     => [$TicketID1, $TicketID2, $TicketID3, $TicketID4],
+            "DynamicField_DFT1$RandomID" => {
+                Empty => 1,
+            },
+            OrderBy => 'Up',
+            SortBy  => 'TicketNumber',
+        },
+        ExpectedReturnLocalData => {
+            Data => {
+                TicketID => [ $TicketID3, $TicketID4 ],
+            },
+            Success => 1
+        },
+        ExpectedReturnRemoteData => {
+            Data => {
+                TicketID => [ $TicketID3, $TicketID4 ],
+            },
+            Success => 1,
+        },
+        Operation => 'TicketSearch',
+    },
+    {
+        Name           => "Test Operator 'Empty' DFT2 - DF " . $TestCounter++,
+        SuccessRequest => 1,
+        RequestData    => {
+            TicketID     => [$TicketID1, $TicketID2, $TicketID3, $TicketID4],
+            "DynamicField_DFT2$RandomID" => {
+                Empty => 1,
+            },
+            OrderBy => 'Up',
+            SortBy  => 'TicketNumber',
+        },
+        ExpectedReturnLocalData => {
+            Data => {
+                TicketID => [ $TicketID3, $TicketID4 ],
+            },
+            Success => 1
+        },
+        ExpectedReturnRemoteData => {
+            Data => {
+                TicketID => [ $TicketID3, $TicketID4 ],
+            },
+            Success => 1,
+        },
+        Operation => 'TicketSearch',
+    },
+    {
+        Name           => "Test Operator 'Empty' DFT3 - DF " . $TestCounter++,
+        SuccessRequest => 1,
+        RequestData    => {
+            TicketID     => [$TicketID1, $TicketID2, $TicketID3, $TicketID4],
+            "DynamicField_DFT3$RandomID" => {
+                Empty => 1,
+            },
+            OrderBy => 'Up',
+            SortBy  => 'TicketNumber',
+        },
+        ExpectedReturnLocalData => {
+            Data => {
+                TicketID => [ $TicketID3, $TicketID4 ],
+            },
+            Success => 1
+        },
+        ExpectedReturnRemoteData => {
+            Data => {
+                TicketID => [ $TicketID3, $TicketID4 ],
+            },
+            Success => 1,
+        },
+        Operation => 'TicketSearch',
+    },
+    {
+        Name           => "Test Operator 'Empty' DFT4 - DF " . $TestCounter++,
+        SuccessRequest => 1,
+        RequestData    => {
+            TicketID     => [$TicketID1, $TicketID2, $TicketID3, $TicketID4],
+            "DynamicField_DFT4$RandomID" => {
+                Empty => 1,
+            },
+            OrderBy => 'Up',
+            SortBy  => 'TicketNumber',
+        },
+        ExpectedReturnLocalData => {
+            Data => {
+                TicketID => [ $TicketID1, $TicketID3, $TicketID4 ],
+            },
+            Success => 1
+        },
+        ExpectedReturnRemoteData => {
+            Data => {
+                TicketID => [ $TicketID1, $TicketID3, $TicketID4, ],
+            },
+            Success => 1,
+        },
+        Operation => 'TicketSearch',
+    },
+    {
+        Name           => "Test Operator 'Empty' DFT ALL - DF " . $TestCounter++,
+        SuccessRequest => 1,
+        RequestData    => {
+            TicketID     => [$TicketID1, $TicketID2, $TicketID3, $TicketID4],
+            "DynamicField_DFT1$RandomID" => {
+                Empty => 1,
+            },
+            "DynamicField_DFT2$RandomID" => {
+                Empty => 1,
+            },
+            "DynamicField_DFT3$RandomID" => {
+                Empty => 1,
+            },
+            "DynamicField_DFT4$RandomID" => {
+                Empty => 1,
+            },
+            OrderBy => 'Up',
+            SortBy  => 'TicketNumber',
+        },
+        ExpectedReturnLocalData => {
+            Data => {
+                TicketID => [ $TicketID3, $TicketID4 ],
+            },
+            Success => 1
+        },
+        ExpectedReturnRemoteData => {
+            Data => {
+                TicketID => [ $TicketID3, $TicketID4 ],
+            },
+            Success => 1,
+        },
+        Operation => 'TicketSearch',
+    },
 );
 
 # Add a wrong value test for each possible parameter on direct search

--- a/scripts/test/Ticket/TicketDynamicFieldSearch.t
+++ b/scripts/test/Ticket/TicketDynamicFieldSearch.t
@@ -140,6 +140,44 @@ for ( 1 .. 2 ) {
         }
 }
 
+# Run initial tests for Empty before assigning values
+for my $DynamicField ( @FieldConfig[0, 2] ) {
+    my %TicketIDsSearch = $TicketObject->TicketSearch(
+        Result                       => 'HASH',
+        Limit                        => 100,
+        TicketID                     => $TicketData[0]{TicketID},
+        "DynamicField_$DynamicField->{Name}" => {
+            Empty => 0,
+        },
+        UserID     => 1,
+        Permission => 'r0',
+    );
+
+    $Self->IsDeeply(
+        \%TicketIDsSearch,
+        { },
+        "Search with Empty => 0, dynamic field absent, type $DynamicField->{FieldType}",
+    );
+
+    %TicketIDsSearch = $TicketObject->TicketSearch(
+        Result                       => 'HASH',
+        Limit                        => 100,
+        TicketID                     => $TicketData[0]{TicketID},
+        "DynamicField_$DynamicField->{Name}" => {
+            Empty => 1,
+        },
+        UserID     => 1,
+        Permission => 'r0',
+    );
+
+    $Self->IsDeeply(
+        \%TicketIDsSearch,
+        { $TicketData[0]{TicketID} => $TicketData[0]{TicketNumber} },
+        "Search with Empty => 1, dynamic field absent, type $DynamicField->{FieldType}",
+    );
+}
+
+
 my @Values = (
     {
         DynamicFieldConfig => $FieldConfig[0],
@@ -206,6 +244,43 @@ for my $Value (@Values) {
         ObjectID           => $Value->{ObjectID},
         Value              => $Value->{Value},
         UserID             => 1,
+    );
+}
+
+# More tests for Empty
+for my $DynamicField ( @FieldConfig[0, 2] ) {
+    my %TicketIDsSearch = $TicketObject->TicketSearch(
+        Result                       => 'HASH',
+        Limit                        => 100,
+        TicketID                     => $TicketData[0]{TicketID},
+        "DynamicField_$DynamicField->{Name}" => {
+            Empty => 1,
+        },
+        UserID     => 1,
+        Permission => 'r0',
+    );
+
+    $Self->IsDeeply(
+        \%TicketIDsSearch,
+        { },
+        "Search with Empty => 1, dynamic field present, type $DynamicField->{FieldType}",
+    );
+
+    %TicketIDsSearch = $TicketObject->TicketSearch(
+        Result                       => 'HASH',
+        Limit                        => 100,
+        TicketID                     => $TicketData[0]{TicketID},
+        "DynamicField_$DynamicField->{Name}" => {
+            Empty => 0,
+        },
+        UserID     => 1,
+        Permission => 'r0',
+    );
+
+    $Self->IsDeeply(
+        \%TicketIDsSearch,
+        { $TicketData[0]{TicketID} => $TicketData[0]{TicketNumber} },
+        "Search with Empty => 0, dynamic field present, type $DynamicField->{FieldType}",
     );
 }
 


### PR DESCRIPTION
This builds on PR #1482 to allow `Empty => 0` in a TicketSearch for a dynamic field, to search for tickets with a non-empty aka present dynamic field.
