### PR TITLE
Marked error message as translatable

### DIFF
--- a/Kernel/System/Ticket/Article.pm
+++ b/Kernel/System/Ticket/Article.pm
@@ -20,6 +20,7 @@ use Kernel::System::VariableCheck qw(:all);
 
 our @ObjectDependencies = (
     'Kernel::Config',
+    'Kernel::Language',
     'Kernel::System::Cache',
     'Kernel::System::CustomerUser',
     'Kernel::System::DB',
@@ -2317,7 +2318,7 @@ sub ArticleSend {
     # return if no mail was able to send
     if ( !$HeadRef || !$BodyRef ) {
         $Kernel::OM->Get('Kernel::System::Log')->Log(
-            Message  => "Impossible to send message to: $Param{'To'} .",
+            Message  => $Kernel::OM->Get('Kernel::Language')->Translate('Impossible to send message to: %s', $Param{'To'}),
             Priority => 'error',
         );
         return;


### PR DESCRIPTION
Hi @mrcbnsls 
There is an error message, that is not marked as translatable. I don't know, what would be the best solution for these kind of strings, because it should be translated in the error message (underlined by red), but it should leave untranslated in the Error details (underlined by green). The first one is a user interface, the latter is a log entry. Both branch rel-5_0 and master are affected.

![error-message](https://cloud.githubusercontent.com/assets/1006118/24633214/a6190dce-18c7-11e7-9c94-fabfa70700a5.jpg)
 