### PR TITLE
[Master - bug 12746 ]Added unit test for ACL ignores checks on dynamic fields

### DIFF
--- a/scripts/test/Ticket/TicketACL.t
+++ b/scripts/test/Ticket/TicketACL.t
@@ -2664,6 +2664,35 @@ $Self->True(
             3 => 'closed',
         },
     },
+    {
+        Name => 'ACL DB-DynamicField - restrict action',
+        ACLs => {
+            'DB-DynamicField' => {
+                Properties => {
+                    DynamicField => {
+                        'DynamicField_' . $DynamicFieldNames[0] => ['Item1'],
+                    },
+                },
+                PossibleNot => {
+                    Action => ['AgentTicketClose'],
+                },
+            },
+        },
+        Config => {
+            Data => {
+                1 => 'AgentTicketPrint',
+                2 => 'AgentTicketClose',
+            },
+            ReturnType    => 'Action',
+            ReturnSubType => '-',
+            TicketID      => $TicketID,
+            UserID        => $UserID,
+        },
+        SuccessMatch     => 1,
+        ReturnActionData => {
+            1 => 'AgentTicketPrint',
+            }
+    },
 
     # user based tests
     {


### PR DESCRIPTION
Hi @dvuckovic,

Herby is extended test TicketACL.t with test case which check restriction action by dynamic fields.

Regards
Zoran