### PR TITLE
[Master Bug 12719] - The result of SQL box displays the unique column headers not with the right character encoding

### DIFF
--- a/Kernel/System/DB.pm
+++ b/Kernel/System/DB.pm
@@ -828,10 +828,10 @@ to retrieve the column names of a database statement
 sub GetColumnNames {
     my $Self = shift;
 
-    my $ColumnNames = $Self->{Cursor}->{NAME};
+    my $ColumnNames = $Kernel::OM->Get('Kernel::System::Encode')->EncodeInput( $Self->{Cursor}->{NAME} );
 
     my @Result;
-    if ( ref $ColumnNames eq 'ARRAY' ) {
+    if ( IsArrayRefWithData($ColumnNames) ) {
         @Result = @{$ColumnNames};
     }
 

--- a/scripts/test/DB/ColumnNames.t
+++ b/scripts/test/DB/ColumnNames.t
@@ -30,6 +30,11 @@ my @Tests = (
         Data   => 'SELECT * FROM groups',
         Result => [qw(id name comments valid_id create_time create_by change_time change_by)],
     },
+    {
+        Name   => 'SELECT with unicode characters',
+        Data   => 'SELECT name AS äöüüßüöä FROM groups',
+        Result => ['äöüüßüöä'],
+    },
 );
 
 for my $Test (@Tests) {


### PR DESCRIPTION
https://bugs.otrs.org/show_bug.cgi?id=12719
Hi @dvuckovic 

Herby is fixed encoding name of the columns names of a database statement. Unit test is updated as well. It is our proposal to fix header names in results table in SQL Box screen.

Regards
S7Design
Zoran