### PR TITLE
[Master Bug - 12696] - Missing save button from personal preferences in mobile mode

### DIFF
--- a/Kernel/Output/HTML/Templates/Standard/AgentPreferences.tt
+++ b/Kernel/Output/HTML/Templates/Standard/AgentPreferences.tt
@@ -162,7 +162,7 @@
     [% RenderBlockEnd("RawHTML") %]
     [% RenderBlockEnd("Block") %]
 
-                                    <div class="SettingUpdateBox">
+                                    <div class="PreferencesUpdateBox SettingUpdateBox">
                                         <button class="CallForAction Update" type="button" value="[% Translate("Save this setting") | html %]" title="[% Translate("Save this setting") | html %]">
                                             <span><i class="fa fa-check"></i></span>
                                         </button>

--- a/var/httpd/htdocs/skins/Agent/default/css/Core.Agent.Preferences.css
+++ b/var/httpd/htdocs/skins/Agent/default/css/Core.Agent.Preferences.css
@@ -35,6 +35,10 @@
     display: none;
 }
 
+.WidgetSimple.Setting.IsLockedByMe .Content .PreferencesUpdateBox.SettingUpdateBox {
+    display: block !important;
+}
+
 fieldset.TableLike > .Field.NoMargin {
     margin-left: 0px;
 }


### PR DESCRIPTION
https://bugs.otrs.org/show_bug.cgi?id=12696

Hi @dvuckovic 

Hereby is fixed issue with update buttons in AgentPreferences. There is style in Core.Agent.Admin.SystemConfiguration.css for class SettingUpdateBox which set property display to 'none'.

>     .WidgetSimple.Setting.IsLockedByMe .Content .SettingUpdateBox {
>         display: none !important;
>     }

So there is added new class for the block element SettingUpdateBox in AgentPreferences. 

Regards
Zoran