### PR TITLE
[ Rel-5_0 Bug 12657 ] - Fixed case sensitive searching for text type of dynamic field values

### DIFF
--- a/Kernel/System/DynamicField/Driver/BaseText.pm
+++ b/Kernel/System/DynamicField/Driver/BaseText.pm
@@ -122,8 +122,17 @@ sub SearchSQLGet {
     my $DBObject = $Kernel::OM->Get('Kernel::System::DB');
 
     if ( $Operators{ $Param{Operator} } ) {
-        my $SQL = " $Param{TableAlias}.value_text $Operators{$Param{Operator}} '";
-        $SQL .= $DBObject->Quote( $Param{SearchTerm} ) . "' ";
+
+        my $SQL;
+        if ( !$DBObject->GetDatabaseFunction('CaseSensitive') ) {
+            $SQL = " $Param{TableAlias}.value_text $Operators{$Param{Operator}} '";
+            $SQL .= $DBObject->Quote( $Param{SearchTerm} ) . "' ";
+        }
+        else {
+            $SQL = " LOWER($Param{TableAlias}.value_text) $Operators{$Param{Operator}} ";
+            $SQL .= "LOWER('" . $DBObject->Quote( $Param{SearchTerm} ) . "') ";
+        }
+
         return $SQL;
     }
 

--- a/scripts/test/DynamicField/SearchSQLGet.t
+++ b/scripts/test/DynamicField/SearchSQLGet.t
@@ -154,6 +154,16 @@ my %DynamicFieldConfigs = (
     },
 );
 
+# Set expected results depends on DB case sensitive property (bug#12657).
+my $TableAlias = 'dfv';
+my $SearchTerm = 'Foo';
+my $ValueText  = 'value_text';
+
+if ( $DBObject->{Backend}->{'DB::CaseSensitive'} == 1 ) {
+    $ValueText  = "LOWER($TableAlias.$ValueText)";
+    $SearchTerm = "LOWER('$SearchTerm')";
+}
+
 # define tests
 my @Tests = (
     {
@@ -218,14 +228,14 @@ my @Tests = (
             },
         },
         ExpectedResult => {
-            Equals            => " dfv.value_text = 'Foo' ",
-            GreaterThan       => " dfv.value_text > 'Foo' ",
-            GreaterThanEquals => " dfv.value_text >= 'Foo' ",
+            Equals            => " $ValueText = $SearchTerm ",
+            GreaterThan       => " $ValueText > $SearchTerm ",
+            GreaterThanEquals => " $ValueText >= $SearchTerm ",
             Like              => {
                 ColumnKey => 'dfv.value_text',
             },
-            SmallerThan       => " dfv.value_text < 'Foo' ",
-            SmallerThanEquals => " dfv.value_text <= 'Foo' ",
+            SmallerThan       => " $ValueText < $SearchTerm ",
+            SmallerThanEquals => " $ValueText <= $SearchTerm ",
         },
     },
     {
@@ -243,14 +253,14 @@ my @Tests = (
             },
         },
         ExpectedResult => {
-            Equals            => " dfv.value_text = 'Foo' ",
-            GreaterThan       => " dfv.value_text > 'Foo' ",
-            GreaterThanEquals => " dfv.value_text >= 'Foo' ",
+            Equals            => " $ValueText = $SearchTerm ",
+            GreaterThan       => " $ValueText > $SearchTerm ",
+            GreaterThanEquals => " $ValueText >= $SearchTerm ",
             Like              => {
                 ColumnKey => 'dfv.value_text',
             },
-            SmallerThan       => " dfv.value_text < 'Foo' ",
-            SmallerThanEquals => " dfv.value_text <= 'Foo' ",
+            SmallerThan       => " $ValueText < $SearchTerm ",
+            SmallerThanEquals => " $ValueText <= $SearchTerm ",
         },
     },
     {


### PR DESCRIPTION
https://bugs.otrs.org/show_bug.cgi?id=12657

Hi @dvuckovic 

There is a proposal for fix a bug on above link.

Check for case sensitive database is added due to SQL requests are not the same. SearchSQLGet Unit test is modified accordingly.

Need for operators is for discussion. Without them everything could be sent to QueryCondition function like in next IF check for 'Like' operator ($Param{Operator} eq 'Like').

If you have any comment please let me know.

Regards,
Milan