### PR TITLE
Hardcoded OTRS in preference label removed

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,4 +1,5 @@
 #6.0.0.beta1 2017-??-??
+ - 2017-03-31 Hardcoded OTRS in preference label removed.
  - 2017-03-26 Fixed bug#[12650](https://bugs.otrs.org/show_bug.cgi?id=12650)(PR#1636) - SendCustomerNotification does not respect newly assigned mail address. Thanks to S7!
  - 2017-03-24 Fixed bug#[12720](https://bugs.otrs.org/show_bug.cgi?id=12720)(PR#1672) - Settings window of Complex LinkObject is not translated. Thanks to S7!
  - 2017-03-24 Modernized address book. It is now possible to search for all configured custom user and customer fields.

--- a/Kernel/Config/Files/Framework.xml
+++ b/Kernel/Config/Files/Framework.xml
@@ -8036,7 +8036,7 @@ You can log in via the following URL:
                 <Item Key="Module">Kernel::Output::HTML::Preferences::Skin</Item>
                 <Item Key="PreferenceGroup">Miscellaneous</Item>
                 <Item Key="Label" Translatable="1">Skin</Item>
-                <Item Key="Desc" Translatable="1">Select your preferred layout for OTRS.</Item>
+                <Item Key="Desc" Translatable="1">Select your preferred layout.</Item>
                 <Item Key="Key" Translatable="1"></Item>
                 <Item Key="PrefKey">UserSkin</Item>
                 <Item Key="Prio">100</Item>

--- a/Kernel/Config/Files/XML/Framework.xml
+++ b/Kernel/Config/Files/XML/Framework.xml
@@ -7638,7 +7638,7 @@ You can log in via the following URL:
                 <Item Key="Module">Kernel::Output::HTML::Preferences::Skin</Item>
                 <Item Key="PreferenceGroup">Miscellaneous</Item>
                 <Item Key="Label" Translatable="1">Skin</Item>
-                <Item Key="Desc" Translatable="1">Select your preferred layout for OTRS.</Item>
+                <Item Key="Desc" Translatable="1">Select your preferred layout.</Item>
                 <Item Key="Key" Translatable="1"></Item>
                 <Item Key="PrefKey">UserSkin</Item>
                 <Item Key="Prio">100</Item>


### PR DESCRIPTION
This mod removes hardcoded "OTRS" from user preference label to avoid
confusing users (friendly system name should be used like in
ced4374723ec7a99c526f10aecf9d7858799efe7).

Related: https://dev.ib.pl/ib/otrs/issues/110
Related: https://github.com/OTRS/otrs/pull/1431
Author-Change-Id: IB#1068184