### PR TITLE
Master - Fixed selecting SysConfig subgroup.

### DIFF
--- a/Kernel/Modules/AdminSysConfig.pm
+++ b/Kernel/Modules/AdminSysConfig.pm
@@ -976,13 +976,13 @@ sub Run {
         );
 
         # list Groups
-        my %List = $SysConfigObject->ConfigGroupList();
+        my %GroupList = $SysConfigObject->ConfigGroupList();
 
         $Group = $ParamObject->GetParam( Param => 'SysConfigGroup' );
 
         # create select Box
         $Data{List} = $LayoutObject->BuildSelection(
-            Data         => \%List,
+            Data         => \%GroupList,
             SelectedID   => $Group,
             Name         => 'SysConfigGroup',
             Translation  => 0,
@@ -1005,16 +1005,17 @@ sub Run {
 
         $LayoutObject->Block( Name => 'OverviewResult' );
 
-        %List = $SysConfigObject->ConfigSubGroupList( Name => $Group ) if $Group;
+        my %SubGroupList;
+        %SubGroupList = $SysConfigObject->ConfigSubGroupList( Name => $Group ) if $Group;
 
         # if there are any results, they are shown
-        if (%List) {
-            for ( sort keys %List ) {
+        if (%SubGroupList) {
+            for my $Item ( sort keys %SubGroupList ) {
                 $LayoutObject->Block(
                     Name => 'Row',
                     Data => {
-                        SubGroup      => $_,
-                        SubGroupCount => $List{$_},
+                        SubGroup      => $Item,
+                        SubGroupCount => $SubGroupList{$Item},
                         Group         => $Group,
                     },
                 );

--- a/scripts/test/Selenium/Agent/Admin/AdminSysConfig.t
+++ b/scripts/test/Selenium/Agent/Admin/AdminSysConfig.t
@@ -43,6 +43,20 @@ $Selenium->RunTest(
             $Selenium->find_element( "#SysConfigGroup option[value='$SysGroupValues']", 'css' );
         }
 
+        # select Ticket sysconfig group
+        $Selenium->execute_script(
+            "\$('#SysConfigGroup').val('Ticket').trigger('redraw.InputField').trigger('change');");
+
+        # remove selected Ticket sysconfig group
+        $Selenium->find_element( ".Remove", 'css' )->VerifiedClick();
+
+        # verify no result are found on after removing sysconfig group
+        $Self->Is(
+            $Selenium->execute_script("return \$('.DataTable tbody td').text().trim();"),
+            'No data found.',
+            "No result message is found"
+        );
+
         # check for the import button
         $Selenium->find_element("//a[contains(\@href, \'Subaction=Import')]");
 


### PR DESCRIPTION
Hi @mgruner 

We saw this issue in the AdminSysConfig.pm

Step by step description:

- go in AdminSysConfig.pm
- select a group in the dropdown list
- remove the group (deselect)
- in Result table there is wrong data - list of group is displayed 
- click on a link one of displayed group in the result 
- empty screen for update sysconfig is displayed.

![sysconfig_bug_1](https://cloud.githubusercontent.com/assets/6348760/20344710/1f32d6f4-abf4-11e6-84cb-df0118f9cca1.png)

![sysconfig_bug_2](https://cloud.githubusercontent.com/assets/6348760/20344717/245751dc-abf4-11e6-9ba3-c3a29e0267b0.png)


Hereby is fixed this issue. If you like we can open the bug report as well.

Regards
Zoran



