### PR TITLE
[ Rel-5_0 Bug 12371 ] - StorageModule ArticleStorageFS fails on attachments with long filenames

### DIFF
--- a/Kernel/System/EmailParser.pm
+++ b/Kernel/System/EmailParser.pm
@@ -695,6 +695,13 @@ sub PartsAttachments {
             String => $Part->head()->recommended_filename(),
             Encode => 'utf-8',
         );
+
+        # cleanup filename
+        $PartData{Filename} = $Kernel::OM->Get('Kernel::System::Main')->FilenameCleanUp(
+            Filename => $PartData{Filename},
+            Type     => 'Local',
+        );
+
         $PartData{ContentDisposition} = $Part->head()->get('Content-Disposition');
         if ( $PartData{ContentDisposition} ) {
             my %Data = $Self->GetContentTypeParams(
@@ -724,11 +731,11 @@ sub PartsAttachments {
         my ($SubjectString) = $Part->as_string() =~ m/^Subject: ([^\n]*(\n[ \t][^\n]*)*)/m;
         my $Subject = $Self->_DecodeString( String => $SubjectString );
 
-        # trim whitespace
-        $Subject =~ s/^\s+|\n|\s+$//g;
-        if ( length($Subject) > 246 ) {
-            $Subject = substr( $Subject, 0, 246 );
-        }
+        # cleanup filename
+        $Subject = $Kernel::OM->Get('Kernel::System::Main')->FilenameCleanUp(
+            Filename => $Subject,
+            Type     => 'Local',
+        );
 
         if ( $Subject eq '' ) {
             $Self->{NoFilenamePartCounter}++;

--- a/Kernel/System/Main.pm
+++ b/Kernel/System/Main.pm
@@ -268,12 +268,8 @@ sub FilenameCleanUp {
     }
     else {
 
-        # replace invalid token like [ ] * : ? " < > ; | \ / for ArticleStorageFS storage module
-        if (
-            $Kernel::OM->Get('Kernel::Config')->Get('Ticket::StorageModule') eq
-            'Kernel::System::Ticket::ArticleStorageFS'
-            )
-        {
+        # replace invalid token like [ ] * : ? " < > ; | \ /
+        if ( !$Param{NoReplace} ) {
             $Param{Filename} =~ s/[<>\?":\\\*\|\/;\[\]]/_/g;
         }
 

--- a/Kernel/System/Ticket/ArticleStorageDB.pm
+++ b/Kernel/System/Ticket/ArticleStorageDB.pm
@@ -275,6 +275,11 @@ sub ArticleWriteAttachment {
         }
     }
 
+    $Param{Filename} = $Kernel::OM->Get('Kernel::System::Main')->FilenameCleanUp(
+        Filename => $Param{Filename},
+        Type     => 'Local',
+    );
+
     my $NewFileName = $Param{Filename};
     my %UsedFile;
     my %Index = $Self->ArticleAttachmentIndex(

--- a/Kernel/System/Ticket/ArticleStorageDB.pm
+++ b/Kernel/System/Ticket/ArticleStorageDB.pm
@@ -276,8 +276,9 @@ sub ArticleWriteAttachment {
     }
 
     $Param{Filename} = $Kernel::OM->Get('Kernel::System::Main')->FilenameCleanUp(
-        Filename => $Param{Filename},
-        Type     => 'Local',
+        Filename  => $Param{Filename},
+        Type      => 'Local',
+        NoReplace => 1,
     );
 
     my $NewFileName = $Param{Filename};

--- a/Kernel/System/Ticket/ArticleStorageFS.pm
+++ b/Kernel/System/Ticket/ArticleStorageFS.pm
@@ -409,11 +409,12 @@ sub ArticleWriteAttachment {
 
     # write attachment content type to fs
     my $SuccessContentType = $MainObject->FileWrite(
-        Directory  => $Param{Path},
-        Filename   => "$Param{Filename}.content_type",
-        Mode       => 'binmode',
-        Content    => \$Param{ContentType},
-        Permission => 660,
+        Directory       => $Param{Path},
+        Filename        => "$Param{Filename}.content_type",
+        Mode            => 'binmode',
+        Content         => \$Param{ContentType},
+        Permission      => 660,
+        NoFilenameClean => 1,
     );
     return if !$SuccessContentType;
 
@@ -425,22 +426,24 @@ sub ArticleWriteAttachment {
     # write attachment content id to fs
     if ( $Param{ContentID} ) {
         $MainObject->FileWrite(
-            Directory  => $Param{Path},
-            Filename   => "$Param{Filename}.content_id",
-            Mode       => 'binmode',
-            Content    => \$Param{ContentID},
-            Permission => 660,
+            Directory       => $Param{Path},
+            Filename        => "$Param{Filename}.content_id",
+            Mode            => 'binmode',
+            Content         => \$Param{ContentID},
+            Permission      => 660,
+            NoFilenameClean => 1,
         );
     }
 
     # write attachment content alternative to fs
     if ( $Param{ContentAlternative} ) {
         $MainObject->FileWrite(
-            Directory  => $Param{Path},
-            Filename   => "$Param{Filename}.content_alternative",
-            Mode       => 'binmode',
-            Content    => \$Param{ContentAlternative},
-            Permission => 660,
+            Directory       => $Param{Path},
+            Filename        => "$Param{Filename}.content_alternative",
+            Mode            => 'binmode',
+            Content         => \$Param{ContentAlternative},
+            Permission      => 660,
+            NoFilenameClean => 1,
         );
     }
 
@@ -450,11 +453,12 @@ sub ArticleWriteAttachment {
         my ( $Disposition, $FileName ) = split ';', $Param{Disposition};
 
         $MainObject->FileWrite(
-            Directory  => $Param{Path},
-            Filename   => "$Param{Filename}.disposition",
-            Mode       => 'binmode',
-            Content    => \$Disposition || '',
-            Permission => 660,
+            Directory       => $Param{Path},
+            Filename        => "$Param{Filename}.disposition",
+            Mode            => 'binmode',
+            Content         => \$Disposition || '',
+            Permission      => 660,
+            NoFilenameClean => 1,
         );
     }
 

--- a/Kernel/System/Ticket/ArticleStorageFS.pm
+++ b/Kernel/System/Ticket/ArticleStorageFS.pm
@@ -354,12 +354,6 @@ sub ArticleWriteAttachment {
     # define path
     $Param{Path} = $Self->{ArticleDataDir} . '/' . $ContentPath . '/' . $Param{ArticleID};
 
-    # strip spaces from filenames
-    $Param{Filename} =~ s/ /_/g;
-
-    # strip dots from filenames
-    $Param{Filename} =~ s/^\.//g;
-
     # get main object
     my $MainObject = $Kernel::OM->Get('Kernel::System::Main');
 

--- a/Kernel/System/Web/Request.pm
+++ b/Kernel/System/Web/Request.pm
@@ -19,6 +19,7 @@ our @ObjectDependencies = (
     'Kernel::Config',
     'Kernel::System::CheckItem',
     'Kernel::System::Encode',
+    'Kernel::System::Main',
 );
 
 =head1 NAME
@@ -267,6 +268,12 @@ sub GetUploadAll {
     # replace all devices like c: or d: and dirs for IE!
     $NewFileName =~ s/.:\\(.*)/$1/g;
     $NewFileName =~ s/.*\\(.+?)/$1/g;
+
+    # cleanup filename
+    $NewFileName = $Kernel::OM->Get('Kernel::System::Main')->FilenameCleanUp(
+        Filename => $NewFileName,
+        Type     => 'Attachment',
+    );
 
     # return a string
     my $Content;

--- a/scripts/test/EmailParser.t
+++ b/scripts/test/EmailParser.t
@@ -601,22 +601,22 @@ $Self->Is(
 );
 $Self->Is(
     $Attachments[5]->{Filename} || '',
-    '報告書①..txt',
+    '報告書_..txt',
     "#12 Filename check",
 );
 $Self->Is(
     $Attachments[6]->{Filename} || '',
-    '金田　美羽',
+    '金田_美羽',
     "#12 Filename check",
 );
 $Self->Is(
     $Attachments[7]->{Filename} || '',
-    '國科會50科學之旅活動計畫徵求書(r_final).doc',
+    '國科會50科學之旅活動計畫徵求書_r_final_.doc',
     "#12 Filename check",
 );
 $Self->Is(
     $Attachments[8]->{Filename} || '',
-    '2차 보도자료.hwp',
+    '2차_보도자료.hwp',
     "#12 Filename check",
 );
 $Self->True(

--- a/scripts/test/EmailParser/FilenameWithNewline.t
+++ b/scripts/test/EmailParser/FilenameWithNewline.t
@@ -42,7 +42,7 @@ $Self->Is(
 
 $Self->Is(
     $Attachments[2]->{'Filename'} || '',
-    'Test testtestt 1231234/34/Testtesttes testes testtesttestt - testtesttes dokumentów/Sprzedaż, testTE [...] [TE#123123123].eml',
+    'Test_testtestt_1231234_34_Testtesttes_testes_testtesttestt_-_testtesttes_dokumentów_Sprzedaż__testTE__...___TE#123123123_.eml',
     "Filename with multiple newlines removed",
 );
 

--- a/scripts/test/Main.t
+++ b/scripts/test/Main.t
@@ -25,7 +25,7 @@ my @Tests = (
     {
         Name         => 'FilenameCleanUp() - Local',
         FilenameOrig => 'me_t o/alal.xml',
-        FilenameNew  => 'me_t o_alal.xml',
+        FilenameNew  => 'me_t_o_alal.xml',
         Type         => 'Local',
     },
     {
@@ -61,15 +61,27 @@ my @Tests = (
     {
         Name         => 'FilenameCleanUp() - Local',
         FilenameOrig => 'me_to/a+lal Grüße 0.xml',
-        FilenameNew  => 'me_to_a+lal Grüße 0.xml',
+        FilenameNew  => 'me_to_a+lal_Grüße_0.xml',
         Type         => 'Local',
+    },
+    {
+        Name         => 'FilenameCleanUp() - leading dots - Local',
+        FilenameOrig => '....test.xml',
+        FilenameNew  => 'test.xml',
+        Type         => 'Local',
+    },
+    {
+        Name         => 'FilenameCleanUp() - leading dots - Attachment',
+        FilenameOrig => '....test.xml',
+        FilenameNew  => 'test.xml',
+        Type         => 'Attachment',
     },
     {
         Name => 'FilenameCleanUp() - Attachment',
         FilenameOrig =>
             'me_to/a+lal123456789012345678901234567890Liebe Grüße aus Straubing123456789012345678901234567890123456789012345678901234567890.xml',
         FilenameNew =>
-            'me_to_a+lal123456789012345678901234567890Liebe_Gruesse_aus_Straubing123456789012345678901234567.xml',
+            'me_to_a+lal123456789012345678901234567890Liebe_Gruesse_aus_Straubing123456789012345678901234567890123456789012345678901234567890.xml',
         Type => 'Attachment',
     },
     {

--- a/scripts/test/Ticket/ArticleStorageNameLenght.t
+++ b/scripts/test/Ticket/ArticleStorageNameLenght.t
@@ -1,0 +1,261 @@
+# --
+# Copyright (C) 2001-2016 OTRS AG, http://otrs.com/
+# --
+# This software comes with ABSOLUTELY NO WARRANTY. For details, see
+# the enclosed file COPYING for license information (AGPL). If you
+# did not receive this file, see http://www.gnu.org/licenses/agpl.txt.
+# --
+
+use strict;
+use warnings;
+use utf8;
+
+use vars (qw($Self));
+
+use Unicode::Normalize;
+
+# get needed objects
+my $ConfigObject = $Kernel::OM->Get('Kernel::Config');
+my $MainObject   = $Kernel::OM->Get('Kernel::System::Main');
+my $TicketObject = $Kernel::OM->Get('Kernel::System::Ticket');
+
+# get helper object
+$Kernel::OM->ObjectParamAdd(
+    'Kernel::System::UnitTest::Helper' => {
+        RestoreDatabase => 1,
+        }
+);
+my $Helper = $Kernel::OM->Get('Kernel::System::UnitTest::Helper');
+
+my $TicketID = $TicketObject->TicketCreate(
+    Title        => 'Some Ticket_Title',
+    Queue        => 'Raw',
+    Lock         => 'unlock',
+    Priority     => '3 normal',
+    State        => 'closed successful',
+    CustomerNo   => '123465',
+    CustomerUser => 'customer@example.com',
+    OwnerID      => 1,
+    UserID       => 1,
+);
+$Self->True(
+    $TicketID,
+    'TicketCreate()',
+);
+
+my $ArticleID = $TicketObject->ArticleCreate(
+    TicketID       => $TicketID,
+    ArticleType    => 'note-internal',
+    SenderType     => 'agent',
+    From           => 'Some Agent <email@example.com>',
+    To             => 'Some Customer <customer-a@example.com>',
+    Subject        => 'some short description',
+    Body           => 'the message text',
+    ContentType    => 'text/plain; charset=ISO-8859-15',
+    HistoryType    => 'OwnerUpdate',
+    HistoryComment => 'Some free text!',
+    UserID         => 1,
+    NoAgentNotify  => 1,
+);
+
+$Self->True(
+    $ArticleID,
+    'ArticleCreate()',
+);
+
+my @Tests = (
+
+    # Latin characters, 1 byte per character when encoding
+    # attachment with 20 character long Latin name,
+    {
+        Description => 'Latin 20 characters',
+        FileName    => 'a' x 20,
+    },
+
+    # attachment with 75 character long Latin FileName
+    {
+        Description => 'Latin 75 characters',
+        FileName    => 'a' x 75,
+    },
+
+    # attachment with 120 character long Latin FileName
+    {
+        Description => 'Latin 120 characters',
+        FileName    => 'a' x 120,
+    },
+
+    # attachment with 140 character long Latin FileName
+    {
+        Description => 'Latin 140 characters',
+        FileName    => 'a' x 140,
+    },
+
+    # attachment with 245 character long Latin FileName
+    {
+        Description => 'Latin 245 characters',
+        FileName    => 'a' x 245,
+    },
+
+    # Cyrillic character, 2 byte per character when encoding
+    # attachment with 20 character long Cyrillic name,
+    {
+        Description => 'Cyrillic 20 characters',
+        FileName    => 'ш' x 20,
+    },
+
+    # attachment with 75 character long Cyrillic FileName
+    {
+        Description => 'Cyrillic 75 characters',
+        FileName    => 'ш' x 75,
+    },
+
+# attachment with 120 character long Cyrillic FileName, approximately limit for Linux file name reaching 255 bytes after encoding Cyrillic letters
+    {
+        Description => 'Cyrillic 120 characters',
+        FileName    => 'ш' x 120,
+    },
+
+    # attachment with 140 character long Cyrillic FileName, have to cut name to create attachment file in FS backend
+    {
+        Description => 'Cyrillic 140 characters',
+        FileName    => 'ш' x 140,
+    },
+
+    # Japanese character, 3 byte per character when encoding
+    # attachment with 20 character long Japanese FileName,
+    {
+        Description => 'Japanese 20 characters',
+        FileName    => '人' x 20,
+    },
+
+    # attachment with 70 character long Japanese FileName
+    {
+        Description => 'Japanese 70 characters',
+        FileName    => '人' x 70,
+    },
+
+    # attachment with 140 character long Japanese FileName
+    {
+        Description => 'Japanese 140 characters',
+        FileName    => '人' x 140,
+    },
+
+);
+
+TEST:
+for my $Test (@Tests) {
+
+    # article attachment checks
+    for my $Backend (qw(DB FS)) {
+
+        # make sure that the TicketObject gets recreated for each loop.
+        $Kernel::OM->ObjectsDiscard( Objects => ['Kernel::System::Ticket'] );
+
+        $ConfigObject->Set(
+            Key   => 'Ticket::StorageModule',
+            Value => 'Kernel::System::Ticket::ArticleStorage' . $Backend,
+        );
+
+        my $TicketObject = $Kernel::OM->Get('Kernel::System::Ticket');
+
+        $Self->True(
+            $TicketObject->isa( 'Kernel::System::Ticket::ArticleStorage' . $Backend ),
+            "TicketObject loaded the correct backend",
+        );
+
+        my $Ext                    = '.txt';
+        my $FileName               = $Test->{FileName} . $Ext;
+        my $Content                = '123';
+        my $MD5Orig                = $MainObject->MD5sum( String => $Content );
+        my $ArticleWriteAttachment = $TicketObject->ArticleWriteAttachment(
+            Content     => $Content,
+            Filename    => $FileName,
+            ContentType => 'text/html',
+            ArticleID   => $ArticleID,
+            UserID      => 1,
+        );
+        $Self->True(
+            $ArticleWriteAttachment,
+            "$Backend ArticleWriteAttachment() - $Test->{Description} - Original name $FileName",
+        );
+
+        my %AttachmentIndex = $TicketObject->ArticleAttachmentIndex(
+            ArticleID => $ArticleID,
+            UserID    => 1,
+        );
+
+        # get target file name
+        my $TargetFileName;
+        if ( $Backend eq 'DB' ) {
+            $TargetFileName = $FileName,
+        }
+        else {
+            $TargetFileName = $MainObject->FilenameCleanUp(
+                Filename => $FileName,
+                Type     => 'Local',
+            );
+        }
+
+        # Mac OS (HFS+) will store all filenames as NFD internally.
+        if ( $^O eq 'darwin' && $Backend eq 'FS' ) {
+            $TargetFileName = Unicode::Normalize::NFD($TargetFileName);
+        }
+
+        $Self->Is(
+            $AttachmentIndex{1}->{Filename},
+            $TargetFileName,
+            "$Backend ArticleAttachmentIndex() Attachment name $Test->{Description}"
+        );
+
+        my %Data = $TicketObject->ArticleAttachment(
+            ArticleID => $ArticleID,
+            FileID    => 1,
+            UserID    => 1,
+        );
+        $Self->True(
+            $Data{Content},
+            "$Backend ArticleAttachment() Content - Attachment name $Test->{Description}",
+        );
+        $Self->True(
+            $Data{ContentType},
+            "$Backend ArticleAttachment() ContentType - Attachment name $Test->{Description}",
+        );
+        $Self->True(
+            $Data{Content} eq $Content,
+            "$Backend ArticleWriteAttachment() / ArticleAttachment() Content - Attachment name $Test->{Description}",
+        );
+        $Self->True(
+            $Data{ContentType} eq 'text/html',
+            "$Backend ArticleWriteAttachment() / ArticleAttachment() ContentType - Attachment name $Test->{Description}",
+        );
+        my $MD5New = $MainObject->MD5sum( String => $Data{Content} );
+        $Self->Is(
+            $MD5Orig || '1',
+            $MD5New  || '2',
+            "$Backend MD5 - Attachment name $Test->{Description}",
+        );
+        my $Delete = $TicketObject->ArticleDeleteAttachment(
+            ArticleID => $ArticleID,
+            UserID    => 1,
+        );
+        $Self->True(
+            $Delete,
+            "$Backend ArticleDeleteAttachment() - Attachment name $Test->{Description}",
+        );
+
+        %AttachmentIndex = $TicketObject->ArticleAttachmentIndex(
+            ArticleID => $ArticleID,
+            UserID    => 1,
+        );
+
+        $Self->IsDeeply(
+            \%AttachmentIndex,
+            {},
+            "$Backend ArticleAttachmentIndex() after delete - Attachment name $Test->{Description}"
+        );
+    }
+}
+
+# cleanup is done by RestoreDatabase.
+
+1;


### PR DESCRIPTION
https://bugs.otrs.org/show_bug.cgi?id=12371

Hello,

Hereby is our proposal for fixing reporters issue. There was an issue when filename is ~250 character long including extension having each character 1 byte in size. Almost all systems allow up to 255 bytes per Filename when trying to save them in system as ArticleStorageFS is doing.

Problem is that ArticleStorageFS is creating additional files of same attachment in system with added extension e.g. ( .content-type , .disposition, .content-alternative). With already reaching maximum Filename length, byte wise, with these extensions we excess limit and attachments are unable to create.

Firstly added check if perhaps some different charset is used in attachment name, resulting in more then 1 byte per character in Filename. This way we can distinguish and treat different encoding separately when shortening Filename in order for it to be acceptable by system Filename byte size limitations.

Secondly added limit of 222 bytes per Filename without extensions, leaving some 'free space' for additional extensions that OTRS is adding in ArticleStorageFS. If this limit is exceeded we shorten by characters appropriately by how much bytes are excess.

Additionally escaped FilenameCleanUp() function for additional files that OTRS is creating to keep file integrity, this function has already been called on main Filename. Created UnitTest ArticleStorageNameLenght.t where we test this behaviour.

My apologise for such a long explanation, but this required such approach. Please if you have any issues or comments regarding this fix let me know, I will be more then glad to clarify anything.

P.S. This fix is also solving bug #11132 http://bugs.otrs.org/show_bug.cgi?id=11132, where issue was Cyrillic letters which use 2 byte per character.

Regards,
Sanjin
