### PR TITLE
[ Master Bug 12611] - In Overview the 'Order by' and the 'Move' buttons are old style

### DIFF
--- a/Kernel/Output/HTML/TicketOverview/Preview.pm
+++ b/Kernel/Output/HTML/TicketOverview/Preview.pm
@@ -407,8 +407,9 @@ sub _Show {
     );
 
     $Param{StandardResponsesStrg} = $LayoutObject->BuildSelection(
-        Name => 'ResponseID',
-        Data => $StandardTemplates{Answer} || {},
+        Name  => 'ResponseID',
+        Class => 'Modernize',
+        Data  => $StandardTemplates{Answer} || {},
     );
 
     # customer info
@@ -1177,9 +1178,10 @@ sub _Show {
 
                     # build html string
                     my $StandardResponsesStrg = $LayoutObject->BuildSelection(
-                        Name => 'ResponseID',
-                        ID   => 'ResponseID' . $ArticleItem->{ArticleID},
-                        Data => \@StandardResponseArray,
+                        Name  => 'ResponseID',
+                        Class => 'Modernize',
+                        ID    => 'ResponseID' . $ArticleItem->{ArticleID},
+                        Data  => \@StandardResponseArray,
                     );
 
                     $LayoutObject->Block(

--- a/var/httpd/htdocs/js/Core.Agent.CustomerSearch.js
+++ b/var/httpd/htdocs/js/Core.Agent.CustomerSearch.js
@@ -133,8 +133,13 @@ Core.Agent.CustomerSearch = (function (TargetNS) {
                 return false;
             });
 
-            $('#CustomerTickets .MasterAction').on('click', function () {
+            $('#CustomerTickets .MasterAction').on('click', function (Event) {
                 var $MasterActionLink = $(this).find('a.MasterActionLink');
+
+                // Prevent MasterAction on Modernize input fields.
+                if ($(Event.target).hasClass('InputField_Search')) {
+                    return true;
+                }
 
                 // Event must be done in the parent window because AgentTicketCustomer is in popup.
                 if (Core.Config.Get('Action') === 'AgentTicketCustomer') {
@@ -177,6 +182,9 @@ Core.Agent.CustomerSearch = (function (TargetNS) {
                     });
                 }
             });
+
+            // Activate Modernize fields.
+            Core.UI.InputFields.Activate();
         }
 
         /**

--- a/var/httpd/htdocs/js/Core.Agent.Overview.js
+++ b/var/httpd/htdocs/js/Core.Agent.Overview.js
@@ -449,6 +449,11 @@ Core.Agent.Overview = (function (TargetNS) {
                 return true;
             }
 
+            // Prevent MasterAction on Modernize input fields.
+            if ($(Event.target).hasClass('InputField_Search')) {
+                return true;
+            }
+
             // only act if the link was not clicked directly
             if (Event.target !== $MasterActionLink.get(0)) {
                 if (Event.ctrlKey || Event.metaKey) {


### PR DESCRIPTION
https://bugs.otrs.org/show_bug.cgi?id=12611

Hello @dvuckovic ,

Reporters issues could not be resolved because of the current technical limitation. Nevertheless while investigating this issue, included modernize input field for 'Reply' in Overview screens and Customer history tables.

Please let me know if there are any questions regarding this PR.

Regards,
Sanjin