### PR TITLE
Modernized input fields, marked strings as translatable

### DIFF
--- a/Kernel/Modules/Installer.pm
+++ b/Kernel/Modules/Installer.pm
@@ -180,7 +180,7 @@ sub Run {
         $LayoutObject->Block(
             Name => 'License',
             Data => {
-                Item => 'License',
+                Item => Translatable('License'),
                 Step => $StepCounter,
             },
         );
@@ -224,6 +224,7 @@ sub Run {
         $Param{SelectDBType} = $LayoutObject->BuildSelection(
             Data       => \%Databases,
             Name       => 'DBType',
+            Class      => 'Modernize',
             Size       => scalar keys %Databases,
             SelectedID => 'mysql',
         );
@@ -236,7 +237,7 @@ sub Run {
         $LayoutObject->Block(
             Name => 'DatabaseStart',
             Data => {
-                Item         => 'Database Selection',
+                Item         => Translatable('Database Selection'),
                 Step         => $StepCounter,
                 SelectDBType => $Param{SelectDBType},
             },
@@ -317,7 +318,7 @@ sub Run {
             $LayoutObject->Block(
                 Name => 'DatabaseMySQL',
                 Data => {
-                    Item                => 'Configure MySQL',
+                    Item                => Translatable('Configure MySQL'),
                     Step                => $StepCounter,
                     InstallType         => $DBInstallType,
                     DefaultDBUser       => $DBInstallType eq 'CreateDB' ? 'root' : 'otrs',
@@ -341,7 +342,7 @@ sub Run {
             $Output .= $LayoutObject->Output(
                 TemplateFile => 'Installer',
                 Data         => {
-                    Item => 'Configure MySQL',
+                    Item => Translatable('Configure MySQL'),
                     Step => $StepCounter,
                 },
             );
@@ -360,7 +361,7 @@ sub Run {
             $LayoutObject->Block(
                 Name => 'DatabasePostgreSQL',
                 Data => {
-                    Item          => 'Database',
+                    Item          => Translatable('Database'),
                     Step          => $StepCounter,
                     InstallType   => $DBInstallType,
                     DefaultDBUser => $DBInstallType eq 'CreateDB' ? 'postgres' : 'otrs',
@@ -383,7 +384,7 @@ sub Run {
             $Output .= $LayoutObject->Output(
                 TemplateFile => 'Installer',
                 Data         => {
-                    Item => 'Configure PostgreSQL',
+                    Item => Translatable('Configure PostgreSQL'),
                     Step => $StepCounter,
                 },
             );
@@ -399,7 +400,7 @@ sub Run {
             $LayoutObject->Block(
                 Name => 'DatabaseOracle',
                 Data => {
-                    Item => 'Database',
+                    Item => Translatable('Database'),
                     Step => $StepCounter,
                 },
             );
@@ -407,7 +408,7 @@ sub Run {
             $Output .= $LayoutObject->Output(
                 TemplateFile => 'Installer',
                 Data         => {
-                    Item => 'Configure Oracle',
+                    Item => Translatable('Configure Oracle'),
                     Step => $StepCounter,
                 },
             );
@@ -460,7 +461,7 @@ sub Run {
         $LayoutObject->Block(
             Name => 'DatabaseResult',
             Data => {
-                Item => 'Create Database',
+                Item => Translatable('Create Database'),
                 Step => $StepCounter,
             },
         );
@@ -723,11 +724,13 @@ sub Run {
         $Param{SystemIDString} = $LayoutObject->BuildSelection(
             Data       => \@SystemIDs,
             Name       => 'SystemID',
+            Class      => 'Modernize',
             SelectedID => $SystemIDs[ int( rand(100) ) ],    # random system ID
         );
         $Param{LanguageString} = $LayoutObject->BuildSelection(
             Data       => $ConfigObject->Get('DefaultUsedLanguages'),
             Name       => 'DefaultLanguage',
+            Class      => 'Modernize',
             HTMLQuote  => 0,
             SelectedID => $LayoutObject->{UserLanguage},
         );
@@ -739,6 +742,7 @@ sub Run {
                 0 => Translatable('No'),
             },
             Name       => 'CheckMXRecord',
+            Class      => 'Modernize',
             SelectedID => '1',
         );
 
@@ -754,7 +758,7 @@ sub Run {
         $LayoutObject->Block(
             Name => 'System',
             Data => {
-                Item => 'System Settings',
+                Item => Translatable('System Settings'),
                 Step => $StepCounter,
                 %Param,
             },
@@ -763,10 +767,11 @@ sub Run {
         if ( !$Self->{Options}->{SkipLog} ) {
             $Param{LogModuleString} = $LayoutObject->BuildSelection(
                 Data => {
-                    'Kernel::System::Log::SysLog' => 'Syslog',
-                    'Kernel::System::Log::File'   => 'File',
+                    'Kernel::System::Log::SysLog' => Translatable('Syslog'),
+                    'Kernel::System::Log::File'   => Translatable('File'),
                 },
                 Name       => 'LogModule',
+                Class      => 'Modernize',
                 HTMLQuote  => 0,
                 SelectedID => $ConfigObject->Get('LogModule'),
             );
@@ -836,7 +841,8 @@ sub Run {
                 smtps    => 'SMTPS',
                 smtptls  => 'SMTPTLS',
             },
-            Name => 'OutboundMailType',
+            Name  => 'OutboundMailType',
+            Class => 'Modernize',
         );
         my $OutboundMailDefaultPorts = $LayoutObject->BuildSelection(
             Class => 'Hidden',
@@ -850,8 +856,9 @@ sub Run {
         );
 
         my $InboundMailTypeSelection = $LayoutObject->BuildSelection(
-            Data => \%MailBackends,
-            Name => 'InboundMailType',
+            Data  => \%MailBackends,
+            Name  => 'InboundMailType',
+            Class => 'Modernize',
         );
 
         my $Output =
@@ -979,7 +986,7 @@ sub Run {
         $LayoutObject->Block(
             Name => 'Finish',
             Data => {
-                Item       => 'Finished',
+                Item       => Translatable('Finished'),
                 Step       => $StepCounter,
                 Host       => $ENV{HTTP_HOST} || $ConfigObject->Get('FQDN'),
                 OTRSHandle => $OTRSHandle,


### PR DESCRIPTION
Hi @mgruner 
This PR turns the installer input fields into modern ones, and marks some strings as translatable. Both branch rel-5_0 and master are affected.