### PR TITLE
Fixed Error Use of uninitialized value $GetParam{"EmailFrom"} in lc at [...]NewTicket.pm line 172

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,4 +1,5 @@
 #6.0.0.beta1 2016-??-??
+ - 2016-11-15 Fixed Error Use of uninitialized value $GetParam{"EmailFrom"} in lc at [...]NewTicket.pm line 172.
  - 2016-11-04 Make it possible to search for emtpy dynamic fields via the TicketSearch API, thanks to Rolf Schmidt and Moritz Lenz.
  - 2016-11-02 Added sort criteria to TicketSearch call in PendingCheck console command. Thanks to Torsten Thau.
  - 2016-10-31 Removed default queue group restriction from TicketQueueOverview dashlet.

--- a/Kernel/System/PostMaster/NewTicket.pm
+++ b/Kernel/System/PostMaster/NewTicket.pm
@@ -166,17 +166,20 @@ sub Run {
                 );
             }
 
-            # get customer user object
-            my $CustomerUserObject = $Kernel::OM->Get('Kernel::System::CustomerUser');
+            if ( $GetParam{EmailFrom} ) {
 
-            my %List = $CustomerUserObject->CustomerSearch(
-                PostMasterSearch => lc( $GetParam{EmailFrom} ),
-            );
+                # get customer user object
+                my $CustomerUserObject = $Kernel::OM->Get('Kernel::System::CustomerUser');
 
-            for my $UserLogin ( sort keys %List ) {
-                %CustomerData = $CustomerUserObject->CustomerUserDataGet(
-                    User => $UserLogin,
+                my %List = $CustomerUserObject->CustomerSearch(
+                    PostMasterSearch => lc( $GetParam{EmailFrom} ),
                 );
+
+                for my $UserLogin ( sort keys %List ) {
+                    %CustomerData = $CustomerUserObject->CustomerUserDataGet(
+                        User => $UserLogin,
+                    );
+                }
             }
         }
 


### PR DESCRIPTION
OTRS postmaster (procmail mode) throws errors like

    otrs.Console.pl: Use of uninitialized value $GetParam{"EmailFrom"} in lc at /opt/otrs/Kernel/System/PostMaster/NewTicket.pm line 172, <DATA> line 751.

and

    Message: Need Search, UserLogin, PostMasterSearch, CustomerIDRaw or CustomerID!

    Traceback (4362):
    Module: Kernel::System::CustomerUser::DB::CustomerSearch Line: 267
    Module: Kernel::System::CustomerUser::CustomerSearch Line: 281
    Module: Kernel::System::PostMaster::NewTicket::Run Line: 172
    Module: Kernel::System::PostMaster::Run Line: 374
    Module: (eval) Line: 111
    Module: Kernel::System::Console::Command::Maint::PostMaster::Read::Run Line: 94
    Module: (eval) Line: 456
    Module: Kernel::System::Console::BaseCommand::Execute Line: 450
    Module: Kernel::System::Console::InterfaceConsole::Run Line: 80
    Module: /opt/otrs/bin/otrs.Console.pl Line: 38

while importing e-mail message with From header like

    From: MAILER-DAEMON

This mod fixes issue described above.

Related: https://dev.ib.pl/ib/otrs/issues/104
Author-Change-Id: IB#1023795