### PR TITLE
Fixed wrong SysConfig descriptions

### DIFF
--- a/Kernel/Config/Files/ProcessManagement.xml
+++ b/Kernel/Config/Files/ProcessManagement.xml
@@ -367,7 +367,7 @@
         </Setting>
     </ConfigItem>
     <ConfigItem Name="Ticket::Frontend::AgentTicketProcess::CustomerIDReadOnly" Required="1" Valid="1">
-        <Description Translatable="1">Controls if CutomerID is editable in the agent interface.</Description>
+        <Description Translatable="1">Controls if CustomerID is read-only in the agent interface.</Description>
         <Group>ProcessManagement</Group>
         <SubGroup>Frontend::Agent::Ticket::ViewProcess</SubGroup>
         <Setting>

--- a/Kernel/Config/Files/Ticket.xml
+++ b/Kernel/Config/Files/Ticket.xml
@@ -3307,7 +3307,7 @@
         </Setting>
     </ConfigItem>
     <ConfigItem Name="Ticket::Frontend::AgentTicketPhone::CustomerIDReadOnly" Required="1" Valid="1">
-        <Description Translatable="1">Controls if CustomerID is editable in the agent interface.</Description>
+        <Description Translatable="1">Controls if CustomerID is read-only in the agent interface.</Description>
         <Group>Ticket</Group>
         <SubGroup>Frontend::Agent::Ticket::ViewPhoneNew</SubGroup>
         <Setting>
@@ -3444,7 +3444,7 @@
         </Setting>
     </ConfigItem>
     <ConfigItem Name="Ticket::Frontend::AgentTicketEmail::CustomerIDReadOnly" Required="1" Valid="1">
-        <Description Translatable="1">Controls if CutomerID is editable in the agent interface.</Description>
+        <Description Translatable="1">Controls if CustomerID is read-only in the agent interface.</Description>
         <Group>Ticket</Group>
         <SubGroup>Frontend::Agent::Ticket::ViewEmailNew</SubGroup>
         <Setting>
@@ -5865,7 +5865,7 @@
         </Setting>
     </ConfigItem>
     <ConfigItem Name="Ticket::Frontend::AgentTicketCustomer::CustomerIDReadOnly" Required="1" Valid="1">
-        <Description Translatable="1">Controls if CutomerID is editable in the agent interface.</Description>
+        <Description Translatable="1">Controls if CustomerID is read-only in the agent interface.</Description>
         <Group>Ticket</Group>
         <SubGroup>Frontend::Agent::Ticket::ViewCustomer</SubGroup>
         <Setting>


### PR DESCRIPTION
Hi @mgruner 
These SysConfig descriptions are wrong, because the SysConfig options have value "Yes" by default, and the associated settings set CustomerIDs as read-only. So the setting _Controls if CustomerID is read-only in the agent interface._
Branch rel-5_0 is also affected.