### PR TITLE
[ Master - Bug 12681 ] - In agent ticket search, profile field is not modernize.

### DIFF
--- a/Kernel/Modules/AgentTicketSearch.pm
+++ b/Kernel/Modules/AgentTicketSearch.pm
@@ -1815,21 +1815,13 @@ sub Run {
             Base      => 'TicketSearch',
             UserLogin => $Self->{UserLogin},
         );
-        delete $Profiles{''};
-        delete $Profiles{'last-search'};
-        if ($EmptySearch) {
-            $Profiles{''} = '-';
-        }
-        else {
-            $Profiles{'last-search'} = '-';
-        }
         $Param{ProfilesStrg} = $LayoutObject->BuildSelection(
-            Data       => \%Profiles,
-            Name       => 'Profile',
-            ID         => 'SearchProfile',
-            SelectedID => $Profile,
-
-            # Do not modernize this field as this causes problems with the automatic focusing of the first element.
+            Data         => \%Profiles,
+            Name         => 'Profile',
+            ID           => 'SearchProfile',
+            SelectedID   => $Profile,
+            Class        => 'Modernize',
+            PossibleNone => 1,
         );
 
         $Param{StatesStrg} = $LayoutObject->BuildSelection(

--- a/Kernel/Output/HTML/Templates/Standard/AgentTicketSearch.tt
+++ b/Kernel/Output/HTML/Templates/Standard/AgentTicketSearch.tt
@@ -15,7 +15,7 @@
         <input type="hidden" name="ShownAttributes" value="" id="ShownAttributes">
         <fieldset class="TableLike">
             <legend><span>[% Translate("Templates") | html %]</span></legend>
-            <label>[% Translate("Search template") | html %]:</label>
+            <label for="SearchProfile" id="LabelSearchProfile">[% Translate("Search template") | html %]:</label>
             <div class="Field">
                 [% Data.ProfilesStrg %]
                 <div id="SearchProfileAddBlock">

--- a/var/httpd/htdocs/js/Core.UI.Dialog.js
+++ b/var/httpd/htdocs/js/Core.UI.Dialog.js
@@ -88,11 +88,14 @@ Core.UI.Dialog = (function (TargetNS) {
      *      Focuses the first element within the dialog.
      */
     function FocusFirstElement() {
-        var FirstElement = $('div.Dialog:visible .Content').find('a:visible, input:visible, textarea:visible, select:visible, button:visible').filter(':first');
+        var FirstElement = $('div.Dialog:visible .Content').find('a:visible, input:visible, textarea:visible, select:visible, button:visible').filter(':first'),
+            FocusField;
 
-        // Check if found first element is modernize input field, do not set focus on it.
+        // Check if found first element is modernize input field, prepend input field which is behind modernize field and set focus on it allowing navigation.
         if (FirstElement.closest('.Field').find('.Modernize').length) {
-            return;
+            FocusField = FirstElement.parent();
+            $('<input>').attr('class','FocusField').prependTo(FocusField);
+            FirstElement = $('div.Dialog:visible .Content').find('a:visible, input:visible, textarea:visible, select:visible, button:visible').filter(':first');
         }
 
         FirstElement.focus();

--- a/var/httpd/htdocs/js/Core.UI.Dialog.js
+++ b/var/httpd/htdocs/js/Core.UI.Dialog.js
@@ -88,10 +88,14 @@ Core.UI.Dialog = (function (TargetNS) {
      *      Focuses the first element within the dialog.
      */
     function FocusFirstElement() {
-        $('div.Dialog:visible .Content')
-            .find('a:visible, input:visible, textarea:visible, select:visible, button:visible')
-            .filter(':first')
-            .focus();
+        var FirstElement = $('div.Dialog:visible .Content').find('a:visible, input:visible, textarea:visible, select:visible, button:visible').filter(':first');
+
+        // Check if found first element is modernize input field, do not set focus on it.
+        if (FirstElement.closest('.Field').find('.Modernize').length) {
+            return;
+        }
+
+        FirstElement.focus();
     }
 
     /**

--- a/var/httpd/htdocs/skins/Agent/default/css/Core.Dialog.css
+++ b/var/httpd/htdocs/skins/Agent/default/css/Core.Dialog.css
@@ -157,6 +157,11 @@
     width: 98%;
 }
 
+.Dialog .Field .FocusField {
+    position: absolute;
+    z-index: -1;
+}
+
 .Dialog .Buttons {
     background: #ddd;
     border-top: 1px solid #ccc;


### PR DESCRIPTION
https://bugs.otrs.org/show_bug.cgi?id=12681

Hello @dvuckovic ,

Hereby is proposal for fixing reporters issue. Implemented 'Modernize' class for SearchProfile field. This was causing issues in past since Core.UI.Dialog.js is calling FocusFirstElement() function which is finding first field and placing focus on it. When that field is modernize, it auto-expand showing available selectable options. Included additional check to not place focus if found field is part of modernize field 'input'.

Additionally added 'id' and 'for' as parts of label for 'Search template'. This way focus is on field when label is clicked.

Please let me know if there are any issues or questions regarding this PR.

Regards,
Sanjin 