### PR TITLE
Marked notification messages as translatable

### DIFF
--- a/Kernel/Output/HTML/Templates/Standard/Notify.tt
+++ b/Kernel/Output/HTML/Templates/Standard/Notify.tt
@@ -15,7 +15,7 @@
             [% Translate(Data.Info) | html %]
 [% RenderBlockEnd("Text") %]
 [% RenderBlockStart("Data") %]
-            [% Data.Data %]
+            [% Translate(Data.Data) | html %]
 [% RenderBlockEnd("Data") %]
 [% RenderBlockStart("LinkStop") %]
         </a>


### PR DESCRIPTION
Hi @mgruner 
This patch makes it possible to translate the notification messages, like select a time zone, etc.
Branch rel-5_0 is also affected.