### PR TITLE
[ Master - Bug 12736 ] - Fixed Internal Server Error when signature part misses

### DIFF
--- a/Kernel/Output/HTML/ArticleCheck/PGP.pm
+++ b/Kernel/Output/HTML/ArticleCheck/PGP.pm
@@ -345,6 +345,8 @@ sub Check {
             $ContentType
             && $ContentType =~ /multipart\/signed/i
             && $ContentType =~ /application\/pgp/i
+            && $Entity->parts(0)
+            && $Entity->parts(1)
             )
         {
 


### PR DESCRIPTION
https://bugs.otrs.org/show_bug.cgi?id=12736

Hi @dvuckovic 

This is a proposal for bug fix. Error was appeared because when signature missed, undefined parts of Entity called "as_string" and "body_as_string" functions. Modification of IF clause solve this wrong calls.

If you have any comment please inform me.

Regards,
Milan