### PR TITLE
[ Master - Bug 12716 ] - Activity dialog causes an Error in customer interface.

### DIFF
--- a/Kernel/Modules/CustomerTicketProcess.pm
+++ b/Kernel/Modules/CustomerTicketProcess.pm
@@ -3664,7 +3664,7 @@ sub _StoreActivityDialog {
         # Make sure the activity dialog to save is still the correct activity
         my $Activity = $Kernel::OM->Get('Kernel::System::ProcessManagement::Activity')->ActivityGet(
             ActivityEntityID => $ActivityEntityID,
-            Interface        => ['AgentInterface'],
+            Interface        => ['CustomerInterface'],
         );
         my %ActivityDialogs = reverse %{ $Activity->{ActivityDialog} // {} };
         if ( !$ActivityDialogs{$ActivityDialogEntityID} ) {


### PR DESCRIPTION
https://bugs.otrs.org/show_bug.cgi?id=12716

Hello @dvuckovic ,

Hereby is fix for reporters issue. Solving bug #12433 added code which check for activities with ActivityGet() function for which in this case (  CustomerTicketProcess.pm ) we need param Interface to match CustomerInterface.

Please let me know if there are any questions regarding this PR.

Regards,
Sanjin