### PR TITLE
[Master - Bug 12726] -  Automatic links to CVE numbers don't work in TicketViewZoom.

### DIFF
--- a/Kernel/Config/Files/Framework.xml
+++ b/Kernel/Config/Files/Framework.xml
@@ -10495,7 +10495,7 @@ via the Preferences button after logging in.
                     <Hash>
                         <Item Key="Description">US-CERT NVD</Item>
                         <Item Key="URL">http://nvd.nist.gov/nvd.cfm?cvename=&lt;MATCH1&gt;-&lt;MATCH2&gt;-&lt;MATCH3&gt;</Item>
-                        <Item Key="Image">http://nvd.nist.gov/favicon.ico</Item>
+                        <Item Key="Image">http://nvd.nist.gov/NVD/Media/images/favicons/favicon.ico</Item>
                         <Item Key="Target">_blank</Item>
                     </Hash>
                 </Item>

--- a/Kernel/Config/Files/XML/Framework.xml
+++ b/Kernel/Config/Files/XML/Framework.xml
@@ -11309,7 +11309,7 @@ via the Preferences button after logging in.
                     <Hash>
                         <Item Key="Description">US-CERT NVD</Item>
                         <Item Key="URL">http://nvd.nist.gov/nvd.cfm?cvename=&lt;MATCH1&gt;-&lt;MATCH2&gt;-&lt;MATCH3&gt;</Item>
-                        <Item Key="Image">http://nvd.nist.gov/favicon.ico</Item>
+                        <Item Key="Image">http://nvd.nist.gov/NVD/Media/images/favicons/favicon.ico</Item>
                         <Item Key="Target">_blank</Item>
                     </Hash>
                 </Item>

--- a/Kernel/Modules/AgentTicketAttachment.pm
+++ b/Kernel/Modules/AgentTicketAttachment.pm
@@ -205,6 +205,7 @@ sub Run {
             .+                                                  # PGP parts may be nested in html
             ^ .* -----END [ ] PGP [ ] MESSAGE-----  .* $        # grep PGP end tag
         }xms
+            || $ConfigObject->Get('Frontend::Output::FilterText')
             )
         {
 

--- a/scripts/test/Selenium/Agent/AgentTicketAttachment.t
+++ b/scripts/test/Selenium/Agent/AgentTicketAttachment.t
@@ -136,6 +136,18 @@ $Selenium->RunTest(
                     $Selenium->find_element("//img[contains(\@src, \'$CVEConfig->{Image}' )]"),
                     "Image for $CVEConfig->{Description} link is found - $CVEConfig->{Image}",
                 );
+
+                my %Response = $Kernel::OM->Get('Kernel::System::WebUserAgent')->Request(
+                    Type => 'GET',
+                    URL  => $CVEConfig->{Image},
+                );
+
+                # check result
+                $Self->Is(
+                    $Response{Status},
+                    '200 OK',
+                    "$CVEConfig->{Image} - there is correct image for the link",
+                );
             }
 
             # set download type to inline

--- a/scripts/test/Selenium/Agent/AgentTicketAttachment.t
+++ b/scripts/test/Selenium/Agent/AgentTicketAttachment.t
@@ -32,6 +32,28 @@ $Selenium->RunTest(
             "Disable RichText with true",
         );
 
+        my %OutputFilterTextAutoLink = $Kernel::OM->Get('Kernel::System::SysConfig')->SettingGet(
+            Name    => 'Frontend::Output::FilterText###OutputFilterTextAutoLink',
+            Default => 1,
+        );
+
+        $Helper->ConfigSettingChange(
+            Valid => 1,
+            Key   => 'Frontend::Output::FilterText###OutputFilterTextAutoLink',
+            Value => $OutputFilterTextAutoLink{EffectiveValue},
+        );
+
+        my %OutputFilterTextAutoLinkCVE = $Kernel::OM->Get('Kernel::System::SysConfig')->SettingGet(
+            Name    => 'Frontend::Output::OutputFilterTextAutoLink###CVE',
+            Default => 1,
+        );
+
+        $Helper->ConfigSettingChange(
+            Valid => 1,
+            Key   => 'Frontend::Output::OutputFilterTextAutoLink###CVE',
+            Value => $OutputFilterTextAutoLinkCVE{EffectiveValue},
+        );
+
         # create test user and login
         my $TestUserLogin = $Helper->TestUserCreate(
             Groups => [ 'admin', 'users' ],


### PR DESCRIPTION
https://bugs.otrs.org/show_bug.cgi?id=12726

Hi,

Herby is fixed an issue with replacing CVE number in article body. There is changed URL to  favicons for US-CERT NVD. 
Unit test is updated with the cases which check if there is links in article body and if there is images for the links that is set in CVE sysconfig item. 

Regards
Zoran