### PR TITLE
[ Rel-5_0 Bug 12480 ] - Fixed bug that Bulk function ignores agent/role permissions

### DIFF
--- a/Kernel/Output/HTML/Templates/Standard/AgentTicketBulk.tt
+++ b/Kernel/Output/HTML/Templates/Standard/AgentTicketBulk.tt
@@ -172,6 +172,11 @@
                     </div>
                     <div class="Clear"></div>
 [% RenderBlockEnd("Type") %]
+                    <label for="QueueID">[% Translate("Queue") | html %]:</label>
+                    <div class="Field">
+                        [% Data.MoveQueuesStrg %]
+                    </div>
+                    <div class="Clear"></div>
 
 [% RenderBlockStart("Owner") %]
                     <label for="OwnerID">[% Translate("Owner") | html %]:</label>
@@ -188,12 +193,6 @@
                     </div>
                     <div class="Clear"></div>
 [% RenderBlockEnd("Responsible") %]
-
-                    <label for="QueueID">[% Translate("Queue") | html %]:</label>
-                    <div class="Field">
-                        [% Data.MoveQueuesStrg %]
-                    </div>
-                    <div class="Clear"></div>
 
 [% RenderBlockStart("Priority") %]
                     <label for="PriorityID">[% Translate("Priority") | html %]:</label>

--- a/scripts/test/Selenium/Agent/AgentTicketBulk.t
+++ b/scripts/test/Selenium/Agent/AgentTicketBulk.t
@@ -26,6 +26,9 @@ $Selenium->RunTest(
         );
         my $Helper          = $Kernel::OM->Get('Kernel::System::UnitTest::Helper');
         my $SysConfigObject = $Kernel::OM->Get('Kernel::System::SysConfig');
+        my $GroupObject     = $Kernel::OM->Get('Kernel::System::Group');
+        my $UserObject      = $Kernel::OM->Get('Kernel::System::User');
+        my $QueueObject     = $Kernel::OM->Get('Kernel::System::Queue');
 
         # enable bulk feature
         $SysConfigObject->ConfigItemUpdate(
@@ -41,35 +44,133 @@ $Selenium->RunTest(
             Value => 1,
         );
 
-        # create test user and login
+        # Get needed variables.
+        my $RandomNumber = $Helper->GetRandomNumber();
+        my $Success;
+
+        # Create groups.
+        my @GroupIDs;
+        my @GroupNames;
+        for my $Count ( 1 .. 2 ) {
+            my $GroupID = $GroupObject->GroupAdd(
+                Name    => "$Count-Group-$RandomNumber",
+                ValidID => 1,
+                UserID  => 1,
+            );
+            $Self->True(
+                $GroupID,
+                "GroupID $GroupID is created",
+            );
+            push @GroupIDs, $GroupID;
+
+            my $GroupName = $GroupObject->GroupLookup(
+                GroupID => $GroupID,
+            );
+            push @GroupNames, $GroupName;
+        }
+
+        # Create test user for login.
         my $TestUserLogin = $Helper->TestUserCreate(
-            Groups => [ 'admin', 'users' ],
+            Groups => [ 'admin', 'users', @GroupNames ],
         ) || die "Did not get test user";
 
-        $Selenium->Login(
-            Type     => 'Agent',
-            User     => $TestUserLogin,
-            Password => $TestUserLogin,
-        );
-
         # get test user ID
-        my $TestUserID = $Kernel::OM->Get('Kernel::System::User')->UserLookup(
+        my $TestUserID = $UserObject->UserLookup(
             UserLogin => $TestUserLogin,
         );
 
+        # Create users.
+        my @UserIDs;
+        for my $Count ( 1 .. 3 ) {
+            my $UserLogin = "$Count-User-$RandomNumber";
+            my $UserID    = $UserObject->UserAdd(
+                UserFirstname => $UserLogin,
+                UserLastname  => $UserLogin,
+                UserLogin     => $UserLogin,
+                UserEmail     => "$UserLogin\@example.com",
+                ValidID       => 1,
+                ChangeUserID  => $TestUserID,
+            );
+            $Self->True(
+                $UserID,
+                "UserID $UserID is created",
+            );
+            push @UserIDs, $UserID;
+        }
+
+        # Add groups to the users.
+        my @GroupUserRelations = (
+            {
+                GID => $GroupIDs[0],
+                UID => $UserIDs[0],
+            },
+            {
+                GID => $GroupIDs[0],
+                UID => $UserIDs[1],
+            },
+            {
+                GID => $GroupIDs[1],
+                UID => $UserIDs[2],
+            },
+        );
+
+        for my $GroupUserRelation (@GroupUserRelations) {
+            $Success = $GroupObject->PermissionGroupUserAdd(
+                GID        => $GroupUserRelation->{GID},
+                UID        => $GroupUserRelation->{UID},
+                Permission => {
+                    ro        => 1,
+                    move_into => 1,
+                    create    => 1,
+                    owner     => 1,
+                    priority  => 1,
+                    rw        => 1,
+                },
+                UserID => 1,
+            );
+            $Self->True(
+                $Success,
+                "Test user '$GroupUserRelation->{UID}' set permission for group '$GroupUserRelation->{GID}'"
+            );
+        }
+
+        # Create queues with test groups.
+        my @QueueIDs;
+        for my $Count ( 1 .. 2 ) {
+            my $QueueID = $QueueObject->QueueAdd(
+                Name            => "$Count-Queue-$RandomNumber",
+                ValidID         => 1,
+                GroupID         => $Count == 1 ? $GroupIDs[0] : $GroupIDs[1],
+                SystemAddressID => 1,
+                SalutationID    => 1,
+                SignatureID     => 1,
+                Comment         => 'Comment',
+                UserID          => $TestUserID,
+            );
+            $Self->True(
+                $QueueID,
+                "QueueID $QueueID is created",
+            );
+            push @QueueIDs, $QueueID;
+        }
+
         # get ticket object
         my $TicketObject = $Kernel::OM->Get('Kernel::System::Ticket');
+
+        my $QueueRawID = $QueueObject->QueueLookup( Queue => 'Raw' );
 
         my @Tests = (
             {
                 TicketTitle => 'TestTicket-One',
                 Lock        => 'lock',
+                QueueID     => $QueueRawID,
                 OwnerID     => $TestUserID,
                 UserID      => $TestUserID,
             },
             {
                 TicketTitle => 'TestTicket-Two',
                 Lock        => 'unlock',
+                QueueID     => $QueueRawID,
                 OwnerID     => $TestUserID,
                 UserID      => $TestUserID,
             },
@@ -77,19 +178,41 @@ $Selenium->RunTest(
                 # ticket locked by another agent
                 TicketTitle => 'TestTicket-Three',
                 Lock        => 'lock',
+                QueueID     => $QueueRawID,
                 OwnerID     => 1,
                 UserID      => 1,
             },
+            {
+                TicketTitle => 'TestTicket-Four',
+                Lock        => 'unlock',
+                QueueID     => $QueueIDs[0],
+                OwnerID     => 1,
+                UserID      => $TestUserID,
+            },
+            {
+                TicketTitle => 'TestTicket-Five',
+                Lock        => 'unlock',
+                QueueID     => $QueueIDs[0],
+                OwnerID     => 1,
+                UserID      => $TestUserID,
+            },
+            {
+                TicketTitle => 'TestTicket-Six',
+                Lock        => 'unlock',
+                QueueID     => $QueueIDs[1],
+                OwnerID     => 1,
+                UserID      => $TestUserID,
+            },
         );
 
-        # create three test tickets
+        # Create test tickets.
         my @Tickets;
         for my $Test (@Tests) {
             my $TicketNumber = $TicketObject->TicketCreateNumber();
             my $TicketID     = $TicketObject->TicketCreate(
                 TN         => $TicketNumber,
                 Title      => $Test->{TicketTitle},
-                Queue      => 'Raw',
+                QueueID    => $Test->{QueueID},
                 Lock       => $Test->{Lock},
                 Priority   => '3 normal',
                 State      => 'open',
@@ -99,7 +222,7 @@ $Selenium->RunTest(
             );
             $Self->True(
                 $TicketID,
-                "Ticket is created -  $Test->{TicketTitle}, $TicketNumber ",
+                "Ticket is created - $Test->{TicketTitle}, $TicketNumber",
             );
 
             my %Ticket = (
@@ -110,6 +233,13 @@ $Selenium->RunTest(
 
             push @Tickets, \%Ticket;
         }
+
+        # Login as test user.
+        $Selenium->Login(
+            Type     => 'Agent',
+            User     => $TestUserLogin,
+            Password => $TestUserLogin,
+        );
 
         # get script alias
         my $ScriptAlias = $Kernel::OM->Get('Kernel::Config')->Get('ScriptAlias');
@@ -211,7 +341,7 @@ $Selenium->RunTest(
 
         # verify which tickets are shown in ticket closed view
         for my $Ticket (@Tickets) {
-            if ( $Ticket->{OwnerID} != 1 ) {
+            if ( $Ticket->{OwnerID} != 1 && $Ticket->{Title} !~ m/-Four|-Five|-Six$/ ) {
                 $Self->True(
                     index( $Selenium->get_page_source(), $Ticket->{TicketNumber} ) > -1,
                     "Closed ticket $Ticket->{TicketNumber} is found on page",
@@ -228,9 +358,88 @@ $Selenium->RunTest(
 
         }
 
+        # Select view of open tickets in the table.
+        $Selenium->find_element("//a[contains(\@href, \'Filter=Open' )]")->VerifiedClick();
+
+        # Check Owner field update after queue select.
+        # Select the last three test created tickets and click on "bulk".
+        $Selenium->find_element("//input[\@value='$Tickets[3]->{TicketID}']")->click();
+        $Selenium->find_element("//input[\@value='$Tickets[4]->{TicketID}']")->click();
+        $Selenium->find_element("//input[\@value='$Tickets[5]->{TicketID}']")->click();
+        $Selenium->find_element( "Bulk", 'link_text' )->click();
+
+        # Switch to bulk window.
+        $Selenium->WaitFor( WindowCount => 2 );
+        $Handles = $Selenium->get_window_handles();
+        $Selenium->switch_to_window( $Handles->[1] );
+
+        # Wait until page has loaded, if necessary.
+        $Selenium->WaitFor( JavaScript => 'return typeof($) === "function" && $("#QueueID").length' );
+
+        @Tests = (
+            {
+                SelectedQueueID => $QueueIDs[0],
+                ExpectedOwners  => {
+                    $UserIDs[0] => 1,
+                    $UserIDs[1] => 1,
+                    $UserIDs[2] => 0,
+                    }
+            },
+            {
+                SelectedQueueID => $QueueIDs[1],
+                ExpectedOwners  => {
+                    $UserIDs[0] => 0,
+                    $UserIDs[1] => 0,
+                    $UserIDs[2] => 1,
+                    }
+            }
+        );
+
+        for my $ConfigValue ( 0 .. 1 ) {
+
+            # Set if everyone or just agents with rw permissions in the queue for the ticket would be shown
+            $Helper->ConfigSettingChange(
+                Valid => 1,
+                Key   => 'Ticket::ChangeOwnerToEveryone',
+                Value => $ConfigValue,
+            );
+
+            for my $Test (@Tests) {
+
+                # Select queue.
+                $Selenium->execute_script(
+                    "\$('#QueueID').val('$Test->{SelectedQueueID}').trigger('redraw.InputField').trigger('change');"
+                );
+
+                # Wait for AJAX finish.
+                $Selenium->WaitFor(
+                    JavaScript => 'return typeof($) === "function" && !$("#AJAXLoaderOwnerID:visible").length'
+                );
+
+                # Check for existence.
+                for my $Key ( sort keys %{ $Test->{ExpectedOwners} } ) {
+                    my $IsFound = $ConfigValue
+                        ?
+                        'is found - ChangeOwnerToEveryone'
+                        :
+                        $Test->{ExpectedOwners}->{$Key} ? 'is found' : 'is not found';
+                    my $Exist = $ConfigValue ? 1 : $Test->{ExpectedOwners}->{$Key};
+
+                    $Self->Is(
+                        $Selenium->execute_script("return \$('#OwnerID option[value=$Key]').length;"),
+                        $Exist,
+                        "Test user $IsFound",
+                    );
+                }
+            }
+        }
+
+        # Close popup.
+        $Selenium->close();
+
         # clean up test data from the DB
         for my $Ticket (@Tickets) {
-            my $Success = $TicketObject->TicketDelete(
+            $Success = $TicketObject->TicketDelete(
                 TicketID => $Ticket->{TicketID},
                 UserID   => 1,
             );
@@ -238,7 +447,65 @@ $Selenium->RunTest(
                 $Success,
                 "Ticket is deleted - $Ticket->{TicketNumber}"
             );
+        }
 
+        my $DBObject = $Kernel::OM->Get('Kernel::System::DB');
+
+        # Delete test created queues.
+        for my $QueueID (@QueueIDs) {
+            $Success = $DBObject->Do(
+                SQL  => "DELETE FROM queue WHERE id = ?",
+                Bind => [ \$QueueID ],
+            );
+            $Self->True(
+                $Success,
+                "QueueID $QueueID is deleted",
+            );
+        }
+
+        # Delete group-user relations.
+        for my $GroupID (@GroupIDs) {
+            $Success = $DBObject->Do(
+                SQL  => "DELETE FROM group_user WHERE group_id = ?",
+                Bind => [ \$GroupID ],
+            );
+            $Self->True(
+                $Success,
+                "Relation for group ID $GroupID is deleted",
+            );
+        }
+
+        # Delete test created users.
+        for my $UserID (@UserIDs) {
+            $Success = $DBObject->Do(
+                SQL  => "DELETE FROM user_preferences WHERE user_id",
+                Bind => [ \$UserID ],
+            );
+            $Self->True(
+                $Success,
+                "User preferences for $UserID is deleted",
+            );
+
+            $Success = $DBObject->Do(
+                SQL  => "DELETE FROM users WHERE id = ?",
+                Bind => [ \$UserID ],
+            );
+            $Self->True(
+                $Success,
+                "UserID $UserID is deleted",
+            );
+        }
+
+        # Delete test created groups.
+        for my $GroupID (@GroupIDs) {
+            $Success = $DBObject->Do(
+                SQL  => "DELETE FROM groups WHERE id = ?",
+                Bind => [ \$GroupID ],
+            );
+            $Self->True(
+                $Success,
+                "GroupID $GroupID is deleted",
+            );
         }
 
         # make sure the cache is correct

--- a/scripts/test/Selenium/Agent/AgentTicketBulk.t
+++ b/scripts/test/Selenium/Agent/AgentTicketBulk.t
@@ -29,6 +29,7 @@ $Selenium->RunTest(
         my $GroupObject     = $Kernel::OM->Get('Kernel::System::Group');
         my $UserObject      = $Kernel::OM->Get('Kernel::System::User');
         my $QueueObject     = $Kernel::OM->Get('Kernel::System::Queue');
+        my $ConfigObject    = $Kernel::OM->Get('Kernel::Config');
 
         # enable bulk feature
         $SysConfigObject->ConfigItemUpdate(
@@ -42,6 +43,24 @@ $Selenium->RunTest(
             Valid => 1,
             Key   => 'Ticket::Frontend::AgentTicketBulk###RequiredLock',
             Value => 1,
+        );
+
+        # Enable ticket responsible feature.
+        $Helper->ConfigSettingChange(
+            Valid => 1,
+            Key   => 'Ticket::Responsible',
+            Value => 1,
+        );
+
+        my $Config = $ConfigObject->Get('Ticket::Frontend::AgentTicketResponsible');
+        $Helper->ConfigSettingChange(
+            Valid => 1,
+            Key   => 'Ticket::Frontend::AgentTicketResponsible',
+            Value => {
+                %{$Config},
+                Note          => 1,
+                NoteMandatory => 1,
+            },
         );
 
         # Get needed variables.
@@ -242,7 +261,7 @@ $Selenium->RunTest(
         );
 
         # get script alias
-        my $ScriptAlias = $Kernel::OM->Get('Kernel::Config')->Get('ScriptAlias');
+        my $ScriptAlias = $ConfigObject->Get('ScriptAlias');
 
         # navigate to AgentTicketStatusView
         $Selenium->VerifiedGet("${ScriptAlias}index.pl?Action=AgentTicketStatusView");
@@ -428,7 +447,13 @@ $Selenium->RunTest(
                     $Self->Is(
                         $Selenium->execute_script("return \$('#OwnerID option[value=$Key]').length;"),
                         $Exist,
-                        "Test user $IsFound",
+                        "OwnerID - Test user $IsFound",
+                    );
+
+                    $Self->Is(
+                        $Selenium->execute_script("return \$('#ResponsibleID option[value=$Key]').length;"),
+                        $Exist,
+                        "ResponsibleID - Test user $IsFound",
                     );
                 }
             }

--- a/var/httpd/htdocs/js/Core.Agent.TicketAction.js
+++ b/var/httpd/htdocs/js/Core.Agent.TicketAction.js
@@ -272,6 +272,11 @@ Core.Agent.TicketAction = (function (TargetNS) {
             $Widget.find('div.WidgetAction.Toggle > a').trigger('click');
         });
 
+        // Add owner field update on queue change
+        $('#QueueID').on('change', function () {
+            Core.AJAX.FormUpdate($('.Validate'), 'AJAXUpdate', 'QueueID', ['OwnerID']);
+        });
+
     };
 
     /**

--- a/var/httpd/htdocs/js/Core.Agent.TicketAction.js
+++ b/var/httpd/htdocs/js/Core.Agent.TicketAction.js
@@ -274,7 +274,7 @@ Core.Agent.TicketAction = (function (TargetNS) {
 
         // Add owner field update on queue change
         $('#QueueID').on('change', function () {
-            Core.AJAX.FormUpdate($('.Validate'), 'AJAXUpdate', 'QueueID', ['OwnerID']);
+            Core.AJAX.FormUpdate($('.Validate'), 'AJAXUpdate', 'QueueID', ['OwnerID', 'ResponsibleID']);
         });
 
     };


### PR DESCRIPTION
https://bugs.otrs.org/show_bug.cgi?id=12480

Hello @dvuckovic  

This is our proposal for ignoring queues - agent/role permissions in Bulk.
JS code for Owner field update on queue change is added in Core.Agent.TicketAction.js and subaction block for AJAX update processing is placed in AgentTicketBulk PM module.
Order of fields in Bulk screen is changed in accordance with suggestions in bug report.
Selenium test is extended for updating of owner field.
Please let me know if you have any suggestion or comment for this PR.

Regards,
Milan