### PR TITLE
[ Rel_5-0_bug_9279 ] - Fixed replacing of article body when attachment name is 'file-1.html'

### DIFF
--- a/Kernel/System/Ticket/Article.pm
+++ b/Kernel/System/Ticket/Article.pm
@@ -3174,6 +3174,7 @@ sub ArticleAttachmentIndex {
                 &&
                 $File{Filename} eq 'file-1'
                 && $File{ContentType} =~ /text\/plain/i
+                && $File{Disposition} eq 'inline'
                 )
             {
                 $AttachmentIDPlain = $AttachmentID;
@@ -3187,6 +3188,7 @@ sub ArticleAttachmentIndex {
                 &&
                 ( $File{Filename} =~ /^file-[12]$/ || $File{Filename} eq 'file-1.html' )
                 && $File{ContentType} =~ /text\/html/i
+                && $File{Disposition} eq 'inline'
                 )
             {
                 $AttachmentIDHTML = $AttachmentID;

--- a/scripts/test/Selenium/Agent/AgentTicketAttachment.t
+++ b/scripts/test/Selenium/Agent/AgentTicketAttachment.t
@@ -15,71 +15,17 @@ my $Selenium = $Kernel::OM->Get('Kernel::System::UnitTest::Selenium');
 
 $Selenium->RunTest(
     sub {
-        # get helper object
-        my $Helper = $Kernel::OM->Get('Kernel::System::UnitTest::Helper');
+
+        # get needed objects
+        my $TicketObject = $Kernel::OM->Get('Kernel::System::Ticket');
+        my $ConfigObject = $Kernel::OM->Get('Kernel::Config');
+        my $Helper       = $Kernel::OM->Get('Kernel::System::UnitTest::Helper');
 
         # set download type to inline
         $Helper->ConfigSettingChange(
             Valid => 1,
             Key   => 'AttachmentDownloadType',
             Value => 'inline'
-        );
-
-        # get ticket object
-        my $TicketObject = $Kernel::OM->Get('Kernel::System::Ticket');
-
-        # create test ticket
-        my $TicketID = $TicketObject->TicketCreate(
-            Title        => 'Selenium Ticket',
-            Queue        => 'Raw',                    # or QueueID => 123,
-            Lock         => 'unlock',
-            Priority     => '3 normal',               # or PriorityID => 2,
-            State        => 'new',                    # or StateID => 5,
-            CustomerID   => '123465',
-            CustomerUser => 'customer@example.com',
-            OwnerID      => 1,
-            UserID       => 1,
-        );
-        $Self->True(
-            $TicketID,
-            "TicketCreate - ID $TicketID",
-        );
-
-        # get config object
-        my $ConfigObject = $Kernel::OM->Get('Kernel::Config');
-
-        # create article for test ticket with attachment
-        my $AttachmentName = "StdAttachment-Test1.txt";
-        my $Location       = $ConfigObject->Get('Home')
-            . "/scripts/test/sample/StdAttachment/$AttachmentName";
-        my $ContentRef = $Kernel::OM->Get('Kernel::System::Main')->FileRead(
-            Location => $Location,
-            Mode     => 'binmode',
-        );
-        my $Content = ${$ContentRef};
-
-        my $ArticleID = $TicketObject->ArticleCreate(
-            TicketID       => $TicketID,
-            ArticleType    => 'note-internal',
-            SenderType     => 'agent',
-            Subject        => 'Selenium subject test',
-            Body           => 'Selenium body test',
-            ContentType    => 'text/plain; charset=ISO-8859-15',
-            HistoryType    => 'OwnerUpdate',
-            HistoryComment => 'Some free text!',
-            UserID         => 1,
-            Attachment     => [
-                {
-                    Content     => $Content,
-                    ContentType => 'text/plain; charset=ISO-8859-15',
-                    Filename    => $AttachmentName,
-                },
-            ],
-            NoAgentNotify => 1,
-        );
-        $Self->True(
-            $ArticleID,
-            "ArticleCreate - ID $ArticleID",
         );
 
         # create test user and login
@@ -96,39 +42,104 @@ $Selenium->RunTest(
         # get script alias
         my $ScriptAlias = $ConfigObject->Get('ScriptAlias');
 
-        # navigate to AgentTicketZoom screen of created test ticket
-        $Selenium->VerifiedGet("${ScriptAlias}index.pl?Action=AgentTicketZoom;TicketID=$TicketID");
-
-        # check if attachment exists
-        $Self->True(
-            $Selenium->find_element("//*[text()=\"$AttachmentName\"]"),
-            "$AttachmentName is found on page",
-        );
-
-        # check ticket attachment
-        $Selenium->get(
-            "${ScriptAlias}index.pl?Action=AgentTicketAttachment;ArticleID=$ArticleID;FileID=1",
+        my @TestAttachments = (
             {
-                NoVerify => 1,
+                Name            => 'StdAttachment-Test1.txt',
+                ExpectedContent => 'Some German Text with Umlaut: ÄÖÜß',
+            },
+            {
+                Name            => 'file-1.html',
+                ExpectedContent => 'This is file-1.html content.',
             }
         );
 
-        # check if attachment is genuine
-        my $ExpectedAttachmentContent = "Some German Text with Umlaut: ÄÖÜß";
-        $Self->True(
-            index( $Selenium->get_page_source(), $ExpectedAttachmentContent ) > -1,
-            "$AttachmentName opened successfully",
-        );
+        for my $TestAttachment (@TestAttachments) {
 
-        # delete created test ticket
-        my $Success = $TicketObject->TicketDelete(
-            TicketID => $TicketID,
-            UserID   => 1,
-        );
-        $Self->True(
-            $Success,
-            "Ticket with ticket ID $TicketID is deleted"
-        );
+            # create test ticket
+            my $TicketID = $TicketObject->TicketCreate(
+                Title        => 'Selenium Ticket',
+                Queue        => 'Raw',
+                Lock         => 'unlock',
+                Priority     => '3 normal',
+                State        => 'new',
+                CustomerID   => '123465',
+                CustomerUser => 'customer@example.com',
+                OwnerID      => 1,
+                UserID       => 1,
+            );
+            $Self->True(
+                $TicketID,
+                "TicketCreate - ID $TicketID",
+            );
+
+            # create article for test ticket with attachment
+            my $Location = $ConfigObject->Get('Home')
+                . "/scripts/test/sample/StdAttachment/$TestAttachment->{Name}";
+            my $ContentRef = $Kernel::OM->Get('Kernel::System::Main')->FileRead(
+                Location => $Location,
+                Mode     => 'binmode',
+            );
+            my $Content = ${$ContentRef};
+
+            my $ArticleID = $TicketObject->ArticleCreate(
+                TicketID       => $TicketID,
+                ArticleType    => 'note-internal',
+                SenderType     => 'agent',
+                Subject        => 'Selenium subject test',
+                Body           => 'Selenium body test',
+                ContentType    => 'text/plain; charset=ISO-8859-15',
+                HistoryType    => 'OwnerUpdate',
+                HistoryComment => 'Some free text!',
+                UserID         => 1,
+                Attachment     => [
+                    {
+                        Content     => $Content,
+                        ContentType => 'text/plain; charset=ISO-8859-15',
+                        Filename    => $TestAttachment->{Name},
+                    },
+                ],
+                NoAgentNotify => 1,
+            );
+            $Self->True(
+                $ArticleID,
+                "ArticleCreate - ID $ArticleID",
+            );
+
+            # navigate to AgentTicketZoom screen of created test ticket
+            $Selenium->VerifiedGet("${ScriptAlias}index.pl?Action=AgentTicketZoom;TicketID=$TicketID");
+
+            # check if attachment exists
+            $Self->True(
+                $Selenium->execute_script(
+                    "return \$('.ArticleMailHeader a[href*=\"Action=AgentTicketAttachment;ArticleID=$ArticleID\"]:contains($TestAttachment->{Name})').length;"
+                ),
+                "'$TestAttachment->{Name}' is found on page",
+            );
+
+            # check ticket attachment
+            $Selenium->get(
+                "${ScriptAlias}index.pl?Action=AgentTicketAttachment;ArticleID=$ArticleID;FileID=1",
+                {
+                    NoVerify => 1,
+                }
+            );
+
+            # check if attachment is genuine
+            $Self->True(
+                index( $Selenium->get_page_source(), $TestAttachment->{ExpectedContent} ) > -1,
+                "'$TestAttachment->{Name}' opened successfully",
+            );
+
+            # delete created test ticket
+            my $Success = $TicketObject->TicketDelete(
+                TicketID => $TicketID,
+                UserID   => 1,
+            );
+            $Self->True(
+                $Success,
+                "Ticket with ticket ID $TicketID is deleted"
+            );
+        }
 
         # make sure the cache is correct
         for my $Cache (qw( Ticket CustomerUser )) {

--- a/scripts/test/sample/StdAttachment/file-1.html
+++ b/scripts/test/sample/StdAttachment/file-1.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>file-1</title>
+</head>
+<body>
+	<p>This is file-1.html content.</p>
+</body>
+</html>


### PR DESCRIPTION
https://bugs.otrs.org/show_bug.cgi?id=9729

Hi @dvuckovic 

There is a proposal for fixing bug on above link. IF conditions are modified in Article PM module.
Case for 'file-1.html' as ticket attachment is added in AgentTicketAttachment Selenium test.

If you have any comment please let me know.

Regards,
Milan