### PR TITLE
Fixed: The format buttons are displayed on the dashboard translated, but during the running of stats they are not translated

### DIFF
--- a/Kernel/Output/HTML/Templates/Standard/Statistics/StatsResultRender/D3.tt
+++ b/Kernel/Output/HTML/Templates/Standard/Statistics/StatsResultRender/D3.tt
@@ -46,5 +46,12 @@ Core.UI.AdvancedChart.Init(
         Duration: 250
     }
 );
+
+// Add translations for statistic previews.
+Core.Config.Set('Grouped', [% Translate("Grouped") | JSON %]);
+Core.Config.Set('Stacked', [% Translate("Stacked") | JSON %]);
+Core.Config.Set('Expanded', [% Translate("Expanded") | JSON %]);
+Core.Config.Set('Stream', [% Translate("Stream") | JSON %]);
+Core.Config.Set('NoDataAvailable', [% Translate("No Data Available.") | JSON %]);
 </script>
 [% END %]


### PR DESCRIPTION
https://bugs.otrs.org/show_bug.cgi?id=12756

Hi @dvuckovic 

Herby is solved translation for action in SVG screens for stats.
It is solved only in rel-5_0, because in master there is used in js Core.Language.Translate.

regards
Zoran