### PR TITLE
add support for X-OTRS-FollowUp-…

### DIFF
--- a/Kernel/System/PostMaster/FollowUp.pm
+++ b/Kernel/System/PostMaster/FollowUp.pm
@@ -54,6 +54,42 @@ sub Run {
     # get ticket object
     my $TicketObject = $Kernel::OM->Get('Kernel::System::Ticket');
 
+    my $OwnerID = $GetParam{'X-OTRS-FollowUp-OwnerID'};
+    if ( $GetParam{'X-OTRS-FollowUp-Owner'} ) {
+
+        my $TmpOwnerID = $Kernel::OM->Get('Kernel::System::User')->UserLookup(
+            UserLogin => $GetParam{'X-OTRS-FollowUp-Owner'},
+        );
+
+        $OwnerID = $TmpOwnerID || $OwnerID;
+    }
+
+    if ( $OwnerID ) {
+        my $Success = $TicketObject->TicketOwnerSet(
+            TicketID  => $Param{TicketID},
+            NewUserID => $OwnerID,
+            UserID    => $Param{InmailUserID},
+        );
+    }
+
+    my $ResponsibleID = $GetParam{'X-OTRS-FollowUp-ResponsibleID'};
+    if ( $GetParam{'X-OTRS-FollowUp-Responsible'} ) {
+
+        my $TmpResponsibleID = $Kernel::OM->Get('Kernel::System::User')->UserLookup(
+            UserLogin => $GetParam{'X-OTRS-FollowUp-Responsible'},
+        );
+
+        $ResponsibleID = $TmpResponsibleID || $ResponsibleID;
+    }
+
+    if ( $ResponsibleID ) {
+        my $Success = $TicketObject->TicketResponsibleSet(
+            TicketID  => $Param{TicketID},
+            NewUserID => $ResponsibleID,
+            UserID    => $Param{InmailUserID},
+        );
+    }
+
     # get ticket data
     my %Ticket = $TicketObject->TicketGet(
         TicketID      => $Param{TicketID},

--- a/scripts/test/PostMaster/X-OTRS-FollowUp-Persons.t
+++ b/scripts/test/PostMaster/X-OTRS-FollowUp-Persons.t
@@ -1,0 +1,272 @@
+# --
+# Copyright (C) 2001-2017 OTRS AG, http://otrs.com/
+# --
+# This software comes with ABSOLUTELY NO WARRANTY. For details, see
+# the enclosed file COPYING for license information (AGPL). If you
+# did not receive this file, see http://www.gnu.org/licenses/agpl.txt.
+# --
+
+use strict;
+use warnings;
+use utf8;
+
+use vars (qw($Self));
+
+use Kernel::System::PostMaster;
+
+$Kernel::OM->ObjectParamAdd(
+    'Kernel::System::UnitTest::Helper' => {
+        RestoreDatabase => 1,
+    },
+);
+my $Helper = $Kernel::OM->Get('Kernel::System::UnitTest::Helper');
+
+# get needed objects
+my $ConfigObject = $Kernel::OM->Get('Kernel::Config');
+my $MainObject   = $Kernel::OM->Get('Kernel::System::Main');
+my $UserObject   = $Kernel::OM->Get('Kernel::System::User');
+my $TicketObject = $Kernel::OM->Get('Kernel::System::Ticket');
+
+# ensure that the appropriate X-Headers are available in the config
+my %NeededXHeaders = (
+    'X-OTRS-FollowUp-OwnerID'       => 1,
+    'X-OTRS-FollowUp-Owner'         => 1,
+    'X-OTRS-FollowUp-ResponsibleID' => 1,
+    'X-OTRS-FollowUp-Responsible'   => 1,
+);
+
+my $XHeaders          = $ConfigObject->Get('PostmasterX-Header');
+my @PostmasterXHeader = @{$XHeaders};
+
+HEADER:
+for my $Header ( sort keys %NeededXHeaders ) {
+    next HEADER if ( grep $_ eq $Header, @PostmasterXHeader );
+    push @PostmasterXHeader, $Header;
+}
+
+$ConfigObject->Set(
+    Key   => 'PostmasterX-Header',
+    Value => \@PostmasterXHeader
+);
+
+# set ticket hook
+$ConfigObject->Set(
+    Key   => 'Ticket::Hook',
+    Value => 'Ticket#',
+);
+$ConfigObject->Set(
+    Key   => 'Ticket::HookDivider',
+    Value => '',
+);
+
+# ticket number is in subject on the left
+$ConfigObject->Set(
+    Key   => 'Ticket::SubjectFormat',
+    Value => 'Left',
+);
+
+my $TicketID = $TicketObject->TicketCreate(
+    Title        => 'My ticket created by Agent',
+    Queue        => 'Junk',
+    Lock         => 'unlock',
+    Priority     => '3 normal',
+    State        => 'removed',
+    CustomerUser => 'external@example.com',
+    OwnerID      => 1,
+    UserID       => 1,
+);
+$TicketID //= '';
+
+$Self->True(
+    $TicketID,
+    "Ticket created - TicketID=$TicketID."
+);
+
+my %TestTicket = $TicketObject->TicketGet(
+    TicketID => $TicketID,
+    UserID   => 1,
+);
+
+my $UserRand;
+TRY:
+for my $Try ( 1 .. 20 ) {
+
+    $UserRand = 'unittest-' . $Helper->GetRandomID();
+
+    my $UserID = $UserObject->UserLookup(
+        UserLogin => $UserRand,
+    );
+
+    last TRY if !$UserID;
+
+    next TRY if $Try ne 20;
+
+    $Self->True(
+        0,
+        'Find non existing user login.',
+    );
+}
+
+$ConfigObject->Set(
+    Key   => 'CheckEmailAddresses',
+    Value => 0,
+);
+
+# add user
+my $UserID = $UserObject->UserAdd(
+    UserFirstname => 'Firstname Test1',
+    UserLastname  => 'Lastname Test1',
+    UserLogin     => $UserRand,
+    UserEmail     => $UserRand . '@example.com',
+    ValidID       => 1,
+    ChangeUserID  => 1,
+);
+
+$Self->True(
+    $UserID,
+    'UserAdd()',
+);
+
+
+
+# filter test
+my @Tests = (
+    {
+        Name  => '#1 - Owner Test',
+        Email => "From: Sender <sender\@example.com>
+To: Some Name <recipient\@example.com>
+Subject: [TNR] A simple question
+X-OTRS-FollowUp-Owner: $UserRand
+
+This is a multiline
+email for server: example.tld
+
+The IP address: 192.168.0.1
+        ",
+        Return => 2,    # it's a followup
+        Check  => {
+            Owner => $UserRand,
+        },
+    },
+    {
+        Name  => '#2 - OwnerID Test',
+        Email => 'From: Sender <sender@example.com>
+To: Some Name <recipient@example.com>
+Subject: [TNR] Another question
+X-OTRS-FollowUp-OwnerID: 1
+
+This is a multiline
+email for server: example.tld
+
+The IP address: 192.168.0.1
+        ',
+        Return => 2,    # it's a followup
+        Check  => {
+            OwnerID => 1,
+        },
+    },
+    {
+        Name  => '#3 - Responsible Test',
+        Email => "From: Sender <sender\@example.com>
+To: Some Name <recipient\@example.com>
+Subject: [TNR] A simple question
+X-OTRS-FollowUp-Responsible: $UserRand
+
+This is a multiline
+email for server: example.tld
+
+The IP address: 192.168.0.1
+        ",
+        Return => 2,    # it's a followup
+        Check  => {
+            Responsible => $UserRand,
+        },
+    },
+    {
+        Name  => '#4 - ResponsibleID Test',
+        Email => 'From: Sender <sender@example.com>
+To: Some Name <recipient@example.com>
+Subject: [TNR] Another question
+X-OTRS-FollowUp-ResponsibleID: 1
+
+This is a multiline
+email for server: example.tld
+
+The IP address: 192.168.0.1
+        ',
+        Return => 2,    # it's a followup
+        Check  => {
+            ResponsibleID => 1,
+        },
+    },
+);
+
+my %TicketNumbers;
+my %TicketIDs;
+
+my $Index = 1;
+for my $Test (@Tests) {
+    my $Name  = $Test->{Name};
+    my $Email = $Test->{Email};
+
+    $Email =~ s{\[TNR\]}{[Ticket#$TestTicket{TicketNumber}]};
+
+    my @Return;
+    {
+        my $PostMasterObject = Kernel::System::PostMaster->new(
+            Email => \$Email,
+        );
+
+        @Return = $PostMasterObject->Run();
+    }
+    $Self->Is(
+        $Return[0] || 0,
+        $Test->{Return},
+        "$Name - NewTicket/FollowUp",
+    );
+    $Self->True(
+        $Return[1] || 0,
+        "$Name - TicketID",
+    );
+
+    # new/clear ticket object
+    $Kernel::OM->ObjectsDiscard( Objects => ['Kernel::System::Ticket'] );
+    my $TicketObject = $Kernel::OM->Get('Kernel::System::Ticket');
+
+    my %Ticket = $TicketObject->TicketGet(
+        TicketID      => $Return[1],
+        DynamicFields => 1,
+    );
+
+    for my $Key ( sort keys %{ $Test->{Check} } ) {
+        $Self->Is(
+            $Ticket{$Key},
+            $Test->{Check}->{$Key},
+            "Run('$Test->{Name}') - $Key",
+        );
+    }
+
+    $TicketNumbers{$Index} = $Ticket{TicketNumber};
+    $TicketIDs{ $Return[1] }++;
+
+    $Index++;
+}
+
+# new/clear ticket object
+$Kernel::OM->ObjectsDiscard( Objects => ['Kernel::System::Ticket'] );
+my $TicketObject = $Kernel::OM->Get('Kernel::System::Ticket');
+
+# delete ticket
+my $Delete = $TicketObject->TicketDelete(
+    TicketID => $TicketID,
+    UserID   => 1,
+);
+
+$Self->True(
+    $Delete || 0,
+    "#Filter TicketDelete()",
+);
+
+# cleanup is done by RestoreDatabase
+
+1;


### PR DESCRIPTION
where … is {Owner|OwnerID|Responsible|ResponsibleID}

For new tickets those headers are already supported, but not for followups.