### PR TITLE
[ Rel-5_0 ] - Improved Selenium test stability for AgentCustomerHistory

### DIFF
--- a/scripts/test/Selenium/Agent/AgentCustomerHistory.t
+++ b/scripts/test/Selenium/Agent/AgentCustomerHistory.t
@@ -146,20 +146,24 @@ $Selenium->RunTest(
         for my $Test (@Tests) {
             $Selenium->VerifiedGet("${ScriptAlias}index.pl?Action=$Test->{Screen}");
 
-            # Choose customer user and wait until customer history table appears.
-            $Selenium->find_element( "#" . $Test->{FieldID}, 'css' )->clear();
-            $Selenium->find_element( "#" . $Test->{FieldID}, 'css' )->send_keys($CustomerUserLogin);
-            $Selenium->WaitFor(
-                JavaScript => 'return typeof($) === "function" && $("li.ui-menu-item:visible").length'
-            );
-            $Selenium->find_element("//li[contains(text(), '$TestUser')]")->VerifiedClick();
+            if ( $Test->{FieldID} ne 'CustomerAutoComplete' ) {
+
+                # Choose customer user and wait until customer history table appears.
+                $Selenium->find_element( "#" . $Test->{FieldID}, 'css' )->clear();
+                $Selenium->find_element( "#" . $Test->{FieldID}, 'css' )->send_keys($CustomerUserLogin);
+                $Selenium->WaitFor(
+                    JavaScript => 'return typeof($) === "function" && $("li.ui-menu-item:visible").length'
+                );
+                $Selenium->find_element("//li[contains(text(), '$TestUser')]")->click();
+            }
+
             $Selenium->WaitFor(
                 JavaScript =>
-                    'return typeof($) === "function" && $("a[href*=\'View=Preview;Subaction=CustomerTickets;\']").length'
+                    'return typeof($) === "function" && $("a[name=OverviewControl][href*=\'View=Preview\']:visible").length'
             );
 
             # Go to 'Large' view because all of events could be checked there.
-            $Selenium->find_element("//a[contains(\@href, \'View=Preview;Subaction=CustomerTickets;')]")->click();
+            $Selenium->find_element("//a[\@name='OverviewControl'][contains(\@href, \'View=Preview')]")->click();
             $Selenium->WaitFor( JavaScript => 'return typeof($) === "function" && $("#TicketOverviewLarge").length' );
 
             # wait for JS event to load


### PR DESCRIPTION
Hi @dvuckovic 

AgentCustomerHistory Selenium test is modified. Part of code for user selection is omitted in the last iteration (AgentTicketCustomer screen) because it has been already selected.

This should be implemented on the Master branch too.
If you have any comment please let me know.

Regards,
Milan