### PR TITLE
[Rel-4_0 Bug 12367] - * in CustomerID breaks all CustomerUser.CustomerIDs

### DIFF
--- a/Kernel/System/CustomerCompany.pm
+++ b/Kernel/System/CustomerCompany.pm
@@ -120,6 +120,15 @@ sub CustomerCompanyAdd {
         }
     }
 
+    # check if special characters '*' or '%' are used in CustomerID param
+    if ( $Param{CustomerID} =~ /[%*]+/ ) {
+        $Kernel::OM->Get('Kernel::System::Log')->Log(
+            Priority => 'error',
+            Message  => "Invalid CustomerID, please do not use '*' or '%' characters!",
+        );
+        return;
+    }
+
     my $Result = $Self->{ $Param{Source} }->CustomerCompanyAdd(%Param);
     return if !$Result;
 
@@ -229,6 +238,15 @@ sub CustomerCompanyUpdate {
         $Kernel::OM->Get('Kernel::System::Log')->Log(
             Priority => 'error',
             Message  => "Need CustomerCompanyID or CustomerID!"
+        );
+        return;
+    }
+
+    # check if special characters '*' or '%' are used in CustomerID param
+    if ( $Param{CustomerID} =~ /[%*]+/ ) {
+        $Kernel::OM->Get('Kernel::System::Log')->Log(
+            Priority => 'error',
+            Message  => "Invalid CustomerID, please do not use '*' or '%' characters!",
         );
         return;
     }

--- a/scripts/test/CustomerCompany.t
+++ b/scripts/test/CustomerCompany.t
@@ -433,4 +433,67 @@ $Self->False(
     "CustomerCompanyList() with Search",
 );
 
+# test CustomerCompany creation and update with invalid special character '*' and '%'
+# without other characters in string
+my $CustomerCompanyRand = 'CustomerCompany' . int( rand(1000000) );
+my $CustomerIDUpdate    = $CustomerCompanyObject->CustomerCompanyAdd(
+    CustomerID             => $CustomerCompanyRand,
+    CustomerCompanyName    => $CustomerCompanyRand . ' Inc',
+    CustomerCompanyStreet  => 'Some Street',
+    CustomerCompanyZIP     => '12345',
+    CustomerCompanyCity    => 'Some city',
+    CustomerCompanyCountry => 'USA',
+    CustomerCompanyURL     => 'http://example.com',
+    CustomerCompanyComment => 'some comment',
+    ValidID                => 1,
+    UserID                 => 1,
+);
+
+$Self->True(
+    $CustomerIDUpdate,
+    "CustomerCompanyAdd() - CustomerID $CustomerCompanyRand"
+);
+
+for my $SpecialCharacters ( '*', '**', '%', '%%', '*%*', 'a*', 'a*a', '*a', 'a%', 'a%a', '%a' ) {
+
+    # create CustomerCompany with special characters as CustomerID
+    my $CustomerID = $CustomerCompanyObject->CustomerCompanyAdd(
+        CustomerID             => $SpecialCharacters,
+        CustomerCompanyName    => $CustomerCompanyRand . $SpecialCharacters . ' Inc',
+        CustomerCompanyStreet  => 'Some Street',
+        CustomerCompanyZIP     => '12345',
+        CustomerCompanyCity    => 'Some city',
+        CustomerCompanyCountry => 'USA',
+        CustomerCompanyURL     => 'http://example.com',
+        CustomerCompanyComment => 'some comment',
+        ValidID                => 1,
+        UserID                 => 1,
+    );
+
+    $Self->False(
+        $CustomerID,
+        "Not possible CustomerCompanyAdd() - CustomerID '$SpecialCharacters'"
+    );
+
+    # update CustomerCompany with special characters as CustomerID
+    my $Update = $CustomerCompanyObject->CustomerCompanyUpdate(
+        CustomerCompanyID      => $CustomerIDUpdate,
+        CustomerID             => $SpecialCharacters,
+        CustomerCompanyName    => $CustomerCompanyRand . $SpecialCharacters . '- updated Inc',
+        CustomerCompanyStreet  => 'Some Street',
+        CustomerCompanyZIP     => '12345',
+        CustomerCompanyCity    => 'Some city',
+        CustomerCompanyCountry => 'USA',
+        CustomerCompanyURL     => 'http://updated.example.com',
+        CustomerCompanyComment => 'some comment updated',
+        ValidID                => 1,
+        UserID                 => 1,
+    );
+
+    $Self->False(
+        $Update,
+        "Not possible CustomerCompanyUpdate() - CustomerID '$SpecialCharacters'",
+    );
+}
+
 1;


### PR DESCRIPTION
http://bugs.otrs.org/show_bug.cgi?id=12367

Hello,

Hereby is our proposal for fixing reportes issue for rel-4_0. Forbid input of special characters '*' and '%' as CustomerID when used alone or in combination with one-another or other characters. Fix is applied for CustomerCompanyAdd() and CustomerCompanyUpdate().

Modified UT check for these restrictions.

Please let me know if you have any questions or issues regarding this bug fix approach.

Regards,
Sanjin
