### PR TITLE
Fixed error argument "" isn't numeric in numeric eq (==) at [...] AdminUserGroup.pm line 153

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,4 +1,5 @@
 #6.0.0.beta1 2016-??-??
+ - 2016-11-14 Fixed error argument "" isn't numeric in numeric eq (==) at [...] AdminUserGroup.pm line 153.
  - 2016-11-04 Make it possible to search for emtpy dynamic fields via the TicketSearch API, thanks to Rolf Schmidt and Moritz Lenz.
  - 2016-11-02 Added sort criteria to TicketSearch call in PendingCheck console command. Thanks to Torsten Thau.
  - 2016-10-31 Removed default queue group restriction from TicketQueueOverview dashlet.

--- a/Kernel/Modules/AdminUserGroup.pm
+++ b/Kernel/Modules/AdminUserGroup.pm
@@ -149,7 +149,9 @@ sub Run {
             for my $Permission ( sort keys %Permissions ) {
                 $NewPermission{$Permission} = 0;
                 my @Array = @{ $Permissions{$Permission} };
+                ID:
                 for my $ID (@Array) {
+                    next ID if !$ID;
                     if ( $UserID == $ID ) {
                         $NewPermission{$Permission} = 1;
                     }


### PR DESCRIPTION
In AdminRoleGroup when saving permissions added for all agents using
column header (i.e. RO), POST request contains empty value in first
array item, i.e.

    Action=AdminUserGroup&Subaction=ChangeGroup&ID=8&ro=&ro=1&ro=2&ro=3&ro=4

which throws warnings like

    -e: Argument "" isn't numeric in numeric eq (==) at /opt/otrs//Kernel/Modules/AdminUserGroup.pm line 153.

to apache error log. Permissions are saved correctly but OTRS should
not pollute logs.

Related: https://dev.ib.pl/ib/otrs/issues/103
Author-Change-Id: IB#1061101