### PR TITLE
Update/add REST API Sample config

### DIFF
--- a/development/webservices/GenericFAQConnectorREST.yml
+++ b/development/webservices/GenericFAQConnectorREST.yml
@@ -34,19 +34,19 @@ Provider:
         LanguageList:
           RequestMethod:
           - GET
-          Route: LanguageList
+          Route: /LanguageList
         PublicCategoryList:
           RequestMethod:
           - GET
-          Route: PublicCategoryList
+          Route: /PublicCategoryList
         PublicFAQGet:
           RequestMethod:
           - GET
-          Route: PublicFAQGet
+          Route: /PublicFAQGet
         PublicFAQSearch:
           RequestMethod:
           - POST
-          Route: PublicFAQSearch
+          Route: /PublicFAQSearch
     Type: HTTP::REST
 RemoteSystem: ''
 Requester:

--- a/development/webservices/GenericFAQConnectorREST.yml
+++ b/development/webservices/GenericFAQConnectorREST.yml
@@ -1,0 +1,54 @@
+---
+Debugger:
+  DebugThreshold: info
+  TestMode: '0'
+Description: FAQ Connector REST Sample
+FrameworkVersion: 5.0.13
+Provider:
+  Operation:
+    LanguageList:
+      Description: List all availables languages
+      MappingInbound: {}
+      MappingOutbound: {}
+      Type: FAQ::LanguageList
+    PublicCategoryList:
+      Description: List all public FAQ categories (with tree information)
+      MappingInbound: {}
+      MappingOutbound: {}
+      Type: FAQ::PublicCategoryList
+    PublicFAQGet:
+      Description: Retrieve public FAQ entries
+      MappingInbound: {}
+      MappingOutbound: {}
+      Type: FAQ::PublicFAQGet
+    PublicFAQSearch:
+      Description: Search for public FAQs
+      MappingInbound: {}
+      MappingOutbound: {}
+      Type: FAQ::PublicFAQGet
+  Transport:
+    Config:
+      KeepAlive: ''
+      MaxLength: '10000000'
+      RouteOperationMapping:
+        LanguageList:
+          RequestMethod:
+          - GET
+          Route: LanguageList
+        PublicCategoryList:
+          RequestMethod:
+          - GET
+          Route: PublicCategoryList
+        PublicFAQGet:
+          RequestMethod:
+          - GET
+          Route: PublicFAQGet
+        PublicFAQSearch:
+          RequestMethod:
+          - POST
+          Route: PublicFAQSearch
+    Type: HTTP::REST
+RemoteSystem: ''
+Requester:
+  Transport:
+    Type: ''

--- a/development/webservices/GenericLinkConnectorREST.yml
+++ b/development/webservices/GenericLinkConnectorREST.yml
@@ -1,0 +1,81 @@
+---
+Debugger:
+  DebugThreshold: info
+  TestMode: '0'
+Description: Link Connector REST Sample
+FrameworkVersion: 5.0.13
+Provider:
+  Operation:
+    LinkAdd:
+      Description: Add a new link between two elements.
+      MappingInbound: {}
+      MappingOutbound: {}
+      Type: Link::LinkAdd
+    LinkDelete:
+      Description: Deletes a link between two elements.
+      MappingInbound: {}
+      MappingOutbound: {}
+      Type: Link::LinkDelete
+    LinkDeleteAll:
+      Description: Deletes all links of an element.
+      MappingInbound: {}
+      MappingOutbound: {}
+      Type: Link::LinkDeleteAll
+    LinkList:
+      Description: Get all existing links for an element.
+      MappingInbound: {}
+      MappingOutbound: {}
+      Type: Link::LinkList
+    PossibleLinkList:
+      Description: Get a list structure of all possible link types.
+      MappingInbound: {}
+      MappingOutbound: {}
+      Type: Link::PossibleLinkList
+    PossibleObjectsList:
+      Description: Get a list of all possible linkable objects for an object.
+      MappingInbound: {}
+      MappingOutbound: {}
+      Type: Link::PossibleObjectsList
+    PossibleTypesList:
+      Description: Get a list of all possible link types between two objects.
+      MappingInbound: {}
+      MappingOutbound: {}
+      Type: Link::PossibleTypesList
+  Transport:
+    Config:
+      KeepAlive: ''
+      MaxLength: '100000000'
+      RouteOperationMapping:
+        LinkAdd:
+          RequestMethod:
+          - POST
+          Route: /LinkAdd
+        LinkDelete:
+          RequestMethod:
+          - DELETE
+          Route: /LinkDelete
+        LinkDeleteAll:
+          RequestMethod:
+          - DELETE
+          Route: /LinkDeleteAll
+        LinkList:
+          RequestMethod:
+          - GET
+          Route: /LinkList
+        PossibleLinkList:
+          RequestMethod:
+          - GET
+          Route: /PossibleLinkList
+        PossibleObjectsList:
+          RequestMethod:
+          - GET
+          Route: /PossibleObjectsList
+        PossibleTypesList:
+          RequestMethod:
+          - GET
+          Route: /PossibleTypesList
+    Type: HTTP::REST
+RemoteSystem: ''
+Requester:
+  Transport:
+    Type: ''

--- a/development/webservices/GenericTicketConnectorREST.yml
+++ b/development/webservices/GenericTicketConnectorREST.yml
@@ -1,9 +1,9 @@
 ---
 Debugger:
-  DebugThreshold: debug
+  DebugThreshold: info
   TestMode: '0'
 Description: Ticket Connector REST Sample
-FrameworkVersion: 4.x git
+FrameworkVersion: 5.0.13
 Provider:
   Operation:
     SessionCreate:
@@ -18,6 +18,11 @@ Provider:
       Type: Ticket::TicketCreate
     TicketGet:
       Description: Retrieves Ticket data
+      MappingInbound: {}
+      MappingOutbound: {}
+      Type: Ticket::TicketGet
+    TicketGetList:
+      Description: Retrieves Ticket data for a List of Ticket IDs
       MappingInbound: {}
       MappingOutbound: {}
       Type: Ticket::TicketGet
@@ -48,6 +53,10 @@ Provider:
           RequestMethod:
           - GET
           Route: /Ticket/:TicketID
+        TicketGetList:
+          RequestMethod:
+          - GET
+          Route: /TicketList
         TicketSearch:
           RequestMethod:
           - GET
@@ -61,3 +70,4 @@ RemoteSystem: ''
 Requester:
   Transport:
     Type: ''
+


### PR DESCRIPTION
This PR adds a new route to the existing example config for the GenericTicketConnectorREST setup.
Additionally this PR adds a REST sample for the the Link API.
