### PR TITLE
[ Rel-5_0 Bug 11422 new ] - List in the Dashboard: standard priority is ignored if you use a filter

### DIFF
--- a/Kernel/Output/HTML/Dashboard/TicketGeneric.pm
+++ b/Kernel/Output/HTML/Dashboard/TicketGeneric.pm
@@ -40,6 +40,9 @@ sub new {
         $Self->{$Item} = $ParamObject->GetParam( Param => $Item ) || $Param{$Item};
     }
 
+    # get add filters param
+    $Self->{AddFilters} = $ParamObject->GetParam( Param => 'AddFilters' ) || $Param{AddFilters} || 0;
+
     # set filter settings
     for my $Item (qw(ColumnFilter GetColumnFilter GetColumnFilterSelect)) {
         $Self->{$Item} = $Param{$Item};
@@ -529,8 +532,31 @@ sub Run {
     );
     $CacheKey .= '-' . $CacheColumns if $CacheColumns;
 
-    $CacheKey .= '-' . $Self->{SortBy}  if defined $Self->{SortBy};
-    $CacheKey .= '-' . $Self->{OrderBy} if defined $Self->{OrderBy};
+    # If SortBy parameter is not defined, set to value from %TicketSearch, otherwise set to default value 'Age'.
+    if ( !defined $Self->{SortBy} ) {
+        if ( defined $TicketSearch{SortBy} && $Self->{ValidSortableColumns}->{ $TicketSearch{SortBy} } ) {
+            $Self->{SortBy} = $TicketSearch{SortBy};
+        }
+        else {
+            $Self->{SortBy} = 'Age';
+        }
+    }
+
+    $CacheKey .= '-' . $Self->{SortBy} if defined $Self->{SortBy};
+
+    # Set OrderBy parameter to the search.
+    my $IsCacheForUse = 0;
+    if ( $Self->{OrderBy} ) {
+        if ( $Self->{AddFilters} ) {
+            $TicketSearch{OrderBy} = $Self->{OrderBy};
+            $IsCacheForUse = 1;
+        }
+        else {
+            $TicketSearch{OrderBy} = $Self->{OrderBy} eq 'Up' ? 'Down' : 'Up';
+        }
+    }
+
+    $CacheKey .= '-' . $TicketSearch{OrderBy} if defined $TicketSearch{OrderBy};
 
     # CustomerInformationCenter shows data per CustomerID
     if ( $Param{CustomerID} ) {
@@ -575,10 +601,7 @@ sub Run {
             }
         }
 
-        # add order by parameter to the search
-        if ( $Self->{OrderBy} ) {
-            $TicketSearch{OrderBy} = $Self->{OrderBy};
-        }
+        $CacheUsed = $IsCacheForUse ? 1 : 0;
 
         # add process management search terms
         if ( $Self->{Config}->{IsProcessWidget} ) {
@@ -587,7 +610,6 @@ sub Run {
             };
         }
 
-        $CacheUsed = 0;
         my @TicketIDsArray;
         if (
             !$Self->{Config}->{IsProcessWidget}
@@ -812,22 +834,28 @@ sub Run {
 
     # show non-labeled table headers
     my $CSS = '';
-    my $OrderBy;
+
+    # Set order for blocks.
+    $TicketSearch{OrderBy} = $TicketSearch{OrderBy} || 'Up';
+
+    my $TitleSort;
     for my $Item (@MetaItems) {
         $CSS = '';
-        my $Title = $Item;
-        if ( $Self->{SortBy} && ( $Self->{SortBy} eq $Item ) ) {
-            if ( $Self->{OrderBy} && ( $Self->{OrderBy} eq 'Up' ) ) {
-                $OrderBy = 'Down';
-                $CSS .= ' SortAscendingLarge';
+        $TitleSort = ( $Self->{SortBy} && ( $Self->{SortBy} eq $Item ) ) ? 1 : 0;
+        my $Title = $LayoutObject->{LanguageObject}->Translate($Item);
+
+        # set title description
+        if ($TitleSort) {
+            my $TitleDesc = '';
+            if ( $TicketSearch{OrderBy} eq 'Down' ) {
+                $CSS .= ' SortDescendingLarge';
+                $TitleDesc = Translatable('sorted descending');
             }
             else {
-                $OrderBy = 'Up';
-                $CSS .= ' SortDescendingLarge';
+                $CSS .= ' SortAscendingLarge';
+                $TitleDesc = Translatable('sorted ascending');
             }
 
-            # set title description
-            my $TitleDesc = $OrderBy eq 'Down' ? Translatable('sorted ascending') : Translatable('sorted descending');
             $TitleDesc = $LayoutObject->{LanguageObject}->Translate($TitleDesc);
             $Title .= ', ' . $TitleDesc;
         }
@@ -858,7 +886,7 @@ sub Run {
                 Data => {
                     %Param,
                     Name             => $Self->{Name},
-                    OrderBy          => $OrderBy || 'Up',
+                    OrderBy          => $TicketSearch{OrderBy},
                     HeaderColumnName => $Item,
                     Title            => $Title,
                 },
@@ -882,21 +910,21 @@ sub Run {
         if ( $HeaderColumn !~ m{\A DynamicField_}xms ) {
 
             $CSS = '';
+            $TitleSort = ( $Self->{SortBy} && ( $Self->{SortBy} eq $HeaderColumn ) ) ? 1 : 0;
             my $Title = $LayoutObject->{LanguageObject}->Translate($HeaderColumn);
 
-            if ( $Self->{SortBy} && ( $Self->{SortBy} eq $HeaderColumn ) ) {
-                if ( $Self->{OrderBy} && ( $Self->{OrderBy} eq 'Up' ) ) {
-                    $OrderBy = 'Down';
-                    $CSS .= ' SortAscendingLarge';
+            # set title description
+            if ($TitleSort) {
+                my $TitleDesc = '';
+                if ( $TicketSearch{OrderBy} eq 'Down' ) {
+                    $CSS .= ' SortDescendingLarge';
+                    $TitleDesc = Translatable('sorted descending');
                 }
                 else {
-                    $OrderBy = 'Up';
-                    $CSS .= ' SortDescendingLarge';
+                    $CSS .= ' SortAscendingLarge';
+                    $TitleDesc = Translatable('sorted ascending');
                 }
 
-                # add title description
-                my $TitleDesc
-                    = $OrderBy eq 'Down' ? Translatable('sorted ascending') : Translatable('sorted descending');
                 $TitleDesc = $LayoutObject->{LanguageObject}->Translate($TitleDesc);
                 $Title .= ', ' . $TitleDesc;
             }
@@ -938,7 +966,7 @@ sub Run {
                         %Param,
                         CSS => $CSS || '',
                         Name    => $Self->{Name},
-                        OrderBy => $OrderBy || 'Up',
+                        OrderBy => $TicketSearch{OrderBy},
                         Filter  => $Self->{Filter},
                         Title   => $Title,
                     },
@@ -996,7 +1024,7 @@ sub Run {
                         CSS                  => $CSS,
                         HeaderNameTranslated => $TranslatedWord || $HeaderColumn,
                         ColumnFilterStrg     => $ColumnFilterHTML,
-                        OrderBy              => $OrderBy || 'Up',
+                        OrderBy              => $TicketSearch{OrderBy},
                         SortBy               => $Self->{SortBy} || 'Age',
                         Name                 => $Self->{Name},
                         Title                => $Title,
@@ -1050,6 +1078,8 @@ sub Run {
                         CSS                  => $CSS,
                         HeaderNameTranslated => $TranslatedWord || $HeaderColumn,
                         ColumnFilterStrg     => $ColumnFilterHTML,
+                        OrderBy              => $TicketSearch{OrderBy},
+                        SortBy               => $Self->{SortBy} || 'Age',
                         Name                 => $Self->{Name},
                         Title                => $Title,
                         FilterTitle          => $FilterTitle,
@@ -1078,7 +1108,7 @@ sub Run {
                         HeaderColumnName     => $HeaderColumn,
                         CSS                  => $CSS,
                         HeaderNameTranslated => $TranslatedWord || $HeaderColumn,
-                        OrderBy              => $OrderBy || 'Up',
+                        OrderBy              => $TicketSearch{OrderBy},
                         SortBy               => $Self->{SortBy} || $HeaderColumn,
                         Name                 => $Self->{Name},
                         Title                => $Title,
@@ -1153,24 +1183,21 @@ sub Run {
             );
 
             if ($IsSortable) {
-                my $OrderBy;
+                my $TitleDesc = '';
                 if (
                     $Self->{SortBy}
                     && ( $Self->{SortBy} eq ( 'DynamicField_' . $DynamicFieldConfig->{Name} ) )
                     )
                 {
-                    if ( $Self->{OrderBy} && ( $Self->{OrderBy} eq 'Up' ) ) {
-                        $OrderBy = 'Down';
-                        $CSS .= ' SortAscendingLarge';
+                    if ( $TicketSearch{OrderBy} eq 'Down' ) {
+                        $CSS .= ' SortDescendingLarge';
+                        $TitleDesc = Translatable('sorted descending');
                     }
                     else {
-                        $OrderBy = 'Up';
-                        $CSS .= ' SortDescendingLarge';
+                        $CSS .= ' SortAscendingLarge';
+                        $TitleDesc = Translatable('sorted ascending');
                     }
 
-                    # add title description
-                    my $TitleDesc
-                        = $OrderBy eq 'Down' ? Translatable('sorted ascending') : Translatable('sorted descending');
                     $TitleDesc = $LayoutObject->{LanguageObject}->Translate($TitleDesc);
                     $Title .= ', ' . $TitleDesc;
                 }
@@ -1201,7 +1228,7 @@ sub Run {
                             CSS                  => $CSS,
                             HeaderNameTranslated => $TranslatedLabel || $DynamicFieldName,
                             ColumnFilterStrg     => $ColumnFilterHTML,
-                            OrderBy              => $OrderBy || 'Up',
+                            OrderBy              => $TicketSearch{OrderBy},
                             SortBy               => $Self->{SortBy} || 'Age',
                             Name                 => $Self->{Name},
                             Title                => $Title,
@@ -1221,7 +1248,7 @@ sub Run {
                             HeaderColumnName     => $DynamicFieldName,
                             CSS                  => $CSS,
                             HeaderNameTranslated => $TranslatedLabel || $DynamicFieldName,
-                            OrderBy              => $OrderBy || 'Up',
+                            OrderBy              => $TicketSearch{OrderBy},
                             SortBy               => $Self->{SortBy} || $DynamicFieldName,
                             Name                 => $Self->{Name},
                             Title                => $Title,
@@ -1259,6 +1286,8 @@ sub Run {
                         CSS                  => $CSS,
                         HeaderNameTranslated => $TranslatedLabel || $DynamicFieldName,
                         ColumnFilterStrg     => $ColumnFilterHTML,
+                        OrderBy              => $TicketSearch{OrderBy},
+                        SortBy               => $Self->{SortBy} || 'Age',
                         Name                 => $Self->{Name},
                         Title                => $Title,
                         FilterTitle          => $FilterTitle,

--- a/Kernel/Output/HTML/Dashboard/TicketGeneric.pm
+++ b/Kernel/Output/HTML/Dashboard/TicketGeneric.pm
@@ -43,6 +43,9 @@ sub new {
     # get add filters param
     $Self->{AddFilters} = $ParamObject->GetParam( Param => 'AddFilters' ) || $Param{AddFilters} || 0;
 
+    # Get previous sorting column.
+    $Self->{SortingColumn} = $ParamObject->GetParam( Param => 'SortingColumn' ) || $Param{SortingColumn};
+
     # set filter settings
     for my $Item (qw(ColumnFilter GetColumnFilter GetColumnFilterSelect)) {
         $Self->{$Item} = $Param{$Item};
@@ -547,7 +550,7 @@ sub Run {
     # Set OrderBy parameter to the search.
     my $IsCacheForUse = 0;
     if ( $Self->{OrderBy} ) {
-        if ( $Self->{AddFilters} ) {
+        if ( $Self->{AddFilters} || ( $Self->{SortingColumn} && $Self->{SortingColumn} ne $Self->{SortBy} ) ) {
             $TicketSearch{OrderBy} = $Self->{OrderBy};
             $IsCacheForUse = 1;
         }
@@ -555,6 +558,9 @@ sub Run {
             $TicketSearch{OrderBy} = $Self->{OrderBy} eq 'Up' ? 'Down' : 'Up';
         }
     }
+
+    # Set previous sorting column parameter for all columns.
+    $Param{SortingColumn} = $Self->{SortBy};
 
     $CacheKey .= '-' . $TicketSearch{OrderBy} if defined $TicketSearch{OrderBy};
 

--- a/Kernel/Output/HTML/Templates/Standard/AgentDashboardTicketGeneric.tt
+++ b/Kernel/Output/HTML/Templates/Standard/AgentDashboardTicketGeneric.tt
@@ -569,23 +569,21 @@ $('.AutoColspan').each(function() {
 [% RenderBlockStart("ContentLargeTicketGenericRefresh") %]
 [% WRAPPER JSOnDocumentComplete %]
 <script type="text/javascript">//<![CDATA[
-Core.Config.Set('RefreshSeconds_[% Data.NameHTML | html %]', parseInt(5, 10) || 0);
+Core.Config.Set('RefreshSeconds_[% Data.NameHTML | html %]', parseInt("[% Data.RefreshTime | html %]", 10) || 0);
 if (Core.Config.Get('RefreshSeconds_[% Data.NameHTML | html %]')) {
     Core.Config.Set('Timer_[% Data.NameHTML | html %]', window.setTimeout(function() {
 
         // get active filter
-        var Filter = $('#Dashboard' + Core.App.EscapeSelector('[% Data.Name | html %]') + '-box').find('.Tab.Actions li.Selected a').attr('data-filter'),
-
-            // last() is added for the case when sorted by Priority because there are two columns - first default column with flags and second normal
+        var Filter      = $('#Dashboard' + Core.App.EscapeSelector('[% Data.Name | html %]') + '-box').find('.Tab.Actions li.Selected a').attr('data-filter'),
             $OrderByObj = $('#Dashboard' + Core.App.EscapeSelector('[% Data.Name | html %]') + '-box').find('th.SortDescendingLarge, th.SortAscendingLarge').last(),
             SortBy      = $OrderByObj.attr('data-column') || '',
             OrderBy     = '';
 
         if ($OrderByObj && $OrderByObj.hasClass('SortDescendingLarge')) {
-            OrderBy = 'Up';
+            OrderBy = 'Down';
         }
         else if ($OrderByObj && $OrderByObj.hasClass('SortAscendingLarge')) {
-            OrderBy = 'Down';
+            OrderBy = 'Up';
         }
 
         $('#Dashboard' + Core.App.EscapeSelector('[% Data.Name | html %]') + '-box').addClass('Loading');

--- a/Kernel/Output/HTML/Templates/Standard/AgentDashboardTicketGeneric.tt
+++ b/Kernel/Output/HTML/Templates/Standard/AgentDashboardTicketGeneric.tt
@@ -115,7 +115,7 @@
         });
 
         $('#Dashboard' + Core.App.EscapeSelector('[% Data.Name | html %]') + '-box').addClass('Loading');
-        Core.AJAX.ContentUpdate($('#Dashboard' + Core.App.EscapeSelector('[% Data.Name | html %]') + ''), '[% Env("Baselink") %]Action=[% Env("Action") %];Subaction=Element;Name=[% Data.Name | html %];Filter=' + Filter + ';' + LinkPage + ';CustomerID=' + CustomerID + ';SortBy=TicketNumber;OrderBy=[% Data.OrderBy | html %]', function () {
+        Core.AJAX.ContentUpdate($('#Dashboard' + Core.App.EscapeSelector('[% Data.Name | html %]') + ''), '[% Env("Baselink") %]Action=[% Env("Action") %];Subaction=Element;Name=[% Data.Name | html %];Filter=' + Filter + ';' + LinkPage + ';CustomerID=' + CustomerID + ';SortBy=TicketNumber;OrderBy=[% Data.OrderBy | html %];SortingColumn=[% Data.SortingColumn | html %]', function () {
             $('#Dashboard' + Core.App.EscapeSelector('[% Data.Name | html %]') + '-box').removeClass('Loading');
         });
         Event.preventDefault();
@@ -198,7 +198,7 @@ Core.Agent.Dashboard.InitUserAutocomplete( $(".UserAutoComplete") );
         });
 
         $('#Dashboard' + Core.App.EscapeSelector('[% Data.Name | html %]') + '-box').addClass('Loading');
-        Core.AJAX.ContentUpdate($('#Dashboard' + Core.App.EscapeSelector('[% Data.Name | html %]')), '[% Env("Baselink") %]Action=[% Env("Action") %];Subaction=Element;Name=[% Data.Name | html %];Filter=' + Filter + ';CustomerID=' + CustomerID + ';SortBy=[% Data.SortBy | html %];OrderBy=[% Data.OrderBy | html %];AddFilters=1;' + LinkPage, function () {
+        Core.AJAX.ContentUpdate($('#Dashboard' + Core.App.EscapeSelector('[% Data.Name | html %]')), '[% Env("Baselink") %]Action=[% Env("Action") %];Subaction=Element;Name=[% Data.Name | html %];Filter=' + Filter + ';CustomerID=' + CustomerID + ';SortBy=[% Data.SortBy | html %];OrderBy=[% Data.OrderBy | html %];AddFilters=1;SortingColumn=[% Data.SortingColumn | html %];' + LinkPage, function () {
             $('#Dashboard' + Core.App.EscapeSelector('[% Data.Name | html %]') + '-box').removeClass('Loading');
         });
         return false;
@@ -236,7 +236,7 @@ Core.Agent.Dashboard.InitUserAutocomplete( $(".UserAutoComplete") );
         });
 
         $('#Dashboard' + Core.App.EscapeSelector('[% Data.Name | html %]') + '-box').addClass('Loading');
-        Core.AJAX.ContentUpdate($('#Dashboard' + Core.App.EscapeSelector('[% Data.Name | html %]')), '[% Env("Baselink") %]Action=[% Env("Action") %];Subaction=Element;Name=[% Data.Name | html %];Filter=' + Filter + ';CustomerID=' + CustomerID + ';SortBy=[% Data.HeaderColumnName | html %];OrderBy=[% Data.OrderBy | html %];' + LinkPage, function () {
+        Core.AJAX.ContentUpdate($('#Dashboard' + Core.App.EscapeSelector('[% Data.Name | html %]')), '[% Env("Baselink") %]Action=[% Env("Action") %];Subaction=Element;Name=[% Data.Name | html %];Filter=' + Filter + ';CustomerID=' + CustomerID + ';SortBy=[% Data.HeaderColumnName | html %];OrderBy=[% Data.OrderBy | html %];SortingColumn=[% Data.SortingColumn | html %];' + LinkPage, function () {
             $('#Dashboard' + Core.App.EscapeSelector('[% Data.Name | html %]') + '-box').removeClass('Loading');
         });
         Event.preventDefault();
@@ -282,7 +282,7 @@ Core.Agent.Dashboard.InitUserAutocomplete( $(".UserAutoComplete") );
         });
 
         $('#Dashboard' + Core.App.EscapeSelector('[% Data.Name | html %]') + '-box').addClass('Loading');
-        Core.AJAX.ContentUpdate($('#Dashboard' + Core.App.EscapeSelector('[% Data.Name | html %]')), '[% Env("Baselink") %]Action=[% Env("Action") %];Subaction=Element;Name=[% Data.Name | html %];Filter=' + Filter + ';CustomerID=' + CustomerID +';SortBy=[% Data.HeaderColumnName | html %];OrderBy=[% Data.OrderBy | html %];' + LinkPage, function () {
+        Core.AJAX.ContentUpdate($('#Dashboard' + Core.App.EscapeSelector('[% Data.Name | html %]')), '[% Env("Baselink") %]Action=[% Env("Action") %];Subaction=Element;Name=[% Data.Name | html %];Filter=' + Filter + ';CustomerID=' + CustomerID +';SortBy=[% Data.HeaderColumnName | html %];OrderBy=[% Data.OrderBy | html %];SortingColumn=[% Data.SortingColumn | html %];' + LinkPage, function () {
             $('#Dashboard' + Core.App.EscapeSelector('[% Data.Name | html %]') + '-box').removeClass('Loading');
         });
         Event.preventDefault();
@@ -349,7 +349,7 @@ Core.Agent.Dashboard.InitCustomerUserAutocomplete( $(".CustomerUserAutoComplete"
         });
 
         $('#Dashboard' + Core.App.EscapeSelector('[% Data.Name | html %]') + '-box').addClass('Loading');
-        Core.AJAX.ContentUpdate($('#Dashboard' + Core.App.EscapeSelector('[% Data.Name | html %]')), '[% Env("Baselink") %]Action=[% Env("Action") %];Subaction=Element;Name=[% Data.Name | html %];Filter=' + Filter + ';CustomerID=' + CustomerID + ';SortBy=[% Data.SortBy | html %];OrderBy=[% Data.OrderBy | html %];AddFilters=1;' + LinkPage, function () {
+        Core.AJAX.ContentUpdate($('#Dashboard' + Core.App.EscapeSelector('[% Data.Name | html %]')), '[% Env("Baselink") %]Action=[% Env("Action") %];Subaction=Element;Name=[% Data.Name | html %];Filter=' + Filter + ';CustomerID=' + CustomerID + ';SortBy=[% Data.SortBy | html %];OrderBy=[% Data.OrderBy | html %];AddFilters=1;SortingColumn=[% Data.SortingColumn | html %];' + LinkPage, function () {
             $('#Dashboard' + Core.App.EscapeSelector('[% Data.Name | html %]') + '-box').removeClass('Loading');
         });
         return false;

--- a/Kernel/Output/HTML/Templates/Standard/AgentDashboardTicketGeneric.tt
+++ b/Kernel/Output/HTML/Templates/Standard/AgentDashboardTicketGeneric.tt
@@ -569,21 +569,23 @@ $('.AutoColspan').each(function() {
 [% RenderBlockStart("ContentLargeTicketGenericRefresh") %]
 [% WRAPPER JSOnDocumentComplete %]
 <script type="text/javascript">//<![CDATA[
-Core.Config.Set('RefreshSeconds_[% Data.NameHTML | html %]', parseInt("[% Data.RefreshTime | html %]", 10) || 0);
+Core.Config.Set('RefreshSeconds_[% Data.NameHTML | html %]', parseInt(5, 10) || 0);
 if (Core.Config.Get('RefreshSeconds_[% Data.NameHTML | html %]')) {
     Core.Config.Set('Timer_[% Data.NameHTML | html %]', window.setTimeout(function() {
 
         // get active filter
-        var Filter      = $('#Dashboard' + Core.App.EscapeSelector('[% Data.Name | html %]') + '-box').find('.Tab.Actions li.Selected a').attr('data-filter'),
+        var Filter = $('#Dashboard' + Core.App.EscapeSelector('[% Data.Name | html %]') + '-box').find('.Tab.Actions li.Selected a').attr('data-filter'),
+
+            // last() is added for the case when sorted by Priority because there are two columns - first default column with flags and second normal
             $OrderByObj = $('#Dashboard' + Core.App.EscapeSelector('[% Data.Name | html %]') + '-box').find('th.SortDescendingLarge, th.SortAscendingLarge').last(),
             SortBy      = $OrderByObj.attr('data-column') || '',
             OrderBy     = '';
 
         if ($OrderByObj && $OrderByObj.hasClass('SortDescendingLarge')) {
-            OrderBy = 'Down';
+            OrderBy = 'Up';
         }
         else if ($OrderByObj && $OrderByObj.hasClass('SortAscendingLarge')) {
-            OrderBy = 'Up';
+            OrderBy = 'Down';
         }
 
         $('#Dashboard' + Core.App.EscapeSelector('[% Data.Name | html %]') + '-box').addClass('Loading');

--- a/Kernel/Output/HTML/Templates/Standard/AgentDashboardTicketGeneric.tt
+++ b/Kernel/Output/HTML/Templates/Standard/AgentDashboardTicketGeneric.tt
@@ -198,7 +198,7 @@ Core.Agent.Dashboard.InitUserAutocomplete( $(".UserAutoComplete") );
         });
 
         $('#Dashboard' + Core.App.EscapeSelector('[% Data.Name | html %]') + '-box').addClass('Loading');
-        Core.AJAX.ContentUpdate($('#Dashboard' + Core.App.EscapeSelector('[% Data.Name | html %]')), '[% Env("Baselink") %]Action=[% Env("Action") %];Subaction=Element;Name=[% Data.Name | html %];Filter=' + Filter + ';CustomerID=' + CustomerID + ';SortBy=[% Data.SortBy | html %];OrderBy=[% Data.OrderBy | html %];' + LinkPage, function () {
+        Core.AJAX.ContentUpdate($('#Dashboard' + Core.App.EscapeSelector('[% Data.Name | html %]')), '[% Env("Baselink") %]Action=[% Env("Action") %];Subaction=Element;Name=[% Data.Name | html %];Filter=' + Filter + ';CustomerID=' + CustomerID + ';SortBy=[% Data.SortBy | html %];OrderBy=[% Data.OrderBy | html %];AddFilters=1;' + LinkPage, function () {
             $('#Dashboard' + Core.App.EscapeSelector('[% Data.Name | html %]') + '-box').removeClass('Loading');
         });
         return false;
@@ -349,7 +349,7 @@ Core.Agent.Dashboard.InitCustomerUserAutocomplete( $(".CustomerUserAutoComplete"
         });
 
         $('#Dashboard' + Core.App.EscapeSelector('[% Data.Name | html %]') + '-box').addClass('Loading');
-        Core.AJAX.ContentUpdate($('#Dashboard' + Core.App.EscapeSelector('[% Data.Name | html %]')), '[% Env("Baselink") %]Action=[% Env("Action") %];Subaction=Element;Name=[% Data.Name | html %];Filter=' + Filter + ';CustomerID=' + CustomerID + ';SortBy=[% Data.SortBy | html %];OrderBy=[% Data.OrderBy | html %];' + LinkPage, function () {
+        Core.AJAX.ContentUpdate($('#Dashboard' + Core.App.EscapeSelector('[% Data.Name | html %]')), '[% Env("Baselink") %]Action=[% Env("Action") %];Subaction=Element;Name=[% Data.Name | html %];Filter=' + Filter + ';CustomerID=' + CustomerID + ';SortBy=[% Data.SortBy | html %];OrderBy=[% Data.OrderBy | html %];AddFilters=1;' + LinkPage, function () {
             $('#Dashboard' + Core.App.EscapeSelector('[% Data.Name | html %]') + '-box').removeClass('Loading');
         });
         return false;
@@ -575,15 +575,15 @@ if (Core.Config.Get('RefreshSeconds_[% Data.NameHTML | html %]')) {
 
         // get active filter
         var Filter      = $('#Dashboard' + Core.App.EscapeSelector('[% Data.Name | html %]') + '-box').find('.Tab.Actions li.Selected a').attr('data-filter'),
-            $OrderByObj = $('#Dashboard' + Core.App.EscapeSelector('[% Data.Name | html %]') + '-box').find('th.SortDescendingLarge, th.SortAscendingLarge'),
+            $OrderByObj = $('#Dashboard' + Core.App.EscapeSelector('[% Data.Name | html %]') + '-box').find('th.SortDescendingLarge, th.SortAscendingLarge').last(),
             SortBy      = $OrderByObj.attr('data-column') || '',
             OrderBy     = '';
 
         if ($OrderByObj && $OrderByObj.hasClass('SortDescendingLarge')) {
-            OrderBy = 'Up';
+            OrderBy = 'Down';
         }
         else if ($OrderByObj && $OrderByObj.hasClass('SortAscendingLarge')) {
-            OrderBy = 'Down';
+            OrderBy = 'Up';
         }
 
         $('#Dashboard' + Core.App.EscapeSelector('[% Data.Name | html %]') + '-box').addClass('Loading');

--- a/scripts/test/Selenium/Output/Dashboard/TicketGeneric.t
+++ b/scripts/test/Selenium/Output/Dashboard/TicketGeneric.t
@@ -107,7 +107,7 @@ $Selenium->RunTest(
         my %Configs = (
             '0100-TicketPendingReminder' => {
                 'Attributes' =>
-                    'TicketPendingTimeOlderMinutes=1;StateType=pending reminder;SortBy=PendingTime;OrderBy=Down;',
+                    'TicketPendingTimeOlderMinutes=1;StateType=pending reminder;SortBy=PendingTime;OrderBy=Up;',
                 'Block'          => 'ContentLarge',
                 'CacheTTLLocal'  => '0.5',
                 'Default'        => '1',
@@ -146,7 +146,7 @@ $Selenium->RunTest(
                 'Title'       => 'Reminder Tickets'
             },
             '0110-TicketEscalation' => {
-                'Attributes'     => 'TicketEscalationTimeOlderMinutes=1;SortBy=EscalationTime;OrderBy=Down;',
+                'Attributes'     => 'TicketEscalationTimeOlderMinutes=1;SortBy=EscalationTime;OrderBy=Up;',
                 'Block'          => 'ContentLarge',
                 'CacheTTLLocal'  => '0.5',
                 'Default'        => '1',

--- a/scripts/test/Selenium/Output/Dashboard/TicketGenericSortOrder.t
+++ b/scripts/test/Selenium/Output/Dashboard/TicketGenericSortOrder.t
@@ -216,16 +216,22 @@ $Selenium->RunTest(
             "Ticket with priority '1 very low' is not found on screen with filter active",
         );
 
-        # click on priority column to order by 'Up'
+        # verify priority order by is not changed
+        $Self->True(
+            $Selenium->find_element("//a[contains(\@title, \'Priority, sorted descending' )]"),
+            "Priority column order by is not changed",
+        );
+
+        # click on priority column - order by is 'Up'
         $Selenium->find_element( "#PriorityOverviewControl0120-TicketNew", 'css' )->click();
 
         # wait for AJAX to load
         $Selenium->WaitFor( JavaScript => 'return typeof($) === "function" && !$(".Loading").length' );
 
-        # verify priority order by is changed
+        # verify priority order by is changed to 'Up'
         $Self->True(
             $Selenium->find_element("//a[contains(\@title, \'Priority, sorted ascending' )]"),
-            "Priority column order by changed",
+            "Priority column order by is changed",
         );
 
         # verify ticket with priority '1 very low' is now on screen

--- a/scripts/test/Selenium/Output/Dashboard/TicketGenericSortOrder.t
+++ b/scripts/test/Selenium/Output/Dashboard/TicketGenericSortOrder.t
@@ -1,0 +1,320 @@
+# --
+# Copyright (C) 2001-2017 OTRS AG, http://otrs.com/
+# --
+# This software comes with ABSOLUTELY NO WARRANTY. For details, see
+# the enclosed file COPYING for license information (AGPL). If you
+# did not receive this file, see http://www.gnu.org/licenses/agpl.txt.
+# --
+
+use strict;
+use warnings;
+use utf8;
+
+use vars (qw($Self));
+
+# get selenium object
+my $Selenium = $Kernel::OM->Get('Kernel::System::UnitTest::Selenium');
+
+$Selenium->RunTest(
+    sub {
+
+        # get helper object
+        $Kernel::OM->ObjectParamAdd(
+            'Kernel::System::UnitTest::Helper' => {
+                RestoreSystemConfiguration => 1,
+            },
+        );
+        my $Helper = $Kernel::OM->Get('Kernel::System::UnitTest::Helper');
+
+        # reset 'DashboardBackend###0120-TicketNew' sysconfig
+        $Kernel::OM->Get('Kernel::System::SysConfig')->ConfigItemReset(
+            Name => 'DashboardBackend###0120-TicketNew',
+        );
+
+        # set 'DashboardBackend###0120-TicketNew' sysconfig
+        $Helper->ConfigSettingChange(
+            Valid => 1,
+            Key   => "DashboardBackend###0120-TicketNew",
+            Value => {
+                'Attributes'     => 'StateType=new;SortBy=Priority;OrderBy=Down;',
+                'Block'          => 'ContentLarge',
+                'CacheTTLLocal'  => '0.001',
+                'Default'        => '1',
+                'DefaultColumns' => {
+                    'Age'                    => '2',
+                    'Changed'                => '1',
+                    'Created'                => '1',
+                    'CustomerCompanyName'    => '1',
+                    'CustomerID'             => '1',
+                    'CustomerName'           => '1',
+                    'CustomerUserID'         => '1',
+                    'EscalationResponseTime' => '1',
+                    'EscalationSolutionTime' => '1',
+                    'EscalationTime'         => '1',
+                    'EscalationUpdateTime'   => '1',
+                    'Lock'                   => '1',
+                    'Owner'                  => '1',
+                    'PendingTime'            => '1',
+                    'Priority'               => '2',
+                    'Queue'                  => '2',
+                    'Responsible'            => '1',
+                    'SLA'                    => '1',
+                    'Service'                => '1',
+                    'State'                  => '1',
+                    'TicketNumber'           => '2',
+                    'Title'                  => '2',
+                    'Type'                   => '1'
+                },
+                'Description' => 'All new tickets, these tickets have not been worked on yet',
+                'Filter'      => 'All',
+                'Group'       => '',
+                'Limit'       => '10',
+                'Module'      => 'Kernel::Output::HTML::Dashboard::TicketGeneric',
+                'Permission'  => 'rw',
+                'Time'        => 'Age',
+                'Title'       => 'New Tickets'
+            },
+        );
+
+        # create test user
+        my $TestUserLogin = $Helper->TestUserCreate(
+            Groups => [ 'admin', 'users' ],
+        ) || die "Did not get test user";
+
+        # get test user ID
+        my $TestUserID = $Kernel::OM->Get('Kernel::System::User')->UserLookup(
+            UserLogin => $TestUserLogin,
+        );
+
+        # create test queue
+        my $QueueName = "Queue" . $Helper->GetRandomID();
+        my $QueueID   = $Kernel::OM->Get('Kernel::System::Queue')->QueueAdd(
+            Name            => $QueueName,
+            ValidID         => 1,
+            GroupID         => 1,
+            SystemAddressID => 1,
+            SalutationID    => 1,
+            SignatureID     => 1,
+            Comment         => 'Selenium Queue',
+            UserID          => $TestUserID,
+        );
+        $Self->True(
+            $QueueID,
+            "Queue ID $QueueID is created",
+        );
+
+        # get ticket object
+        my $TicketObject = $Kernel::OM->Get('Kernel::System::Ticket');
+
+        # create 11 test tickets
+        my @TicketIDs;
+        my @TicketNumbers;
+        for my $TicketCreate ( 1 .. 11 ) {
+            my $TicketNumber = $TicketObject->TicketCreateNumber();
+            my $TicketID     = $TicketObject->TicketCreate(
+                TN           => $TicketNumber,
+                Title        => 'Selenium Test Ticket',
+                QueueID      => $QueueID,
+                Lock         => 'lock',
+                Priority     => '3 normal',
+                State        => 'new',
+                CustomerID   => '123465',
+                CustomerUser => 'customer@example.com',
+                OwnerID      => $TestUserID,
+                UserID       => $TestUserID,
+            );
+            $Self->True(
+                $TicketID,
+                "Ticket is created - ID $TicketID",
+            );
+            push @TicketNumbers, $TicketNumber;
+            push @TicketIDs,     $TicketID;
+        }
+
+        # update last ticket to priority '1 very low' for test purpose
+        my $Success = $TicketObject->TicketPrioritySet(
+            TicketID => $TicketIDs[10],
+            Priority => '1 very low',
+            UserID   => $TestUserID,
+        );
+        $Self->True(
+            $Success,
+            "Ticket ID $TicketIDs[10] updated priority to '1 very low'"
+        );
+
+        # login
+        $Selenium->Login(
+            Type     => 'Agent',
+            User     => $TestUserLogin,
+            Password => $TestUserLogin,
+        );
+
+        # get script alias
+        my $ScriptAlias = $Kernel::OM->Get('Kernel::Config')->Get('ScriptAlias');
+
+        # navigate to AgentPreferences screen
+        $Selenium->VerifiedGet("${ScriptAlias}index.pl?Action=AgentPreferences");
+
+        # set MyQueue preferences
+        $Selenium->execute_script("\$('#QueueID').val('$QueueID').trigger('redraw.InputField').trigger('change');");
+        $Selenium->find_element( "#QueueIDUpdate", 'css' )->VerifiedClick();
+
+        # login test user again
+        $Selenium->Login(
+            Type     => 'Agent',
+            User     => $TestUserLogin,
+            Password => $TestUserLogin,
+        );
+
+        # click on 'Tickets in My Queues'
+        $Selenium->find_element( "#Dashboard0120-TicketNewMyQueues", 'css' )->click();
+
+        # wait for AJAX to load
+        $Selenium->WaitFor( JavaScript => 'return typeof($) === "function" && !$(".Loading").length' );
+
+        # verify sorting by priority as initial sort on loading page
+        $Self->True(
+            $Selenium->find_element("//a[contains(\@title, \'Priority, sorted descending' )]"),
+            "Sorting by priority on loading page",
+        );
+
+        # verify ticket with different priority is not present without filter, it's on second page
+        $Self->True(
+            index( $Selenium->get_page_source(), 'Queue, filter not active' ) > -1,
+            "There is no filter for 'New Tickets' widget",
+        );
+        $Self->True(
+            index( $Selenium->get_page_source(), $TicketNumbers[10] ) == -1,
+            "Ticket with priority '1 very low' is not found on screen without filter",
+        );
+
+        # click to set filter for queue column
+        $Selenium->find_element("//a[contains(\@title, \'Queue, filter not active' )]")->click();
+
+        # wait for filter options to load
+        $Selenium->WaitFor(
+            JavaScript => 'return typeof($) === "function" && $("#ColumnFilterQueue0120-TicketNew:visible").length'
+        );
+
+        # set test queue as filter
+        $Selenium->find_element( "#ColumnFilterQueue0120-TicketNew", 'css' )->click();
+        $Selenium->execute_script(
+            "\$('#ColumnFilterQueue0120-TicketNew').val('$QueueID').trigger('redraw.ColumnFilter').trigger('change');"
+        );
+
+        # wait for AJAX to load
+        $Selenium->WaitFor( JavaScript => 'return typeof($) === "function" && !$(".Loading").length' );
+
+     # verify ticket with different priority is not present on screen with filter, it's still on second page
+     # see bug #11422 ( http://bugs.otrs.org/show_bug.cgi?id=11422 ), there is no change in order when activating filter
+        $Self->True(
+            $Selenium->find_element("//a[contains(\@title, \'Queue, filter active' )]"),
+            "There is filter for queue column in 'New Tickets' widget",
+        );
+        $Self->True(
+            index( $Selenium->get_page_source(), $TicketNumbers[10] ) == -1,
+            "Ticket with priority '1 very low' is not found on screen with filter active",
+        );
+
+        # click on priority column to order by 'Up'
+        $Selenium->find_element( "#PriorityOverviewControl0120-TicketNew", 'css' )->click();
+
+        # wait for AJAX to load
+        $Selenium->WaitFor( JavaScript => 'return typeof($) === "function" && !$(".Loading").length' );
+
+        # verify priority order by is changed
+        $Self->True(
+            $Selenium->find_element("//a[contains(\@title, \'Priority, sorted ascending' )]"),
+            "Priority column order by changed",
+        );
+
+        # verify ticket with priority '1 very low' is now on screen
+        $Self->True(
+            index( $Selenium->get_page_source(), $TicketNumbers[10] ) > -1,
+            "Ticket with priority '1 very low' is found on screen with filter active and changed priority column order by",
+        );
+
+        # remove queue filter to test that priority order by column will remain same
+        # click to set filter for queue column
+        $Selenium->find_element("//a[contains(\@title, \'Queue, filter active' )]")->click();
+
+        # wait for filter options to load
+        $Selenium->WaitFor(
+            JavaScript => 'return typeof($) === "function" && $("#ColumnFilterQueue0120-TicketNew:visible").length'
+        );
+
+        # remove queue filter
+        $Selenium->find_element( "#ColumnFilterQueue0120-TicketNew", 'css' )->click();
+        $Selenium->execute_script(
+            "\$('#ColumnFilterQueue0120-TicketNew').val('DeleteFilter').trigger('redraw.ColumnFilter').trigger('change');"
+        );
+
+        # wait for AJAX to load
+        $Selenium->WaitFor( JavaScript => 'return typeof($) === "function" && !$(".Loading").length' );
+
+        # verify filter is removed
+        $Self->True(
+            $Selenium->find_element("//a[contains(\@title, \'Queue, filter not active' )]"),
+            "There is filter for queue column in 'New Tickets' widget",
+        );
+
+        # verify priority order remained same after removing filter
+        $Self->True(
+            $Selenium->find_element("//a[contains(\@title, \'Priority, sorted ascending' )]"),
+            "Priority column order by remained same after removing filter",
+        );
+
+        # verify ticket with priority '1 very low' is still on screen
+        $Self->True(
+            index( $Selenium->get_page_source(), $TicketNumbers[10] ) > -1,
+            "Ticket with priority '1 very low' is found on screen without filter",
+        );
+
+        # verify change of order by in priority column on click
+        $Selenium->find_element( "#PriorityOverviewControl0120-TicketNew", 'css' )->click();
+
+        # wait for AJAX to load
+        $Selenium->WaitFor( JavaScript => 'return typeof($) === "function" && !$(".Loading").length' );
+
+        $Self->True(
+            $Selenium->find_element("//a[contains(\@title, \'Priority, sorted descending' )]"),
+            "Priority column order by changed",
+        );
+
+        # delete test tickets
+        for my $Ticket (@TicketIDs) {
+            my $Success = $TicketObject->TicketDelete(
+                TicketID => $Ticket,
+                UserID   => 1,
+            );
+            $Self->True(
+                $Success,
+                "Ticket ID $Ticket is deleted"
+            );
+        }
+
+        # get DB object
+        my $DBObject = $Kernel::OM->Get('Kernel::System::DB');
+
+        # delete personal queue for test agent
+        $Success = $DBObject->Do(
+            SQL => "DELETE FROM personal_queues WHERE queue_id = $QueueID",
+        );
+        $Self->True(
+            $Success,
+            "Personal queue is deleted",
+        );
+
+        # delete test queue
+        $Success = $DBObject->Do(
+            SQL => "DELETE FROM queue WHERE id = $QueueID",
+        );
+        $Self->True(
+            $Success,
+            "Queue ID $QueueID is deleted",
+        );
+    }
+
+);
+
+1;


### PR DESCRIPTION
http://bugs.otrs.org/show_bug.cgi?id=11422

Hi @mgruner 

New PR is created because there were a lot of changes for rebase (#955).

First commit [572ec7](https://github.com/s7design/otrs/commit/572ec7122395751f645f2f7e2f72d1d3cec6fb3e) separates filtering and ordering. OrderBy is not changed after filtering table by any column but when user clicks on column header, OrderBy is switched from 'Up' to 'Down' and vice versa.
Block parameter OrderBy is determined before passing through the 'for' loops of arrays of columns and all Core.AJAX.ContentUpdate JS events will have the same OrderBy argument.
In AgentDashboardTicketGeneric.tt Refresh block, OrderBy values 'Up' and 'Down' are changed. I think this is more natural that OrderBy is not changed when page is reloaded. In other case, it is much less comfortable.
Selenium test is added appropriately.

Our proposal is in second commit [afa7fa](https://github.com/OTRS/otrs/commit/afa7fac289bdca4501b2d5ac461c4698c7bd16ca) - modified OrderBy changing. Only when user clicks on the same column header, OrderBy will be change from 'Up' to 'Down' and vice versa (or 'Asc' to 'Desc' and 'Desc' to 'Asc'). In other cases, when user clicks on other columns or filters table, OrderBy will not be changed. New parameter 'SortingColumn' is needed for this.
Selenium tests is modified for new 'logic'.

Please inform me what do you think about this PR.

Regards,
Milan