### PR TITLE
Rel-5_0 - Extended JS validation for radio button

### DIFF
--- a/var/httpd/htdocs/js/Core.Form.Validate.js
+++ b/var/httpd/htdocs/js/Core.Form.Validate.js
@@ -395,7 +395,8 @@ Core.Form.Validate = (function (TargetNS) {
     }, "");
 
     $.validator.addMethod("Validate_DateInFuture", function (Value, Element) {
-        var $DateSelection = $(Element).parent().find('input[type=checkbox].DateSelection');
+        var $DateSelection = $(Element).parent().find('input[type=checkbox].DateSelection, input[type=radio][value=1]');
+
         // do not do this check for unchecked date/datetime fields
         // check first if the field exists to regard the check for the pending reminder field
         if ($DateSelection.length && !$DateSelection.prop("checked")) {
@@ -405,7 +406,8 @@ Core.Form.Validate = (function (TargetNS) {
     }, "");
 
     $.validator.addMethod("Validate_DateNotInFuture", function (Value, Element) {
-        var $DateSelection = $(Element).parent().find('input[type=checkbox].DateSelection');
+        var $DateSelection = $(Element).parent().find('input[type=checkbox].DateSelection, input[type=radio][value=1]');
+
         // do not do this check for unchecked date/datetime fields
         // check first if the field exists to regard the check for the pending reminder field
         if ($DateSelection.length && !$DateSelection.prop("checked")) {

--- a/var/httpd/htdocs/js/Core.Form.Validate.js
+++ b/var/httpd/htdocs/js/Core.Form.Validate.js
@@ -395,7 +395,7 @@ Core.Form.Validate = (function (TargetNS) {
     }, "");
 
     $.validator.addMethod("Validate_DateInFuture", function (Value, Element) {
-        var $DateSelection = $(Element).parent().find('input[type=checkbox].DateSelection, input[type=radio][value=1]');
+        var $DateSelection = $(Element).parent().find('input[type=checkbox].DateSelection, input[type=radio].DateSelection');
 
         // do not do this check for unchecked date/datetime fields
         // check first if the field exists to regard the check for the pending reminder field
@@ -406,7 +406,7 @@ Core.Form.Validate = (function (TargetNS) {
     }, "");
 
     $.validator.addMethod("Validate_DateNotInFuture", function (Value, Element) {
-        var $DateSelection = $(Element).parent().find('input[type=checkbox].DateSelection, input[type=radio][value=1]');
+        var $DateSelection = $(Element).parent().find('input[type=checkbox].DateSelection, input[type=radio].DateSelection');
 
         // do not do this check for unchecked date/datetime fields
         // check first if the field exists to regard the check for the pending reminder field

--- a/var/httpd/htdocs/js/test/Core.Form.Validate.UnitTest.js
+++ b/var/httpd/htdocs/js/test/Core.Form.Validate.UnitTest.js
@@ -281,7 +281,7 @@ Core.Form.Validate = (function (Namespace) {
 
             // Test: Validate_DateInFuture - with radio button
             $TestForm.append('<input type="radio" name="Radio" value="0" id="Radio0" />');
-            $TestForm.append('<input type="radio" name="Radio" value="1" id="Radio1" />');
+            $TestForm.append('<input type="radio" class="DateSelection" name="Radio" value="1" id="Radio1" />');
 
             NewDate = new Date();
             NewDate.setDate(NewDate.getDate() - 2);
@@ -390,7 +390,7 @@ Core.Form.Validate = (function (Namespace) {
 
             // Test: Validate_DateNotInFuture - with radio button
             $TestForm.append('<input type="radio" name="Radio" value="0" id="Radio0" />');
-            $TestForm.append('<input type="radio" name="Radio" value="1" id="Radio1" />');
+            $TestForm.append('<input type="radio" class="DateSelection" name="Radio" value="1" id="Radio1" />');
 
             NewDate = new Date();
             NewDate.setDate(NewDate.getDate() + 2);

--- a/var/httpd/htdocs/js/test/Core.Form.Validate.UnitTest.js
+++ b/var/httpd/htdocs/js/test/Core.Form.Validate.UnitTest.js
@@ -186,7 +186,7 @@ Core.Form.Validate = (function (Namespace) {
 
             Core.Form.Validate.Init();
 
-            expect(26);
+            expect(44);
 
             // Test: Validate_DateDay
             $('#ObjectOne').addClass('Validate_DateDay Validate_DateYear_ObjectTwo Validate_DateMonth_ObjectThree');
@@ -238,7 +238,197 @@ Core.Form.Validate = (function (Namespace) {
 
             equal($('#ObjectOne').hasClass('Error'), false, 'Validate_DateInFuture: today + 2 days');
 
+
+            // Test: Validate_DateInFuture - with checkbox
+            $TestForm.append('<input type="checkbox" class="DateSelection" value="" id="Checkbox" />');
+
+            NewDate = new Date();
+            NewDate.setDate(NewDate.getDate() - 2);
+
+            $('#ObjectOne').val(NewDate.getDate());
+            $('#ObjectTwo').val(NewDate.getFullYear());
+            $('#ObjectThree').val(NewDate.getMonth() + 1);
+
+            $('#Checkbox').prop('checked', false);
+            Core.Form.Validate.ValidateElement($('#ObjectOne'));
+
+            equal($('#ObjectOne').hasClass('Error'), false, 'Validate_DateInFuture with unchecked checkbox: today - 2 days');
+
+            $('#Checkbox').prop('checked', true);
+            Core.Form.Validate.ValidateElement($('#ObjectOne'));
+
+            equal($('#ObjectOne').hasClass('Error'), true, 'Validate_DateInFuture with checked checkbox: today - 2 days');
+
+            NewDate = new Date();
+            NewDate.setDate(NewDate.getDate() + 2);
+
+            $('#ObjectOne').val(NewDate.getDate());
+            $('#ObjectTwo').val(NewDate.getFullYear());
+            $('#ObjectThree').val(NewDate.getMonth() + 1);
+
+            $('#Checkbox').prop('checked', false);
+            Core.Form.Validate.ValidateElement($('#ObjectOne'));
+
+            equal($('#ObjectOne').hasClass('Error'), false, 'Validate_DateInFuture with unchecked checkbox: today + 2 days');
+
+            $('#Checkbox').prop('checked', true);
+            Core.Form.Validate.ValidateElement($('#ObjectOne'));
+
+            equal($('#ObjectOne').hasClass('Error'), false, 'Validate_DateInFuture with checked checkbox: today + 2 days');
+
+            $('#Checkbox').remove();
+
+
+            // Test: Validate_DateInFuture - with radio button
+            $TestForm.append('<input type="radio" name="Radio" value="0" id="Radio0" />');
+            $TestForm.append('<input type="radio" name="Radio" value="1" id="Radio1" />');
+
+            NewDate = new Date();
+            NewDate.setDate(NewDate.getDate() - 2);
+
+            $('#ObjectOne').val(NewDate.getDate());
+            $('#ObjectTwo').val(NewDate.getFullYear());
+            $('#ObjectThree').val(NewDate.getMonth() + 1);
+
+            $('#Radio0').prop('checked', true);
+            Core.Form.Validate.ValidateElement($('#ObjectOne'));
+
+            equal($('#ObjectOne').hasClass('Error'), false, 'Validate_DateInFuture with unchecked radio button: today - 2 days');
+
+            $('#Radio1').prop('checked', true);
+            Core.Form.Validate.ValidateElement($('#ObjectOne'));
+
+            equal($('#ObjectOne').hasClass('Error'), true, 'Validate_DateInFuture with checked radio button: today - 2 days');
+
+            NewDate = new Date();
+            NewDate.setDate(NewDate.getDate() + 2);
+
+            $('#ObjectOne').val(NewDate.getDate());
+            $('#ObjectTwo').val(NewDate.getFullYear());
+            $('#ObjectThree').val(NewDate.getMonth() + 1);
+
+            $('#Radio0').prop('checked', true);
+            Core.Form.Validate.ValidateElement($('#ObjectOne'));
+
+            equal($('#ObjectOne').hasClass('Error'), false, 'Validate_DateInFuture with unchecked radio button: today + 2 days');
+
+            $('#Radio1').prop('checked', true);
+            Core.Form.Validate.ValidateElement($('#ObjectOne'));
+
+            equal($('#ObjectOne').hasClass('Error'), false, 'Validate_DateInFuture with checked radio button: today + 2 days');
+
+            $('input[type="radio"][name="Radio"]').remove();
+
             $('#ObjectOne').removeClass('Validate_DateDay Validate_DateYear_ObjectTwo Validate_DateMonth_ObjectThree Validate_DateInFuture');
+
+
+            // Test: Validate_DateNotInFuture
+            $('#ObjectOne').addClass('Validate_DateDay Validate_DateYear_ObjectTwo Validate_DateMonth_ObjectThree Validate_DateNotInFuture');
+
+            NewDate = new Date();
+            NewDate.setDate(NewDate.getDate() + 2);
+
+            $('#ObjectOne').val(NewDate.getDate());
+            $('#ObjectTwo').val(NewDate.getFullYear());
+            $('#ObjectThree').val(NewDate.getMonth() + 1);
+
+            Core.Form.Validate.ValidateElement($('#ObjectOne'));
+
+            equal($('#ObjectOne').hasClass('Error'), true, 'Validate_DateNotInFuture: today + 2 days');
+
+            NewDate = new Date();
+            NewDate.setDate(NewDate.getDate() - 2);
+
+            $('#ObjectOne').val(NewDate.getDate());
+            $('#ObjectTwo').val(NewDate.getFullYear());
+            $('#ObjectThree').val(NewDate.getMonth() + 1);
+
+            Core.Form.Validate.ValidateElement($('#ObjectOne'));
+
+            equal($('#ObjectOne').hasClass('Error'), false, 'Validate_DateNotInFuture: today - 2 days');
+
+
+            // Test: Validate_DateNotInFuture - with checkbox
+            $TestForm.append('<input type="checkbox" class="DateSelection" value="" id="Checkbox" />');
+
+            NewDate = new Date();
+            NewDate.setDate(NewDate.getDate() + 2);
+
+            $('#ObjectOne').val(NewDate.getDate());
+            $('#ObjectTwo').val(NewDate.getFullYear());
+            $('#ObjectThree').val(NewDate.getMonth() + 1);
+
+            $('#Checkbox').prop('checked', false);
+            Core.Form.Validate.ValidateElement($('#ObjectOne'));
+
+            equal($('#ObjectOne').hasClass('Error'), false, 'Validate_DateNotInFuture with unchecked checkbox: today + 2 days');
+
+            $('#Checkbox').prop('checked', true);
+            Core.Form.Validate.ValidateElement($('#ObjectOne'));
+
+            equal($('#ObjectOne').hasClass('Error'), true, 'Validate_DateNotInFuture with checked checkbox: today + 2 days');
+
+            NewDate = new Date();
+            NewDate.setDate(NewDate.getDate() - 2);
+
+            $('#ObjectOne').val(NewDate.getDate());
+            $('#ObjectTwo').val(NewDate.getFullYear());
+            $('#ObjectThree').val(NewDate.getMonth() + 1);
+
+            $('#Checkbox').prop('checked', false);
+            Core.Form.Validate.ValidateElement($('#ObjectOne'));
+
+            equal($('#ObjectOne').hasClass('Error'), false, 'Validate_DateNotInFuture with unchecked checkbox: today - 2 days');
+
+            $('#Checkbox').prop('checked', true);
+            Core.Form.Validate.ValidateElement($('#ObjectOne'));
+
+            equal($('#ObjectOne').hasClass('Error'), false, 'Validate_DateNotInFuture with checked checkbox: today - 2 days');
+
+            $('#Checkbox').remove();
+
+
+            // Test: Validate_DateNotInFuture - with radio button
+            $TestForm.append('<input type="radio" name="Radio" value="0" id="Radio0" />');
+            $TestForm.append('<input type="radio" name="Radio" value="1" id="Radio1" />');
+
+            NewDate = new Date();
+            NewDate.setDate(NewDate.getDate() + 2);
+
+            $('#ObjectOne').val(NewDate.getDate());
+            $('#ObjectTwo').val(NewDate.getFullYear());
+            $('#ObjectThree').val(NewDate.getMonth() + 1);
+
+            $('#Radio0').prop('checked', true);
+            Core.Form.Validate.ValidateElement($('#ObjectOne'));
+
+            equal($('#ObjectOne').hasClass('Error'), false, 'Validate_DateNotInFuture with unchecked radio button: today + 2 days');
+
+            $('#Radio1').prop('checked', true);
+            Core.Form.Validate.ValidateElement($('#ObjectOne'));
+
+            equal($('#ObjectOne').hasClass('Error'), true, 'Validate_DateNotInFuture with checked radio button: today + 2 days');
+
+            NewDate = new Date();
+            NewDate.setDate(NewDate.getDate() - 2);
+
+            $('#ObjectOne').val(NewDate.getDate());
+            $('#ObjectTwo').val(NewDate.getFullYear());
+            $('#ObjectThree').val(NewDate.getMonth() + 1);
+
+            $('#Radio0').prop('checked', true);
+            Core.Form.Validate.ValidateElement($('#ObjectOne'));
+
+            equal($('#ObjectOne').hasClass('Error'), false, 'Validate_DateNotInFuture with unchecked radio button: today - 2 days');
+
+            $('#Radio1').prop('checked', true);
+            Core.Form.Validate.ValidateElement($('#ObjectOne'));
+
+            equal($('#ObjectOne').hasClass('Error'), false, 'Validate_DateNotInFuture with checked radio button: today - 2 days');
+
+            $('input[type="radio"][name="Radio"]').remove();
+
+            $('#ObjectOne').removeClass('Validate_DateDay Validate_DateYear_ObjectTwo Validate_DateMonth_ObjectThree Validate_DateNotInFuture');
 
 
             // Test: Validate_Equal


### PR DESCRIPTION
Hello @mgruner 

This is our proposal for extending of JS validation for radio button. First, we rolled back fix in OTRSAdvancedGenericAgent package. On Rel 5_0 branch extending for radio buttons is done for 'Validate_DateInFuture' and 'Validate_DateNotInFuture' validation methods. On Master branch there are some differences and it will be done separately.

There is not the most generic solution because finding by value but there are more than one radio buttons in parent HTML element and they can be distinguished only by value (0, relative, 1). Maybe it could be found like the last radio button in this parent element but this is also not general solution.
JS Unit test is extended too.

This is input radio button in OTRSAdvancedGenericAgent
> <input type="radio" value="1" name="${Prefix}Used" $UsedAbsolute>

because of that in Core.Form.Validate.js the element is found on this way

> input[type=radio][value=1]');


If you have any comments or suggestions for these changes, please let me know.

Regards,
Milan