### PR TITLE
Fixed use of uninitialized value in string eq errors

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,4 +1,5 @@
 #6.0.0.beta1 2016-??-??
+ - 2016-10-12 Fixed use of uninitialized value in string eq errors.
  - 2016-09-21 Fixed bug#[12065](http://bugs.otrs.org/show_bug.cgi?id=12065) - queue and state not mandatory.
  - 2016-09-12 Fixed bug#[11365](http://bugs.otrs.org/show_bug.cgi?id=11365) - ACLs editor shows actions where ACLs does not apply.
  - 2016-09-08 Made possible to define ServiceIDs and SLAIDs as default shown ticket search attributes, thanks to Paweł Bogusławski.

--- a/Kernel/Modules/AdminACL.pm
+++ b/Kernel/Modules/AdminACL.pm
@@ -328,7 +328,8 @@ sub Run {
             );
         }
 
-        if ( $ParamObject->GetParam( Param => 'ContinueAfterSave' ) eq '1' ) {
+        if ( defined $ParamObject->GetParam( Param => 'ContinueAfterSave' )
+            && ( $ParamObject->GetParam( Param => 'ContinueAfterSave' ) eq '1' ) ) {
 
             # if the user would like to continue editing the ACL, just redirect to the edit screen
             return $LayoutObject->Redirect(

--- a/Kernel/Modules/AdminAttachment.pm
+++ b/Kernel/Modules/AdminAttachment.pm
@@ -93,7 +93,8 @@ sub Run {
             if ($Update) {
 
                 # if the user would like to continue editing the attachment, just redirect to the edit screen
-                if ( $ParamObject->GetParam( Param => 'ContinueAfterSave' ) eq '1' ) {
+                if ( defined $ParamObject->GetParam( Param => 'ContinueAfterSave' )
+                    && ( $ParamObject->GetParam( Param => 'ContinueAfterSave' ) eq '1' ) ) {
                     my $ID = $ParamObject->GetParam( Param => 'ID' ) || '';
                     return $LayoutObject->Redirect( OP => "Action=$Self->{Action};Subaction=Change;ID=$ID" );
                 }

--- a/Kernel/Modules/AdminAutoResponse.pm
+++ b/Kernel/Modules/AdminAutoResponse.pm
@@ -94,7 +94,8 @@ sub Run {
             {
 
                 # if the user would like to continue editing the auto response, just redirect to the edit screen
-                if ( $ParamObject->GetParam( Param => 'ContinueAfterSave' ) eq '1' ) {
+                if ( defined $ParamObject->GetParam( Param => 'ContinueAfterSave' )
+                    && ( $ParamObject->GetParam( Param => 'ContinueAfterSave' ) eq '1' ) ) {
                     my $ID = $ParamObject->GetParam( Param => 'ID' ) || '';
                     return $LayoutObject->Redirect( OP => "Action=$Self->{Action};Subaction=Change;ID=$ID" );
                 }

--- a/Kernel/Modules/AdminCustomerUser.pm
+++ b/Kernel/Modules/AdminCustomerUser.pm
@@ -436,7 +436,8 @@ sub Run {
                 if ( !$Note ) {
 
                     # if the user would like to continue editing the priority, just redirect to the edit screen
-                    if ( $ParamObject->GetParam( Param => 'ContinueAfterSave' ) eq '1' ) {
+                    if ( defined $ParamObject->GetParam( Param => 'ContinueAfterSave' )
+                        && ( $ParamObject->GetParam( Param => 'ContinueAfterSave' ) eq '1' ) ) {
                         my $ID = $ParamObject->GetParam( Param => 'ID' ) || '';
                         return $LayoutObject->Redirect(
                             OP =>

--- a/Kernel/Modules/AdminCustomerUserGroup.pm
+++ b/Kernel/Modules/AdminCustomerUserGroup.pm
@@ -203,7 +203,8 @@ sub Run {
         }
 
      # if the user would like to continue editing the customer user relations for group just redirect to the edit screen
-        if ( $ParamObject->GetParam( Param => 'ContinueAfterSave' ) eq '1' ) {
+        if ( defined $ParamObject->GetParam( Param => 'ContinueAfterSave' )
+            && ( $ParamObject->GetParam( Param => 'ContinueAfterSave' ) eq '1' ) ) {
             return $LayoutObject->Redirect(
                 OP =>
                     "Action=$Self->{Action};Subaction=Group;ID=$ID;CustomerUserSearch=$Param{CustomerUserSearch}"
@@ -259,8 +260,9 @@ sub Run {
             );
         }
 
-     # if the user would like to continue editing the customer user relations for group just redirect to the edit screen
-        if ( $ParamObject->GetParam( Param => 'ContinueAfterSave' ) eq '1' ) {
+        # if the user would like to continue editing the customer user relations for group just redirect to the edit screen
+        if ( defined $ParamObject->GetParam( Param => 'ContinueAfterSave' )
+            && ( $ParamObject->GetParam( Param => 'ContinueAfterSave' ) eq '1' ) ) {
             return $LayoutObject->Redirect(
                 OP =>
                     "Action=$Self->{Action};Subaction=CustomerUser;ID=$ID;CustomerUserSearch=$Param{CustomerUserSearch}"

--- a/Kernel/Modules/AdminCustomerUserService.pm
+++ b/Kernel/Modules/AdminCustomerUserService.pm
@@ -195,7 +195,8 @@ sub Run {
         }
 
         # if the user would like to continue editing the customer user allocating just redirect to the edit screen
-        if ( $ParamObject->GetParam( Param => 'ContinueAfterSave' ) eq '1' ) {
+        if ( defined $ParamObject->GetParam( Param => 'ContinueAfterSave' )
+            && ( $ParamObject->GetParam( Param => 'ContinueAfterSave' ) eq '1' ) ) {
             return $LayoutObject->Redirect(
                 OP =>
                     "Action=$Self->{Action};Subaction=AllocateCustomerUser;CustomerUserLogin=$Param{CustomerUserLogin};CustomerUserSearch=$Param{CustomerUserSearch}"
@@ -247,7 +248,8 @@ sub Run {
         }
 
         # if the user would like to continue editing the customer user allocating just redirect to the edit screen
-        if ( $ParamObject->GetParam( Param => 'ContinueAfterSave' ) eq '1' ) {
+        if ( defined $ParamObject->GetParam( Param => 'ContinueAfterSave' )
+            && ( $ParamObject->GetParam( Param => 'ContinueAfterSave' ) eq '1' ) ) {
             return $LayoutObject->Redirect(
                 OP =>
                     "Action=$Self->{Action};Subaction=AllocateService;ServiceID=$Param{ServiceID};CustomerUserSearch=$Param{CustomerUserSearch}"

--- a/Kernel/Modules/AdminDynamicFieldCheckbox.pm
+++ b/Kernel/Modules/AdminDynamicFieldCheckbox.pm
@@ -404,7 +404,8 @@ sub _ChangeAction {
     }
 
     # if the user would like to continue editing the dynamic field, just redirect to the change screen
-    if ( $ParamObject->GetParam( Param => 'ContinueAfterSave' ) eq '1' ) {
+    if ( defined $ParamObject->GetParam( Param => 'ContinueAfterSave' )
+        && ( $ParamObject->GetParam( Param => 'ContinueAfterSave' ) eq '1' ) ) {
         return $LayoutObject->Redirect(
             OP =>
                 "Action=$Self->{Action};Subaction=Change;ObjectType=$DynamicFieldData->{ObjectType};FieldType=$DynamicFieldData->{FieldType};ID=$FieldID"

--- a/Kernel/Modules/AdminDynamicFieldDateTime.pm
+++ b/Kernel/Modules/AdminDynamicFieldDateTime.pm
@@ -463,7 +463,8 @@ sub _ChangeAction {
     }
 
     # if the user would like to continue editing the dynamic field, just redirect to the change screen
-    if ( $ParamObject->GetParam( Param => 'ContinueAfterSave' ) eq '1' ) {
+    if ( defined $ParamObject->GetParam( Param => 'ContinueAfterSave' )
+       && ( $ParamObject->GetParam( Param => 'ContinueAfterSave' ) eq '1' ) ) {
         return $LayoutObject->Redirect(
             OP =>
                 "Action=$Self->{Action};Subaction=Change;ObjectType=$DynamicFieldData->{ObjectType};FieldType=$DynamicFieldData->{FieldType};ID=$FieldID"

--- a/Kernel/Modules/AdminDynamicFieldDropdown.pm
+++ b/Kernel/Modules/AdminDynamicFieldDropdown.pm
@@ -524,7 +524,8 @@ sub _ChangeAction {
     }
 
     # if the user would like to continue editing the dynamic field, just redirect to the change screen
-    if ( $ParamObject->GetParam( Param => 'ContinueAfterSave' ) eq '1' ) {
+    if ( defined $ParamObject->GetParam( Param => 'ContinueAfterSave' )
+        && ( $ParamObject->GetParam( Param => 'ContinueAfterSave' ) eq '1' ) ) {
         return $LayoutObject->Redirect(
             OP =>
                 "Action=$Self->{Action};Subaction=Change;ObjectType=$DynamicFieldData->{ObjectType};FieldType=$DynamicFieldData->{FieldType};ID=$FieldID"

--- a/Kernel/Modules/AdminDynamicFieldMultiselect.pm
+++ b/Kernel/Modules/AdminDynamicFieldMultiselect.pm
@@ -516,7 +516,8 @@ sub _ChangeAction {
     }
 
     # if the user would like to continue editing the dynamic field, just redirect to the change screen
-    if ( $ParamObject->GetParam( Param => 'ContinueAfterSave' ) eq '1' ) {
+    if ( defined $ParamObject->GetParam( Param => 'ContinueAfterSave' )
+        && ( $ParamObject->GetParam( Param => 'ContinueAfterSave' ) eq '1' ) ) {
         return $LayoutObject->Redirect(
             OP =>
                 "Action=$Self->{Action};Subaction=Change;ObjectType=$DynamicFieldData->{ObjectType};FieldType=$DynamicFieldData->{FieldType};ID=$FieldID"

--- a/Kernel/Modules/AdminDynamicFieldText.pm
+++ b/Kernel/Modules/AdminDynamicFieldText.pm
@@ -471,7 +471,8 @@ sub _ChangeAction {
     }
 
     # if the user would like to continue editing the dynamic field, just redirect to the change screen
-    if ( $ParamObject->GetParam( Param => 'ContinueAfterSave' ) eq '1' ) {
+    if ( defined $ParamObject->GetParam( Param => 'ContinueAfterSave' )
+        && ( $ParamObject->GetParam( Param => 'ContinueAfterSave' ) eq '1' ) ) {
         return $LayoutObject->Redirect(
             OP =>
                 "Action=$Self->{Action};Subaction=Change;ObjectType=$DynamicFieldData->{ObjectType};FieldType=$DynamicFieldData->{FieldType};ID=$FieldID"

--- a/Kernel/Modules/AdminGenericAgent.pm
+++ b/Kernel/Modules/AdminGenericAgent.pm
@@ -283,7 +283,8 @@ sub Run {
             if ($JobAddResult) {
 
                 # if the user would like to continue editing the generic agent job, just redirect to the edit screen
-                if ( $ParamObject->GetParam( Param => 'ContinueAfterSave' ) eq '1' ) {
+                if ( defined $ParamObject->GetParam( Param => 'ContinueAfterSave' )
+                    && ( $ParamObject->GetParam( Param => 'ContinueAfterSave' ) eq '1' ) ) {
                     my $Profile = $Self->{Profile} || '';
                     return $LayoutObject->Redirect( OP => "Action=$Self->{Action};Subaction=Update;Profile=$Profile" );
                 }

--- a/Kernel/Modules/AdminGroup.pm
+++ b/Kernel/Modules/AdminGroup.pm
@@ -92,7 +92,8 @@ sub Run {
             if ($GroupUpdate) {
 
                 # if the user would like to continue editing the group, just redirect to the edit screen
-                if ( $ParamObject->GetParam( Param => 'ContinueAfterSave' ) eq '1' ) {
+                if ( defined $ParamObject->GetParam( Param => 'ContinueAfterSave' )
+                    && ( $ParamObject->GetParam( Param => 'ContinueAfterSave' ) eq '1' ) ) {
                     my $ID = $ParamObject->GetParam( Param => 'ID' ) || '';
                     return $LayoutObject->Redirect(
                         OP => "Action=$Self->{Action};Subaction=Change;ID=$GetParam{ID};Notification=Update"

--- a/Kernel/Modules/AdminMailAccount.pm
+++ b/Kernel/Modules/AdminMailAccount.pm
@@ -224,7 +224,8 @@ sub Run {
             if ($Update) {
 
                 # if the user would like to continue editing the mail account just redirect to the edit screen
-                if ( $ParamObject->GetParam( Param => 'ContinueAfterSave' ) eq '1' ) {
+                if ( defined $ParamObject->GetParam( Param => 'ContinueAfterSave' )
+                    && ( $ParamObject->GetParam( Param => 'ContinueAfterSave' ) eq '1' ) ) {
                     my $ID = $ParamObject->GetParam( Param => 'ID' ) || '';
                     return $LayoutObject->Redirect(
                         OP => "Action=$Self->{Action};Subaction=Update;ID=$ID"

--- a/Kernel/Modules/AdminNotificationEvent.pm
+++ b/Kernel/Modules/AdminNotificationEvent.pm
@@ -228,7 +228,8 @@ sub Run {
         if ($Ok) {
 
             # if the user would like to continue editing the notification event, just redirect to the edit screen
-            if ( $ParamObject->GetParam( Param => 'ContinueAfterSave' ) eq '1' ) {
+            if ( defined $ParamObject->GetParam( Param => 'ContinueAfterSave' )
+                && ( $ParamObject->GetParam( Param => 'ContinueAfterSave' ) eq '1' ) ) {
                 my $ID = $ParamObject->GetParam( Param => 'ID' ) || '';
                 return $LayoutObject->Redirect(
                     OP => "Action=$Self->{Action};Subaction=Change;ID=$ID;Notification=Update"

--- a/Kernel/Modules/AdminPostMasterFilter.pm
+++ b/Kernel/Modules/AdminPostMasterFilter.pm
@@ -163,7 +163,8 @@ sub Run {
         );
 
         # if the user would like to continue editing the postmaster filter, just redirect to the update screen
-        if ( $ParamObject->GetParam( Param => 'ContinueAfterSave' ) eq '1' ) {
+        if ( defined $ParamObject->GetParam( Param => 'ContinueAfterSave' )
+            && ( $ParamObject->GetParam( Param => 'ContinueAfterSave' ) eq '1' ) ) {
             return $LayoutObject->Redirect( OP => "Action=$Self->{Action};Subaction=Update;Name=$Name" );
         }
         else {

--- a/Kernel/Modules/AdminPriority.pm
+++ b/Kernel/Modules/AdminPriority.pm
@@ -91,7 +91,8 @@ sub Run {
             if ($Update) {
 
                 # if the user would like to continue editing the priority, just redirect to the edit screen
-                if ( $ParamObject->GetParam( Param => 'ContinueAfterSave' ) eq '1' ) {
+                if ( defined $ParamObject->GetParam( Param => 'ContinueAfterSave' )
+                    && ( $ParamObject->GetParam( Param => 'ContinueAfterSave' ) eq '1' ) ) {
                     my $PriorityID = $ParamObject->GetParam( Param => 'PriorityID' ) || '';
                     return $LayoutObject->Redirect(
                         OP => "Action=$Self->{Action};Subaction=Change;PriorityID=$PriorityID"

--- a/Kernel/Modules/AdminProcessManagement.pm
+++ b/Kernel/Modules/AdminProcessManagement.pm
@@ -1067,7 +1067,8 @@ sub Run {
             );
         }
 
-        if ( $ParamObject->GetParam( Param => 'ContinueAfterSave' ) eq '1' ) {
+        if ( defined $ParamObject->GetParam( Param => 'ContinueAfterSave' )
+            && ( $ParamObject->GetParam( Param => 'ContinueAfterSave' ) eq '1' ) ) {
 
             # if the user would like to continue editing the process, just redirect to the edit screen
             return $LayoutObject->Redirect(

--- a/Kernel/Modules/AdminQueue.pm
+++ b/Kernel/Modules/AdminQueue.pm
@@ -240,7 +240,8 @@ sub Run {
                 }
 
                 # if the user would like to continue editing the queue, just redirect to the edit screen
-                if ( $ParamObject->GetParam( Param => 'ContinueAfterSave' ) eq '1' ) {
+                if ( defined $ParamObject->GetParam( Param => 'ContinueAfterSave' )
+                    && ( $ParamObject->GetParam( Param => 'ContinueAfterSave' ) eq '1' ) ) {
                     return $LayoutObject->Redirect(
                         OP => "Action=$Self->{Action};Subaction=Change;QueueID=$QueueID;Notification=Update"
                     );

--- a/Kernel/Modules/AdminQueueAutoResponse.pm
+++ b/Kernel/Modules/AdminQueueAutoResponse.pm
@@ -131,7 +131,8 @@ sub Run {
 
        # if the user would like to continue editing the queue - auto response relation, just redirect to the edit screen
        # otherwise return to overview
-        if ( $ParamObject->GetParam( Param => 'ContinueAfterSave' ) eq '1' ) {
+        if ( defined $ParamObject->GetParam( Param => 'ContinueAfterSave' )
+            && ( $ParamObject->GetParam( Param => 'ContinueAfterSave' ) eq '1' ) ) {
             return $LayoutObject->Redirect( OP => "Action=$Self->{Action};Subaction=Change;ID=$Param{ID}" );
         }
         else {

--- a/Kernel/Modules/AdminQueueTemplates.pm
+++ b/Kernel/Modules/AdminQueueTemplates.pm
@@ -141,7 +141,8 @@ sub Run {
 
         # if the user would like to continue editing the templates - queue relation just redirect to the edit screen
         # otherwise return to relations overview
-        if ( $ParamObject->GetParam( Param => 'ContinueAfterSave' ) eq '1' ) {
+        if ( defined $ParamObject->GetParam( Param => 'ContinueAfterSave' )
+            && ( $ParamObject->GetParam( Param => 'ContinueAfterSave' ) eq '1' ) ) {
             return $LayoutObject->Redirect(
                 OP => "Action=$Self->{Action};Subaction=Queue;ID=$QueueID"
             );
@@ -185,7 +186,8 @@ sub Run {
 
         # if the user would like to continue editing the queue - templates relation just redirect to the edit screen
         # otherwise return to relations overview
-        if ( $ParamObject->GetParam( Param => 'ContinueAfterSave' ) eq '1' ) {
+        if ( defined $ParamObject->GetParam( Param => 'ContinueAfterSave' )
+            && ( $ParamObject->GetParam( Param => 'ContinueAfterSave' ) eq '1' ) ) {
             return $LayoutObject->Redirect(
                 OP => "Action=$Self->{Action};Subaction=Template;ID=$TemplateID"
             );

--- a/Kernel/Modules/AdminRole.pm
+++ b/Kernel/Modules/AdminRole.pm
@@ -92,7 +92,8 @@ sub Run {
 
                 # if the user would like to continue editing the role, just redirect to the edit screen
                 # otherwise return to overview
-                if ( $ParamObject->GetParam( Param => 'ContinueAfterSave' ) eq '1' ) {
+                if ( defined $ParamObject->GetParam( Param => 'ContinueAfterSave' )
+                    && ( $ParamObject->GetParam( Param => 'ContinueAfterSave' ) eq '1' ) ) {
                     return $LayoutObject->Redirect(
                         OP => "Action=$Self->{Action};Subaction=Change;ID=$GetParam{ID};Notification=Update"
                     );

--- a/Kernel/Modules/AdminRoleGroup.pm
+++ b/Kernel/Modules/AdminRoleGroup.pm
@@ -141,7 +141,8 @@ sub Run {
 
         # if the user would like to continue editing the role-group relation just redirect to the edit screen
         # otherwise return to relations overview
-        if ( $ParamObject->GetParam( Param => 'ContinueAfterSave' ) eq '1' ) {
+        if ( defined $ParamObject->GetParam( Param => 'ContinueAfterSave' )
+            && ( $ParamObject->GetParam( Param => 'ContinueAfterSave' ) eq '1' ) ) {
             return $LayoutObject->Redirect( OP => "Action=$Self->{Action};Subaction=Group;ID=$ID" );
         }
         else {
@@ -189,7 +190,8 @@ sub Run {
 
         # if the user would like to continue editing the group-role relation just redirect to the edit screen
         # otherwise return to relations overview
-        if ( $ParamObject->GetParam( Param => 'ContinueAfterSave' ) eq '1' ) {
+        if ( defined $ParamObject->GetParam( Param => 'ContinueAfterSave' )
+            && ( $ParamObject->GetParam( Param => 'ContinueAfterSave' ) eq '1' ) ) {
             return $LayoutObject->Redirect( OP => "Action=$Self->{Action};Subaction=Role;ID=$ID" );
         }
         else {

--- a/Kernel/Modules/AdminRoleUser.pm
+++ b/Kernel/Modules/AdminRoleUser.pm
@@ -135,7 +135,8 @@ sub Run {
 
         # if the user would like to continue editing the role-user relation just redirect to the edit screen
         # otherwise return to relations overview
-        if ( $ParamObject->GetParam( Param => 'ContinueAfterSave' ) eq '1' ) {
+        if ( defined $ParamObject->GetParam( Param => 'ContinueAfterSave' )
+            && ( $ParamObject->GetParam( Param => 'ContinueAfterSave' ) eq '1' ) ) {
             return $LayoutObject->Redirect( OP => "Action=$Self->{Action};Subaction=Role;ID=$ID" );
         }
         else {
@@ -179,7 +180,8 @@ sub Run {
 
         # if the user would like to continue editing the role-user relation just redirect to the edit screen
         # otherwise return to relations overview
-        if ( $ParamObject->GetParam( Param => 'ContinueAfterSave' ) eq '1' ) {
+        if ( defined $ParamObject->GetParam( Param => 'ContinueAfterSave' )
+            && ( $ParamObject->GetParam( Param => 'ContinueAfterSave' ) eq '1' ) ) {
             return $LayoutObject->Redirect( OP => "Action=$Self->{Action};Subaction=User;ID=$ID" );
         }
         else {

--- a/Kernel/Modules/AdminSLA.pm
+++ b/Kernel/Modules/AdminSLA.pm
@@ -159,7 +159,8 @@ sub Run {
                 }
 
                 # if the user would like to continue editing the SLA, just redirect to the edit screen
-                if ( $ParamObject->GetParam( Param => 'ContinueAfterSave' ) eq '1' ) {
+                if ( defined $ParamObject->GetParam( Param => 'ContinueAfterSave' )
+                    && ( $ParamObject->GetParam( Param => 'ContinueAfterSave' ) eq '1' ) ) {
                     return $LayoutObject->Redirect(
                         OP => "Action=$Self->{Action};Subaction=SLAEdit;SLAID=$GetParam{SLAID}"
                     );

--- a/Kernel/Modules/AdminSalutation.pm
+++ b/Kernel/Modules/AdminSalutation.pm
@@ -97,7 +97,8 @@ sub Run {
             if ($Update) {
 
                 # if the user would like to continue editing the salutation, just redirect to the edit screen
-                if ( $ParamObject->GetParam( Param => 'ContinueAfterSave' ) eq '1' ) {
+                if ( defined $ParamObject->GetParam( Param => 'ContinueAfterSave' )
+                    && ( $ParamObject->GetParam( Param => 'ContinueAfterSave' ) eq '1' ) ) {
                     my $ID = $ParamObject->GetParam( Param => 'ID' ) || '';
                     return $LayoutObject->Redirect( OP => "Action=$Self->{Action};Subaction=Change;ID=$ID" );
                 }

--- a/Kernel/Modules/AdminService.pm
+++ b/Kernel/Modules/AdminService.pm
@@ -146,7 +146,8 @@ sub Run {
                 }
 
                 # if the user would like to continue editing the service, just redirect to the edit screen
-                if ( $ParamObject->GetParam( Param => 'ContinueAfterSave' ) eq '1' ) {
+                if ( defined $ParamObject->GetParam( Param => 'ContinueAfterSave' )
+                    && ( $ParamObject->GetParam( Param => 'ContinueAfterSave' ) eq '1' ) ) {
                     my $ID = $ParamObject->GetParam( Param => 'ServiceID' ) || '';
                     return $LayoutObject->Redirect(
                         OP => "Action=$Self->{Action};Subaction=ServiceEdit;ServiceID=$ID"

--- a/Kernel/Modules/AdminSignature.pm
+++ b/Kernel/Modules/AdminSignature.pm
@@ -101,7 +101,8 @@ sub Run {
             if ($Update) {
 
                 # if the user would like to continue editing the signature, just redirect to the edit screen
-                if ( $ParamObject->GetParam( Param => 'ContinueAfterSave' ) eq '1' ) {
+                if ( defined $ParamObject->GetParam( Param => 'ContinueAfterSave' )
+                    && ( $ParamObject->GetParam( Param => 'ContinueAfterSave' ) eq '1' ) ) {
                     my $ID = $ParamObject->GetParam( Param => 'ID' ) || '';
                     return $LayoutObject->Redirect(
                         OP => "Action=$Self->{Action};Subaction=Change;ID=$ID;Notification=Update"

--- a/Kernel/Modules/AdminState.pm
+++ b/Kernel/Modules/AdminState.pm
@@ -84,7 +84,8 @@ sub Run {
             if ($UpdateSuccess) {
 
                 # if the user would like to continue editing the state, just redirect to the edit screen
-                if ( $ParamObject->GetParam( Param => 'ContinueAfterSave' ) eq '1' ) {
+                if ( defined $ParamObject->GetParam( Param => 'ContinueAfterSave' )
+                    && ( $ParamObject->GetParam( Param => 'ContinueAfterSave' ) eq '1' ) ) {
                     my $ID = $ParamObject->GetParam( Param => 'ID' ) || '';
                     return $LayoutObject->Redirect( OP => "Action=$Self->{Action};Subaction=Change;ID=$ID" );
                 }

--- a/Kernel/Modules/AdminSystemAddress.pm
+++ b/Kernel/Modules/AdminSystemAddress.pm
@@ -101,7 +101,8 @@ sub Run {
             {
                 # if the user would like to continue editing system e-mail address, just redirect to the edit screen
                 # otherwise return to overview
-                if ( $ParamObject->GetParam( Param => 'ContinueAfterSave' ) eq '1' ) {
+                if ( defined $ParamObject->GetParam( Param => 'ContinueAfterSave' )
+                    && ( $ParamObject->GetParam( Param => 'ContinueAfterSave' ) eq '1' ) ) {
                     return $LayoutObject->Redirect(
                         OP => "Action=$Self->{Action};Subaction=Change;ID=$GetParam{ID}"
                     );

--- a/Kernel/Modules/AdminSystemMaintenance.pm
+++ b/Kernel/Modules/AdminSystemMaintenance.pm
@@ -168,7 +168,8 @@ sub Run {
         }
 
         # redirect to edit screen
-        if ( $ParamObject->GetParam( Param => 'ContinueAfterSave' ) eq '1' ) {
+        if ( defined $ParamObject->GetParam( Param => 'ContinueAfterSave' )
+            && ( $ParamObject->GetParam( Param => 'ContinueAfterSave' ) eq '1' ) ) {
             return $LayoutObject->Redirect(
                 OP =>
                     "Action=$Self->{Action};Subaction=SystemMaintenanceEdit;SystemMaintenanceID=$SystemMaintenanceID;Notification=Add"
@@ -354,7 +355,8 @@ sub Run {
         }
 
         # redirect to edit screen
-        if ( $ParamObject->GetParam( Param => 'ContinueAfterSave' ) eq '1' ) {
+        if ( defined $ParamObject->GetParam( Param => 'ContinueAfterSave' )
+            && ( $ParamObject->GetParam( Param => 'ContinueAfterSave' ) eq '1' ) ) {
             return $LayoutObject->Redirect(
                 OP =>
                     "Action=$Self->{Action};Subaction=SystemMaintenanceEdit;SystemMaintenanceID=$SystemMaintenanceID;Notification=Update"

--- a/Kernel/Modules/AdminTemplate.pm
+++ b/Kernel/Modules/AdminTemplate.pm
@@ -143,7 +143,8 @@ sub Run {
                 }
 
                 # if the user would like to continue editing the template, just redirect to the edit screen
-                if ( $ParamObject->GetParam( Param => 'ContinueAfterSave' ) eq '1' ) {
+                if ( defined $ParamObject->GetParam( Param => 'ContinueAfterSave' )
+                    && ( $ParamObject->GetParam( Param => 'ContinueAfterSave' ) eq '1' ) ) {
                     my $ID = $ParamObject->GetParam( Param => 'ID' ) || '';
                     return $LayoutObject->Redirect(
                         OP => "Action=$Self->{Action};Subaction=Change;ID=$ID;Notification=Update"

--- a/Kernel/Modules/AdminTemplateAttachment.pm
+++ b/Kernel/Modules/AdminTemplateAttachment.pm
@@ -139,7 +139,8 @@ sub Run {
 
         # if the user would like to continue editing the template-attachment relation just redirect to the edit screen
         # otherwise return to relations overview
-        if ( $ParamObject->GetParam( Param => 'ContinueAfterSave' ) eq '1' ) {
+        if ( defined $ParamObject->GetParam( Param => 'ContinueAfterSave' )
+            && ( $ParamObject->GetParam( Param => 'ContinueAfterSave' ) eq '1' ) ) {
             return $LayoutObject->Redirect(
                 OP => "Action=$Self->{Action};Subaction=Attachment;ID=$AttachmentID;Notification=Update"
             );
@@ -181,7 +182,8 @@ sub Run {
 
         # if the user would like to continue editing the template-attachment relation just redirect to the edit screen
         # otherwise return to relations overview
-        if ( $ParamObject->GetParam( Param => 'ContinueAfterSave' ) eq '1' ) {
+        if ( defined $ParamObject->GetParam( Param => 'ContinueAfterSave' )
+            && ( $ParamObject->GetParam( Param => 'ContinueAfterSave' ) eq '1' ) ) {
             return $LayoutObject->Redirect(
                 OP => "Action=$Self->{Action};Subaction=Template;ID=$TemplateID;Notification=Update"
             );

--- a/Kernel/Modules/AdminType.pm
+++ b/Kernel/Modules/AdminType.pm
@@ -108,7 +108,8 @@ sub Run {
             if ($Update) {
 
                 # if the user would like to continue editing the type, just redirect to the edit screen
-                if ( $ParamObject->GetParam( Param => 'ContinueAfterSave' ) eq '1' ) {
+                if ( defined $ParamObject->GetParam( Param => 'ContinueAfterSave' )
+                    && ( $ParamObject->GetParam( Param => 'ContinueAfterSave' ) eq '1' ) ) {
                     my $ID = $ParamObject->GetParam( Param => 'ID' ) || '';
                     return $LayoutObject->Redirect( OP => "Action=$Self->{Action};Subaction=Change;ID=$ID" );
                 }

--- a/Kernel/Modules/AdminUser.pm
+++ b/Kernel/Modules/AdminUser.pm
@@ -265,7 +265,8 @@ sub Run {
 
                     # if the user would like to continue editing the agent, just redirect to the edit screen
                     # otherwise return to overview
-                    if ( $ParamObject->GetParam( Param => 'ContinueAfterSave' ) eq '1' ) {
+                    if ( defined $ParamObject->GetParam( Param => 'ContinueAfterSave' )
+                        && ( $ParamObject->GetParam( Param => 'ContinueAfterSave' ) eq '1' ) ) {
                         my $ID = $ParamObject->GetParam( Param => 'ID' ) || '';
                         return $LayoutObject->Redirect(
                             OP => "Action=$Self->{Action};Subaction=Change;UserID=$GetParam{UserID};Notification=Update"

--- a/Kernel/Modules/AdminUserGroup.pm
+++ b/Kernel/Modules/AdminUserGroup.pm
@@ -165,7 +165,8 @@ sub Run {
 
         # if the user would like to continue editing the group-user relation just redirect to the edit screen
         # otherwise return to relations overview
-        if ( $ParamObject->GetParam( Param => 'ContinueAfterSave' ) eq '1' ) {
+        if ( defined $ParamObject->GetParam( Param => 'ContinueAfterSave' )
+            && ( $ParamObject->GetParam( Param => 'ContinueAfterSave' ) eq '1' ) ) {
             return $LayoutObject->Redirect( OP => "Action=$Self->{Action};Subaction=Group;ID=$ID" );
         }
         else {
@@ -215,7 +216,8 @@ sub Run {
 
         # if the user would like to continue editing the group-user relation just redirect to the edit screen
         # otherwise return to relations overview
-        if ( $ParamObject->GetParam( Param => 'ContinueAfterSave' ) eq '1' ) {
+        if ( defined $ParamObject->GetParam( Param => 'ContinueAfterSave' )
+            && ( $ParamObject->GetParam( Param => 'ContinueAfterSave' ) eq '1' ) ) {
             return $LayoutObject->Redirect( OP => "Action=$Self->{Action};Subaction=User;ID=$ID" );
         }
         else {


### PR DESCRIPTION
OTRS throws warnings like...

```
[Wed Oct 12 11:58:11 2016] -e: Use of uninitialized value in string eq at /opt/otrs//Kernel/Modules/AdminService.pm line 149.
[Wed Oct 12 11:58:25 2016] -e: Use of uninitialized value in string eq at /opt/otrs//Kernel/Modules/AdminSLA.pm line 162.
```

...to apache error log when adding new service/sla.

This mod fixes the issue described above.

Related: https://dev.ib.pl/ib/otrs/issues/98
Author-Change-Id: IB#1058876
