### PR TITLE
[ Rel-5_0 Bug 12596 ] - AgentTicketQueue articles are not sorted.

### DIFF
--- a/Kernel/Output/HTML/TicketOverview/Preview.pm
+++ b/Kernel/Output/HTML/TicketOverview/Preview.pm
@@ -1012,25 +1012,17 @@ sub _Show {
 
         # otherwise display the last article in the list as expanded (default)
         else {
-            # find latest not seen article
+
             my $ArticleSelected;
             my $IgnoreSystemSender = $ConfigObject->Get('Ticket::NewArticleIgnoreSystemSender');
 
             ARTICLE:
             for my $ArticleItem (@ArticleBody) {
 
-                my %ArticleFlags = $TicketObject->ArticleFlagGet(
-                    ArticleID => $ArticleItem->{ArticleID},
-                    UserID    => $Self->{UserID},
-                );
-
                 # ignore system sender type
                 next ARTICLE
                     if $IgnoreSystemSender
                     && $ArticleItem->{SenderType} eq 'system';
-
-                # ignore already seen articles
-                next ARTICLE if $ArticleFlags{Seen};
 
                 $ArticleItem->{Class} = 'Active';
                 $ArticleSelected = 1;
@@ -1039,19 +1031,7 @@ sub _Show {
 
             # set selected article
             if ( !$ArticleSelected ) {
-
-                # set last customer article as selected article
-                ARTICLETMP:
-                for my $ArticleTmp (@ArticleBody) {
-                    if ( $ArticleTmp->{SenderType} eq 'customer' ) {
-                        $ArticleTmp->{Class} = 'Active';
-                        $ArticleSelected = 1;
-                        last ARTICLETMP;
-                    }
-                }
-                if ( !$ArticleSelected ) {
-                    $ArticleBody[0]->{Class} = 'Active';
-                }
+                $ArticleBody[0]->{Class} = 'Active';
             }
         }
 

--- a/scripts/test/Selenium/Output/Ticket/OverviewPreview.t
+++ b/scripts/test/Selenium/Output/Ticket/OverviewPreview.t
@@ -60,8 +60,10 @@ $Selenium->RunTest(
             UserLogin => $TestUserLogin,
         );
 
+        my $RandomID = $Helper->GetRandomID();
+
         # create test queue
-        my $QueueName = 'Queue' . $Helper->GetRandomID();
+        my $QueueName = 'Queue' . $RandomID;
         my $QueueID   = $Kernel::OM->Get('Kernel::System::Queue')->QueueAdd(
             Name            => $QueueName,
             ValidID         => 1,
@@ -81,7 +83,7 @@ $Selenium->RunTest(
 
         # create auto response
         my $AutoResponseID = $AutoResponseObject->AutoResponseAdd(
-            Name        => 'TestOTRSAutoResponse',
+            Name        => 'AutoResponse' . $RandomID,
             ValidID     => 1,
             Subject     => 'Some Subject..',
             Response    => 'Auto Response Test....',
@@ -188,27 +190,6 @@ $Selenium->RunTest(
                     "Second article created for ticket# $Index",
                 );
             }
-
-            if ( $Index > 0 ) {
-
-                # mark articles seen
-                my @ArticleIDs = $TicketObject->ArticleIndex(
-                    TicketID => $TicketIDs[$Index],
-                );
-
-                for my $ArticleID (@ArticleIDs) {
-                    my $SeenSuccess = $TicketObject->ArticleFlagSet(
-                        ArticleID => $ArticleID,
-                        Key       => 'Seen',
-                        Value     => 1,
-                        UserID    => $TestUserID,
-                    );
-                    $Self->True(
-                        $SeenSuccess,
-                        "Article $ArticleID marked as seen",
-                    );
-                }
-            }
         }
 
         # go to queue ticket overview
@@ -283,7 +264,7 @@ $Selenium->RunTest(
         );
         $Self->Is(
             $SelectedArticle2,
-            0,
+            1,
             "Selected article for Second ticket is OK.",
         );
 
@@ -292,7 +273,7 @@ $Selenium->RunTest(
         );
         $Self->Is(
             $SelectedArticle3,
-            0,
+            2,
             "Selected article for Third ticket is OK.",
         );
 
@@ -341,7 +322,7 @@ $Selenium->RunTest(
         );
         $Self->Is(
             $SelectedArticle3,
-            0,
+            2,
             "Selected article for Third ticket is OK(Ticket::NewArticleIgnoreSystemSender enabled).",
         );
 


### PR DESCRIPTION
https://bugs.otrs.org/show_bug.cgi?id=12596

Hello @mgruner and @dvuckovic ,

Hereby is partially reverted fix from bug [#11073](https://bugs.otrs.org/show_bug.cgi?id=11073). Removed check if articles are seen by agent and later to flag last customer article. This is no longer needed IMO since 1st available (newest) article will be expanded now if 'Ticket::NewArticleIgnoreSystemSender' SysConfig is activated. Selenium test is updated accordingly to reflect these changes.

Please let me know if you have any issues or questions regarding this PR.

Regards,
Sanjin