### PR TITLE
Put Save buttons into a separate widget

### DIFF
--- a/Kernel/Output/HTML/Templates/Standard/AdminACLEdit.tt
+++ b/Kernel/Output/HTML/Templates/Standard/AdminACLEdit.tt
@@ -231,7 +231,17 @@
                     <div class="Hidden">
                         [% Data.ACLKeysLevel3Actions %]
                     </div>
+                </div>
+            </div>
 
+            <div class="WidgetSimple ScreenXL">
+                <div class="Header Expanded">
+                    <div class="WidgetAction Toggle">
+                        <a href="#" title="[% Translate("Save settings") | html %]"></a>
+                    </div>
+                    <h2>[% Translate("Save ACL") | html %]</h2>
+                </div>
+                <div class="Content">
                     <fieldset class="TableLike">
                         <div class="Field SpacingTop SaveButtons">
                             <button class="Primary CallForAction" id="SubmitAndContinue" type="submit" value="[% Translate("Save") | html %]"><span>[% Translate("Save") | html %]</span></button>


### PR DESCRIPTION
Hi @mgruner 
Now the save buttons are inside the "Edit ACL structure" widget. If the user collapses the widget, the buttons disappear. This pull request puts these buttons into a separate widget (as it is in [AdminProcessManagementProcessEdit.tt](/OTRS/otrs/blob/master/Kernel/Output/HTML/Templates/Standard/AdminProcessManagementProcessEdit.tt)).
Branch rel-5_0 is also affected.