### PR TITLE
Fixed: ACL to restrict Status based on InputFields (TicketProperties) not working as expected

### DIFF
--- a/Kernel/Modules/AgentTicketActionCommon.pm
+++ b/Kernel/Modules/AgentTicketActionCommon.pm
@@ -1351,6 +1351,7 @@ sub Run {
 
         # create html strings for all dynamic fields
         my %DynamicFieldHTML;
+        my $DynamicFieldACL;
 
         # cycle trough the activated Dynamic Fields for this screen
         DYNAMICFIELD:
@@ -1407,6 +1408,9 @@ sub Run {
 
                 # get value stored on the database from Ticket
                 $Value = $Ticket{ 'DynamicField_' . $DynamicFieldConfig->{Name} };
+
+                # convert dynamic field value into a structure for ACLs
+                $DynamicFieldACL->{ 'DynamicField_' . $DynamicFieldConfig->{Name} } = $Value if $Value;
             }
 
             # get field html
@@ -1439,6 +1443,7 @@ sub Run {
             %GetParam,
             %Ticket,
             DynamicFieldHTML => \%DynamicFieldHTML,
+            DynamicFieldACL  => $DynamicFieldACL,
         );
         $Output .= $LayoutObject->Footer(
             Type => 'Small',
@@ -1798,9 +1803,10 @@ sub _Mask {
 
         my %State;
         my %StateList = $TicketObject->TicketStateList(
-            Action   => $Self->{Action},
-            TicketID => $Self->{TicketID},
-            UserID   => $Self->{UserID},
+            DynamicField => $Param{DynamicFieldACL},
+            Action       => $Self->{Action},
+            TicketID     => $Self->{TicketID},
+            UserID       => $Self->{UserID},
         );
         if ( !$Param{NewStateID} ) {
             if ( $Config->{StateDefault} ) {


### PR DESCRIPTION
https://bugs.otrs.org/show_bug.cgi?id=12671

Hi @carlosfrodriguez 

There is our proposal for fixing this issue. With the fix is solved only ACL for State as it is reported in the bug, but in my opinion we should check if there is needed some changes for  other fields (e.g. Owner, Priority ... )

I suppose ACL for Services was fixed with 
https://github.com/OTRS/otrs/commit/6522d6287c9a4cfa6beb72bf8000d61c8f06f284

Your expert knowledge with ACL will be welcomed.

Regards
Zoran