### PR TITLE
[ Master Bug 12657 ] - Fixed case sensitive searching for text type dynamic field values

### DIFF
--- a/Kernel/System/DynamicField/Driver/BaseText.pm
+++ b/Kernel/System/DynamicField/Driver/BaseText.pm
@@ -149,19 +149,13 @@ sub SearchSQLGet {
     }
 
     my $DBObject = $Kernel::OM->Get('Kernel::System::DB');
-    my $SQL;
-    if (
-        $Kernel::OM->Get('Kernel::Config')->{CustomerUser}->{Params}->{SearchCaseSensitive} &&
-        $DBObject->GetDatabaseFunction('CaseSensitive')
-        )
-    {
-        $SQL = " $Param{TableAlias}.value_text $Operators{$Param{Operator}} '";
-        $SQL .= $DBObject->Quote( $Param{SearchTerm} ) . "' ";
+    my $Lower    = '';
+    if ( !$DBObject->GetDatabaseFunction('CaseSensitive') ) {
+        $Lower = 'LOWER';
     }
-    else {
-        $SQL = " LOWER($Param{TableAlias}.value_text) $Operators{$Param{Operator}} ";
-        $SQL .= "LOWER('" . $DBObject->Quote( $Param{SearchTerm} ) . "') ";
-    }
+
+    my $SQL = " $Lower($Param{TableAlias}.value_text) $Operators{$Param{Operator}} ";
+    $SQL .= "$Lower('" . $DBObject->Quote( $Param{SearchTerm} ) . "') ";
 
     return $SQL;
 }

--- a/scripts/test/DynamicField/SearchSQLGet.t
+++ b/scripts/test/DynamicField/SearchSQLGet.t
@@ -157,17 +157,13 @@ my %DynamicFieldConfigs = (
     },
 );
 
-# Set expected results depends on SearchCaseSensitive and DB case sensitive properties (bug#12657).
-my $SearchTerm = "\'Foo\'";
-my $ValueText  = 'dfv.value_text';
+# Set expected results depends on database case sensitivity (bug#12657).
+my $SearchTerm = "(\'Foo\')";
+my $ValueText  = '(dfv.value_text)';
 
-if (
-    !$DBObject->GetDatabaseFunction('CaseSensitive') ||
-    !$Kernel::OM->Get('Kernel::Config')->{CustomerUser}->{Params}->{SearchCaseSensitive}
-    )
-{
-    $ValueText  = "LOWER($ValueText)";
-    $SearchTerm = "LOWER($SearchTerm)";
+if ( !$DBObject->GetDatabaseFunction('CaseSensitive') ) {
+    $ValueText  = 'LOWER' . $ValueText;
+    $SearchTerm = 'LOWER' . $SearchTerm;
 }
 
 # define tests

--- a/scripts/test/DynamicField/SearchSQLGet.t
+++ b/scripts/test/DynamicField/SearchSQLGet.t
@@ -157,6 +157,19 @@ my %DynamicFieldConfigs = (
     },
 );
 
+# Set expected results depends on SearchCaseSensitive and DB case sensitive properties (bug#12657).
+my $SearchTerm = "\'Foo\'";
+my $ValueText  = 'dfv.value_text';
+
+if (
+    !$DBObject->GetDatabaseFunction('CaseSensitive') ||
+    !$Kernel::OM->Get('Kernel::Config')->{CustomerUser}->{Params}->{SearchCaseSensitive}
+    )
+{
+    $ValueText  = "LOWER($ValueText)";
+    $SearchTerm = "LOWER($SearchTerm)";
+}
+
 # define tests
 my @Tests = (
     {
@@ -223,14 +236,14 @@ my @Tests = (
         },
         ExpectedResult => {
             Empty             => " dfv.value_text IS NULL ",
-            Equals            => " dfv.value_text = 'Foo' ",
-            GreaterThan       => " dfv.value_text > 'Foo' ",
-            GreaterThanEquals => " dfv.value_text >= 'Foo' ",
+            Equals            => " $ValueText = $SearchTerm ",
+            GreaterThan       => " $ValueText > $SearchTerm ",
+            GreaterThanEquals => " $ValueText >= $SearchTerm ",
             Like              => {
                 ColumnKey => 'dfv.value_text',
             },
-            SmallerThan       => " dfv.value_text < 'Foo' ",
-            SmallerThanEquals => " dfv.value_text <= 'Foo' ",
+            SmallerThan       => " $ValueText < $SearchTerm ",
+            SmallerThanEquals => " $ValueText <= $SearchTerm ",
         },
     },
     {
@@ -250,14 +263,14 @@ my @Tests = (
         },
         ExpectedResult => {
             Empty             => " dfv.value_text IS NULL ",
-            Equals            => " dfv.value_text = 'Foo' ",
-            GreaterThan       => " dfv.value_text > 'Foo' ",
-            GreaterThanEquals => " dfv.value_text >= 'Foo' ",
+            Equals            => " $ValueText = $SearchTerm ",
+            GreaterThan       => " $ValueText > $SearchTerm ",
+            GreaterThanEquals => " $ValueText >= $SearchTerm ",
             Like              => {
                 ColumnKey => 'dfv.value_text',
             },
-            SmallerThan       => " dfv.value_text < 'Foo' ",
-            SmallerThanEquals => " dfv.value_text <= 'Foo' ",
+            SmallerThan       => " $ValueText < $SearchTerm ",
+            SmallerThanEquals => " $ValueText <= $SearchTerm ",
         },
     },
     {


### PR DESCRIPTION
https://bugs.otrs.org/show_bug.cgi?id=12657

Hi @dvuckovic

There is a proposal for fix a bug on above link.

Check for SearchCaseSensitive param and database case sensitive property are added due to SQL requests are not the same. SearchSQLGet Unit test is modified accordingly.

Need for operators is for discussion. Is text value could have just 'Like', 'Equals' and 'Empty' operators?

If you have any comment please let me know.

Regards,
Milan