### PR TITLE
Master - Fixed uninitialized value in Sort.pm.

### DIFF
--- a/Kernel/Output/HTML/TicketOverviewMenu/Sort.pm
+++ b/Kernel/Output/HTML/TicketOverviewMenu/Sort.pm
@@ -121,7 +121,7 @@ sub Run {
         my @SplittedLinkFilters = split( /[;&]/, $Param{LinkFilter} );
         for my $CurrentLinkFilter ( sort @SplittedLinkFilters ) {
             my @KeyValue = split( /=/, $CurrentLinkFilter );
-            $RedirectParams{ $KeyValue[0] } = "\'$KeyValue[1]\'";
+            $RedirectParams{ $KeyValue[0] } = "\'$KeyValue[1]\'" if defined $KeyValue[1];
         }
     }
 


### PR DESCRIPTION
Hi @mgruner 

There is small fix that we noticed working on the framework.

Step by step description:

- go in AgentTicketPhone (or similar crating ticket screens )
- select cutomer which has ticket
- there will be displayed Ticket history overview table at below
- set large overview 
- click on link CustomerID in Ticket History - large view
- it will open AgentCustomerInformationCenter screen
- Fred logs message
`[Wed Nov 16 11:32:01 2016] -e: Use of uninitialized value $KeyValue[1] in concatenation (.) or string at /opt/otrs//Kernel/Output/HTML/TicketOverviewMenu/Sort.pm line 124`

I know that is not so urgent, however I like suggesting such fix when I see it. IMHO it is better that there is not this log message.

Regards
Zoran
