### PR TITLE
Display accounted time units in the Customer web frontend

### DIFF
--- a/Kernel/Config/Files/Ticket.xml
+++ b/Kernel/Config/Files/Ticket.xml
@@ -8309,6 +8309,17 @@
             </Hash>
         </Setting>
     </ConfigItem>
+    <ConfigItem Name="Ticket::Frontend::CustomerTicketZoom###ZoomTimeDisplay" Required="1" Valid="1">
+        <Description Translatable="1">Displays the accounted time for an article in the ticket zoom view.</Description>
+        <Group>Ticket</Group>
+        <SubGroup>Frontend::Customer::Ticket::ViewZoom</SubGroup>
+        <Setting>
+            <Option SelectedID="0">
+                <Item Key="0" Translatable="1">No</Item>
+                <Item Key="1" Translatable="1">Yes</Item>
+            </Option>
+        </Setting>
+    </ConfigItem>
     <ConfigItem Name="Ticket::CustomerTicketSearch::SearchLimit" Required="1" Valid="1">
         <Description Translatable="1">Maximum number of tickets to be displayed in the result of a search in the customer interface.</Description>
         <Group>Ticket</Group>

--- a/Kernel/Modules/CustomerTicketZoom.pm
+++ b/Kernel/Modules/CustomerTicketZoom.pm
@@ -1556,7 +1556,7 @@ sub _Mask {
                 Data => {
                     ArticleTimeUnits => $TicketObject->ArticleAccountedTimeGet(
                         ArticleID => $Article{ArticleID},
-                    );
+                    ),
                 },
             );
         }

--- a/Kernel/Modules/CustomerTicketZoom.pm
+++ b/Kernel/Modules/CustomerTicketZoom.pm
@@ -1020,6 +1020,14 @@ sub _Mask {
 
     my $Config = $ConfigObject->Get("Ticket::Frontend::$Self->{Action}");
 
+    # ticket accounted time
+    if ( $Config->{ZoomTimeDisplay} ) {
+        $LayoutObject->Block(
+            Name => 'TicketTimeUnits',
+            Data => \%Param,
+        );
+    }
+
     # ticket priority flag
     if ( $Config->{AttributesView}->{Priority} ) {
         $LayoutObject->Block(
@@ -1537,6 +1545,18 @@ sub _Mask {
                     Realname             => $Article{ $Key . 'Realname' },
                     ArticleID            => $Article{ArticleID},
                     $HiddenType . Hidden => 'Hidden',
+                },
+            );
+        }
+
+        # ticket accounted time
+        if ( $Config->{ZoomTimeDisplay} ) {
+            $LayoutObject->Block(
+                Name => 'ArticleTimeUnits',
+                Data => {
+                    ArticleTimeUnits => $TicketObject->ArticleAccountedTimeGet(
+                        ArticleID => $Article{ArticleID},
+                    );
                 },
             );
         }

--- a/Kernel/Output/HTML/Templates/Standard/CustomerTicketZoom.tt
+++ b/Kernel/Output/HTML/Templates/Standard/CustomerTicketZoom.tt
@@ -93,6 +93,12 @@
                                 <div class="Label">[% Translate("Subject") | html %]:</div> <span title="[% Data.Subject | html %]">[% Data.Subject | html %]</span>
                                 <div class="Clear"></div>
                             </div>
+[% RenderBlockStart("ArticleTimeUnits") %]
+                            <div>
+                                <div class="Label">[% Translate("Accounted time") | html %]:</div> <span title="[% Data.ArticleTimeUnits | html %]">[% Data.ArticleTimeUnits | html %]</span>
+                                <div class="Clear"></div>
+                            </div>
+[% RenderBlockEnd("ArticleTimeUnits") %]
 
 # show article dynamic fields
 [% RenderBlockStart("ArticleDynamicField") %]
@@ -195,6 +201,10 @@
                     </li>
                     <li><span class="Key">[% Data.Hook | html %]:</span> <span>[% Data.TicketNumber | html %]</span></li>
 
+[% RenderBlockStart("TicketTimeUnits") %]
+                    <li><span class="Key">[% Translate("Accounted time") | html %]:</span>
+                    <span title="[% Data.TicketTimeUnits | html %]">[% Data.TicketTimeUnits %]</span></li>
+[% RenderBlockEnd("TicketTimeUnits") %]
 [% RenderBlockStart("Type") %]
                     <li><span class="Key">[% Translate("Type") | html %]:</span> <span title="[% Data.Type | html %]">[% Data.Type | html %]</span></li>
 [% RenderBlockEnd("Type") %]


### PR DESCRIPTION
Show accounted time per ticket and per article in the Customer web frontend. In order to do so, set new variable Ticket::Frontend::CustomerTicketZoom###ZoomTimeDisplay to 'yes'