### PR TITLE
Fixed e-mail address validation while sending autoresponses and article creation on send errors

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,4 +1,5 @@
 #6.0.0.beta1 2016-??-??
+ - 2016-11-08 Fixed quotation in log message.
  - 2016-10-24 Fixed e-mail address validation while sending autoresponses and article creation on send errors.
  - 2016-09-21 Fixed bug#[12065](http://bugs.otrs.org/show_bug.cgi?id=12065) - queue and state not mandatory.
  - 2016-09-12 Fixed bug#[11365](http://bugs.otrs.org/show_bug.cgi?id=11365) - ACLs editor shows actions where ACLs does not apply.

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,4 +1,5 @@
 #6.0.0.beta1 2016-??-??
+ - 2016-10-24 Fixed e-mail address validation while sending autoresponses and article creation on send errors.
  - 2016-09-21 Fixed bug#[12065](http://bugs.otrs.org/show_bug.cgi?id=12065) - queue and state not mandatory.
  - 2016-09-12 Fixed bug#[11365](http://bugs.otrs.org/show_bug.cgi?id=11365) - ACLs editor shows actions where ACLs does not apply.
  - 2016-09-08 Made possible to define ServiceIDs and SLAIDs as default shown ticket search attributes, thanks to Paweł Bogusławski.

--- a/Kernel/System/Ticket/Article.pm
+++ b/Kernel/System/Ticket/Article.pm
@@ -2326,7 +2326,7 @@ sub ArticleSend {
         Priority => 'info',
         Message  => "Sent email to '$ToOrig' "
             . ( $CcOrig ? "(cc '$CcOrig') " : '' )
-            . "from '$Param{From} (Message-ID: $MessageID)'. "
+            . "from '$Param{From}' (Message-ID: $MessageID). "
             . "HistoryType => $HistoryType, Subject => $Param{Subject};",
     );
 


### PR DESCRIPTION
OTRS does not check if e-mail specified in From/Reply-To message headers
is valid before using it for sending autoresponse which throws sending
errors in case of invalid addresses like

```
test <test@>
```

present in From or Reply-To.

In case of e-mail (i.e. autoresponse, forwarding, reply) sending error
(i.e. bad address like above or other SMTP error like too big message)
ArticleSend() creates article in DB which is misleading because
no e-mail message was sent in fact. ArticleSend() should not create
article in DB if no message was successfully sent to allow agent
to clearly notice the problem.

This mod fixes issues described above.

Related: https://dev.ib.pl/ib/otrs/issues/101
Author-Change-Id: IB#1023814
