### PR TITLE
Marked strings as translatable

### DIFF
--- a/Kernel/System/ACL/DB/ACL.pm
+++ b/Kernel/System/ACL/DB/ACL.pm
@@ -11,6 +11,7 @@ package Kernel::System::ACL::DB::ACL;
 use strict;
 use warnings;
 
+use Kernel::Language qw(Translatable);
 use Kernel::System::VariableCheck qw(:all);
 
 our @ObjectDependencies = (
@@ -1007,8 +1008,9 @@ sub ACLImport {
     if ( ref $ACLData ne 'ARRAY' ) {
         return {
             Success => 0,
-            Message =>
-                "Couldn't read ACL configuration file. Please make sure the file is valid.",
+            Message => Translatable(
+                'Couldn\'t read ACL configuration file. Please make sure the file is valid.'
+            ),
         };
     }
 

--- a/Kernel/System/NotificationEvent.pm
+++ b/Kernel/System/NotificationEvent.pm
@@ -11,6 +11,7 @@ package Kernel::System::NotificationEvent;
 use strict;
 use warnings;
 
+use Kernel::Language qw(Translatable);
 use Kernel::System::VariableCheck qw(:all);
 
 our @ObjectDependencies = (
@@ -768,8 +769,9 @@ sub NotificationImport {
     if ( ref $NotificationData ne 'ARRAY' ) {
         return {
             Success => 0,
-            Message =>
-                "Couldn't read Notification configuration file. Please make sure the file is valid.",
+            Message => Translatable(
+                'Couldn\'t read Notification configuration file. Please make sure the file is valid.'
+            ),
         };
     }
 


### PR DESCRIPTION
Hi @mgruner 
I found two error messages, that are not marked for translation. Both rel-5_0 and master are affected.