### PR TITLE
Marked notification title as translatable

### DIFF
--- a/Kernel/Output/HTML/Templates/Standard/PreferencesNotificationEvent.tt
+++ b/Kernel/Output/HTML/Templates/Standard/PreferencesNotificationEvent.tt
@@ -24,7 +24,7 @@
         </tr>
 [% RenderBlockEnd("NoDataFoundMsg") %]
 [% RenderBlockStart("BodyRow") %]
-        <tr title="[% Data.NotificationTitle | html %]"[% IF Data.VisibleForAgent == 2 %] class="Mandatory"[% END %]>
+        <tr title="[% Data.NotificationTitle | Translate | html %]"[% IF Data.VisibleForAgent == 2 %] class="Mandatory"[% END %]>
             <td>[% IF Data.VisibleForAgent == 2 %]<span class="Mandatory">* [% END %][% Translate(Data.NotificationName) | html %][% IF Data.VisibleForAgent == 2 %]</span>[% END %]</td>
 [% RenderBlockStart("BodyTransportColumn") %]
             <td class="Center">


### PR DESCRIPTION
Hi @mgruner 
If you hover the mouse over the notification names on the settings screen, the titles of the rows show only English tooltips. This PR enables translation for them.
Branch rel-5_0 is also affected.