### PR TITLE
[Master - Bug 12661] - In overview views wrong dates are displayed in the Created column

### DIFF
--- a/Kernel/Output/HTML/TicketOverview/Small.pm
+++ b/Kernel/Output/HTML/TicketOverview/Small.pm
@@ -434,20 +434,17 @@ sub Run {
 
             # Fallback for tickets without articles: get at least basic ticket data
             if ( !%Article ) {
-                %Article = $TicketObject->TicketGet(
-                    TicketID      => $TicketID,
-                    DynamicFields => 0,
-                );
+                %Article = %Ticket;
                 if ( !$Article{Title} ) {
                     $Article{Title} = $LayoutObject->{LanguageObject}->Translate(
                         'This ticket has no title or subject'
                     );
                 }
                 $Article{Subject} = $Article{Title};
-
-                # show ticket create time in small view
-                $Article{Created} = $Ticket{Created};
             }
+
+            # show ticket create time in small view
+            $Article{Created} = $Ticket{Created};
 
             # prepare a "long" version of the subject to show in the title attribute. We don't take
             # the whole string (which could be VERY long) to avoid polluting the DOM and having too


### PR DESCRIPTION
https://bugs.otrs.org/show_bug.cgi?id=12661

Hi @dvuckovic,

  Hereby is fixed the issue in small overview screens. There was a problem with wrong data for Created column. There is used logic as well as  in Medium.pm. So the code is tidied a little bit; TicketGet is called outside statement, and it not need to call it again. 

Regards
Zoran
S7design