### PR TITLE
LDAP Size Limit issue (bug#12290)

### DIFF
--- a/Kernel/System/CustomerUser/LDAP.pm
+++ b/Kernel/System/CustomerUser/LDAP.pm
@@ -396,10 +396,23 @@ sub CustomerSearch {
 
     # log ldap errors
     if ( $Result->code() ) {
-        $Kernel::OM->Get('Kernel::System::Log')->Log(
-            Priority => 'error',
-            Message  => $Result->error(),
-        );
+
+        if ( $Result->code() == 4 ) {
+
+            # Result code 4 (LDAP_SIZELIMIT_EXCEEDED) is normal if there
+            # are more items in LDAP than search limit defined in OTRS or
+            # in LDAP server. Avoid spamming logs with such errors.
+            $Kernel::OM->Get('Kernel::System::Log')->Log(
+                Priority => 'debug',
+                Message  => 'LDAP size limit exceeded (' . $Result->error() . ').',
+            );
+        }
+        else {
+            $Kernel::OM->Get('Kernel::System::Log')->Log(
+                Priority => 'error',
+                Message  => 'Search failed! ' . $Result->error(),
+            );
+        }
     }
 
     my %Users;


### PR DESCRIPTION
Extended(copy & paste) fix of bug#12290 (initially fixed in 5.0.13) to another LDAP Query in order to do not receive size limit notifications as error.