### PR TITLE
Mandatory Owner removes empty selection

### DIFF
--- a/Kernel/Modules/AgentTicketProcess.pm
+++ b/Kernel/Modules/AgentTicketProcess.pm
@@ -3051,15 +3051,12 @@ sub _RenderOwner {
         ValidateRequired => '',
     );
 
-    my $PossibleNone = 1;
-
     # if field is required put in the necessary variables for
     #    ValidateRequired class input field, Mandatory class for the label
     #    do not allow empty selection
     if ( $Param{ActivityDialogField}->{Display} && $Param{ActivityDialogField}->{Display} == 2 ) {
         $Data{ValidateRequired} = 'Validate_Required';
         $Data{MandatoryClass}   = 'Mandatory';
-        $PossibleNone           = 0;
     }
 
     my $SelectedValue;
@@ -3147,7 +3144,7 @@ sub _RenderOwner {
         Translation  => 1,
         SelectedID   => $SelectedID || '',
         Class        => "Modernize $ServerError",
-        PossibleNone => $PossibleNone,
+        PossibleNone => 1, # even if mandatory an explcit selection should be done
     );
 
     # set fields that will get an AJAX loader icon when this field changes

--- a/Kernel/Modules/AgentTicketProcess.pm
+++ b/Kernel/Modules/AgentTicketProcess.pm
@@ -3099,7 +3099,6 @@ sub _RenderOwner {
     #    (if any)
     if (
         !$SelectedValue
-        && !$PossibleNone
         && IsHashRefWithData( $Param{Ticket} )
         )
     {

--- a/Kernel/Modules/AgentTicketProcess.pm
+++ b/Kernel/Modules/AgentTicketProcess.pm
@@ -3114,7 +3114,6 @@ sub _RenderOwner {
     #    set it to none (as it doesn't need to be changed afterall)
     elsif (
         $SelectedValue
-        && $PossibleNone
         && IsHashRefWithData( $Param{Ticket} )
         && $SelectedValue eq $Param{Ticket}->{Owner}
         )


### PR DESCRIPTION
If Owner is set to mandatory the empty selection must not be removed in order to force an explicit selection of value. If no empty selection is possible, the user is likely to forget to actually pick a new owner.