### PR TITLE
[ Master - Bug 12714 ] - In dynamic matrix statistics preview x-axis is not sorted.

### DIFF
--- a/Kernel/System/Stats.pm
+++ b/Kernel/System/Stats.pm
@@ -2779,6 +2779,11 @@ sub _GenerateDynamicStats {
             # Do not translate the values, please see bug#12384 for more information.
             push @HeaderLine, $Xvalue->{Values}{$Valuename};
         }
+
+        # Prevent randomization of x-axis in preview, sort it alphabetically see bug#12714.
+        if ($Preview) {
+            @HeaderLine = sort { lc($a) cmp lc($b) } @HeaderLine;
+        }
     }
 
     # get the value series


### PR DESCRIPTION
https://bugs.otrs.org/show_bug.cgi?id=12714,

Hello @dvuckovic ,

Hereby is proposal for fixing reporters issue. Added sorting of x-axis in dynamic matrix statistics preview.

Please let me know if there are any issues or questions regarding this PR.

Regards,
Sanjin