### PR TITLE
[Master Bug 12703 ] Fixed: dynamic list and dynamic matrix interpret agent/user Userfirsname

### DIFF
--- a/Kernel/System/Stats/Dynamic/TicketList.pm
+++ b/Kernel/System/Stats/Dynamic/TicketList.pm
@@ -1363,6 +1363,11 @@ sub GetStatTable {
                 );
                 $Ticket{$Attribute} .= " ($Param{TimeZone})";
             }
+
+            if( $Attribute =~ /Owner|Responsible/ ){
+                $Ticket{$Attribute} = $Kernel::OM->Get('Kernel::System::User')->UserName( User => $Ticket{$Attribute}, )
+            }
+
             push @ResultRow, $Ticket{$Attribute};
         }
         push @StatArray, \@ResultRow;
@@ -1603,7 +1608,7 @@ sub _TicketAttributes {
 
         #CreateTimeUnix => 'CreateTimeUnix',
         CustomerUserID => 'Customer User',
-        Lock           => 'lock',
+        Lock           => 'Lock',
 
         #LockID         => 'LockID',
         UnlockTimeout       => 'UnlockTimeout',

--- a/Kernel/System/User.pm
+++ b/Kernel/System/User.pm
@@ -991,7 +991,7 @@ sub UserLookup {
 get user name
 
     my $Name = $UserObject->UserName(
-        UserLogin => 'some-login',
+        User => 'some-login',
     );
 
     or


### PR DESCRIPTION
https://bugs.otrs.org/show_bug.cgi?id=12703
Hi @dvuckovic,

Hereby is fixed the bug. There is also fixed comment for function UserName, that is used in the fix. There was wrong param in example UserLogin insted User. In this function is called GetUserData which expect User or UserID.

Lock param in list of ticket attributes is also changed in upper case first latter. 

Regards
Zoran