### PR TITLE
[ Master - Bug 12749 ] - Fixed logo scaling on mobile view

### DIFF
--- a/var/httpd/htdocs/skins/Agent/default/css/Core.Responsive.css
+++ b/var/httpd/htdocs/skins/Agent/default/css/Core.Responsive.css
@@ -107,7 +107,7 @@
 
     #Header #Logo {
         width: 208px !important;
-        background-size: 100%;
+        background-size: contain;
         position: static;
         margin: -2px auto 0px auto;
         background-position: center;


### PR DESCRIPTION
https://bugs.otrs.org/show_bug.cgi?id=12749

Hi @dvuckovic 

There is a proposal for fix scaling of logo image on mobile view. Property 'background-size' is changed to 'contain' to keep image aspect ratio unchanged.

If you have any comment  please inform me.

Regards,
Milan