### PR TITLE
[ Master - Bug 7811 ] - GenericAgent Search produces inconsistent results

### DIFF
--- a/Kernel/Modules/AdminGenericAgent.pm
+++ b/Kernel/Modules/AdminGenericAgent.pm
@@ -1290,23 +1290,27 @@ sub _MaskRun {
     # perform ticket search
     my $GenericAgentTicketSearch = $ConfigObject->Get("Ticket::GenericAgentTicketSearch") || {};
     my $Counter = $TicketObject->TicketSearch(
-        Result          => 'COUNT',
-        SortBy          => 'Age',
-        OrderBy         => 'Down',
-        UserID          => 1,
-        Limit           => 60_000,
-        ConditionInline => $GenericAgentTicketSearch->{ExtendedSearchCondition},
+        Result              => 'COUNT',
+        SortBy              => 'Age',
+        OrderBy             => 'Down',
+        UserID              => 1,
+        Limit               => 60_000,
+        ContentSearchPrefix => '*',
+        ContentSearchSuffix => '*',
+        ConditionInline     => $GenericAgentTicketSearch->{ExtendedSearchCondition},
         %JobData,
         %DynamicFieldSearchParameters,
     ) || 0;
 
     my @TicketIDs = $TicketObject->TicketSearch(
-        Result          => 'ARRAY',
-        SortBy          => 'Age',
-        OrderBy         => 'Down',
-        UserID          => 1,
-        Limit           => 30,
-        ConditionInline => $GenericAgentTicketSearch->{ExtendedSearchCondition},
+        Result              => 'ARRAY',
+        SortBy              => 'Age',
+        OrderBy             => 'Down',
+        UserID              => 1,
+        Limit               => 30,
+        ContentSearchPrefix => '*',
+        ContentSearchSuffix => '*',
+        ConditionInline     => $GenericAgentTicketSearch->{ExtendedSearchCondition},
         %JobData,
         %DynamicFieldSearchParameters,
     );


### PR DESCRIPTION
https://bugs.otrs.org/show_bug.cgi?id=7811

Hello @dvuckovic ,

Hereby is proposal for fixing this issue. Added 'ContentSearchPrefix' and 'ContentSearchSuffix' params in AdminGenericAgent when calling TicketSearch() function.

Please let me know if there are any issues or questions regarding this PR.

Regards,
Sanjin