### PR TITLE
Missing "UserID" parameter in AgentTicketActionCommon.pm

### DIFF
--- a/Kernel/Modules/AgentTicketActionCommon.pm
+++ b/Kernel/Modules/AgentTicketActionCommon.pm
@@ -1034,6 +1034,7 @@ sub Run {
         }
         my $SLAs = $Self->_GetSLAs(
             %GetParam,
+            UserID         => $Self->{UserID},
             CustomerUserID => $CustomerUser,
             QueueID        => $QueueID,
             StateID        => $StateID,


### PR DESCRIPTION
Added a missing "UserID" parameter to the call to _GetSLAs in AgentTicketActionCommon.pm.

Without this additional parameter, the call will failed when no CustomerUser is assigned to the ticket.

Cyrille