### PR TITLE
[ Master ] - Improved Selenium test stability for News and ProductNotify

### DIFF
--- a/scripts/test/Selenium/Output/Dashboard/News.t
+++ b/scripts/test/Selenium/Output/Dashboard/News.t
@@ -12,30 +12,30 @@ use utf8;
 
 use vars (qw($Self));
 
-# get selenium object
 my $Selenium = $Kernel::OM->Get('Kernel::System::UnitTest::Selenium');
 
 $Selenium->RunTest(
     sub {
 
-        # get helper object
-        my $Helper = $Kernel::OM->Get('Kernel::System::UnitTest::Helper');
+        # Get needed objects.
+        my $Helper       = $Kernel::OM->Get('Kernel::System::UnitTest::Helper');
+        my $ConfigObject = $Kernel::OM->Get('Kernel::Config');
 
-        # disable all dashboard plugins
-        my $Config = $Kernel::OM->Get('Kernel::Config')->Get('DashboardBackend');
+        # Disable all dashboard plugins.
+        my $Config = $ConfigObject->Get('DashboardBackend');
         $Helper->ConfigSettingChange(
             Valid => 0,
             Key   => 'DashboardBackend',
             Value => $Config,
         );
 
-        # get dashboard News plugin default sysconfig
+        # Get dashboard News plugin default sysconfig.
         my %NewsConfig = $Kernel::OM->Get('Kernel::System::SysConfig')->ConfigItemGet(
             Name    => 'DashboardBackend###0405-News',
             Default => 1,
         );
 
-        # set dashboard News plugin to valid
+        # Set dashboard News plugin to valid.
         %NewsConfig = map { $_->{Key} => $_->{Content} }
             grep { defined $_->{Key} } @{ $NewsConfig{Setting}->[1]->{Hash}->[1]->{Item} };
 
@@ -45,7 +45,61 @@ $Selenium->RunTest(
             Value => \%NewsConfig,
         );
 
-        # create test user and login
+        my @NewsData;
+        for ( 0 .. 1 ) {
+            my $Number = $Helper->GetRandomNumber();
+            push @NewsData, {
+                Title => "UT Breaking News - $Number",
+                Link  => "https://www.otrs.com/$Number",
+            };
+        }
+
+        # Override Request() from WebUserAgent to always return some test data without making any
+        #   actual web service calls. This should prevent instability in case cloud services are
+        #   unavailable at the exact moment of this test run.
+        # File that overrides the method will be deleted at the end of the test by Helper method
+        #   ConfigSettingCleanup() because of similarity with temporary configuration file names:
+        #   ZZZZUnitTest*.
+        my $PackageName = 'ZZZZUnitTestNews' . $Helper->GetRandomNumber();
+        my $Content     = <<"EOS";
+package Kernel::System::WebUserAgent;
+
+use strict;
+use warnings;
+
+use Kernel::System::WebUserAgent;
+
+{
+    no warnings 'redefine';
+
+    sub Request {
+
+        my \$JSONString = '{"Results":{"PublicFeeds":[{"Success":"1","Operation":"NewsFeed","Data":{"News":[{"Title":"$NewsData[0]->{Title}","Link":"$NewsData[0]->{Link}","Time":"2017-01-25T15:05:59+00:00"},{"Title":"$NewsData[1]->{Title}","Link":"$NewsData[1]->{Link}","Time":"2017-01-25T15:05:59+00:00"}]}}]},"ErrorMessage":"","Success":1}';
+
+        return (
+            'Content' => \\\$JSONString,
+            'Status' => '200 OK'
+        );
+    }
+}
+
+1;
+EOS
+        my $Home     = $ConfigObject->Get('Home');
+        my $FileName = "$Home/Kernel/Config/Files/$PackageName.pm";
+        $Kernel::OM->Get('Kernel::System::Main')->FileWrite(
+            Location => $FileName,
+            Mode     => 'utf8',
+            Content  => \$Content,
+        ) || die "Could not write $FileName";
+
+        # Make sure cache is correct.
+        $Kernel::OM->Get('Kernel::System::Cache')->Delete(
+            Type => 'Dashboard',
+            Key  => 'RSSNewsFeed-en',
+        );
+
+        # Create test user and login.
         my $TestUserLogin = $Helper->TestUserCreate(
             Groups => [ 'admin', 'users' ],
         ) || die "Did not get test user";
@@ -56,21 +110,24 @@ $Selenium->RunTest(
             Password => $TestUserLogin,
         );
 
-        # get script alias
-        my $ScriptAlias = $Kernel::OM->Get('Kernel::Config')->Get('ScriptAlias');
+        # Get script alias.
+        my $ScriptAlias = $ConfigObject->Get('ScriptAlias');
 
-        # navigate dashboard screen and wait until page has loaded
+        # Navigate to dashboard screen.
         $Selenium->VerifiedGet("${ScriptAlias}index.pl?Action=AgentDashboard");
 
-        # test if News plugin shows correct link
-        my $NewsLink = "https://www.otrs.com/";
-        $Self->True(
-            $Selenium->execute_script(
-                "return \$('#Dashboard0405-News').find(\"a.AsBlock[href*='$NewsLink']\").length;"
-                ) > 0,
-            "News dashboard plugin link ($NewsLink) - found",
-        );
+        # Check if News plugin has items with correct titles and links.
+        for my $Item (@NewsData) {
+            $Self->True(
+                $Selenium->execute_script(
+                    "return \$('#Dashboard0405-News tbody a[href=\"$Item->{Link}\"]:contains(\"$Item->{Title}\")').length;"
+                ),
+                "News dashboard plugin with title '$Item->{Title}' and link '$Item->{Link}' - found",
+            );
+        }
     }
 );
+
+# Cleanup will be done by ConfigSettingCleanup.
 
 1;

--- a/scripts/test/Selenium/Output/Dashboard/ProductNotify.t
+++ b/scripts/test/Selenium/Output/Dashboard/ProductNotify.t
@@ -18,16 +18,25 @@ my $Selenium = $Kernel::OM->Get('Kernel::System::UnitTest::Selenium');
 $Selenium->RunTest(
     sub {
 
-        # get helper object
-        my $Helper = $Kernel::OM->Get('Kernel::System::UnitTest::Helper');
+        # Get needed objects.
+        my $Helper       = $Kernel::OM->Get('Kernel::System::UnitTest::Helper');
+        my $ConfigObject = $Kernel::OM->Get('Kernel::Config');
 
-        # get dashboard ProductNotify plugin default sysconfig
+        # Disable all dashboard plugins.
+        my $Config = $ConfigObject->Get('DashboardBackend');
+        $Helper->ConfigSettingChange(
+            Valid => 0,
+            Key   => 'DashboardBackend',
+            Value => $Config,
+        );
+
+        # Get dashboard ProductNotify plugin default sysconfig.
         my %ProductNotifyConfig = $Kernel::OM->Get('Kernel::System::SysConfig')->ConfigItemGet(
             Name    => 'DashboardBackend###0000-ProductNotify',
             Default => 1,
         );
 
-        # set dashboard ProductNotify plugin to valid
+        # Set dashboard ProductNotify plugin to valid.
         %ProductNotifyConfig = map { $_->{Key} => $_->{Content} }
             grep { defined $_->{Key} } @{ $ProductNotifyConfig{Setting}->[1]->{Hash}->[1]->{Item} };
 
@@ -37,64 +46,98 @@ $Selenium->RunTest(
             Value => \%ProductNotifyConfig,
         );
 
-        # get main object
-        my $MainObject = $Kernel::OM->Get('Kernel::System::Main');
+        # Get current properties and set next version.
+        my $Product                = $ConfigObject->Get('Product');
+        my $Version                = $ConfigObject->Get('Version');
+        my @Parts                  = split /\./, $Version;
+        my $NextVersionFirstNumber = $Parts[0] + 1;
 
-        # get content of RELEASE
-        my $Home = $Kernel::OM->Get('Kernel::Config')->Get('Home');
-        my $Content = $MainObject->FileRead( Location => "$Home/RELEASE" );
+        my @ProductFeeds;
+        for ( 0 .. 1 ) {
+            my $Number = $Helper->GetRandomNumber();
+            push @ProductFeeds, {
+                Version => "$NextVersionFirstNumber.0.$Number",
+                Link    => "https://www.otrs.com/release-notes-$Number",
+            };
+        }
 
-        my $OriginalContent = ${$Content};
+        # Override Request() from WebUserAgent to always return some test data without making any
+        #   actual web service calls. This should prevent instability in case cloud services are
+        #   unavailable at the exact moment of this test run.
+        # File that overrides the method will be deleted at the end of the test by Helper method
+        #   ConfigSettingCleanup() because of similarity with temporary configuration file names:
+        #   ZZZZUnitTest*.
+        my $PackageName = 'ZZZZUnitTestProductNotify' . $Helper->GetRandomNumber();
+        my $Content     = <<"EOS";
+package Kernel::System::WebUserAgent;
 
-        # Fake an OTRS 4.0.0 release so that we always have update news available.
-        my $TestContent = <<EOF;
-PRODUCT = OTRS
-VERSION = 4.0.0
-EOF
+use strict;
+use warnings;
 
-        eval {
-            # update RELEASE with test version
-            $MainObject->FileWrite(
-                Location => "$Home/RELEASE",
-                Content  => \$TestContent,
-            );
+use Kernel::System::WebUserAgent;
 
-            # create test user and login
-            my $TestUserLogin = $Helper->TestUserCreate(
-                Groups => [ 'admin', 'users' ],
-            ) || die "Did not get test user";
+{
+    no warnings 'redefine';
 
-            $Selenium->Login(
-                Type     => 'Agent',
-                User     => $TestUserLogin,
-                Password => $TestUserLogin,
-            );
+    sub Request {
 
-            # wait until page has loaded, if necessary
-            $Selenium->WaitFor(
-                JavaScript =>
-                    'return typeof($) === "function" && $(".WidgetSimple").length;'
-            );
+        my \$JSONString = '{"Results":{"PublicFeeds":[{"Success":"1","Operation":"ProductFeed","Data":{"CacheTTL":"4320","Release":[{"Name":"OTRS","Severity":"Patch","Version":"$ProductFeeds[0]->{Version}","Link":"$ProductFeeds[0]->{Link}"},{"Name":"OTRS","Severity":"Patch","Version":"$ProductFeeds[1]->{Version}","Link":"$ProductFeeds[1]->{Link}"}]}}]},"ErrorMessage":"","Success":1}';
 
-            # test if ProductNotify plugin shows correct link
-            my $ProductNotifyLink = "https://www.otrs.com/release-notes-otrs-help-desk";
-            $Self->True(
-                index( $Selenium->get_page_source(), $ProductNotifyLink ) > -1,
-                "ProductNotify dashboard plugin link - found",
-            );
-        };
+        return (
+            'Content' => \\\$JSONString,
+            'Status' => '200 OK'
+        );
+    }
+}
 
-        my $EvalError = $@;
+1;
+EOS
+        my $Home     = $ConfigObject->Get('Home');
+        my $FileName = "$Home/Kernel/Config/Files/$PackageName.pm";
 
-        # restore default RELEASE version
-        $MainObject->FileWrite(
-            Location => "$Home/RELEASE",
-            Content  => \$OriginalContent,
+        $Kernel::OM->Get('Kernel::System::Main')->FileWrite(
+            Location => $FileName,
+            Mode     => 'utf8',
+            Content  => \$Content,
+        ) || die "Could not write $FileName";
+
+        # Make sure cache is correct.
+        $Kernel::OM->Get('Kernel::System::Cache')->Delete(
+            Type => 'DashboardProductNotify',
+            Key  => "CloudService::PublicFeeds::Operation::ProductFeed::Language::"
+                . $Kernel::OM->Get('Kernel::Output::HTML::Layout')->{UserLanguage}
+                . "::Product::${Product}::Version::$Version",
         );
 
-        die $EvalError if $EvalError;
+        # Create test user and login.
+        my $TestUserLogin = $Helper->TestUserCreate(
+            Groups => [ 'admin', 'users' ],
+        ) || die "Did not get test user";
 
+        $Selenium->Login(
+            Type     => 'Agent',
+            User     => $TestUserLogin,
+            Password => $TestUserLogin,
+        );
+
+        # Get script alias.
+        my $ScriptAlias = $ConfigObject->Get('ScriptAlias');
+
+        # Navigate to dashboard screen.
+        $Selenium->VerifiedGet("${ScriptAlias}index.pl?Action=AgentDashboard");
+
+        # Check if ProductNotify plugin has items with correct text and links.
+        for my $Item (@ProductFeeds) {
+            $Self->True(
+                $Selenium->execute_script(
+                    "return \$('#Dashboard0000-ProductNotify tbody tr:contains(\"$Item->{Version}\") a[href=\"$Item->{Link}\"]').length;"
+                ),
+                "ProductNotify dashboard plugin which text contains '$Item->{Version}' and link '$Item->{Link}' - found",
+            );
+        }
     }
 );
+
+# Cleanup will be done by ConfigSettingCleanup.
 
 1;


### PR DESCRIPTION
Hi @dvuckovic 

There are News and ProductNotify Selenium tests modified for increased stability.
In both tests Request function is overridden to prevent any cloud service instability.

If you have any comment please let me know.

Regards,
Milan