### PR TITLE
[ Rel-5_0 Bug 12582 ] - Select All Checkbox is shown in Ticket Overview screens when table is empty

### DIFF
--- a/var/httpd/htdocs/js/Core.UI.ActionRow.js
+++ b/var/httpd/htdocs/js/Core.UI.ActionRow.js
@@ -177,6 +177,12 @@ Core.UI.ActionRow = (function (TargetNS) {
             TicketView = 'Small';
         }
 
+        // Hide 'Select all' checkbox and stylize 'Bulk' in Large and Medium view when table is empty.
+        if ((TicketView === 'Medium' || TicketView === 'Large') && $('#EmptyMessage' + TicketView).length === 1) {
+            $('#SelectAllTickets').parent().parent().hide();
+            $('#BulkAction').css('margin-left', '5px');
+        }
+
         $('#SelectAllTickets').bind('click', function () {
             var Status = $(this).prop('checked');
             $(TicketElementSelectors[TicketView]).prop('checked', Status).triggerHandler('click');


### PR DESCRIPTION
https://bugs.otrs.org/show_bug.cgi?id=12582

Hi @dvuckovic 

There is our proposal for change behavior described in report on above link. 'Select all' checkbox was shown in Medium and Preview (Large) view when table has no data and it is changed that this checkbox is hidden when table is empty.
If you have any comment please let me know.

Regards,
Milan