### PR TITLE
[ Master - Bug 12735 ] - Console does not allow adding of sub services when their name exists as a service

### DIFF
--- a/Kernel/System/Console/Command/Admin/Service/Add.pm
+++ b/Kernel/System/Console/Command/Admin/Service/Add.pm
@@ -49,27 +49,32 @@ sub Configure {
 sub PreRun {
     my ( $Self, %Param ) = @_;
 
-    # check if service already exists
+    # Get all services.
     $Self->{Name} = $Self->GetOption('name');
     my %ServiceList = $Kernel::OM->Get('Kernel::System::Service')->ServiceList(
         Valid  => 0,
         UserID => 1,
     );
     my %Reverse = reverse %ServiceList;
-    if ( $Reverse{ $Self->{Name} } ) {
-        die "Service '$Self->{Name}' already exists!\n";
-    }
 
-    # check if parent exists (if given)
     $Self->{ParentName} = $Self->GetOption('parent-name');
     if ( $Self->{ParentName} ) {
+
+        # Check if Parent service exists.
         $Self->{ParentID} = $Kernel::OM->Get('Kernel::System::Service')->ServiceLookup(
             Name   => $Self->{ParentName},
             UserID => 1,
         );
-        if ( !$Self->{ParentID} ) {
-            die "Parent service $Self->{ParentName} does not exist.\n";
-        }
+        die "Parent service $Self->{ParentName} does not exist.\n" if !$Self->{ParentID};
+
+        # Check if Parent::Child service combination exists.
+        my $ServiceName = $Self->{ParentName} . '::' . $Self->{Name};
+        die "Service '$ServiceName' already exists!\n" if $Reverse{$ServiceName};
+    }
+    else {
+
+        # Check if service already exists.
+        die "Service '$Self->{Name}' already exists!\n" if $Reverse{ $Self->{Name} };
     }
 
     return;

--- a/scripts/test/Console/Command/Admin/Service/Add.t
+++ b/scripts/test/Console/Command/Admin/Service/Add.t
@@ -67,6 +67,32 @@ $Self->Is(
     "Existing parent ( service is added - $ChildServiceName )",
 );
 
+# Same again (should fail because already exists).
+$ExitCode = $CommandObject->Execute( '--name', $ChildServiceName, '--parent-name', $ParentServiceName );
+$Self->Is(
+    $ExitCode,
+    1,
+    "Existing parent ( service ${ParentServiceName}::$ChildServiceName already exists )",
+);
+
+# Parent and child service same name.
+$ExitCode = $CommandObject->Execute( '--name', $ParentServiceName, '--parent-name', $ParentServiceName );
+my $ServiceName = $ParentServiceName . '::' . $ParentServiceName;
+$Self->Is(
+    $ExitCode,
+    0,
+    "Parent and child service same name - $ServiceName - is created",
+);
+
+# Parent (two levels) and child same name.
+$ExitCode = $CommandObject->Execute( '--name', $ParentServiceName, '--parent-name', $ServiceName );
+$ServiceName = $ServiceName . '::' . $ParentServiceName;
+$Self->Is(
+    $ExitCode,
+    0,
+    "Parent (two levels) and child service same name - $ServiceName - is created",
+);
+
 # cleanup is done by RestoreDatabase
 
 1;


### PR DESCRIPTION
https://bugs.otrs.org/show_bug.cgi?id=12735,

Hello @dvuckovic ,

Hereby is proposal for fixing reporters issue. In console command Admin::Service::Add, there was just check every time if option 'name' exists as service, regardless if it's used as subservice. Updated UT to check for these types of behaviour, where we create in multiple sublevels with same name for parent and child.

Please let me know if there are any issues or questions regarding this PR.

Regards,
Sanjin