### PR TITLE
Superfluous colon in table heading

### DIFF
--- a/Kernel/Output/HTML/Templates/Standard/AdminPackageManager.tt
+++ b/Kernel/Output/HTML/Templates/Standard/AdminPackageManager.tt
@@ -637,12 +637,12 @@
                     <table class="DataTable W100pc">
                         <thead>
                             <tr>
-                                <th>[% Translate("Type") | html %]: </th>
-                                <th>[% Translate("Name") | html %]: </th>
-                                <th>[% Translate("Required") | html %]: </th>
-                                <th>[% Translate("Size") | html %]: </th>
-                                <th>[% Translate("PrimaryKey") | html %]: </th>
-                                <th>[% Translate("AutoIncrement") | html %]: </th>
+                                <th>[% Translate("Type") | html %]</th>
+                                <th>[% Translate("Name") | html %]</th>
+                                <th>[% Translate("Required") | html %]</th>
+                                <th>[% Translate("Size") | html %]</th>
+                                <th>[% Translate("Primary Key") | html %]</th>
+                                <th>[% Translate("Auto Increment") | html %]</th>
                             </tr>
                         </thead>
                         <tbody>


### PR DESCRIPTION
Hi @mgruner 
There are no colons in table headings - except in this table. This proposal removes the superfluous colons. I also apply a small wording improvement. Branch rel-5_0 is also affected.