### PR TITLE
Fixed race condition in ArticleCreate

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,4 +1,5 @@
 #6.0.0.beta1 2016-??-??
+ - 2016-11-16 Fixed race condition in ArticleCreate.
  - 2016-11-04 Make it possible to search for emtpy dynamic fields via the TicketSearch API, thanks to Rolf Schmidt and Moritz Lenz.
  - 2016-11-02 Added sort criteria to TicketSearch call in PendingCheck console command. Thanks to Torsten Thau.
  - 2016-10-31 Removed default queue group restriction from TicketQueueOverview dashlet.


### PR DESCRIPTION
OTRS searches for ID of article inserted to database using

    TicketID
    MessageID
    From
    Subject
    IncomingTime

and highest ID in table; because IncomingTime resolution is 1 s, if two
articles with the same MessageID arrive to database in the same second
(i.e. poor web browser sends duplicated POST creating same note or two
e-mail messages arrive with the same Message-ID /if send To more than
one OTRS system address/) , race may occur and OTRS process may append
article data (attachments, plain and html files) to other ArticleID
than inserted by this process.

Related: https://dev.ib.pl/ib/otrs/issues/105
Author-Change-Id: IB#1021899