### PR TITLE
[Master bug 12742] IE 11: magnifying glass isn't visible

### DIFF
--- a/var/httpd/htdocs/js/Core.Agent.js
+++ b/var/httpd/htdocs/js/Core.Agent.js
@@ -577,7 +577,8 @@ Core.Agent = (function (TargetNS) {
                 + parseInt($(this).css('margin-left'), 10)
                 + parseInt($(this).css('margin-right'), 10)
                 + parseInt($(this).css('border-left-width'), 10)
-                + parseInt($(this).css('border-right-width'), 10);
+                + parseInt($(this).css('border-right-width'), 10)
+                + 1;
         });
         $('#Navigation').css('width', NavigationBarWidth);
 


### PR DESCRIPTION
https://bugs.otrs.org/show_bug.cgi?id=12742

Hi @dvuckovic 

Hereby is solved with the issue when search icon is not visible in some browser. As you have suggested recently, it is fixed for some browser in bug https://bugs.otrs.org/show_bug.cgi?id=12665, but obviously IE is always a little bit specific ;)

I added 1px in calculation for navigation width. I am not sure if it is the best solution. I saw that some languages make problem (e.g. German, Spanish, but in English is OK). Actually if navigation item names is longer there is a problem that there is no enough space to display search link.

Regards
Zoran