### PR TITLE
Fixed: Customer Menu can be clicked through in a certain instance.

### DIFF
--- a/var/httpd/htdocs/skins/Agent/default/css/Core.WidgetMenu.css
+++ b/var/httpd/htdocs/skins/Agent/default/css/Core.WidgetMenu.css
@@ -221,6 +221,7 @@ ul.ContextFunctions li:last-child:hover > a {
     line-height: 18px;
     font-size: 11px;
     display: inline-block;
+    z-index: 19;
 }
 
 .Actions li:after {


### PR DESCRIPTION
https://bugs.otrs.org/show_bug.cgi?id=12679

Hi @dvuckovic,

Herby is solved the issue in Safari. There is different behavior in Safari and  other browsers. Our proposal is to set z-index property for Action menu items. 

Regards
Zoran