### PR TITLE
Improved dialog buttons

### DIFF
--- a/var/httpd/htdocs/js/Core.UI.Dialog.js
+++ b/var/httpd/htdocs/js/Core.UI.Dialog.js
@@ -362,7 +362,7 @@ Core.UI.Dialog = (function (TargetNS) {
                 Type: 'Close',
                 Function: Params.OnClose
             }];
-            $Content.append('<div class="Center Spacing"><button type="button" id="DialogButton1" class="CallForAction Close"><span>Ok</span></button></div>');
+            $Content.append('<div class="Center Spacing"><button type="button" id="DialogButton1" class="CallForAction Close"><span>OK</span></button></div>');
         }
         // Define different other types here...
         else if (Params.Type === 'Search') {
@@ -382,14 +382,14 @@ Core.UI.Dialog = (function (TargetNS) {
                 $Content.append('<div class="InnerContent"></div>').find('.InnerContent').append(Params.HTML);
                 $ButtonFooter = $('<div class="ContentFooter Center"></div>');
                 $.each(Params.Buttons, function (Index, Value) {
-                    var Classes = '';
+                    var Classes = 'CallForAction';
                     if (Value.Type === 'Close') {
-                        Classes = 'Close';
+                        Classes += ' Close';
                     }
                     if (Value.Class) {
                         Classes += ' ' + Value.Class;
                     }
-                    $ButtonFooter.append('<button id="DialogButton' + (Index - 0 + 1) + '" ' + (Classes.length ? ('class="' + Classes + ' CallForAction" ') : '') + 'type="button"><span>' + Value.Label + '</span></button> ');
+                    $ButtonFooter.append('<button id="DialogButton' + (Index - 0 + 1) + '" class="' + Classes + '" type="button"><span>' + Value.Label + '</span></button> ');
                 });
                 $ButtonFooter.appendTo($Content);
             }


### PR DESCRIPTION
Hi @mrcbnsls,

This PR adds "`CallForAction`" class to dialog buttons. I'm not sure about to also add "`Primary`" class for the buttons. If only "`CallForAction`" is added, the deletion of process element has strange look and feel. See this screenshot:

![dialog-buttons](https://cloud.githubusercontent.com/assets/1006118/21081856/cffa9078-bfcf-11e6-9009-01fbe0197137.png)

Where can I find further information about the use of CSS classes in OTRS? What does `CallForAction`, `Primary`, etc. means? I think, the look and feel chapter is missing from the developer manual. [Bootstrap](http://getbootstrap.com/) has very good documentation, maybe the developer manual would need something similar.

Please, apply this patch also to rel-5_0.