### PR TITLE
[Master - Bug 12650] - SendCustomerNotification does not respect newly assigned mail address

### DIFF
--- a/Kernel/System/Ticket/Event/NotificationEvent.pm
+++ b/Kernel/System/Ticket/Event/NotificationEvent.pm
@@ -14,6 +14,7 @@ use warnings;
 use List::Util qw(first);
 
 use Kernel::System::VariableCheck qw(:all);
+use Email::Valid;
 
 our @ObjectDependencies = (
     'Kernel::Config',
@@ -769,8 +770,15 @@ sub _RecipientsGet {
 
                     );
 
-                    # join Recipient data with CustomerUser data
-                    %Recipient = ( %Recipient, %CustomerUser );
+                    # check if customer user is email address, in case it is not stored in system
+                    if ( !IsHashRefWithData( \%CustomerUser ) && Email::Valid->address( $Article{CustomerUserID} ) ) {
+                        $Recipient{UserEmail} = $Article{CustomerUserID};
+                    }
+                    else {
+
+                        # join Recipient data with CustomerUser data
+                        %Recipient = ( %Recipient, %CustomerUser );
+                    }
 
                     # get user language
                     if ( $CustomerUser{UserLanguage} ) {


### PR DESCRIPTION
https://bugs.otrs.org/show_bug.cgi?id=12650

Hi  @carlosgarciac,

This is our proposal to fix this bug. I addressed you for this bug because you are expert for ticket notification. I spoke with @dvuckovic about this issue  to be honest, we are not sure if fix, which we have provided in this PR, is the best possible solution but I think it could help you.

We assign you for this bug because, as you know, there is very strange logic how Recipient is set for send notification, actually there are many cases (in one case it is Article{From}, another one is Article{To}, CustomerUser{Email} and so on ... ). This one which is reported in the bug is new one. With our fix maybe we cover and solve this new case , but who knows how side effect could be happened. So please take a look this.

Regards
Zoran 