### PR TITLE
Followup for bug#12418

### DIFF
--- a/var/httpd/htdocs/skins/Agent/default/css/Core.AgentTicketQueue.css
+++ b/var/httpd/htdocs/skins/Agent/default/css/Core.AgentTicketQueue.css
@@ -147,7 +147,6 @@
 
 .QueueOverview .Oldest {
     color: red;
-    font-weight: bold;
     animation: blinking 1s steps(5, start) infinite;
     -webkit-animation: blinking 1s steps(5, start) infinite;
 }


### PR DESCRIPTION
Hi @mrcbnsls 
According to [admin manual](http://otrs.github.io/doc/manual/admin/stable/en/html/what-is-the-queue-overview.html) only the current queue will be bolded.