### PR TITLE
[ Rel-5_0 bug#12684] The format buttons are missing from the stacked area chart on the dashboard if the language is not English

### DIFF
--- a/Kernel/Output/HTML/Templates/Standard/AgentDashboardStats.tt
+++ b/Kernel/Output/HTML/Templates/Standard/AgentDashboardStats.tt
@@ -78,6 +78,7 @@ Core.Config.Set('Grouped', [% Translate("Grouped") | JSON %]);
 Core.Config.Set('Stacked', [% Translate("Stacked") | JSON %]);
 Core.Config.Set('Expanded', [% Translate("Expanded") | JSON %]);
 Core.Config.Set('Stream', [% Translate("Stream") | JSON %]);
+Core.Config.Set('NoDataAvailable', [% Translate("No Data Available.") | JSON %]);
 
 (function(){
     var Timeout = 500;

--- a/Kernel/Output/HTML/Templates/Standard/Statistics/PreviewWidget.tt
+++ b/Kernel/Output/HTML/Templates/Standard/Statistics/PreviewWidget.tt
@@ -132,7 +132,7 @@
         <div class="PreviewSettings">
             [% Translate('Preview format:') | html %]
             [% FOREACH Format IN PreviewFormats.sort %]
-            <button class="CallForAction SwitchPreviewFormat" data-format="[% Format %]"><span>[% FormatConfig.item(Format) %]</span></button>
+            <button class="CallForAction SwitchPreviewFormat" data-format="[% Format %]"><span>[% Translate(FormatConfig.item(Format)) | html %]</span></button>
             [% END %]
             <span class="Warning">
                 [% Translate('Please note that the preview uses random data and does not consider data filters.') | html %]
@@ -140,6 +140,14 @@
         </div>
         [% WRAPPER JSOnDocumentComplete %]
         <script type="text/javascript">
+
+        // add translations
+        Core.Config.Set('Grouped', [% Translate("Grouped") | JSON %]);
+        Core.Config.Set('Stacked', [% Translate("Stacked") | JSON %]);
+        Core.Config.Set('Expanded', [% Translate("Expanded") | JSON %]);
+        Core.Config.Set('Stream', [% Translate("Stream") | JSON %]);
+        Core.Config.Set('NoDataAvailable', [% Translate("No Data Available.") | JSON %]);
+
         $('.SwitchPreviewFormat').on('click', function() {
             var Format = $(this).data('format'),
                 FormatCleaned = Format.replace('::', '');

--- a/var/httpd/htdocs/js/thirdparty/nvd3-1.7.1/models/OTRSLineChart.js
+++ b/var/httpd/htdocs/js/thirdparty/nvd3-1.7.1/models/OTRSLineChart.js
@@ -36,7 +36,7 @@ nv.models.OTRSlineChart = function() {
         , y
         , state = nv.utils.state()
         , defaultState = null
-        , noData = 'No Data Available.'
+        , noData = Core.Config.Get('NoDataAvailable')
         , dispatch = d3.dispatch('tooltipShow', 'tooltipHide', 'stateChange', 'changeState', 'renderEnd')
         , duration = 250
         ;

--- a/var/httpd/htdocs/js/thirdparty/nvd3-1.7.1/models/OTRSMultiBarChart.js
+++ b/var/httpd/htdocs/js/thirdparty/nvd3-1.7.1/models/OTRSMultiBarChart.js
@@ -34,9 +34,14 @@ nv.models.OTRSmultiBarChart = function() {
         , y //can be accessed via chart.yScale()
         , state = nv.utils.state()
         , defaultState = null
-        , noData = "No Data Available."
+        , noData = Core.Config.Get('NoDataAvailable')
         , dispatch = d3.dispatch('tooltipShow', 'tooltipHide', 'stateChange', 'changeState', 'renderEnd')
-        , controlWidth = function() { return showControls ? 180 : 0 }
+// ---
+// OTRS
+// ---        
+        // , controlWidth = function() { return showControls ? 180 : 0 }
+        , controlWidth = function() { return showControls ? 220 : 0 }
+// ---        
         , duration = 250
         ;
 
@@ -211,8 +216,8 @@ nv.models.OTRSmultiBarChart = function() {
             // Controls
             if (showControls) {
                 var controlsData = [
-                    { key: controlLabels.grouped || 'Grouped', disabled: multibar.stacked() },
-                    { key: controlLabels.stacked || 'Stacked', disabled: !multibar.stacked() }
+                    { key: controlLabels.grouped || Core.Config.Get('Grouped') || 'Grouped', disabled: multibar.stacked() },
+                    { key: controlLabels.stacked || Core.Config.Get('Stacked') || 'Stacked', disabled: !multibar.stacked() }
                 ];
 
                 controls.width(controlWidth()).color(['#444', '#444', '#444']);
@@ -329,10 +334,10 @@ nv.models.OTRSmultiBarChart = function() {
                 d.disabled = false;
 
                 switch (d.key) {
-                    case 'Grouped':
+                    case Core.Config.Get('Grouped') || 'Grouped':
                         multibar.stacked(false);
                         break;
-                    case 'Stacked':
+                    case Core.Config.Get('Grouped') || 'Stacked':
                         multibar.stacked(true);
                         break;
                 }

--- a/var/httpd/htdocs/js/thirdparty/nvd3-1.7.1/models/OTRSStackedAreaChart.js
+++ b/var/httpd/htdocs/js/thirdparty/nvd3-1.7.1/models/OTRSStackedAreaChart.js
@@ -39,7 +39,7 @@ nv.models.OTRSstackedAreaChart = function() {
         , yAxisTickFormat = d3.format(',.2f')
         , state = nv.utils.state()
         , defaultState = null
-        , noData = 'No Data Available.'
+        , noData = Core.Config.Get('NoDataAvailable')
         , dispatch = d3.dispatch('tooltipShow', 'tooltipHide', 'stateChange', 'changeState','renderEnd')
         , controlWidth = 250
 // ---
@@ -197,20 +197,20 @@ nv.models.OTRSstackedAreaChart = function() {
             if (showControls) {
                 var controlsData = [
                     {
-                        key: controlLabels.stacked || 'Stacked',
-                        metaKey: 'Stacked',
+                        key: controlLabels.stacked || Core.Config.Get('Stacked') || 'Stacked',
+                        metaKey: Core.Config.Get('Stacked') || 'Stacked',
                         disabled: stacked.style() != 'stack',
                         style: 'stack'
                     },
                     {
-                        key: controlLabels.stream || 'Stream',
-                        metaKey: 'Stream',
+                        key: controlLabels.stream || Core.Config.Get('Stream') || 'Stream',
+                        metaKey: Core.Config.Get('Stream') || 'Stream',
                         disabled: stacked.style() != 'stream',
                         style: 'stream'
                     },
                     {
-                        key: controlLabels.expanded || 'Expanded',
-                        metaKey: 'Expanded',
+                        key: controlLabels.expanded || Core.Config.Get('Expanded') || 'Expanded',
+                        metaKey: Core.Config.Get('Expanded') || 'Expanded',
                         disabled: stacked.style() != 'expand',
                         style: 'expand'
                     },


### PR DESCRIPTION
Hi @dvuckovic,

Herby is solved translation of the controls labels in stats for OTRS5. There is also translate Format name in preview screen.

Regards
Zoran