### PR TITLE
Swich to https

### DIFF
--- a/Kernel/Output/HTML/Templates/Standard/Error.tt
+++ b/Kernel/Output/HTML/Templates/Standard/Error.tt
@@ -32,7 +32,7 @@
                 </div>
                 [% END %]
 
-                <form action="http://bugs.otrs.org/enter_bug.cgi" target="_blank">
+                <form action="https://bugs.otrs.org/enter_bug.cgi" target="_blank">
                     <input type="hidden" name="product" value="OTRS Helpdesk" />
 
                     <textarea class="Hidden" name="comment" rows="1" cols="1">


### PR DESCRIPTION
Hi @mgruner 
If an error occurs in OTRS, and the user wants to send the bug report, he will be informed, that the connection is not secure, a third party may see the submitted data. This patch avoids this warning message.

I looked for "http" in the source code, and there are many comments that contains "http" instead of "https" (e. g. all copyright text in the beginning of the files, or many places in the CHANGES.md). Maybe it would be good to change these occurrences, too.