### PR TITLE
[ Master Bug 12663 ] - Fixed jumping to the first unread article in AgentTicketZoom

### DIFF
--- a/Kernel/Modules/AgentTicketZoom.pm
+++ b/Kernel/Modules/AgentTicketZoom.pm
@@ -769,6 +769,22 @@ sub MaskAgentZoom {
     # get article page
     my $ArticlePage = $ParamObject->GetParam( Param => 'ArticlePage' );
 
+    # get all articles
+    my @ArticleContentArgsAll = (
+        TicketID                   => $Self->{TicketID},
+        StripPlainBodyAsAttachment => $Self->{StripPlainBodyAsAttachment},
+        UserID                     => $Self->{UserID},
+        Order                      => $Order,
+        DynamicFields => 0,    # fetch later only for the article(s) to display
+    );
+    my @ArticleBoxAll = $TicketObject->ArticleContentIndex(@ArticleContentArgsAll);
+
+    my %ArticleFlags = $TicketObject->ArticleFlagsOfTicketGet(
+        TicketID => $Ticket{TicketID},
+        UserID   => $Self->{UserID},
+    );
+    my $ArticleID;
+
     if ( $Self->{ArticleID} ) {
         $Page = $TicketObject->ArticlePage(
             TicketID    => $Self->{TicketID},
@@ -782,7 +798,32 @@ sub MaskAgentZoom {
         $Page = $ArticlePage;
     }
     else {
-        $Page = 1;
+
+        # find latest not seen article
+        ARTICLE:
+        for my $Article (@ArticleBoxAll) {
+
+            # ignore system sender type
+            next ARTICLE
+                if $ConfigObject->Get('Ticket::NewArticleIgnoreSystemSender')
+                && $Article->{SenderType} eq 'system';
+
+            next ARTICLE if $ArticleFlags{ $Article->{ArticleID} }->{Seen};
+            $ArticleID = $Article->{ArticleID};
+
+            $Page = $TicketObject->ArticlePage(
+                TicketID    => $Self->{TicketID},
+                ArticleID   => $ArticleID,
+                RowsPerPage => $Limit,
+                Order       => $Order,
+                %{ $Self->{ArticleFilter} // {} },
+            );
+            last ARTICLE;
+        }
+
+        if ( !$ArticleID ) {
+            $Page = 1;
+        }
     }
 
     # We need to find out whether pagination is actually necessary.
@@ -864,16 +905,6 @@ sub MaskAgentZoom {
         $Count = 0;
     }
 
-    # get all articles
-    my @ArticleContentArgsAll = (
-        TicketID                   => $Self->{TicketID},
-        StripPlainBodyAsAttachment => $Self->{StripPlainBodyAsAttachment},
-        UserID                     => $Self->{UserID},
-        Order                      => $Order,
-        DynamicFields => 0,    # fetch later only for the article(s) to display
-    );
-    my @ArticleBoxAll = $TicketObject->ArticleContentIndex(@ArticleContentArgsAll);
-
     if ( scalar @ArticleBox != scalar @ArticleBoxAll ) {
 
         if ( $ConfigObject->Get('Ticket::Frontend::ZoomExpandSort') eq 'reverse' ) {
@@ -916,46 +947,24 @@ sub MaskAgentZoom {
         $ArticleIDFound = 1;
     }
 
-    my %ArticleFlags = $TicketObject->ArticleFlagsOfTicketGet(
-        TicketID => $Ticket{TicketID},
-        UserID   => $Self->{UserID},
-    );
-
     # get selected or last customer article
-    my $ArticleID;
     if ($ArticleIDFound) {
         $ArticleID = $Self->{ArticleID};
     }
     else {
-
-        # find latest not seen article
-        ARTICLE:
-        for my $Article (@ArticleBox) {
-
-            # ignore system sender type
-            next ARTICLE
-                if $ConfigObject->Get('Ticket::NewArticleIgnoreSystemSender')
-                && $Article->{SenderType} eq 'system';
-
-            next ARTICLE if $ArticleFlags{ $Article->{ArticleID} }->{Seen};
-            $ArticleID = $Article->{ArticleID};
-            last ARTICLE;
-        }
-
-        # set selected article
         if ( !$ArticleID ) {
             if (@ArticleBox) {
 
                 # set first listed article as fallback
                 $ArticleID = $ArticleBox[0]->{ArticleID};
-            }
 
-            # set last customer article as selected article replacing last set
-            ARTICLETMP:
-            for my $ArticleTmp (@ArticleBox) {
-                if ( $ArticleTmp->{SenderType} eq 'customer' ) {
-                    $ArticleID = $ArticleTmp->{ArticleID};
-                    last ARTICLETMP if $Self->{ZoomExpandSort} eq 'reverse';
+                # set last customer article as selected article replacing last set
+                ARTICLETMP:
+                for my $ArticleTmp (@ArticleBox) {
+                    if ( $ArticleTmp->{SenderType} eq 'customer' ) {
+                        $ArticleID = $ArticleTmp->{ArticleID};
+                        last ARTICLETMP if $Self->{ZoomExpandSort} eq 'reverse';
+                    }
                 }
             }
         }

--- a/scripts/test/Selenium/Agent/AgentTicketZoomActiveArticle.t
+++ b/scripts/test/Selenium/Agent/AgentTicketZoomActiveArticle.t
@@ -1,0 +1,162 @@
+# --
+# Copyright (C) 2001-2017 OTRS AG, http://otrs.com/
+# --
+# This software comes with ABSOLUTELY NO WARRANTY. For details, see
+# the enclosed file COPYING for license information (AGPL). If you
+# did not receive this file, see http://www.gnu.org/licenses/agpl.txt.
+# --
+
+use strict;
+use warnings;
+use utf8;
+
+use vars (qw($Self));
+
+# Get selenium object.
+my $Selenium = $Kernel::OM->Get('Kernel::System::UnitTest::Selenium');
+
+$Selenium->RunTest(
+    sub {
+
+        # Get needed objects.
+        my $Helper       = $Kernel::OM->Get('Kernel::System::UnitTest::Helper');
+        my $TicketObject = $Kernel::OM->Get('Kernel::System::Ticket');
+
+        # Set zoom sort to reverse.
+        $Helper->ConfigSettingChange(
+            Valid => 1,
+            Key   => 'Ticket::Frontend::ZoomExpandSort',
+            Value => 'reverse',
+        );
+
+        # Set maximum number of articles per page.
+        $Helper->ConfigSettingChange(
+            Valid => 1,
+            Key   => 'Ticket::Frontend::MaxArticlesPerPage',
+            Value => 10,
+        );
+
+        # Create test customer.
+        my $TestCustomerUser = $Helper->TestCustomerUserCreate(
+        ) || die "Did not get test customer user";
+
+        # Get test customer user ID.
+        my %TestCustomerUserData = $Kernel::OM->Get('Kernel::System::CustomerUser')->CustomerUserDataGet(
+            User => $TestCustomerUser,
+        );
+
+        # Create test user.
+        my $TestUserLogin = $Helper->TestUserCreate(
+            Groups => [ 'admin', 'users' ],
+        ) || die "Did not get test user";
+
+        # Get test user ID.
+        my $TestUserID = $Kernel::OM->Get('Kernel::System::User')->UserLookup(
+            UserLogin => $TestUserLogin,
+        );
+
+        # Create test ticket.
+        my $TicketID = $TicketObject->TicketCreate(
+            TN         => $TicketObject->TicketCreateNumber(),
+            Title      => 'TestTicketTitle',
+            Queue      => 'Raw',
+            Lock       => 'unlock',
+            Priority   => '3 normal',
+            State      => 'open',
+            CustomerID => $TestCustomerUserData{UserCustomerID},
+            OwnerID    => 1,
+            UserID     => 1,
+        );
+        $Self->True(
+            $TicketID,
+            "TicketID $TicketID is created",
+        );
+
+        # Create ticket articles.
+        my @ArticleIDs;
+        for my $Count ( 1 .. 15 ) {
+            my $ArticleID = $TicketObject->ArticleCreate(
+                TicketID       => $TicketID,
+                ArticleType    => 'email-external',
+                SenderType     => 'customer',
+                Subject        => 'Selenium subject test',
+                Body           => "Article $Count",
+                ContentType    => 'text/plain; charset=ISO-8859-15',
+                HistoryType    => 'OwnerUpdate',
+                HistoryComment => 'Some free text!',
+                UserID         => 1,
+                NoAgentNotify  => 1,
+            );
+            $Self->True(
+                $ArticleID,
+                "ArticleID $ArticleID is created",
+            );
+            push @ArticleIDs, $ArticleID;
+
+            # Set first page articles to 'seen'.
+            if ( $Count > 5 ) {
+                my $Set = $TicketObject->ArticleFlagSet(
+                    ArticleID => $ArticleID,
+                    Key       => 'Seen',
+                    Value     => 1,
+                    UserID    => $TestUserID,
+                );
+                $Self->True(
+                    $Set,
+                    "ArticleID $ArticleID is set to 'Seen'",
+                );
+            }
+        }
+
+        # Login as test user.
+        $Selenium->Login(
+            Type     => 'Agent',
+            User     => $TestUserLogin,
+            Password => $TestUserLogin,
+        );
+
+        # Get script alias.
+        my $ScriptAlias = $Kernel::OM->Get('Kernel::Config')->Get('ScriptAlias');
+
+        # Navigate to AgentTicketZoom for test created ticket.
+        $Selenium->VerifiedGet("${ScriptAlias}index.pl?Action=AgentTicketZoom;TicketID=$TicketID");
+
+        # Check if selected article is in the first row on page 2 - it is the last not seen article (see bug#12663).
+        # Check if there are exactly two pages.
+        $Self->Is(
+            $Selenium->execute_script("return \$('.ArticlePages a[title*=Page]').length;"),
+            2,
+            "There are 2 article pages",
+        );
+
+        # Check if page 2 is active.
+        $Self->Is(
+            $Selenium->execute_script("return \$('.ArticlePages a.Active').text();"),
+            2,
+            "Active article page is page 2",
+        );
+
+        # Check if active article is in the first row (Article 5).
+        $Self->Is(
+            $Selenium->execute_script("return \$('#ArticleTable tbody tr:eq(0).Active').attr('id');"),
+            'Row5',
+            "Active article is in the first table row - Row5",
+        );
+
+        # Cleanup.
+        my $Success = $TicketObject->TicketDelete(
+            TicketID => $TicketID,
+            UserID   => 1,
+        );
+        $Self->True(
+            $Success,
+            "TicketID $TicketID is deleted"
+        );
+
+        # Make sure the cache is correct.
+        $Kernel::OM->Get('Kernel::System::Cache')->CleanUp( Type => 'Ticket' );
+
+    }
+);
+
+1;


### PR DESCRIPTION
https://bugs.otrs.org/show_bug.cgi?id=12663

Hi @dvuckovic 

There is a proposal for fix reported bug on above link.
Case with only TicketID parameter (without ArticlePage and ArticleID) is modified in AgentTicketZoom PM module. First, there is searching for the latest not seen article and based on this result, page is determined. If all of articles are seen, page jump to the latest created article.
Selenium test is added to check these changes.

If you have any comment please let me know.

Regards,
Milan