### PR TITLE
Master - fixed modernize checkbox DF in search screens

### DIFF
--- a/Kernel/System/DynamicField/Driver/Checkbox.pm
+++ b/Kernel/System/DynamicField/Driver/Checkbox.pm
@@ -526,7 +526,7 @@ sub SearchFieldRender {
     }
 
     # check and set class if necessary
-    my $FieldClass = 'DynamicFieldDropdown';
+    my $FieldClass = 'DynamicFieldDropdown Modernize';
 
     my $HTMLString = $Param{LayoutObject}->BuildSelection(
         Data => {


### PR DESCRIPTION
Hi @mgruner, @mrcbnsls 

We found that there is small inconsequence in Search screens. Checkbox DF is not modernize field. There is fix, if you like you can marge in master. 
I saw this when I work on TME and HSDF AddOns.

Regards
Zoran  
