### PR TITLE
[ Master - Bug 10783 ] - Fixed inconsistent handling for dynamic field in articles

### DIFF
--- a/Kernel/Output/HTML/Templates/Standard/AgentTicketActionCommon.tt
+++ b/Kernel/Output/HTML/Templates/Standard/AgentTicketActionCommon.tt
@@ -279,14 +279,13 @@
 #                           <div class="Clear"></div>
 #                       </div>
 #[% RenderBlockEnd("DynamicField_Field2") %]
-                    </fieldset>>
+                    </fieldset>
                 </div>
             </div>
 [% RenderBlockEnd("WidgetTicketActions") %]
 
 [% RenderBlockStart("WidgetArticle") %]
                 <div class="WidgetSimple [% Data.WidgetStatus | html %]" id="WidgetArticle">
-                    <input type="hidden" id="WidgetArticleStatus" name="WidgetArticleStatus" value="[% Data.WidgetStatus | html %]" />
                     <div class="Header">
                         <div class="WidgetAction Toggle">
                             <a href="#" title="[% Translate("Toggle this widget") | html %]"><i class="fa fa-caret-right"></i><i class="fa fa-caret-down"></i></a>
@@ -301,7 +300,7 @@
 [% ELSE %]
                             <label for="CreateArticle">[% Translate("Create an Article") | html %]:</label>
                             <div class="Field">
-                                <input type="checkbox" id="CreateArticle" name="CreateArticle" value="1" />
+                                <input type="checkbox" id="CreateArticle" name="CreateArticle" value="1" [% IF Data.CreateArticle %] checked="checked"[% END %] />
                             </div>
                             <div class="Clear"></div>
 [% END %]

--- a/Kernel/Output/HTML/Templates/Standard/AgentTicketActionCommon.tt
+++ b/Kernel/Output/HTML/Templates/Standard/AgentTicketActionCommon.tt
@@ -441,6 +441,11 @@
                             [% Data.Label %]
                                 <div class="Field">
                                 [% Data.Field %]
+[% RenderBlockStart("ArticleTypeDynamicFieldError") %]
+                                    <div id="DynamicField_[% Data.Name %]Error" class="TooltipErrorMessage">
+                                        <p>[% Translate("This field is required.") | html %]</p>
+                                    </div>
+[% RenderBlockEnd("ArticleTypeDynamicFieldError") %]
                                 </div>
                                 <div class="Clear"></div>
                             </div>

--- a/Kernel/Output/HTML/Templates/Standard/AgentTicketActionCommon.tt
+++ b/Kernel/Output/HTML/Templates/Standard/AgentTicketActionCommon.tt
@@ -247,58 +247,46 @@
                         </div>
                         <div class="Clear"></div>
 [% RenderBlockEnd("Priority") %]
-                    </div>
-                </div>
-[% RenderBlockEnd("WidgetTicketActions") %]
 
-[% RenderBlockStart("WidgetDynamicFields") %]
-                <div class="WidgetSimple Expanded">
-                    <div class="Header">
-                        <div class="WidgetAction Toggle">
-                            <a href="#" title="[% Translate("Toggle this widget") | html %]"><i class="fa fa-caret-right"></i><i class="fa fa-caret-down"></i></a>
-                        </div>
-                        <h2>[% Translate("Dynamic Fields") | html %]</h2>
-                    </div>
-                    <div class="Content">
-                        <fieldset class="TableLike FixedLabel">
-[% RenderBlockStart("DynamicField") %]
-                            <div class="Row Row_DynamicField_[% Data.Name | html %]">
-                            [% Data.Label %]
-                                <div class="Field">
-                                [% Data.Field %]
-                                </div>
-                                <div class="Clear"></div>
+[% RenderBlockStart("TicketTypeDynamicField") %]
+                        <div class="Row Row_DynamicField_[% Data.Name | html %]">
+                        [% Data.Label %]
+                            <div class="Field">
+                            [% Data.Field %]
                             </div>
-[% RenderBlockEnd("DynamicField") %]
+                            <div class="Clear"></div>
+                        </div>
+[% RenderBlockEnd("TicketTypeDynamicField") %]
 
 # example of how to use fixed dynamic field blocks for customizations
 # Note: Field1 and Field2 are the names of the fields and had to be replaced with the actual
 # field names
 #[% RenderBlockStart("DynamicField_Field1") %]
-#                <div class="Row Row_DynamicField_[% Data.Name | html %]">
-#                    [% Data.Label %]
-#                    <div class="Field">
-#                        [% Data.Field %]
-#                    </div>
-#                    <div class="Clear"></div>
-#                </div>
+#                       <div class="Row Row_DynamicField_[% Data.Name | html %]">
+#                           [% Data.Label %]
+#                           <div class="Field">
+#                               [% Data.Field %]
+#                           </div>
+#                           <div class="Clear"></div>
+#                       </div>
 #[% RenderBlockEnd("DynamicField_Field1") %]
 #[% RenderBlockStart("DynamicField_Field2") %]
-#                <div class="Row Row_DynamicField_[% Data.Name | html %]">
-#                    [% Data.Label %]
-#                    <div class="Field">
-#                        [% Data.Field %]
-#                    </div>
-#                    <div class="Clear"></div>
-#                </div>
+#                       <div class="Row Row_DynamicField_[% Data.Name | html %]">
+#                           [% Data.Label %]
+#                           <div class="Field">
+#                               [% Data.Field %]
+#                           </div>
+#                           <div class="Clear"></div>
+#                       </div>
 #[% RenderBlockEnd("DynamicField_Field2") %]
-                        </fieldset>
-                    </div>
+                    </fieldset>>
                 </div>
-[% RenderBlockEnd("WidgetDynamicFields") %]
+            </div>
+[% RenderBlockEnd("WidgetTicketActions") %]
 
 [% RenderBlockStart("WidgetArticle") %]
                 <div class="WidgetSimple [% Data.WidgetStatus | html %]" id="WidgetArticle">
+                    <input type="hidden" id="WidgetArticleStatus" name="WidgetArticleStatus" value="[% Data.WidgetStatus | html %]" />
                     <div class="Header">
                         <div class="WidgetAction Toggle">
                             <a href="#" title="[% Translate("Toggle this widget") | html %]"><i class="fa fa-caret-right"></i><i class="fa fa-caret-down"></i></a>
@@ -448,6 +436,17 @@
                             </div>
                             <div class="Clear"></div>
 [% RenderBlockEnd("TimeUnits") %]
+
+[% RenderBlockStart("ArticleTypeDynamicField") %]
+                            <div class="Row Row_DynamicField_[% Data.Name | html %]">
+                            [% Data.Label %]
+                                <div class="Field">
+                                [% Data.Field %]
+                                </div>
+                                <div class="Clear"></div>
+                            </div>
+[% RenderBlockEnd("ArticleTypeDynamicField") %]
+
                         </fieldset>
                     </div>
                 </div>

--- a/var/httpd/htdocs/js/Core.Agent.TicketAction.js
+++ b/var/httpd/htdocs/js/Core.Agent.TicketAction.js
@@ -142,26 +142,6 @@ Core.Agent.TicketAction = (function (TargetNS) {
             return false;
         });
 
-        // Set initial values to see whether validation is needed or not.
-        if ($('#WidgetArticle').hasClass('Expanded')) {
-            Core.Form.Validate.EnableValidation($('#WidgetArticle'));
-        }
-        else {
-            Core.Form.Validate.DisableValidation($('#WidgetArticle'));
-        }
-
-        // Click event to set validation of article widget.
-        $('#WidgetArticle .Toggle > a').on('click', function () {
-            if ($('#WidgetArticle').hasClass('Expanded')) {
-                Core.Form.Validate.EnableValidation($('#WidgetArticle'));
-                $('#WidgetArticleStatus').val('Expanded');
-            }
-            else {
-                Core.Form.Validate.DisableValidation($('#WidgetArticle'));
-                $('#WidgetArticleStatus').val('Collapsed');
-            }
-        });
-
         // check if spell check is being used
         if (parseInt(Core.Config.Get('SpellChecker'), 10) === 1 && parseInt(Core.Config.Get('NeedSpellCheck'), 10) === 1) {
 
@@ -231,7 +211,7 @@ Core.Agent.TicketAction = (function (TargetNS) {
             }
 
             if ($WidgetElement.hasClass('Expanded')) {
-                // if widget is being opened, add checbkox to create article
+                // if widget is being opened, add checkbox to create article
                 $('#CreateArticle').prop('checked', true);
             }
         });

--- a/var/httpd/htdocs/js/Core.Agent.TicketAction.js
+++ b/var/httpd/htdocs/js/Core.Agent.TicketAction.js
@@ -142,6 +142,26 @@ Core.Agent.TicketAction = (function (TargetNS) {
             return false;
         });
 
+        // Set initial values to see whether validation is needed or not.
+        if ($('#WidgetArticle').hasClass('Expanded')) {
+            Core.Form.Validate.EnableValidation($('#WidgetArticle'));
+        }
+        else {
+            Core.Form.Validate.DisableValidation($('#WidgetArticle'));
+        }
+
+        // Click event to set validation of article widget.
+        $('#WidgetArticle .Toggle > a').on('click', function () {
+            if ($('#WidgetArticle').hasClass('Expanded')) {
+                Core.Form.Validate.EnableValidation($('#WidgetArticle'));
+                $('#WidgetArticleStatus').val('Expanded');
+            }
+            else {
+                Core.Form.Validate.DisableValidation($('#WidgetArticle'));
+                $('#WidgetArticleStatus').val('Collapsed');
+            }
+        });
+
         // check if spell check is being used
         if (parseInt(Core.Config.Get('SpellChecker'), 10) === 1 && parseInt(Core.Config.Get('NeedSpellCheck'), 10) === 1) {
 

--- a/var/httpd/htdocs/js/Core.Agent.TicketActionCommon.js
+++ b/var/httpd/htdocs/js/Core.Agent.TicketActionCommon.js
@@ -72,6 +72,23 @@ Core.Agent.TicketActionCommon = (function (TargetNS) {
             $Form.find('#AttachmentUpload').val('1').end().submit();
         });
 
+        // Bind click event to CreateArticle checkbox and toggle widget.
+        $('#CreateArticle, #WidgetArticle .WidgetAction.Toggle').on('click', function () {
+            $('#WidgetArticle .Validate_DependingRequiredAND.Validate_Depending_CreateArticle').each(function () {
+                var _this = $(this);
+                var ClosestClass = 'Field';
+                if (_this.attr('id') === 'RichText') {
+                    ClosestClass = 'RichTextField';
+                }
+                if ($('#CreateArticle').prop('checked') && $('#WidgetArticle').hasClass('Expanded')) {
+                    _this.closest('.' + ClosestClass).prev('label').addClass('Mandatory').prepend('<span class="Marker">*</span>');
+                }
+                else {
+                    _this.closest('.' + ClosestClass).prev('label').removeClass('Mandatory').find('span').remove();
+                }
+            });
+        });
+
         // Initialize the ticket action popup.
         Core.Agent.TicketAction.Init();
     };


### PR DESCRIPTION
https://bugs.otrs.org/show_bug.cgi?id=10783

Hi @dvuckovic 

There is a proposal for fix inconsistent handling for dynamic fields in Article section.

Ticket type dynamic fields are moved to "Ticket Settings" section and Article type dynamic fields to "Add Article" section.

AgentTicketActionCommon PM module does not determine server errors if dynamic field type is Article and article widget is collapsed.

Core.Agent.TicketAction.js has initial determination of classes for taking validation or not. It also has the same determination depends on click event.

If you have any comment please let me know.

Regards,
Milan