### PR TITLE
Remove redundant and wrong permission check

### DIFF
--- a/Kernel/Modules/AgentTicketCustomer.pm
+++ b/Kernel/Modules/AgentTicketCustomer.pm
@@ -68,22 +68,6 @@ sub Run {
         );
     }
 
-    # check permissions
-    if ( $Self->{TicketID} ) {
-        if (
-            !$TicketObject->TicketPermission(
-                Type     => 'customer',
-                TicketID => $Self->{TicketID},
-                UserID   => $Self->{UserID}
-            )
-            )
-        {
-
-            # no permission screen, don't show ticket
-            return $LayoutObject->NoPermission( WithHeader => 'yes' );
-        }
-    }
-
     # get ACL restrictions
     my %PossibleActions = ( 1 => $Self->{Action} );
 


### PR DESCRIPTION
There does not seem to be a permission type "customer", and there is a check for a configurable permission type right above it.
