### PR TITLE
Fixed standard available permissions settings

### DIFF
--- a/Kernel/Config/Files/Framework.xml
+++ b/Kernel/Config/Files/Framework.xml
@@ -7723,28 +7723,6 @@ You can log in via the following URL:
             </TextArea>
         </Setting>
     </ConfigItem>
-    <ConfigItem Name="System::Permission" Required="1" Valid="1">
-        <Description Translatable="1">Defines the standard permissions available for agents within the application. If more permissions are needed, you can enter them here. Permissions must be hard coded to be effective. Please ensure, when adding any of the afore mentioned permissions, that the "rw" permission remains the last entry.</Description>
-        <Group>Framework</Group>
-        <SubGroup>Core</SubGroup>
-        <Setting>
-            <Array>
-                <Item>ro</Item>
-                <Item>rw</Item>
-            </Array>
-        </Setting>
-    </ConfigItem>
-    <ConfigItem Name="System::Customer::Permission" Required="1" Valid="1">
-        <Description Translatable="1">Defines the standard permissions available for customers within the application. If more permissions are needed, you can enter them here. Permissions must be hard coded to be effective. Please ensure, when adding any of the afore mentioned permissions, that the "rw" permission remains the last entry.</Description>
-        <Group>Framework</Group>
-        <SubGroup>Core</SubGroup>
-        <Setting>
-            <Array>
-                <Item>ro</Item>
-                <Item>rw</Item>
-            </Array>
-        </Setting>
-    </ConfigItem>
     <ConfigItem Name="ReferenceData::OwnCountryList" Required="0" Valid="0">
         <Description Translatable="1">This setting allows you to override the built-in country list with your own list of countries. This is particularly handy if you just want to use a small select group of countries.</Description>
         <Group>Framework</Group>

--- a/Kernel/Config/Files/Ticket.xml
+++ b/Kernel/Config/Files/Ticket.xml
@@ -6986,7 +6986,7 @@
         </Setting>
     </ConfigItem>
     <ConfigItem Name="System::Permission" Required="1" Valid="1">
-        <Description Translatable="1">Standard available permissions for agents within the application. If more permissions are needed, they can be entered here. Permissions must be defined to be effective. Some other good permissions have also been provided built-in: note, close, pending, customer, freetext, move, compose, responsible, forward, and bounce. Make sure that "rw" is always the last registered permission.</Description>
+        <Description Translatable="1">Defines the standard available permissions for agents within the application. If more permissions are needed, you can enter them here. Permissions must be hard coded to be effective. Some other good permissions have also been provided built-in: note, close, pending, customer, freetext, move, compose, responsible, forward, and bounce. Make sure that "rw" is always the last registered permission.</Description>
         <Group>Ticket</Group>
         <SubGroup>Core::Ticket</SubGroup>
         <Setting>
@@ -7001,6 +7001,18 @@
             </Array>
         </Setting>
     </ConfigItem>
+    <ConfigItem Name="System::Customer::Permission" Required="1" Valid="1">
+        <Description Translatable="1">Defines the standard available permissions for customers within the application. If more permissions are needed, you can enter them here. Permissions must be hard coded to be effective. Please ensure, when adding any of the afore mentioned permissions, that the "rw" permission remains the last entry.</Description>
+        <Group>Framework</Group>
+        <SubGroup>Core::Ticket</SubGroup>
+        <Setting>
+            <Array>
+                <Item>ro</Item>
+                <Item>rw</Item>
+            </Array>
+        </Setting>
+    </ConfigItem>
+
     <ConfigItem Name="Ticket::Permission###1-OwnerCheck" Required="0" Valid="1">
         <Description Translatable="1">Module to grant access to the owner of a ticket.</Description>
         <Group>Ticket</Group>


### PR DESCRIPTION
Hi @mgruner 
The setting "System::Permission" is in both Framework.xml and Ticket.xml, so always the latter will be applied. Therefore I delete it from Framework.xml, and also moved the setting "System::Customer::Permission" into the Ticket.xml
Branch rel-5_0 is also affected.