### PR TITLE
Renamed Favourite to Bookmark

### DIFF
--- a/Kernel/Config/Files/Framework.xml
+++ b/Kernel/Config/Files/Framework.xml
@@ -9111,7 +9111,7 @@ via the Preferences button after logging in.
         </Setting>
     </ConfigItem>
     <ConfigItem Name="Frontend::NavBarModule###2-AdminFavourites" Required="0" Valid="1">
-        <Description Translatable="1">Frontend module registration (show personal favourites as sub navigation items of 'Admin').</Description>
+        <Description Translatable="1">Frontend module registration (show personal bookmarks as sub navigation items of 'Admin').</Description>
         <Group>Framework</Group>
         <SubGroup>Frontend::Agent::NavBarModule</SubGroup>
         <Setting>

--- a/Kernel/Output/HTML/Templates/Standard/AdminNavigationBar.tt
+++ b/Kernel/Output/HTML/Templates/Standard/AdminNavigationBar.tt
@@ -22,7 +22,7 @@
 
         <div class="WidgetSimple">
             <div class="Header">
-                <h2>[% Translate("Favourites") | html %]</h2>
+                <h2>[% Translate("Bookmarks") | html %]</h2>
             </div>
             <div class="Content FavouriteList">
                 <table class="DataTable Favourites" [% IF !Data.Favourites.size() %]style="display: none;"[% END %]>
@@ -38,7 +38,7 @@
                     </tbody>
                 </table>
                 <p class="FieldExplanation">
-                    [% Translate("You can add favourites by moving your cursor over items on the right side and clicking the star icon.") | html %]
+                    [% Translate("You can add bookmarks by moving your cursor over items on the right side and clicking the star icon.") | html %]
                 </p>
             </div>
         </div>
@@ -95,7 +95,7 @@
                                     [% Translate(Item.Name) | html %]
                                 </span>
                                 <span class="Description">[% Translate(Item.Description) | html %]</span>
-                                <span class="Favourite AddAsFavourite" data-module="[% Item.item("Frontend::Module") | html %]" title="[% Translate("Set as favourite") | html %]">
+                                <span class="Favourite AddAsFavourite" data-module="[% Item.item("Frontend::Module") | html %]" title="[% Translate("Set as bookmark") | html %]">
                                     <i class="fa fa-star"></i>
                                     <i class="fa fa-star-o"></i>
                                 </span>
@@ -111,7 +111,7 @@
                             <tr>
                                 <th class="W20pc">[% Translate("Name") %]</th>
                                 <th>[% Translate("Description") %]</th>
-                                <th class="W10pc Center">[% Translate("As Favourite") %]</th>
+                                <th class="W10pc Center">[% Translate("As Bookmark") %]</th>
                             </tr>
                         </thead>
                         <tbody>
@@ -121,7 +121,7 @@
                                 <td>[% Translate(Item.Description) | html %]</td>
                                 <td class="W10pc Center FavouriteButtons">
                                     <span><i class="fa fa-star"></i></span>
-                                    <a href="#" class="Favourite AddAsFavourite" data-module="[% Item.item("Frontend::Module") | html %]" title="[% Translate("Set as favourite") | html %]">
+                                    <a href="#" class="Favourite AddAsFavourite" data-module="[% Item.item("Frontend::Module") | html %]" title="[% Translate("Set as bookmark") | html %]">
                                         <i class="fa fa-star"></i>
                                         <i class="fa fa-star-o"></i>
                                     </a>


### PR DESCRIPTION
Hi @mgruner 
Here is an other wording change proposal (like in https://github.com/OTRS/otrs/pull/1395).
In the redesigned admin panel of OTRS 6 the admin can mark some widget as "Favourite". These widgets will display in the menu, so the word "Bookmark" will be better choice. Furthermore the star icon means bookmark in many other places (e. g. in browsers).
I changed only the visible strings. There are many inner variables in the source code with name "favourite" (partly or fully). If you agree with my proposal, then it also would be great to rename the related variables in the source code.