### PR TITLE
[ Master - Bug 12188 ] - Dashboard stats do not refresh automatically.

### DIFF
--- a/Kernel/Output/HTML/Dashboard/Stats.pm
+++ b/Kernel/Output/HTML/Dashboard/Stats.pm
@@ -248,6 +248,19 @@ sub Run {
         },
     );
 
+    if ( $Self->{UserRefreshTime} ) {
+        my $Refresh = 60 * $Self->{UserRefreshTime};
+
+        $LayoutObject->AddJSData(
+            Key   => 'WidgetRefreshStat' . $StatID,
+            Value => {
+                Name        => $Self->{Name},
+                NameHTML    => $Self->{Name},
+                RefreshTime => $Refresh,
+            },
+        );
+    }
+
     my $Content = $LayoutObject->Output(
         TemplateFile => 'AgentDashboardStats',
         Data         => {

--- a/var/httpd/htdocs/js/Core.Agent.Dashboard.js
+++ b/var/httpd/htdocs/js/Core.Agent.Dashboard.js
@@ -691,7 +691,7 @@ Core.Agent.Dashboard = (function (TargetNS) {
                 // Subscribe to ContentUpdate event to initiate stats widget event on updated widget
                 Core.App.Subscribe('Event.AJAX.ContentUpdate.Callback', function($WidgetElement) {
                     StatsData = Core.Config.Get('StatsData' + Value);
-                    if (typeof $WidgetElement !== 'undefined' && $WidgetElement.search('GraphWidget' + StatsData.Name) !== parseInt('-1', 10)) {
+                    if (typeof StatsData !== 'undefined' && typeof $WidgetElement !== 'undefined' && $WidgetElement.search('GraphWidget' + StatsData.Name) !== parseInt('-1', 10)) {
                         StatsWidget(Value);
                     }
                 });
@@ -709,7 +709,8 @@ Core.Agent.Dashboard = (function (TargetNS) {
      *      Initializes each available stats dashboard widget functionality.
      */
     function StatsWidget (ID) {
-        var StatsData = Core.Config.Get('StatsData' + ID);
+        var StatsData = Core.Config.Get('StatsData' + ID),
+            WidgetRefreshStat = Core.Config.Get('WidgetRefreshStat' + ID);
 
         if (typeof StatsData === 'undefined') {
             return;
@@ -760,6 +761,22 @@ Core.Agent.Dashboard = (function (TargetNS) {
 
         Core.Config.Set('StatsMaxXaxisAttributes', parseInt(StatsData.MaxXaxisAttributes, 10));
         TargetNS.InitStatsConfiguration($('#StatsSettingsBox' + Core.App.EscapeSelector(StatsData.Name) + ''));
+
+        // Initiate dashboard stat refresh event.
+        Core.Config.Set('RefreshSeconds_' + WidgetRefreshStat.NameHTML, parseInt(WidgetRefreshStat.RefreshTime, 10) || 0);
+        if (Core.Config.Get('RefreshSeconds_' + WidgetRefreshStat.NameHTML)) {
+            Core.Config.Set('Timer_' + WidgetRefreshStat.NameHTML, window.setTimeout(
+                function() {
+                    $('#Dashboard' + Core.App.EscapeSelector(WidgetRefreshStat.Name) + '-box').addClass('Loading');
+                    Core.AJAX.ContentUpdate($('#Dashboard' + Core.App.EscapeSelector(WidgetRefreshStat.Name)), Core.Config.Get('Baselink') + 'Action=' + Core.Config.Get('Action') + ';Subaction=Element;Name=' + WidgetRefreshStat.Name, function () {
+                        $('#Dashboard' + Core.App.EscapeSelector(WidgetRefreshStat.Name) + '-box').removeClass('Loading');
+                    });
+
+                    clearTimeout(Core.Config.Get('Timer_' + WidgetRefreshStat.NameHTML));
+                },
+                Core.Config.Get('RefreshSeconds_' + WidgetRefreshStat.NameHTML) * 1000)
+            );
+        }
     }
 
     /**


### PR DESCRIPTION
https://bugs.otrs.org/show_bug.cgi?id=12188

Hello @dvuckovic ,

Hereby is proposal for fixing reporters issue. Implemented similar way to refresh dashboard stats widgets as it has been done for other dashboard widgets.

Please let me know if there are any questions regarding this PR.

Regards,
Sanjin