### PR TITLE
[ Master Bug 8822 ] - PasswordMinSize returns %s instead of minimum size in the AgentPrefrence

### DIFF
--- a/Kernel/Output/HTML/Preferences/Password.pm
+++ b/Kernel/Output/HTML/Preferences/Password.pm
@@ -144,9 +144,6 @@ sub Run {
     my $AuthObject = $Kernel::OM->Get( 'Kernel::System::' . $AuthModule );
     return 1 if !$AuthObject;
 
-    # get layout object
-    my $LayoutObject = $Kernel::OM->Get('Kernel::Output::HTML::Layout');
-
     # validate current password
     if (
         !$AuthObject->Auth(
@@ -185,7 +182,7 @@ sub Run {
 
     # check min size of password
     if ( $Config->{PasswordMinSize} && length $Pw < $Config->{PasswordMinSize} ) {
-        $Self->{Error} = Translatable(
+        $Self->{Error} = $Kernel::OM->Get('Kernel::Output::HTML::Layout')->{LanguageObject}->Translate(
             'Can\'t update password, it must be at least %s characters long!',
             $Config->{PasswordMinSize}
         );


### PR DESCRIPTION
https://bugs.otrs.org/show_bug.cgi?id=8657

Hello @dvuckovic ,

Hereby is fix for reported bug. There was just an issue with calling Translatable() function for string with placeholder. Adding LayoutObject->Translate() solved issue.

Regards,
Sanjin