### PR TITLE
[ Rel-5_0 Bug 12720 ] - Settings window of Complex LinkObject is not translated

### DIFF
--- a/Kernel/Output/HTML/Layout/LinkObject.pm
+++ b/Kernel/Output/HTML/Layout/LinkObject.pm
@@ -357,6 +357,43 @@ sub LinkObjectTableCreateComplex {
                 PrefKey => "LinkObject::ComplexTable-" . $Block->{Blockname},
             );
 
+            # Add translations for the allocation lists for regular columns.
+            for my $Column ( @{ $Preferences{AllColumns} } ) {
+                my $TranslatedWord = $Column;
+                if ( $Column eq 'EscalationTime' ) {
+                    $TranslatedWord = Translatable('Service Time');
+                }
+                elsif ( $Column eq 'EscalationResponseTime' ) {
+                    $TranslatedWord = Translatable('First Response Time');
+                }
+                elsif ( $Column eq 'EscalationSolutionTime' ) {
+                    $TranslatedWord = Translatable('Solution Time');
+                }
+                elsif ( $Column eq 'EscalationUpdateTime' ) {
+                    $TranslatedWord = Translatable('Update Time');
+                }
+                elsif ( $Column eq 'PendingTime' ) {
+                    $TranslatedWord = Translatable('Pending till');
+                }
+                elsif ( $Column eq 'CustomerCompanyName' ) {
+                    $TranslatedWord = Translatable('Customer Company Name');
+                }
+                elsif ( $Column eq 'CustomerUserID' ) {
+                    $TranslatedWord = Translatable('Customer User ID');
+                }
+
+                $LayoutObject->Block(
+                    Name => 'ColumnTranslation',
+                    Data => {
+                        ColumnName      => $Column,
+                        TranslateString => $TranslatedWord,
+                    },
+                );
+                $LayoutObject->Block(
+                    Name => 'ColumnTranslationSeparator',
+                );
+            }
+
             $LayoutObject->Block(
                 Name => 'ContentLargePreferencesForm',
                 Data => {
@@ -808,6 +845,8 @@ sub ComplexTablePreferencesGet {
         }
     }
 
+    my @AllColumns = ( @ColumnsAvailable, @ColumnsEnabled );
+
     # check if the user has filter preferences for this widget
     my %Preferences = $Kernel::OM->Get('Kernel::System::User')->GetPreferences(
         UserID => $Self->{UserID},
@@ -862,6 +901,7 @@ sub ComplexTablePreferencesGet {
         ColumnsEnabled   => $JSONObject->Encode( Data => \@ColumnsEnabled ),
         ColumnsAvailable => $JSONObject->Encode( Data => \@ColumnsAvailableNotEnabled ),
         Translation      => 1,
+        AllColumns       => \@AllColumns,
     );
 
     return %Params;

--- a/Kernel/Output/HTML/Templates/Standard/LinkObject.tt
+++ b/Kernel/Output/HTML/Templates/Standard/LinkObject.tt
@@ -238,5 +238,12 @@ Core.UI.RegisterToggleTwoContainer($('#linkobject-' + Core.App.EscapeSelector('[
         var Status = $(this).prop('checked');
         $(this).closest('.WidgetSimple').find('table input[type=checkbox]').prop('checked', Status);
     });
+
+    Core.Config.AddConfig({
+[% RenderBlockStart("ColumnTranslation") %]
+        'Column[% Data.ColumnName | html %]': [% Translate(Data.TranslateString) | JSON %][% RenderBlockStart("ColumnTranslationSeparator") %],[% RenderBlockEnd("ColumnTranslationSeparator") %]
+[% RenderBlockEnd("ColumnTranslation") %]
+    });
+
 //]]></script>
 [% END %]

--- a/var/httpd/htdocs/js/Core.Agent.LinkObject.js
+++ b/var/httpd/htdocs/js/Core.Agent.LinkObject.js
@@ -46,7 +46,5 @@ Core.Agent.LinkObject = (function (TargetNS) {
         Core.UI.InitWidgetActionToggle();
     };
 
-    Core.Agent.TableFilters.SetAllocationList();
-
     return TargetNS;
 }(Core.Agent.LinkObject || {}));

--- a/var/httpd/htdocs/js/Core.Agent.TicketZoom.js
+++ b/var/httpd/htdocs/js/Core.Agent.TicketZoom.js
@@ -441,6 +441,9 @@ Core.Agent.TicketZoom = (function (TargetNS) {
         $('label.Switchable').off('click.Switch').on('click.Switch', function() {
             $(this).next('p.Value').find('.Switch').toggleClass('Hidden');
         });
+
+        // Initialize allocation list for link object table.
+        Core.Agent.TableFilters.SetAllocationList();
     };
 
     return TargetNS;


### PR DESCRIPTION
https://bugs.otrs.org/show_bug.cgi?id=12720

Hello @dvuckovic ,

Hereby is fix proposal for reporters issue in Rel-5_0. Implemented slightly different approach then how it is proposed for master fix. Moved calling function Core.Agent.TableFilters.SetAllocationList() from LinkObject.js to TicketZoom.js, this way we get correctly translated configs-columns when page is loaded. Similar approach is used for dashboard modules.

Please let me know if there are any issues or questions regarding this PR.

Regards,
Sanjin