### PR TITLE
[ Master - Bug 12745 ] - AgentTicketSearch missing 'Extended' param in Article and Ticket get methods

### DIFF
--- a/Kernel/Modules/AgentTicketSearch.pm
+++ b/Kernel/Modules/AgentTicketSearch.pm
@@ -680,6 +680,7 @@ sub Run {
                     # get ticket data instead
                     %Data = $TicketObject->TicketGet(
                         TicketID      => $TicketID,
+                        Extended      => 1,
                         DynamicFields => 1,
                     );
 

--- a/Kernel/Output/HTML/TicketOverview/Small.pm
+++ b/Kernel/Output/HTML/TicketOverview/Small.pm
@@ -437,12 +437,14 @@ sub Run {
             # get last customer article
             my %Article = $ArticleObject->ArticleLastCustomerArticle(
                 TicketID      => $TicketID,
+                Extended      => 1,
                 DynamicFields => 0,
             );
 
             # get ticket data
             my %Ticket = $TicketObject->TicketGet(
                 TicketID      => $TicketID,
+                Extended      => 1,
                 DynamicFields => 0,
             );
 


### PR DESCRIPTION
https://bugs.otrs.org/show_bug.cgi?id=12745

Hello @dvuckovic ,

Hereby is proposal for fixing reporters issue. There was missing param Extended for both Article and Ticket get methots. This param is required in order to call _TicketGetExtended() and in that function there is _TicketGetClosed()  function which returns "collected attributes of (last) closing for given ticket" from ticket_history table. With this fix, closed tickets with or without any articles will show 'Closed' data in normal, CSV or Excel output.

Please let me know if there are any issues or questions regarding this PR.

Regards,
Sanjin