### PR TITLE
Size limit for e-mail messages created in OTRS web panels

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,4 +1,5 @@
 #6.0.0.beta1 2016-??-??
+ - 2016-10-26 Size limit for e-mail messages created in OTRS web panels.
  - 2016-10-21 Fixed bug#[12285](http://bugs.otrs.org/show_bug.cgi?id=12285) - Invalid customer user still receive admin notification.
  - 2016-10-20 Simplified the way how fontawesome is being integrated to ease future updates and updated to 4.6.3.
  - 2016-09-21 Fixed bug#[12065](http://bugs.otrs.org/show_bug.cgi?id=12065) - queue and state not mandatory.

--- a/Kernel/Config/Files/Ticket.xml
+++ b/Kernel/Config/Files/Ticket.xml
@@ -1606,6 +1606,14 @@
             <String>5</String>
         </Setting>
     </ConfigItem>
+    <ConfigItem Name="AgentMessageSizeLimit" Required="1" Valid="1" ConfigLevel="200">
+        <Description Translatable="1">Defines the size limit (in bytes) for e-mail message created via the browser in agent panel (sum of subject, body and attachment sizes).</Description>
+        <Group>Ticket</Group>
+        <SubGroup>Frontend::Agent</SubGroup>
+        <Setting>
+            <String Regex="^[0-9]{1,11}$">26214400</String>
+        </Setting>
+    </ConfigItem>
     <ConfigItem Name="Ticket::Frontend::ListType" Required="1" Valid="1">
         <Description Translatable="1">Shows existing parent/child queue lists in the system in the form of a tree or a list.</Description>
         <Group>Ticket</Group>
@@ -1941,6 +1949,14 @@
                 <Item Key="0" Translatable="1">No</Item>
                 <Item Key="Sortable" Translatable="1">Yes</Item>
             </Option>
+        </Setting>
+    </ConfigItem>
+    <ConfigItem Name="CustomerMessageSizeLimit" Required="1" Valid="1" ConfigLevel="200">
+        <Description Translatable="1">Defines the size limit (in bytes) for message created via the browser in customer panel (sum of subject, body and attachment sizes).</Description>
+        <Group>Ticket</Group>
+        <SubGroup>Frontend::Customer</SubGroup>
+        <Setting>
+            <String Regex="^[0-9]{1,11}$">26214400</String>
         </Setting>
     </ConfigItem>
     <ConfigItem Name="Ticket::Frontend::CustomerDisableCompanyTicketAccess" Required="1" Valid="1">

--- a/Kernel/Modules/AgentTicketEmail.pm
+++ b/Kernel/Modules/AgentTicketEmail.pm
@@ -967,6 +967,30 @@ sub Run {
                 $Error{'BodyInvalid'} = 'ServerError';
             }
 
+            # check message size (sum of subject, body and attachment sizes)
+            # throw error if message size limit is exceeded
+            my $MessageSizeLimit = $ConfigObject->Get('AgentMessageSizeLimit') || 26214400;
+            my $MessageSize = 0;
+
+            if ( $GetParam{Subject} ) {
+                $MessageSize += bytes::length( $GetParam{Subject} );
+            }
+
+            if ( $GetParam{Body} ) {
+                $MessageSize += bytes::length( $GetParam{Body} );
+            }
+
+            ATTACHMENT:
+            for my $Attachment ( @Attachments ) {
+                $MessageSize += $Attachment->{FilesizeRaw};
+            }
+
+            if ( $MessageSize > $MessageSizeLimit ) {
+                $Error{'MessageIsTooBig'} = 'ServerError';
+                $GetParam{MessageSize} = $MainObject->HumanReadableDataSize(Size => $MessageSize);
+                $GetParam{MessageSizeLimit} = $MainObject->HumanReadableDataSize(Size => $MessageSizeLimit);
+            }
+
             # check if date is valid
             if (
                 !$ExpandCustomerName
@@ -1121,6 +1145,13 @@ sub Run {
             if ( $Error{BccIsLocalAddress} ) {
                 $LayoutObject->Block(
                     Name => 'BccIsLocalAddressServerErrorMsg',
+                    Data => \%GetParam,
+                );
+            }
+
+            if ( $Error{MessageIsTooBig} ) {
+                $LayoutObject->Block(
+                    Name => 'MessageIsTooBigServerErrorMsg',
                     Data => \%GetParam,
                 );
             }

--- a/Kernel/Modules/AgentTicketForward.pm
+++ b/Kernel/Modules/AgentTicketForward.pm
@@ -610,6 +610,7 @@ sub SendEmail {
     # get needed objects
     my $DynamicFieldBackendObject = $Kernel::OM->Get('Kernel::System::DynamicField::Backend');
     my $LayoutObject              = $Kernel::OM->Get('Kernel::Output::HTML::Layout');
+    my $MainObject                = $Kernel::OM->Get('Kernel::System::Main');
     my $ParamObject               = $Kernel::OM->Get('Kernel::System::Web::Request');
 
     # cycle through the activated Dynamic Fields for this screen
@@ -936,6 +937,39 @@ sub SendEmail {
     my @Attachments = $UploadCacheObject->FormIDGetAllFilesMeta(
         FormID => $GetParam{FormID},
     );
+
+    # check message size (sum of subject, body and attachment sizes)
+    # throw error if message size limit is exceeded
+    if ( !$ParamObject->GetParam( Param => 'AttachmentUpload' ) ) {
+        my $MessageSizeLimit = $ConfigObject->Get('AgentMessageSizeLimit') || 26214400;
+        my $MessageSize = 0;
+
+        if ( $GetParam{Subject} ) {
+            $MessageSize += bytes::length( $GetParam{Subject} );
+        }
+
+        if ( $GetParam{Body} ) {
+            $MessageSize += bytes::length( $GetParam{Body} );
+        }
+
+        ATTACHMENT:
+        for my $Attachment ( @Attachments ) {
+            $MessageSize += $Attachment->{FilesizeRaw};
+        }
+
+        if ( $MessageSize > $MessageSizeLimit ) {
+            $Error{'MessageIsTooBig'} = 'ServerError';
+            $GetParam{MessageSize} = $MainObject->HumanReadableDataSize(Size => $MessageSize);
+            $GetParam{MessageSizeLimit} = $MainObject->HumanReadableDataSize(Size => $MessageSizeLimit);
+        }
+
+        if ( $Error{MessageIsTooBig} ) {
+            $LayoutObject->Block(
+                Name => 'MessageIsTooBigServerErrorMsg',
+                Data => \%GetParam,
+            );
+        }
+    }
 
     # check if there is an error
     if (%Error) {

--- a/Kernel/Output/HTML/Templates/Standard/AgentTicketCompose.tt
+++ b/Kernel/Output/HTML/Templates/Standard/AgentTicketCompose.tt
@@ -47,7 +47,7 @@
 
                     <label for="ToCustomer" class="Mandatory"><span class="Marker">*</span>[% Translate("To") | html %]:</label>
                     <div class="Field">
-                        <input id="ToCustomer" type="text" name="ToCustomer" value="" class="CustomerAutoComplete W75pc [% Data.ToIsLocalAddress | html %] [% Data.ToInvalid | html %]" autocomplete="off" />
+                        <input id="ToCustomer" type="text" name="ToCustomer" value="" class="CustomerAutoComplete W75pc [% Data.ToIsLocalAddress | html %] [% Data.ToInvalid | html %] [% Data.MessageIsTooBig | html %]" autocomplete="off" />
 
                         <div id="ToCustomerServerError" class="TooltipErrorMessage">
 [% RenderBlockStart("ToIsLocalAddressServerErrorMsg") %]
@@ -57,6 +57,10 @@
 [% RenderBlockStart("ToServerErrorMsg") %]
                             <p>[% Translate("Please include at least one recipient") | html %]</p>
 [% RenderBlockEnd("ToServerErrorMsg") %]
+
+[% RenderBlockStart("MessageIsTooBigServerErrorMsg") %]
+                            <p>[% Translate("Message size (%s) exceeds allowable limit (%s).", Data.MessageSize, Data.MessageSizeLimit) | html %]</p>
+[% RenderBlockEnd("MessageIsTooBigServerErrorMsg") %]
                         </div>
                     </div>
                     <div class="Clear"></div>

--- a/Kernel/Output/HTML/Templates/Standard/AgentTicketEmail.tt
+++ b/Kernel/Output/HTML/Templates/Standard/AgentTicketEmail.tt
@@ -67,7 +67,7 @@
 
                     <label for="ToCustomer" class="Mandatory"><span class="Marker">*</span>[% Translate("To customer user") | html %]:</label>
                     <div class="Field">
-                        <input id="ToCustomer" type="text" name="ToCustomer" value="" class="CustomerAutoComplete W75pc [% Data.ToIsLocalAddress | html %] [% Data.ToInvalid | html %]" autocomplete="off" />
+                        <input id="ToCustomer" type="text" name="ToCustomer" value="" class="CustomerAutoComplete W75pc [% Data.ToIsLocalAddress | html %] [% Data.ToInvalid | html %] [% Data.MessageIsTooBig | html %]" autocomplete="off" />
                         <div id="ToCustomerServerError" class="TooltipErrorMessage">
 [% RenderBlockStart("ToServerErrorMsg") %]
                             <p>[% Translate("Please include at least one customer user for the ticket.") | html %]</p>
@@ -76,6 +76,10 @@
 [% RenderBlockStart("ToIsLocalAddressServerErrorMsg") %]
                     <p>[% Translate("This address is registered as system address and cannot be used: %s", Data.To) | html %]</p>
 [% RenderBlockEnd("ToIsLocalAddressServerErrorMsg") %]
+
+[% RenderBlockStart("MessageIsTooBigServerErrorMsg") %]
+                            <p>[% Translate("Message size (%s) exceeds allowable limit (%s).", Data.MessageSize, Data.MessageSizeLimit) | html %]</p>
+[% RenderBlockEnd("MessageIsTooBigServerErrorMsg") %]
                         </div>
                     </div>
                     <div class="Clear"></div>

--- a/Kernel/Output/HTML/Templates/Standard/AgentTicketEmailOutbound.tt
+++ b/Kernel/Output/HTML/Templates/Standard/AgentTicketEmailOutbound.tt
@@ -46,7 +46,7 @@
 
                 <label for="ToCustomer" class="Mandatory"><span class="Marker">*</span>[% Translate("To") | html %]:</label>
                 <div class="Field">
-                    <input id="ToCustomer" type="text" name="ToCustomer" value="" class="CustomerAutoComplete W75pc [% Data.ToIsLocalAddress | html %] [% Data.ToInvalid | html %]" autocomplete="off" />
+                    <input id="ToCustomer" type="text" name="ToCustomer" value="" class="CustomerAutoComplete W75pc [% Data.ToIsLocalAddress | html %] [% Data.ToInvalid | html %] [% Data.MessageIsTooBig | html %]" autocomplete="off" />
 
                     <div id="ToCustomerServerError" class="TooltipErrorMessage">
 [% RenderBlockStart("ToServerErrorMsg") %]
@@ -56,6 +56,10 @@
 [% RenderBlockStart("ToIsLocalAddressServerErrorMsg") %]
                             <p>[% Translate("This address is registered as system address and cannot be used: %s", Data.To) | html %]</p>
 [% RenderBlockEnd("ToIsLocalAddressServerErrorMsg") %]
+
+[% RenderBlockStart("MessageIsTooBigServerErrorMsg") %]
+                            <p>[% Translate("Message size (%s) exceeds allowable limit (%s).", Data.MessageSize, Data.MessageSizeLimit) | html %]</p>
+[% RenderBlockEnd("MessageIsTooBigServerErrorMsg") %]
                     </div>
                 </div>
                 <div class="Clear"></div>

--- a/Kernel/Output/HTML/Templates/Standard/AgentTicketForward.tt
+++ b/Kernel/Output/HTML/Templates/Standard/AgentTicketForward.tt
@@ -48,7 +48,7 @@
 
                 <label for="ToCustomer" class="Mandatory"><span class="Marker">*</span>[% Translate("To") | html %]:</label>
                 <div class="Field">
-                    <input id="ToCustomer" type="text" name="ToCustomer" value="" class="CustomerAutoComplete W75pc [% Data.ToIsLocalAddress | html %] [% Data.ToInvalid | html %]" autocomplete="off" />
+                    <input id="ToCustomer" type="text" name="ToCustomer" value="" class="CustomerAutoComplete W75pc [% Data.ToIsLocalAddress | html %] [% Data.ToInvalid | html %] [% Data.MessageIsTooBig | html %]" autocomplete="off" />
 
                     <div id="ToCustomerServerError" class="TooltipErrorMessage">
 [% RenderBlockStart("ToServerErrorMsg") %]
@@ -58,6 +58,10 @@
 [% RenderBlockStart("ToIsLocalAddressServerErrorMsg") %]
                     <p>[% Translate("This address is registered as system address and cannot be used: %s", Data.To) | html %]</p>
 [% RenderBlockEnd("ToIsLocalAddressServerErrorMsg") %]
+
+[% RenderBlockStart("MessageIsTooBigServerErrorMsg") %]
+                            <p>[% Translate("Message size (%s) exceeds allowable limit (%s).", Data.MessageSize, Data.MessageSizeLimit) | html %]</p>
+[% RenderBlockEnd("MessageIsTooBigServerErrorMsg") %]
                     </div>
                 </div>
                 <div class="Clear"></div>

--- a/Kernel/Output/HTML/Templates/Standard/CustomerTicketMessage.tt
+++ b/Kernel/Output/HTML/Templates/Standard/CustomerTicketMessage.tt
@@ -79,9 +79,16 @@
                         <span class="Marker">*</span>
                         [% Translate("Subject") | html %]:
                     </label>
-                    <input title="[% Translate("Subject") | html %]" type="text" id="Subject" name="Subject" value="[% Data.Subject | html %]" class="Validate_Required [% Data.SubjectInvalid | html %]" />
+                    <input title="[% Translate("Subject") | html %]" type="text" id="Subject" name="Subject" value="[% Data.Subject | html %]" class="Validate_Required [% Data.SubjectInvalid | html %] [% Data.MessageIsTooBig | html %]" />
                     <div id="SubjectError" class="TooltipErrorMessage" ><p>[% Translate("This field is required.") | html %]</p></div>
-                    <div id="SubjectServerError" class="TooltipErrorMessage NoJavaScriptMessage[% Data.SubjectInvalid | html %]" ><p>[% Translate("This field is required.") | html %]</p></div>
+                    <div id="SubjectServerError" class="TooltipErrorMessage NoJavaScriptMessage[% Data.SubjectInvalid | html %] NoJavaScriptMessage[% Data.MessageIsTooBig | html %]" >
+[% IF Data.SubjectInvalid %]
+                        <p>[% Translate("This field is required.") | html %]</p>
+[% END %]
+[% IF Data.MessageIsTooBig %]
+                        <p>[% Translate("Message size (%s) exceeds allowable limit (%s).", Data.MessageSize, Data.MessageSizeLimit) | html %]</p>
+[% END %]
+                    </div>
                     <div class="Clear"></div>
                 </div>
                 <div class="RichTextHolder">

--- a/Kernel/Output/HTML/Templates/Standard/CustomerTicketZoom.tt
+++ b/Kernel/Output/HTML/Templates/Standard/CustomerTicketZoom.tt
@@ -273,7 +273,12 @@
                             <label for="Subject">
                                 [% Translate("Subject") | html %]:
                             </label>
-                            <input class="DontPrint" type="text" name="Subject" id="Subject" title="[% Translate("Subject") | html %]" value="[% Data.Subject | html %]" />
+                            <input class="DontPrint Validate_Required [% Data.MessageIsTooBig | html %]" type="text" name="Subject" id="Subject" title="[% Translate("Subject") | html %]" value="[% Data.Subject | html %]" />
+                            <div id="SubjectServerError" class="TooltipErrorMessage NoJavaScriptMessage[% Data.MessageIsTooBig | html %]" >
+[% IF Data.MessageIsTooBig %]
+                                <p>[% Translate("Message size (%s) exceeds allowable limit (%s).", Data.MessageSize, Data.MessageSizeLimit) | html %]</p>
+[% END %]
+                            </div>
                             <div class="Clear"></div>
                         </div>
                         <div>

--- a/Kernel/System/Web/UploadCache.pm
+++ b/Kernel/System/Web/UploadCache.pm
@@ -134,7 +134,7 @@ returns an array with a hash ref of all files for a Form ID
         FormID => 12345,
     );
 
-    Return data of on hash is Content, ContentType, ContentID, Filename, Filesize, FileID;
+    Return data of on hash is Content, ContentType, ContentID, Filename, Filesize, FilesizeRaw, FileID;
 
 =cut
 
@@ -154,7 +154,7 @@ Note: returns no content, only meta data.
         FormID => 12345,
     );
 
-    Return data of hash is ContentType, ContentID, Filename, Filesize, FileID;
+    Return data of hash is ContentType, ContentID, Filename, Filesize, FilesizeRaw, FileID;
 
 =cut
 

--- a/Kernel/System/Web/UploadCache/DB.pm
+++ b/Kernel/System/Web/UploadCache/DB.pm
@@ -184,16 +184,10 @@ sub FormIDGetAllFilesData {
 
         # human readable file size
         my $Filesize;
-        if ( $Row[2] ) {
-            if ( $Row[2] > ( 1024 * 1024 ) ) {
-                $Filesize = sprintf "%.1f MBytes", ( $Row[2] / ( 1024 * 1024 ) );
-            }
-            elsif ( $Row[2] > 1024 ) {
-                $Filesize = sprintf "%.1f KBytes", ( ( $Row[2] / 1024 ) );
-            }
-            else {
-                $Filesize = $Row[2] . ' Bytes';
-            }
+        if ( defined $Row[2] ) {
+            $Filesize = $MainObject->HumanReadableDataSize(
+                Size => $Row[2],
+            );
         }
 
         # encode attachment if it's a postgresql backend!!!
@@ -255,16 +249,10 @@ sub FormIDGetAllFilesMeta {
 
         # human readable file size
         my $Filesize;
-        if ( $Row[2] ) {
-            if ( $Row[2] > ( 1024 * 1024 ) ) {
-                $Filesize = sprintf "%.1f MBytes", ( $Row[2] / ( 1024 * 1024 ) );
-            }
-            elsif ( $Row[2] > 1024 ) {
-                $Filesize = sprintf "%.1f KBytes", ( ( $Row[2] / 1024 ) );
-            }
-            else {
-                $Filesize = $Row[2] . ' Bytes';
-            }
+        if ( defined $Row[2] ) {
+            $Filesize = $MainObject->HumanReadableDataSize(
+                Size => $Row[2],
+            );
         }
 
         # add the info

--- a/Kernel/System/Web/UploadCache/DB.pm
+++ b/Kernel/System/Web/UploadCache/DB.pm
@@ -18,6 +18,7 @@ our @ObjectDependencies = (
     'Kernel::System::DB',
     'Kernel::System::Encode',
     'Kernel::System::Log',
+    'Kernel::System::Main',
 );
 
 sub new {
@@ -162,6 +163,9 @@ sub FormIDGetAllFilesData {
         }
     }
 
+    # get main object
+    my $MainObject = $Kernel::OM->Get('Kernel::System::Main');
+
     # get database object
     my $DBObject = $Kernel::OM->Get('Kernel::System::DB');
 
@@ -179,15 +183,16 @@ sub FormIDGetAllFilesData {
         $Counter++;
 
         # human readable file size
+        my $Filesize;
         if ( $Row[2] ) {
             if ( $Row[2] > ( 1024 * 1024 ) ) {
-                $Row[2] = sprintf "%.1f MBytes", ( $Row[2] / ( 1024 * 1024 ) );
+                $Filesize = sprintf "%.1f MBytes", ( $Row[2] / ( 1024 * 1024 ) );
             }
             elsif ( $Row[2] > 1024 ) {
-                $Row[2] = sprintf "%.1f KBytes", ( ( $Row[2] / 1024 ) );
+                $Filesize = sprintf "%.1f KBytes", ( ( $Row[2] / 1024 ) );
             }
             else {
-                $Row[2] = $Row[2] . ' Bytes';
+                $Filesize = $Row[2] . ' Bytes';
             }
         }
 
@@ -204,7 +209,8 @@ sub FormIDGetAllFilesData {
                 ContentID   => $Row[4],
                 ContentType => $Row[1],
                 Filename    => $Row[0],
-                Filesize    => $Row[2],
+                FilesizeRaw => $Row[2],
+                Filesize    => $Filesize,
                 Disposition => $Row[5],
                 FileID      => $Counter,
             }
@@ -229,6 +235,9 @@ sub FormIDGetAllFilesMeta {
         }
     }
 
+    # get main object
+    my $MainObject = $Kernel::OM->Get('Kernel::System::Main');
+
     # get database object
     my $DBObject = $Kernel::OM->Get('Kernel::System::DB');
 
@@ -245,15 +254,16 @@ sub FormIDGetAllFilesMeta {
         $Counter++;
 
         # human readable file size
+        my $Filesize;
         if ( $Row[2] ) {
             if ( $Row[2] > ( 1024 * 1024 ) ) {
-                $Row[2] = sprintf "%.1f MBytes", ( $Row[2] / ( 1024 * 1024 ) );
+                $Filesize = sprintf "%.1f MBytes", ( $Row[2] / ( 1024 * 1024 ) );
             }
             elsif ( $Row[2] > 1024 ) {
-                $Row[2] = sprintf "%.1f KBytes", ( ( $Row[2] / 1024 ) );
+                $Filesize = sprintf "%.1f KBytes", ( ( $Row[2] / 1024 ) );
             }
             else {
-                $Row[2] = $Row[2] . ' Bytes';
+                $Filesize = $Row[2] . ' Bytes';
             }
         }
 
@@ -264,7 +274,8 @@ sub FormIDGetAllFilesMeta {
                 ContentID   => $Row[3],
                 ContentType => $Row[1],
                 Filename    => $Row[0],
-                Filesize    => $Row[2],
+                FilesizeRaw => $Row[2],
+                Filesize    => $Filesize,
                 Disposition => $Row[4],
                 FileID      => $Counter,
             }

--- a/Kernel/System/Web/UploadCache/FS.pm
+++ b/Kernel/System/Web/UploadCache/FS.pm
@@ -246,23 +246,20 @@ sub FormIDGetAllFilesData {
         next FILE if $File =~ /\.Disposition$/;
 
         $Counter++;
-        my $FileSize = -s $File;
+        my $FilesizeRaw = -s $File;
+        my $Filesize;
 
         # human readable file size
-        if ($FileSize) {
+        if ( defined $FilesizeRaw ) {
 
-            # remove meta data in files
-            if ( $FileSize > 30 ) {
-                $FileSize = $FileSize - 30
+            if ( $FilesizeRaw > 1048576 ) {    # 1024 * 1024
+                $Filesize = sprintf "%.1f MBytes", ( $FilesizeRaw / 1048576 );    # 1024 * 1024
             }
-            if ( $FileSize > 1048576 ) {    # 1024 * 1024
-                $FileSize = sprintf "%.1f MBytes", ( $FileSize / 1048576 );    # 1024 * 1024
-            }
-            elsif ( $FileSize > 1024 ) {
-                $FileSize = sprintf "%.1f KBytes", ( ( $FileSize / 1024 ) );
+            elsif ( $FilesizeRaw > 1024 ) {
+                $Filesize = sprintf "%.1f KBytes", ( ( $FilesizeRaw / 1024 ) );
             }
             else {
-                $FileSize = $FileSize . ' Bytes';
+                $Filesize = $FilesizeRaw . ' Bytes';
             }
         }
         my $Content = $MainObject->FileRead(
@@ -303,7 +300,8 @@ sub FormIDGetAllFilesData {
                 ContentID   => ${$ContentID},
                 ContentType => ${$ContentType},
                 Filename    => $File,
-                Filesize    => $FileSize,
+                FilesizeRaw => $FilesizeRaw,
+                Filesize    => $Filesize,
                 FileID      => $Counter,
                 Disposition => ${$Disposition},
             },
@@ -351,23 +349,20 @@ sub FormIDGetAllFilesMeta {
         next FILE if $File =~ /\.Disposition$/;
 
         $Counter++;
-        my $FileSize = -s $File;
+        my $FilesizeRaw = -s $File;
+        my $Filesize;
 
         # human readable file size
-        if ($FileSize) {
+        if ( defined $FilesizeRaw ) {
 
-            # remove meta data in files
-            if ( $FileSize > 30 ) {
-                $FileSize = $FileSize - 30
+            if ( $FilesizeRaw > 1048576 ) {    # 1024 * 1024
+                $Filesize = sprintf "%.1f MBytes", ( $FilesizeRaw / 1048576 );    # 1024 * 1024
             }
-            if ( $FileSize > 1048576 ) {    # 1024 * 1024
-                $FileSize = sprintf "%.1f MBytes", ( $FileSize / 1048576 );    # 1024 * 1024
-            }
-            elsif ( $FileSize > 1024 ) {
-                $FileSize = sprintf "%.1f KBytes", ( ( $FileSize / 1024 ) );
+            elsif ( $FilesizeRaw > 1024 ) {
+                $Filesize = sprintf "%.1f KBytes", ( ( $FilesizeRaw / 1024 ) );
             }
             else {
-                $FileSize = $FileSize . ' Bytes';
+                $Filesize = $FilesizeRaw . ' Bytes';
             }
         }
 
@@ -402,7 +397,8 @@ sub FormIDGetAllFilesMeta {
                 ContentID   => ${$ContentID},
                 ContentType => ${$ContentType},
                 Filename    => $File,
-                Filesize    => $FileSize,
+                FilesizeRaw => $FilesizeRaw,
+                Filesize    => $Filesize,
                 FileID      => $Counter,
                 Disposition => ${$Disposition},
             },

--- a/Kernel/System/Web/UploadCache/FS.pm
+++ b/Kernel/System/Web/UploadCache/FS.pm
@@ -251,17 +251,11 @@ sub FormIDGetAllFilesData {
 
         # human readable file size
         if ( defined $FilesizeRaw ) {
-
-            if ( $FilesizeRaw > 1048576 ) {    # 1024 * 1024
-                $Filesize = sprintf "%.1f MBytes", ( $FilesizeRaw / 1048576 );    # 1024 * 1024
-            }
-            elsif ( $FilesizeRaw > 1024 ) {
-                $Filesize = sprintf "%.1f KBytes", ( ( $FilesizeRaw / 1024 ) );
-            }
-            else {
-                $Filesize = $FilesizeRaw . ' Bytes';
-            }
+            $Filesize = $MainObject->HumanReadableDataSize(
+                Size => $FilesizeRaw,
+            );
         }
+
         my $Content = $MainObject->FileRead(
             Location => $File,
             Mode     => 'binmode',                                             # optional - binmode|utf8
@@ -354,16 +348,9 @@ sub FormIDGetAllFilesMeta {
 
         # human readable file size
         if ( defined $FilesizeRaw ) {
-
-            if ( $FilesizeRaw > 1048576 ) {    # 1024 * 1024
-                $Filesize = sprintf "%.1f MBytes", ( $FilesizeRaw / 1048576 );    # 1024 * 1024
-            }
-            elsif ( $FilesizeRaw > 1024 ) {
-                $Filesize = sprintf "%.1f KBytes", ( ( $FilesizeRaw / 1024 ) );
-            }
-            else {
-                $Filesize = $FilesizeRaw . ' Bytes';
-            }
+            $Filesize = $MainObject->HumanReadableDataSize(
+                Size => $FilesizeRaw,
+            );
         }
 
         my $ContentType = $MainObject->FileRead(


### PR DESCRIPTION
This mod forces OTRS o control size of e-mail messages created in agent and customer panel and block sending if message size (sum of subject, body and attachments) exceeds limit defined in SysConfig parameter AgentMessageSizeLimit (for agent panel) and CustomerMessageSizeLimit.

Without this mod OTRS may produce large e-mail messages that may be bounced by SMTP servers which should be avoided and allows customers to create messages with many large attachments.

Please note: this mod requires tided filesize formatting - routine HumanReadableDataSize() introduced e73877a13e3ec963bbbfd27832b45ab391610d73 - still not tided in upstream code.

Related: https://github.com/OTRS/otrs/pull/1224/commits/e73877a13e3ec963bbbfd27832b45ab391610d73
Related: https://dev.ib.pl/ib/otrs/issues/102
Related: https://dev.ib.pl/ib/otrs/issues/65
Author-Change-Id: IB#1011160