### PR TITLE
[ Rel-5_0 Bug 10691 ] - No CustomerID shown after TicketCreate and modified Unit test

### DIFF
--- a/Kernel/System/PostMaster/NewTicket.pm
+++ b/Kernel/System/PostMaster/NewTicket.pm
@@ -206,6 +206,11 @@ sub Run {
         }
     }
 
+    # if there is no customer user found!
+    if ( !$GetParam{'X-OTRS-CustomerUser'} ) {
+        $GetParam{'X-OTRS-CustomerUser'} = $GetParam{SenderEmailAddress};
+    }
+
     # get ticket owner
     my $OwnerID = $GetParam{'X-OTRS-OwnerID'} || $Param{InmailUserID};
     if ( $GetParam{'X-OTRS-Owner'} ) {

--- a/Kernel/System/PostMaster/NewTicket.pm
+++ b/Kernel/System/PostMaster/NewTicket.pm
@@ -184,7 +184,7 @@ sub Run {
         }
 
         # take CustomerID from customer backend lookup or from from field
-        if ( $CustomerData{UserLogin} && !$GetParam{'X-OTRS-CustomerUser'} ) {
+        if ( $CustomerData{UserLogin} ) {
             $GetParam{'X-OTRS-CustomerUser'} = $CustomerData{UserLogin};
 
             # notice that UserLogin is from customer source backend
@@ -204,16 +204,6 @@ sub Run {
                     . " from customer source backend based on ($GetParam{'EmailFrom'}).",
             );
         }
-    }
-
-    # if there is no customer id found!
-    if ( !$GetParam{'X-OTRS-CustomerNo'} ) {
-        $GetParam{'X-OTRS-CustomerNo'} = $GetParam{SenderEmailAddress};
-    }
-
-    # if there is no customer user found!
-    if ( !$GetParam{'X-OTRS-CustomerUser'} ) {
-        $GetParam{'X-OTRS-CustomerUser'} = $GetParam{SenderEmailAddress};
     }
 
     # get ticket owner

--- a/scripts/test/Console/Command/Maint/PostMaster/Read.t
+++ b/scripts/test/Console/Command/Maint/PostMaster/Read.t
@@ -12,7 +12,7 @@ use utf8;
 
 use vars (qw($Self));
 
-# get helper object
+# Get helper object.
 $Kernel::OM->ObjectParamAdd(
     'Kernel::System::UnitTest::Helper' => {
         RestoreDatabase => 1,
@@ -20,7 +20,77 @@ $Kernel::OM->ObjectParamAdd(
 );
 my $Helper = $Kernel::OM->Get('Kernel::System::UnitTest::Helper');
 
+# Get needed objects.
 my $CommandObject = $Kernel::OM->Get('Kernel::System::Console::Command::Maint::PostMaster::Read');
+my $TicketObject  = $Kernel::OM->Get('Kernel::System::Ticket');
+my $ConfigObject  = $Kernel::OM->Get('Kernel::Config');
+
+my $RandomNumber = $Helper->GetRandomNumber();
+
+# use Test email backend
+$ConfigObject->Set(
+    Key   => 'SendmailModule',
+    Value => 'Kernel::System::Email::Test',
+);
+$ConfigObject->Set(
+    Key   => 'CheckEmailAddresses',
+    Value => '0',
+);
+
+# Create customer company.
+my $CustomerCompany   = 'Company' . $RandomNumber;
+my $CustomerCompanyID = $Kernel::OM->Get('Kernel::System::CustomerCompany')->CustomerCompanyAdd(
+    CustomerID             => $CustomerCompany,
+    CustomerCompanyName    => $CustomerCompany,
+    CustomerCompanyStreet  => $CustomerCompany,
+    CustomerCompanyZIP     => $CustomerCompany,
+    CustomerCompanyCity    => $CustomerCompany,
+    CustomerCompanyCountry => 'Germany',
+    CustomerCompanyURL     => 'http://www.otrs.com',
+    CustomerCompanyComment => $CustomerCompany,
+    ValidID                => 1,
+    UserID                 => 1,
+);
+$Self->True(
+    $CustomerCompany,
+    "CustomerCompanyID $CustomerCompanyID is created",
+);
+
+# Create customer user.
+my $CustomerUser             = 'User' . $RandomNumber;
+my $CustomerUserEmailAddress = $CustomerUser . '@example.com';
+my $CustomerUserID           = $Kernel::OM->Get('Kernel::System::CustomerUser')->CustomerUserAdd(
+    Source         => 'CustomerUser',
+    UserFirstname  => $CustomerUser,
+    UserLastname   => $CustomerUser,
+    UserCustomerID => $CustomerCompanyID,
+    UserLogin      => $CustomerUser,
+    UserEmail      => $CustomerUserEmailAddress,
+    UserPassword   => 'password',
+    ValidID        => 1,
+    UserID         => 1,
+);
+$Self->True(
+    $CustomerUserID,
+    "CustomerUserID $CustomerUserID is created",
+);
+
+my @Tests = (
+    {
+        EmailAddress => 'Unknown' . $CustomerUserEmailAddress,
+        Result       => {
+            CustomerUserID => undef,
+            CustomerID     => undef,
+        },
+    },
+    {
+        EmailAddress => $CustomerUserEmailAddress,
+        Result       => {
+            CustomerUserID => $CustomerUserID,
+            CustomerID     => $CustomerCompanyID,
+        },
+    }
+);
 
 my ( $ExitCode, $Result );
 
@@ -36,28 +106,54 @@ $Self->Is(
     "Maint::PostMaster::Read exit code without email input",
 );
 
-{
-    my $Email = "From: me\@home.com\nTo: you\@home.com\nSubject: Test\nUnit tests rock.\n";
-    local *STDIN;
-    open STDIN, '<:utf8', \$Email;    ## no critic
-    local *STDOUT;
-    open STDOUT, '>:utf8', \$Result;    ## no critic
-    $ExitCode = $CommandObject->Execute('--debug');
+# Run tests.
+for my $Test (@Tests) {
+
+    # Make sure the postmaster object will be recreated for each loop.
+    $Kernel::OM->ObjectsDiscard(
+        Objects => [
+            'Kernel::System::PostMaster',
+        ],
+    );
+
+    {
+        my $Email = "From: $Test->{EmailAddress}\nTo: you\@home.com\nSubject: Test\nUnit tests rock.\n";
+        local *STDIN;
+        open STDIN, '<:utf8', \$Email;    ## no critic
+        local *STDOUT;
+        open STDOUT, '>:utf8', \$Result;    ## no critic
+        $ExitCode = $CommandObject->Execute('--debug');
+    }
+
+    $Self->Is(
+        $ExitCode,
+        0,
+        "Maint::PostMaster::Read exit code with email input",
+    );
+
+    my ($TicketID) = $Result =~ m{TicketID:\s+(\d+)};
+
+    $Self->True(
+        $TicketID,
+        'Ticket is created from email',
+    );
+
+    my %Ticket = $TicketObject->TicketGet(
+        TicketID => $TicketID,
+    );
+
+    $Self->Is(
+        $Ticket{CustomerID},
+        $Test->{Result}->{CustomerID},
+        "Ticket customer ID is expected",
+    );
+    $Self->Is(
+        $Ticket{CustomerUserID},
+        $Test->{Result}->{CustomerUserID},
+        "Ticket customer user ID is expected",
+    );
 }
 
-$Self->Is(
-    $ExitCode,
-    0,
-    "Maint::PostMaster::Read exit code with email input",
-);
-
-my ($TicketID) = $Result =~ m{TicketID:\s+(\d+)};
-
-$Self->True(
-    $TicketID,
-    'Ticket created from email',
-);
-
-# cleanup is done by RestoreDatabase
+# Cleanup is done by RestoreDatabase.
 
 1;

--- a/scripts/test/Console/Command/Maint/PostMaster/Read.t
+++ b/scripts/test/Console/Command/Maint/PostMaster/Read.t
@@ -12,7 +12,7 @@ use utf8;
 
 use vars (qw($Self));
 
-# Get helper object.
+# get helper object
 $Kernel::OM->ObjectParamAdd(
     'Kernel::System::UnitTest::Helper' => {
         RestoreDatabase => 1,
@@ -20,77 +20,7 @@ $Kernel::OM->ObjectParamAdd(
 );
 my $Helper = $Kernel::OM->Get('Kernel::System::UnitTest::Helper');
 
-# Get needed objects.
 my $CommandObject = $Kernel::OM->Get('Kernel::System::Console::Command::Maint::PostMaster::Read');
-my $TicketObject  = $Kernel::OM->Get('Kernel::System::Ticket');
-my $ConfigObject  = $Kernel::OM->Get('Kernel::Config');
-
-my $RandomNumber = $Helper->GetRandomNumber();
-
-# use Test email backend
-$ConfigObject->Set(
-    Key   => 'SendmailModule',
-    Value => 'Kernel::System::Email::Test',
-);
-$ConfigObject->Set(
-    Key   => 'CheckEmailAddresses',
-    Value => '0',
-);
-
-# Create customer company.
-my $CustomerCompany   = 'Company' . $RandomNumber;
-my $CustomerCompanyID = $Kernel::OM->Get('Kernel::System::CustomerCompany')->CustomerCompanyAdd(
-    CustomerID             => $CustomerCompany,
-    CustomerCompanyName    => $CustomerCompany,
-    CustomerCompanyStreet  => $CustomerCompany,
-    CustomerCompanyZIP     => $CustomerCompany,
-    CustomerCompanyCity    => $CustomerCompany,
-    CustomerCompanyCountry => 'Germany',
-    CustomerCompanyURL     => 'http://www.otrs.com',
-    CustomerCompanyComment => $CustomerCompany,
-    ValidID                => 1,
-    UserID                 => 1,
-);
-$Self->True(
-    $CustomerCompany,
-    "CustomerCompanyID $CustomerCompanyID is created",
-);
-
-# Create customer user.
-my $CustomerUser             = 'User' . $RandomNumber;
-my $CustomerUserEmailAddress = $CustomerUser . '@example.com';
-my $CustomerUserID           = $Kernel::OM->Get('Kernel::System::CustomerUser')->CustomerUserAdd(
-    Source         => 'CustomerUser',
-    UserFirstname  => $CustomerUser,
-    UserLastname   => $CustomerUser,
-    UserCustomerID => $CustomerCompanyID,
-    UserLogin      => $CustomerUser,
-    UserEmail      => $CustomerUserEmailAddress,
-    UserPassword   => 'password',
-    ValidID        => 1,
-    UserID         => 1,
-);
-$Self->True(
-    $CustomerUserID,
-    "CustomerUserID $CustomerUserID is created",
-);
-
-my @Tests = (
-    {
-        EmailAddress => 'Unknown' . $CustomerUserEmailAddress,
-        Result       => {
-            CustomerUserID => undef,
-            CustomerID     => undef,
-        },
-    },
-    {
-        EmailAddress => $CustomerUserEmailAddress,
-        Result       => {
-            CustomerUserID => $CustomerUserID,
-            CustomerID     => $CustomerCompanyID,
-        },
-    }
-);
 
 my ( $ExitCode, $Result );
 
@@ -106,54 +36,28 @@ $Self->Is(
     "Maint::PostMaster::Read exit code without email input",
 );
 
-# Run tests.
-for my $Test (@Tests) {
-
-    # Make sure the postmaster object will be recreated for each loop.
-    $Kernel::OM->ObjectsDiscard(
-        Objects => [
-            'Kernel::System::PostMaster',
-        ],
-    );
-
-    {
-        my $Email = "From: $Test->{EmailAddress}\nTo: you\@home.com\nSubject: Test\nUnit tests rock.\n";
-        local *STDIN;
-        open STDIN, '<:utf8', \$Email;    ## no critic
-        local *STDOUT;
-        open STDOUT, '>:utf8', \$Result;    ## no critic
-        $ExitCode = $CommandObject->Execute('--debug');
-    }
-
-    $Self->Is(
-        $ExitCode,
-        0,
-        "Maint::PostMaster::Read exit code with email input",
-    );
-
-    my ($TicketID) = $Result =~ m{TicketID:\s+(\d+)};
-
-    $Self->True(
-        $TicketID,
-        'Ticket is created from email',
-    );
-
-    my %Ticket = $TicketObject->TicketGet(
-        TicketID => $TicketID,
-    );
-
-    $Self->Is(
-        $Ticket{CustomerID},
-        $Test->{Result}->{CustomerID},
-        "Ticket customer ID is expected",
-    );
-    $Self->Is(
-        $Ticket{CustomerUserID},
-        $Test->{Result}->{CustomerUserID},
-        "Ticket customer user ID is expected",
-    );
+{
+    my $Email = "From: me\@home.com\nTo: you\@home.com\nSubject: Test\nUnit tests rock.\n";
+    local *STDIN;
+    open STDIN, '<:utf8', \$Email;    ## no critic
+    local *STDOUT;
+    open STDOUT, '>:utf8', \$Result;    ## no critic
+    $ExitCode = $CommandObject->Execute('--debug');
 }
 
-# Cleanup is done by RestoreDatabase.
+$Self->Is(
+    $ExitCode,
+    0,
+    "Maint::PostMaster::Read exit code with email input",
+);
+
+my ($TicketID) = $Result =~ m{TicketID:\s+(\d+)};
+
+$Self->True(
+    $TicketID,
+    'Ticket created from email',
+);
+
+# cleanup is done by RestoreDatabase
 
 1;

--- a/scripts/test/PostMaster/CustomerID.t
+++ b/scripts/test/PostMaster/CustomerID.t
@@ -1,0 +1,139 @@
+# --
+# Copyright (C) 2001-2016 OTRS AG, http://otrs.com/
+# --
+# This software comes with ABSOLUTELY NO WARRANTY. For details, see
+# the enclosed file COPYING for license information (AGPL). If you
+# did not receive this file, see http://www.gnu.org/licenses/agpl.txt.
+# --
+
+use strict;
+use warnings;
+use utf8;
+
+use vars (qw($Self));
+
+use Kernel::System::PostMaster;
+
+# Get needed objects.
+my $ConfigObject = $Kernel::OM->Get('Kernel::Config');
+my $TicketObject = $Kernel::OM->Get('Kernel::System::Ticket');
+
+# Get helper object.
+$Kernel::OM->ObjectParamAdd(
+    'Kernel::System::UnitTest::Helper' => {
+        RestoreDatabase => 1,
+    },
+);
+my $Helper = $Kernel::OM->Get('Kernel::System::UnitTest::Helper');
+
+my $RandomNumber = $Helper->GetRandomNumber();
+
+# Use Test email backend.
+$ConfigObject->Set(
+    Key   => 'SendmailModule',
+    Value => 'Kernel::System::Email::Test',
+);
+$ConfigObject->Set(
+    Key   => 'CheckEmailAddresses',
+    Value => '0',
+);
+
+# Create customer company.
+my $CustomerName = 'Company' . $RandomNumber;
+my $CustomerID   = $Kernel::OM->Get('Kernel::System::CustomerCompany')->CustomerCompanyAdd(
+    CustomerID             => $CustomerName,
+    CustomerCompanyName    => $CustomerName,
+    CustomerCompanyStreet  => $CustomerName,
+    CustomerCompanyZIP     => $CustomerName,
+    CustomerCompanyCity    => $CustomerName,
+    CustomerCompanyCountry => 'Germany',
+    CustomerCompanyURL     => 'http://www.otrs.com',
+    CustomerCompanyComment => $CustomerName,
+    ValidID                => 1,
+    UserID                 => 1,
+);
+$Self->True(
+    $CustomerID,
+    "CustomerID $CustomerID is created",
+);
+
+# Create customer user.
+my $CustomerUser             = 'User' . $RandomNumber;
+my $CustomerUserEmailAddress = $CustomerUser . '@example.com';
+my $CustomerUserLogin        = $Kernel::OM->Get('Kernel::System::CustomerUser')->CustomerUserAdd(
+    Source         => 'CustomerUser',
+    UserFirstname  => $CustomerUser,
+    UserLastname   => $CustomerUser,
+    UserCustomerID => $CustomerID,
+    UserLogin      => $CustomerUser,
+    UserEmail      => $CustomerUserEmailAddress,
+    UserPassword   => 'password',
+    ValidID        => 1,
+    UserID         => 1,
+);
+$Self->True(
+    $CustomerUserLogin,
+    "CustomerUser '$CustomerUserLogin' is created",
+);
+
+my $UknownEmailAddress = 'Unknown' . $CustomerUserEmailAddress;
+
+my @Tests = (
+    {
+        EmailAddress => $UknownEmailAddress,
+        Result       => {
+            CustomerUserID => $UknownEmailAddress,
+            CustomerID     => '',
+        },
+    },
+    {
+        EmailAddress => $CustomerUserEmailAddress,
+        Result       => {
+            CustomerUserID => $CustomerUserLogin,
+            CustomerID     => $CustomerID,
+        },
+    }
+);
+
+for my $Test (@Tests) {
+
+    my $Email = "From: $Test->{EmailAddress}\nTo: you\@home.com\nSubject: Test\nContent in Body.\n";
+    my @Return;
+
+    {
+        my $PostMasterObject = Kernel::System::PostMaster->new(
+            Email => \$Email,
+        );
+
+        @Return = $PostMasterObject->Run();
+    }
+
+    $Self->Is(
+        $Return[0],
+        1,
+        "New ticket is created",
+    );
+    $Self->True(
+        $Return[1],
+        "New created ticket ID is $Return[1]",
+    );
+
+    my %Ticket = $TicketObject->TicketGet(
+        TicketID => $Return[1],
+    );
+
+    $Self->Is(
+        $Ticket{CustomerID},
+        $Test->{Result}->{CustomerID},
+        "Ticket customer ID is expected",
+    );
+    $Self->Is(
+        $Ticket{CustomerUserID},
+        $Test->{Result}->{CustomerUserID},
+        "Ticket customer user ID is expected",
+    );
+}
+
+# Cleanup is done by RestoreDatabase.
+
+1;


### PR DESCRIPTION
https://bugs.otrs.org/show_bug.cgi?id=10691

Hello @mgruner 

This is proposal for no auto-assigning CustomerID and CustomerUser for unknown incoming emails in accordance with your suggestion. Because of that, if there are no CustomerID and CustomerUser found, parameters with their values which are used later for ticket creating stay undefined.

IF condition is modified because there is the same condition in parent IF and '$GetParam{'X-OTRS-CustomerUser'}'  can not change 
(https://github.com/s7design/otrs/blob/5241e87234e22ba647dac196f57253926e7d18e3/Kernel/System/PostMaster/NewTicket.pm#L187).

Please let me know if you have any suggestion for this PR.

Regards,
Milan