### PR TITLE
[ Rel-5_0 Bug 12628 ] - Sorting of columns in Dashboard-Ticket-Widgets is toggling with every refresh of the widget

### DIFF
--- a/Kernel/Output/HTML/Templates/Standard/AgentDashboardTicketGeneric.tt
+++ b/Kernel/Output/HTML/Templates/Standard/AgentDashboardTicketGeneric.tt
@@ -575,15 +575,17 @@ if (Core.Config.Get('RefreshSeconds_[% Data.NameHTML | html %]')) {
 
         // get active filter
         var Filter      = $('#Dashboard' + Core.App.EscapeSelector('[% Data.Name | html %]') + '-box').find('.Tab.Actions li.Selected a').attr('data-filter'),
-            $OrderByObj = $('#Dashboard' + Core.App.EscapeSelector('[% Data.Name | html %]') + '-box').find('th.SortDescendingLarge, th.SortAscendingLarge'),
+
+            // last() is added for the case when ordered column is Priority because there are two columns - one with flags and one normal
+            $OrderByObj = $('#Dashboard' + Core.App.EscapeSelector('[% Data.Name | html %]') + '-box').find('th.SortDescendingLarge, th.SortAscendingLarge').last(),
             SortBy      = $OrderByObj.attr('data-column') || '',
             OrderBy     = '';
 
         if ($OrderByObj && $OrderByObj.hasClass('SortDescendingLarge')) {
-            OrderBy = 'Up';
+            OrderBy = 'Down';
         }
         else if ($OrderByObj && $OrderByObj.hasClass('SortAscendingLarge')) {
-            OrderBy = 'Down';
+            OrderBy = 'Up';
         }
 
         $('#Dashboard' + Core.App.EscapeSelector('[% Data.Name | html %]') + '-box').addClass('Loading');


### PR DESCRIPTION
https://bugs.otrs.org/show_bug.cgi?id=12628

Hi @dvuckovic 

This is our proposal for fixing reported issue. In Refresh block in AgentDashboardTicketGeneric.tt function Core.AJAX.ContentUpdate must get opposing values for described behavior.

Function 'last()' is added for the case when table is sorted by Priority because there are two columns with priority - first is default with flags and second is normal column - and second (or last) column is needed for AJAX update.

If you have any comment please let me know.

Regards,
Milan