### PR TITLE
Asynchronous Loading of Widgets in AgentTicketZoom, take 2

### DIFF
--- a/Kernel/Config/Files/Ticket.xml
+++ b/Kernel/Config/Files/Ticket.xml
@@ -11371,6 +11371,7 @@ Thanks for your help!
             <Hash>
                 <Item Key="Module">Kernel::Output::HTML::TicketZoom::CustomerInformation</Item>
                 <Item Key="Location">Sidebar</Item>
+                <Item Key="Async">1</Item>
             </Hash>
         </Setting>
     </ConfigItem>

--- a/Kernel/Modules/AgentTicketZoom.pm
+++ b/Kernel/Modules/AgentTicketZoom.pm
@@ -14,6 +14,7 @@ use warnings;
 our $ObjectManagerDisabled = 1;
 
 use POSIX qw/ceil/;
+use Digest::SHA1 ();
 use Kernel::System::EmailParser;
 use Kernel::System::VariableCheck qw(:all);
 use Kernel::Language qw(Translatable);
@@ -342,8 +343,73 @@ sub Run {
         );
     }
 
-    # get param object
+    # get required objects
     my $ParamObject = $Kernel::OM->Get('Kernel::System::Web::Request');
+    my $MainObject  = $Kernel::OM->Get('Kernel::System::Main');
+
+    if ( $Self->{Subaction} eq 'LoadWidget' ) {
+        my $ElementID = $ParamObject->GetParam( Param => 'ElementID' );
+        my $Config;
+        WIDGET:
+        for my $Key ( sort keys %{ $Self->{DisplaySettings}->{Widgets} // {} } ) {
+            if ( $ElementID eq 'Async_' . Digest::SHA1::sha1_hex( $Key ) ) {
+                $Config = $Self->{DisplaySettings}->{Widgets}->{$Key};
+                last WIDGET;
+            }
+        }
+        if ( $Config ) {
+            my $Success = eval { $MainObject->Require( $Config->{Module} ) };
+            if (!$Success) {
+                $Kernel::OM->Get('Kernel::System::Log')->Log(
+                    Priority => 'error',
+                    Message  => "Cannot load $Config->{Module}: $@",
+                );
+                return $LayoutObject->Attachment(
+                    ContentType => 'text/html',
+                    Content     => '',
+                    Type        => 'inline',
+                    NoCache     => 1,
+                );
+            }
+            my $Module = eval { $Config->{Module}->new(%$Self) };
+            if ( !$Module ) {
+                $Kernel::OM->Get('Kernel::System::Log')->Log(
+                    Priority => 'error',
+                    Message  => "new() of Widget module $Config->{Module} not successful!",
+
+                );
+                return $LayoutObject->Attachment(
+                    ContentType => 'text/html',
+                    Content     => '',
+                    Type        => 'inline',
+                    NoCache     => 1,
+                );
+            }
+            my $WidgetOutput = $Module->Run(
+                Ticket    => \%Ticket,
+                AclAction => \%AclAction,
+                Config    => $Config,
+            );
+            return $LayoutObject->Attachment(
+                ContentType => 'text/html',
+                Content     => $WidgetOutput->{Output},
+                Type        => 'inline',
+                NoCache     => 1,
+            );
+        }
+        else {
+            $Kernel::OM->Get('Kernel::System::Log')->Log(
+                Priority => 'error',
+                Message  => "Cannot locate module for ElementID $ElementID",
+            );
+            return $LayoutObject->Attachment(
+                ContentType => 'text/html',
+                Content     => '',
+                Type        => 'inline',
+                NoCache     => 1,
+            );
+        }
+    }
 
     # mark shown article as seen
     if ( $Self->{Subaction} eq 'MarkAsSeen' ) {
@@ -928,11 +994,29 @@ sub MaskAgentZoom {
         Space => ' '
     );
 
-    my %Widgets;
     my $MainObject = $Kernel::OM->Get('Kernel::System::Main');
+
+    my %Widgets;
     WIDGET:
     for my $Key ( sort keys %{ $Self->{DisplaySettings}->{Widgets} // {} } ) {
         my $Config = $Self->{DisplaySettings}->{Widgets}->{$Key};
+
+        if ( $Config->{Async} ) {
+            if ( ! $Config->{Location} ) {
+                $Kernel::OM->Get('Kernel::System::Log')->Log(
+                    Priority => 'error',
+                    Message  => "The configuration for $Config->{Module} must contain a Location, because it is marked as Async.",
+                );
+                next WIDGET;
+            }
+            push @{ $Widgets{ $Config->{Location} } }, {
+                Async => 1,
+                Rank  => $Config->{Rank} || $Key,
+                %Ticket,
+                ElementID => 'Async_' . Digest::SHA1::sha1_hex( $Key ),
+            };
+            next WIDGET;
+        }
         my $Success = eval { $MainObject->Require( $Config->{Module} ) };
         next WIDGET if !$Success;
         my $Module = eval { $Config->{Module}->new(%$Self) };
@@ -958,8 +1042,7 @@ sub MaskAgentZoom {
     }
     for my $Location ( sort keys %Widgets ) {
         $Param{ $Location . 'Widgets' } = [
-            map      { $_->{Output} }
-                sort { $a->{Rank} cmp $b->{Rank} } @{ $Widgets{$Location} }
+            sort { $a->{Rank} cmp $b->{Rank} } @{ $Widgets{$Location} }
         ];
     }
 

--- a/Kernel/Modules/AgentTicketZoom.pm
+++ b/Kernel/Modules/AgentTicketZoom.pm
@@ -14,7 +14,6 @@ use warnings;
 our $ObjectManagerDisabled = 1;
 
 use POSIX qw/ceil/;
-use Digest::SHA1 ();
 use Kernel::System::EmailParser;
 use Kernel::System::VariableCheck qw(:all);
 use Kernel::Language qw(Translatable);
@@ -352,7 +351,7 @@ sub Run {
         my $Config;
         WIDGET:
         for my $Key ( sort keys %{ $Self->{DisplaySettings}->{Widgets} // {} } ) {
-            if ( $ElementID eq 'Async_' . Digest::SHA1::sha1_hex( $Key ) ) {
+            if ( $ElementID eq 'Async_' . $LayoutObject->LinkEncode( $Key ) ) {
                 $Config = $Self->{DisplaySettings}->{Widgets}->{$Key};
                 last WIDGET;
             }
@@ -1013,7 +1012,7 @@ sub MaskAgentZoom {
                 Async => 1,
                 Rank  => $Config->{Rank} || $Key,
                 %Ticket,
-                ElementID => 'Async_' . Digest::SHA1::sha1_hex( $Key ),
+                ElementID => 'Async_' . $LayoutObject->LinkEncode( $Key ),
             };
             next WIDGET;
         }

--- a/Kernel/Output/HTML/Templates/Standard/AgentTicketZoom.tt
+++ b/Kernel/Output/HTML/Templates/Standard/AgentTicketZoom.tt
@@ -223,7 +223,19 @@
             </div>
 
             [% FOREACH Widget IN Data.MainWidgets; %]
-                [% Widget.Output %]
+                [% IF Widget.Async; %]
+                    <div id="[% Widget.ElementID %]"></div>
+                    [% WRAPPER JSOnDocumentComplete %]
+                    <script type="text/javascript">//<![CDATA[
+                        Core.AJAX.ContentUpdate($('#[% Widget.ElementID %]'),
+                            '[% Env("Baselink") %]Action=[% Env("Action") %];Subaction=LoadWidget;'
+                             + 'TicketID=[% Widget.TicketID %];ElementID=[% Widget.ElementID %]',
+                             Core.Agent.Init, true);
+                    //]]></script>
+                    [% END %]
+                [% ELSE; %]
+                    [% Widget.Output %]
+                [% END; %]
             [% END; %]
 
         </div>

--- a/Kernel/Output/HTML/Templates/Standard/AgentTicketZoom.tt
+++ b/Kernel/Output/HTML/Templates/Standard/AgentTicketZoom.tt
@@ -81,7 +81,7 @@
                         Core.AJAX.ContentUpdate($('#[% Widget.ElementID %]'),
                             '[% Env("Baselink") %]Action=[% Env("Action") %];Subaction=LoadWidget;'
                              + 'TicketID=[% Widget.TicketID %];ElementID=[% Widget.ElementID %]',
-                             null, true);
+                             Core.Agent.Init, true);
                     //]]></script>
                     [% END %]
                 [% ELSE; %]

--- a/Kernel/Output/HTML/Templates/Standard/AgentTicketZoom.tt
+++ b/Kernel/Output/HTML/Templates/Standard/AgentTicketZoom.tt
@@ -73,8 +73,20 @@
 
     <div class="LayoutFixedSidebar SidebarLast">
         <div class="SidebarColumn">
-            [% FOREACH widget IN Data.SidebarWidgets; %]
-                [% widget %]
+            [% FOREACH Widget IN Data.SidebarWidgets; %]
+                [% IF Widget.Async; %]
+                    <div id="[% Widget.ElementID %]"></div>
+                    [% WRAPPER JSOnDocumentComplete %]
+                    <script type="text/javascript">//<![CDATA[
+                        Core.AJAX.ContentUpdate($('#[% Widget.ElementID %]'),
+                            '[% Env("Baselink") %]Action=[% Env("Action") %];Subaction=LoadWidget;'
+                             + 'TicketID=[% Widget.TicketID %];ElementID=[% Widget.ElementID %]',
+                             null, true);
+                    //]]></script>
+                    [% END %]
+                [% ELSE; %]
+                    [% Widget.Output %]
+                [% END; %]
             [% END; %]
         </div>
         <div class="ContentColumn">
@@ -210,8 +222,8 @@
 [% Data.ArticleItems %]
             </div>
 
-            [% FOREACH widget IN Data.MainWidgets; %]
-                [% widget %]
+            [% FOREACH Widget IN Data.MainWidgets; %]
+                [% Widget.Output %]
             [% END; %]
 
         </div>

--- a/Kernel/Output/HTML/Templates/Standard/AgentTicketZoom.tt
+++ b/Kernel/Output/HTML/Templates/Standard/AgentTicketZoom.tt
@@ -76,14 +76,6 @@
             [% FOREACH Widget IN Data.SidebarWidgets; %]
                 [% IF Widget.Async; %]
                     <div id="[% Widget.ElementID %]"></div>
-                    [% WRAPPER JSOnDocumentComplete %]
-                    <script type="text/javascript">//<![CDATA[
-                        Core.AJAX.ContentUpdate($('#[% Widget.ElementID %]'),
-                            '[% Env("Baselink") %]Action=[% Env("Action") %];Subaction=LoadWidget;'
-                             + 'TicketID=[% Widget.TicketID %];ElementID=[% Widget.ElementID %]',
-                             Core.Agent.Init, true);
-                    //]]></script>
-                    [% END %]
                 [% ELSE; %]
                     [% Widget.Output %]
                 [% END; %]
@@ -225,14 +217,6 @@
             [% FOREACH Widget IN Data.MainWidgets; %]
                 [% IF Widget.Async; %]
                     <div id="[% Widget.ElementID %]"></div>
-                    [% WRAPPER JSOnDocumentComplete %]
-                    <script type="text/javascript">//<![CDATA[
-                        Core.AJAX.ContentUpdate($('#[% Widget.ElementID %]'),
-                            '[% Env("Baselink") %]Action=[% Env("Action") %];Subaction=LoadWidget;'
-                             + 'TicketID=[% Widget.TicketID %];ElementID=[% Widget.ElementID %]',
-                             Core.Agent.Init, true);
-                    //]]></script>
-                    [% END %]
                 [% ELSE; %]
                     [% Widget.Output %]
                 [% END; %]

--- a/var/httpd/htdocs/js/Core.AJAX.js
+++ b/var/httpd/htdocs/js/Core.AJAX.js
@@ -511,11 +511,10 @@ Core.AJAX = (function (TargetNS) {
      * @param {jQueryObject} $ElementToUpdate - The jQuery object of the element(s) which should be updated
      * @param {String} URL - The URL which is called via Ajax
      * @param {Function} Callback - The additional callback function which is called after the request returned from the server
-     * @param {Bool} Replace - replace the DOM container with the response instead of updating the contents
      * @description
      *      Calls an URL via Ajax and updates a html element with the answer html of the server.
      */
-    TargetNS.ContentUpdate = function ($ElementToUpdate, URL, Callback, Replace) {
+    TargetNS.ContentUpdate = function ($ElementToUpdate, URL, Callback) {
         var QueryString, QueryIndex = URL.indexOf("?"), GlobalResponse;
 
         if (QueryIndex >= 0) {
@@ -540,12 +539,7 @@ Core.AJAX = (function (TargetNS) {
                 }
                 else if ($ElementToUpdate && isJQueryObject($ElementToUpdate) && $ElementToUpdate.length) {
                     GlobalResponse = Response;
-                    if ( Replace ) {
-                        $ElementToUpdate.replaceWith(Response);
-                    }
-                    else {
-                        $ElementToUpdate.html(Response);
-                    }
+                    $ElementToUpdate.html(Response);
                 }
                 else {
                     // We are out of the OTRS App scope, that's why an exception would not be caught. Therefore we handle the error manually.

--- a/var/httpd/htdocs/js/Core.AJAX.js
+++ b/var/httpd/htdocs/js/Core.AJAX.js
@@ -511,10 +511,11 @@ Core.AJAX = (function (TargetNS) {
      * @param {jQueryObject} $ElementToUpdate - The jQuery object of the element(s) which should be updated
      * @param {String} URL - The URL which is called via Ajax
      * @param {Function} Callback - The additional callback function which is called after the request returned from the server
+     * @param {Bool} Replace - replace the DOM container with the response instead of updating the contents
      * @description
      *      Calls an URL via Ajax and updates a html element with the answer html of the server.
      */
-    TargetNS.ContentUpdate = function ($ElementToUpdate, URL, Callback) {
+    TargetNS.ContentUpdate = function ($ElementToUpdate, URL, Callback, Replace) {
         var QueryString, QueryIndex = URL.indexOf("?"), GlobalResponse;
 
         if (QueryIndex >= 0) {
@@ -539,7 +540,12 @@ Core.AJAX = (function (TargetNS) {
                 }
                 else if ($ElementToUpdate && isJQueryObject($ElementToUpdate) && $ElementToUpdate.length) {
                     GlobalResponse = Response;
-                    $ElementToUpdate.html(Response);
+                    if ( Replace ) {
+                        $ElementToUpdate.replaceWith(Response);
+                    }
+                    else {
+                        $ElementToUpdate.html(Response);
+                    }
                 }
                 else {
                     // We are out of the OTRS App scope, that's why an exception would not be caught. Therefore we handle the error manually.

--- a/var/httpd/htdocs/js/Core.Agent.TicketZoom.js
+++ b/var/httpd/htdocs/js/Core.Agent.TicketZoom.js
@@ -629,6 +629,7 @@ Core.Agent.TicketZoom = (function (TargetNS) {
             TicketID = Core.Config.Get('TicketID'),
             Count, ArticleIDs = Core.Config.Get('ArticleIDs'),
             ArticleFilterDialog = parseInt(Core.Config.Get('ArticleFilterDialog'), 10),
+            AsyncWidgetActions = Core.Config.Get('AsyncWidgetActions') || {},
             TimelineView = Core.Config.Get('TimelineView'),
             ProcessWidget = Core.Config.Get('ProcessWidget');
 
@@ -702,6 +703,13 @@ Core.Agent.TicketZoom = (function (TargetNS) {
         $('a.Timeline').on('click', function() {
             $(this).attr('href', $(this).attr('href') + ';ArticleID=' + URLHash);
         });
+
+        // Start asynchronous loading of widgets
+        for (var ElementID in AsyncWidgetActions) {
+            if (AsyncWidgetActions.hasOwnProperty(ElementID)) {
+                Core.AJAX.ContentUpdate($('#' + ElementID), Core.Config.Get('Baselink') + AsyncWidgetActions[ElementID], Core.Agent.Init);
+            }
+        }
 
         // loading new articles
         $('#ArticleTable tbody tr').on('click', function () {


### PR DESCRIPTION
This is the successor pull request to #984. I believe I have addressed the issued brought up by @mgruner.

I've also rebased it on top of current master.

However, due to `Core.Agent.Init` now being gone, simply calling that function again doesn't work anymore, so now the asynchronously loaded widgets don't benefit from progressive enhancements, namely that clicking on the title bar doesn't collapse them. @mrcbnsls, do you have any idea how to fix that in a post-`Core.Agent.Init`-OTRS?