### PR TITLE
[ Rel-5_0 Bug 12577 ] - Select All Checkboxes in Ticket Overview screens

### DIFF
--- a/var/httpd/htdocs/js/Core.UI.ActionRow.js
+++ b/var/httpd/htdocs/js/Core.UI.ActionRow.js
@@ -185,6 +185,7 @@ Core.UI.ActionRow = (function (TargetNS) {
         $(TicketElementSelectors[TicketView]).bind('click', function (Event) {
             Event.stopPropagation();
             Core.UI.ActionRow.UpdateActionRow($(this), $(TicketElementSelectors[TicketView]), $('div.OverviewActions ul.Actions'));
+            Core.Form.SelectAllCheckboxes($(this), $('#SelectAllTickets'));
         });
 
         $('#BulkAction a').bind('click', function () {


### PR DESCRIPTION
https://bugs.otrs.org/show_bug.cgi?id=12577

Hi @dvuckovic 

There is a fix for unwanted behavior of 'Select all' checkbox. 'Core.Form.SelectAllCheckboxes' function call is added in checkbox click event.
Please let me know if you have any comment.

Regards,
Milan