### PR TITLE
[ Master Follow-up Bug 12720 ] - Settings window of Complex LinkObject is not translated

### DIFF
--- a/Kernel/Output/HTML/Layout/LinkObject.pm
+++ b/Kernel/Output/HTML/Layout/LinkObject.pm
@@ -361,6 +361,14 @@ sub LinkObjectTableCreateComplex {
                 PrefKey => "LinkObject::ComplexTable-" . $Block->{Blockname},
             );
 
+            # Add translations for the allocation lists for regular columns.
+            for my $Column ( @{ $Block->{AllColumns} } ) {
+                $LayoutObject->AddJSData(
+                    Key   => 'Column' . $Column->{ColumnName},
+                    Value => $LayoutObject->{LanguageObject}->Translate( $Column->{ColumnTranslate} ),
+                );
+            }
+
             # send data to JS
             $LayoutObject->AddJSData(
                 Key   => 'LinkObjectPreferences',
@@ -816,42 +824,6 @@ sub ComplexTablePreferencesGet {
             @ColumnsEnabled
                 = sort { $Param{Config}->{Priority}->{$a} <=> $Param{Config}->{Priority}->{$b} } @ColumnsEnabled;
         }
-    }
-
-    # Translate all columns and send it to JS.
-    my $LayoutObject   = $Kernel::OM->Get('Kernel::Output::HTML::Layout');
-    my $LanguageObject = $Kernel::OM->Get('Kernel::Language');
-
-    my @AllColumns = ( @ColumnsAvailable, @ColumnsEnabled );
-    for my $Column (@AllColumns) {
-        my $TranslatedWord = $Column;
-        if ( $Column eq 'EscalationTime' ) {
-            $TranslatedWord = Translatable('Service Time');
-        }
-        elsif ( $Column eq 'EscalationResponseTime' ) {
-            $TranslatedWord = Translatable('First Response Time');
-        }
-        elsif ( $Column eq 'EscalationSolutionTime' ) {
-            $TranslatedWord = Translatable('Solution Time');
-        }
-        elsif ( $Column eq 'EscalationUpdateTime' ) {
-            $TranslatedWord = Translatable('Update Time');
-        }
-        elsif ( $Column eq 'PendingTime' ) {
-            $TranslatedWord = Translatable('Pending till');
-        }
-        elsif ( $Column eq 'CustomerCompanyName' ) {
-            $TranslatedWord = Translatable('Customer Company Name');
-        }
-        elsif ( $Column eq 'CustomerUserID' ) {
-            $TranslatedWord = Translatable('Customer User ID');
-        }
-
-        # Send data to JS.
-        $LayoutObject->AddJSData(
-            Key   => 'Column' . $Column,
-            Value => $LanguageObject->Translate($TranslatedWord),
-        );
     }
 
     # check if the user has filter preferences for this widget

--- a/Kernel/Output/HTML/LinkObject/Appointment.pm
+++ b/Kernel/Output/HTML/LinkObject/Appointment.pm
@@ -273,8 +273,14 @@ sub TableCreateComplex {
     # Define Headline columns
 
     # Sort
+    my @AllColumns;
     COLUMN:
     for my $Column ( sort { $SortOrder{$a} <=> $SortOrder{$b} } keys %UserColumns ) {
+
+        push @AllColumns, {
+            ColumnName      => $Column,
+            ColumnTranslate => $Column,
+        };
 
         next COLUMN if $Column eq 'Title';    # Always present, already added.
 
@@ -369,6 +375,7 @@ sub TableCreateComplex {
         ObjectID   => $Param{ObjectID},
         Headline   => \@Headline,
         ItemList   => \@ItemList,
+        AllColumns => \@AllColumns,
     );
 
     return ( \%Block );

--- a/Kernel/Output/HTML/LinkObject/Ticket.pm
+++ b/Kernel/Output/HTML/LinkObject/Ticket.pm
@@ -300,8 +300,37 @@ sub TableCreateComplex {
     # Define Headline columns
 
     # Sort
+    my @AllColumns;
     COLUMN:
     for my $Column ( sort { $SortOrder{$a} <=> $SortOrder{$b} } keys %UserColumns ) {
+
+        my $ColumnTranslate = $Column;
+        if ( $Column eq 'EscalationTime' ) {
+            $ColumnTranslate = Translatable('Service Time');
+        }
+        elsif ( $Column eq 'EscalationResponseTime' ) {
+            $ColumnTranslate = Translatable('First Response Time');
+        }
+        elsif ( $Column eq 'EscalationSolutionTime' ) {
+            $ColumnTranslate = Translatable('Solution Time');
+        }
+        elsif ( $Column eq 'EscalationUpdateTime' ) {
+            $ColumnTranslate = Translatable('Update Time');
+        }
+        elsif ( $Column eq 'PendingTime' ) {
+            $ColumnTranslate = Translatable('Pending till');
+        }
+        elsif ( $Column eq 'CustomerCompanyName' ) {
+            $ColumnTranslate = Translatable('Customer Company Name');
+        }
+        elsif ( $Column eq 'CustomerUserID' ) {
+            $ColumnTranslate = Translatable('Customer User ID');
+        }
+
+        push @AllColumns, {
+            ColumnName      => $Column,
+            ColumnTranslate => $ColumnTranslate,
+        };
 
         # if enabled by default
         if ( $UserColumns{$Column} == 2 ) {
@@ -514,6 +543,7 @@ sub TableCreateComplex {
         ObjectID   => $Param{ObjectID},
         Headline   => \@Headline,
         ItemList   => \@ItemList,
+        AllColumns => \@AllColumns,
     );
 
     return ( \%Block );


### PR DESCRIPTION
Hello @dvuckovic ,

Hereby is follow-up for bug fix for master. With this PR we make LinkObject agnostic about column names. Included changes in LinkObject/Appointment.pm to use this way of translating allocation columns.

Please let me know if there is any questions or issues regarding this PR.

Regards,
Sanjin