### PR TITLE
Configurable resolver timeout

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,4 +1,5 @@
 #6.0.0.beta1 2016-??-??
+ - 2016-10-13 Configurable resolver timeout.
  - 2016-09-21 Fixed bug#[12065](http://bugs.otrs.org/show_bug.cgi?id=12065) - queue and state not mandatory.
  - 2016-09-12 Fixed bug#[11365](http://bugs.otrs.org/show_bug.cgi?id=11365) - ACLs editor shows actions where ACLs does not apply.
  - 2016-09-08 Made possible to define ServiceIDs and SLAIDs as default shown ticket search attributes, thanks to Paweł Bogusławski.

--- a/Kernel/Config/Files/Framework.xml
+++ b/Kernel/Config/Files/Framework.xml
@@ -574,6 +574,14 @@
             <String Regex="">ns.example.com</String>
         </Setting>
     </ConfigItem>
+    <ConfigItem Name="ResolverTimeout" Required="0" Valid="0">
+        <Description Translatable="1">Sets the timeout (in seconds) for resolver DNS queries (i.e. during checking MX record if CheckMXRecord is enabled to protect against long agent UI responses in case of very slow DNS queries).</Description>
+        <Group>Framework</Group>
+        <SubGroup>Core</SubGroup>
+        <Setting>
+            <String Regex="">3</String>
+        </Setting>
+    </ConfigItem>
     <ConfigItem Name="CheckEmailAddresses" Required="1" Valid="1">
         <Description Translatable="1">Makes the application check the syntax of email addresses.</Description>
         <Group>Framework</Group>

--- a/Kernel/System/CheckItem.pm
+++ b/Kernel/System/CheckItem.pm
@@ -142,8 +142,9 @@ sub CheckEmail {
         if ($Resolver) {
 
             # it's no fun to have this hanging in the web interface
-            $Resolver->tcp_timeout(3);
-            $Resolver->udp_timeout(3);
+            my $ResolverTimeout = $ConfigObject->Get('ResolverTimeout') // 3;
+            $Resolver->tcp_timeout($ResolverTimeout);
+            $Resolver->udp_timeout($ResolverTimeout);
 
             # check if we need to use a specific name server
             my $Nameserver = $ConfigObject->Get('CheckMXRecord::Nameserver');


### PR DESCRIPTION
OTRS uses hardcoded 3s timeout for DNS queries while checking MX
(if CheckMXRecord is enabled). 3s may be too short in some scenarios
(sporadic errors in MX validation of remote addresses). DNS timeout
should be configurable to allow admin to fine-tune this setting.

This mod introduces new SysConfig parameter ResolverTimeout that
allows one to set custom timeout for DNS queries fired by OTRS
(now only for CheckMXRecord algo).

Related: https://dev.ib.pl/ib/otrs/issues/99
Author-Change-Id: IB#1058919
