### PR TITLE
Unified error messages and marked as translatable

### DIFF
--- a/Kernel/System/ACL/DB/ACL.pm
+++ b/Kernel/System/ACL/DB/ACL.pm
@@ -157,7 +157,8 @@ sub ACLAdd {
     if ($ACLExists) {
         $Kernel::OM->Get('Kernel::System::Log')->Log(
             Priority => 'error',
-            Message  => "The Name:$Param{Name} already exists for an ACL!"
+            Message  => $Kernel::OM->Get('Kernel::Language')
+                ->Translate( 'An ACL with the name "%s" already exists.', $Param{Name} ),
         );
         return;
     }
@@ -494,7 +495,8 @@ sub ACLUpdate {
     if ($ACLExists) {
         $Kernel::OM->Get('Kernel::System::Log')->Log(
             Priority => 'error',
-            Message  => "The Name:$Param{Name} already exists for a different ACL!",
+            Message  => $Kernel::OM->Get('Kernel::Language')
+                ->Translate( 'An ACL with the name "%s" already exists.', $Param{Name} ),
         );
         return;
     }

--- a/Kernel/System/AutoResponse.pm
+++ b/Kernel/System/AutoResponse.pm
@@ -575,7 +575,7 @@ sub _NameExistsCheck {
         $Kernel::OM->Get('Kernel::System::Log')->Log(
             Priority => 'error',
             Message  => $Kernel::OM->Get('Kernel::Language')
-                ->Translate( 'An auto-response with the name "%s" already exists!', $Param{Name} ),
+                ->Translate( 'An auto-response with the name "%s" already exists.', $Param{Name} ),
         );
         return;
     }

--- a/Kernel/System/AutoResponse.pm
+++ b/Kernel/System/AutoResponse.pm
@@ -574,7 +574,8 @@ sub _NameExistsCheck {
     if ($Flag) {
         $Kernel::OM->Get('Kernel::System::Log')->Log(
             Priority => 'error',
-            Message  => "An Auto-Response with name '$Param{Name}' already exists!",
+            Message  => $Kernel::OM->Get('Kernel::Language')
+                ->Translate( 'An auto-response with the name "%s" already exists!', $Param{Name} ),
         );
         return;
     }

--- a/Kernel/System/DynamicField.pm
+++ b/Kernel/System/DynamicField.pm
@@ -134,7 +134,8 @@ sub DynamicFieldAdd {
     if ($NameExists) {
         $Kernel::OM->Get('Kernel::System::Log')->Log(
             Priority => 'error',
-            Message  => "The name $Param{Name} already exists for a dynamic field!"
+            Message  => $Kernel::OM->Get('Kernel::Language')
+                ->Translate( 'A dynamic field with the name "%s" already exists.', $Param{Name} ),
         );
         return;
     }
@@ -416,7 +417,8 @@ sub DynamicFieldUpdate {
     if ($NameExists) {
         $Kernel::OM->Get('Kernel::System::Log')->Log(
             Priority => 'error',
-            Message  => "The name $Param{Name} already exists for a dynamic field!",
+            Message  => $Kernel::OM->Get('Kernel::Language')
+                ->Translate( 'A dynamic field with the name "%s" already exists.', $Param{Name} ),
         );
         return;
     }

--- a/Kernel/System/Group.pm
+++ b/Kernel/System/Group.pm
@@ -118,7 +118,8 @@ sub GroupAdd {
     if ( defined $ExistingGroups{ $Param{Name} } ) {
         $Kernel::OM->Get('Kernel::System::Log')->Log(
             Priority => 'error',
-            Message  => "A Group with the name $Param{Name} already exists.",
+            Message  => $Kernel::OM->Get('Kernel::Language')
+                ->Translate( 'A group with the name "%s" already exists.', $Param{Name} ),
         );
         return;
     }
@@ -249,7 +250,8 @@ sub GroupUpdate {
     if ( defined $ExistingGroups{ $Param{Name} } && $ExistingGroups{ $Param{Name} } != $Param{ID} ) {
         $Kernel::OM->Get('Kernel::System::Log')->Log(
             Priority => 'error',
-            Message  => "A Group with the name $Param{Name} already exists.",
+            Message  => $Kernel::OM->Get('Kernel::Language')
+                ->Translate( 'A group with the name "%s" already exists.', $Param{Name} ),
         );
         return;
     }
@@ -607,7 +609,8 @@ sub RoleAdd {
     if ( defined $ExistingRoles{ $Param{Name} } ) {
         $Kernel::OM->Get('Kernel::System::Log')->Log(
             Priority => 'error',
-            Message  => "A Role with the name $Param{Name} already exists.",
+            Message  => $Kernel::OM->Get('Kernel::Language')
+                ->Translate( 'A role with the name "%s" already exists.', $Param{Name} ),
         );
         return;
     }
@@ -689,7 +692,8 @@ sub RoleUpdate {
     if ( defined $ExistingRoles{ $Param{Name} } && $ExistingRoles{ $Param{Name} } != $Param{ID} ) {
         $Kernel::OM->Get('Kernel::System::Log')->Log(
             Priority => 'error',
-            Message  => "A Role with the name $Param{Name} already exists.",
+            Message  => $Kernel::OM->Get('Kernel::Language')
+                ->Translate( 'A role with the name "%s" already exists.', $Param{Name} ),
         );
         return;
     }

--- a/Kernel/System/NotificationEvent.pm
+++ b/Kernel/System/NotificationEvent.pm
@@ -309,7 +309,8 @@ sub NotificationAdd {
     if (%Check) {
         $Kernel::OM->Get('Kernel::System::Log')->Log(
             Priority => 'error',
-            Message  => "Can't add notification '$Param{Name}', notification already exists!",
+            Message  => $Kernel::OM->Get('Kernel::Language')
+                ->Translate( 'A notification with the name "%s" already exists.', $Param{Name} ),
         );
         return;
     }

--- a/Kernel/System/Queue.pm
+++ b/Kernel/System/Queue.pm
@@ -816,7 +816,8 @@ sub QueueAdd {
     if ( $Self->NameExistsCheck( Name => $Param{Name} ) ) {
         $Kernel::OM->Get('Kernel::System::Log')->Log(
             Priority => 'error',
-            Message  => "A queue with name '$Param{Name}' already exists!"
+            Message  => $Kernel::OM->Get('Kernel::Language')
+                ->Translate( 'A queue with the name "%s" already exists.', $Param{Name} ),
         );
         return;
     }
@@ -1171,7 +1172,8 @@ sub QueueUpdate {
     {
         $Kernel::OM->Get('Kernel::System::Log')->Log(
             Priority => 'error',
-            Message  => "A queue with name '$Param{Name}' already exists!"
+            Message  => $Kernel::OM->Get('Kernel::Language')
+                ->Translate( 'A queue with the name "%s" already exists.', $Param{Name} ),
         );
         return;
     }

--- a/Kernel/System/SLA.pm
+++ b/Kernel/System/SLA.pm
@@ -472,7 +472,8 @@ sub SLAAdd {
     if ($NoAdd) {
         $Kernel::OM->Get('Kernel::System::Log')->Log(
             Priority => 'error',
-            Message  => "Can't add new SLA! '$Param{Name}' already exists.",
+            Message  => $Kernel::OM->Get('Kernel::Language')
+                ->Translate( 'An SLA with the name "%s" already exists.', $Param{Name} ),
         );
         return;
     }
@@ -623,7 +624,8 @@ sub SLAUpdate {
     if ($Update) {
         $Kernel::OM->Get('Kernel::System::Log')->Log(
             Priority => 'error',
-            Message  => "Can't update SLA! '$Param{Name}' already exists.",
+            Message  => $Kernel::OM->Get('Kernel::Language')
+                ->Translate( 'An SLA with the name "%s" already exists.', $Param{Name} ),
         );
         return;
     }

--- a/Kernel/System/StandardTemplate.pm
+++ b/Kernel/System/StandardTemplate.pm
@@ -79,7 +79,8 @@ sub StandardTemplateAdd {
     if ( $Self->NameExistsCheck( Name => $Param{Name} ) ) {
         $Kernel::OM->Get('Kernel::System::Log')->Log(
             Priority => 'error',
-            Message  => "A standard template with name '$Param{Name}' already exists!"
+            Message  => $Kernel::OM->Get('Kernel::Language')
+                ->Translate( 'A standard template with name "%s" already exists!', $Param{Name} ), 
         );
         return;
     }
@@ -279,7 +280,8 @@ sub StandardTemplateUpdate {
     {
         $Kernel::OM->Get('Kernel::System::Log')->Log(
             Priority => 'error',
-            Message  => "A standard template with name '$Param{Name}' already exists!"
+            Message  => $Kernel::OM->Get('Kernel::Language')
+                ->Translate( 'A standard template with name "%s" already exists!', $Param{Name} ), 
         );
         return;
     }

--- a/Kernel/System/StandardTemplate.pm
+++ b/Kernel/System/StandardTemplate.pm
@@ -80,7 +80,7 @@ sub StandardTemplateAdd {
         $Kernel::OM->Get('Kernel::System::Log')->Log(
             Priority => 'error',
             Message  => $Kernel::OM->Get('Kernel::Language')
-                ->Translate( 'A standard template with name "%s" already exists!', $Param{Name} ), 
+                ->Translate( 'A standard template with name "%s" already exists.', $Param{Name} ), 
         );
         return;
     }
@@ -281,7 +281,7 @@ sub StandardTemplateUpdate {
         $Kernel::OM->Get('Kernel::System::Log')->Log(
             Priority => 'error',
             Message  => $Kernel::OM->Get('Kernel::Language')
-                ->Translate( 'A standard template with name "%s" already exists!', $Param{Name} ), 
+                ->Translate( 'A standard template with name "%s" already exists.', $Param{Name} ), 
         );
         return;
     }

--- a/Kernel/System/Type.pm
+++ b/Kernel/System/Type.pm
@@ -82,7 +82,7 @@ sub TypeAdd {
         $Kernel::OM->Get('Kernel::System::Log')->Log(
             Priority => 'error',
             Message  => $Kernel::OM->Get('Kernel::Language')
-                ->Translate( 'A type with name "%s" already exists!', $Param{Name} ),
+                ->Translate( 'A type with name "%s" already exists.', $Param{Name} ),
         );
         return;
     }
@@ -269,7 +269,7 @@ sub TypeUpdate {
         $Kernel::OM->Get('Kernel::System::Log')->Log(
             Priority => 'error',
             Message  => $Kernel::OM->Get('Kernel::Language')
-                ->Translate( 'A type with name "%s" already exists!', $Param{Name} ), 
+                ->Translate( 'A type with name "%s" already exists.', $Param{Name} ), 
         );
         return;
     }

--- a/Kernel/System/Type.pm
+++ b/Kernel/System/Type.pm
@@ -81,7 +81,8 @@ sub TypeAdd {
     if ( $Self->NameExistsCheck( Name => $Param{Name} ) ) {
         $Kernel::OM->Get('Kernel::System::Log')->Log(
             Priority => 'error',
-            Message  => "A type with name '$Param{Name}' already exists!"
+            Message  => $Kernel::OM->Get('Kernel::Language')
+                ->Translate( 'A type with name "%s" already exists!', $Param{Name} ),
         );
         return;
     }
@@ -267,7 +268,8 @@ sub TypeUpdate {
     {
         $Kernel::OM->Get('Kernel::System::Log')->Log(
             Priority => 'error',
-            Message  => "A type with name '$Param{Name}' already exists!"
+            Message  => $Kernel::OM->Get('Kernel::Language')
+                ->Translate( 'A type with name "%s" already exists!', $Param{Name} ), 
         );
         return;
     }

--- a/Kernel/System/User.pm
+++ b/Kernel/System/User.pm
@@ -357,7 +357,8 @@ sub UserAdd {
     if ( $Self->UserLoginExistsCheck( UserLogin => $Param{UserLogin} ) ) {
         $Kernel::OM->Get('Kernel::System::Log')->Log(
             Priority => 'error',
-            Message  => "A user with username '$Param{UserLogin}' already exists!"
+            Message  => $Kernel::OM->Get('Kernel::Language')
+                ->Translate( 'A user with the username "%s" already exists.', $Param{UserLogin} ),
         );
         return;
     }
@@ -509,7 +510,8 @@ sub UserUpdate {
     {
         $Kernel::OM->Get('Kernel::System::Log')->Log(
             Priority => 'error',
-            Message  => "A user with username '$Param{UserLogin}' already exists!"
+            Message  => $Kernel::OM->Get('Kernel::Language')
+                ->Translate( 'A user with the username "%s" already exists.', $Param{UserLogin} ),
         );
         return;
     }


### PR DESCRIPTION
Hi @mgruner 
I noticed, that when adding new items (group, role, SLA, service, etc.) the error messages are different when the name is already exists. I can unified the existing error messages, but the following items have no error message, the SQL error is displayed for the user (both branch rel-5_0 and master are affected):

Attachment:
![kep](https://cloud.githubusercontent.com/assets/1006118/25132531/2a25ae28-244a-11e7-9857-0467de6a6e27.png)

Salutation:
![kep](https://cloud.githubusercontent.com/assets/1006118/25132557/3b2185d0-244a-11e7-9251-bb19be6cb3b4.png)

Signature:
![kep](https://cloud.githubusercontent.com/assets/1006118/25132575/4707ded0-244a-11e7-8205-86091560898a.png)

ACL (error screen instead of ribbon):
![kep](https://cloud.githubusercontent.com/assets/1006118/25132586/51627444-244a-11e7-889a-993c673d8c1a.png)

State:
![kep](https://cloud.githubusercontent.com/assets/1006118/25132593/5b390af0-244a-11e7-92d4-45d8e844fca0.png)

Priority:
![kep](https://cloud.githubusercontent.com/assets/1006118/25132606/63e685c4-244a-11e7-9c9a-30bcd1f598bc.png)

Service (missing name):
![kep](https://cloud.githubusercontent.com/assets/1006118/25132651/85ce41cc-244a-11e7-976f-2e7e67825b84.png)

**EDIT**: Bug report for this issue: https://bugs.otrs.org/show_bug.cgi?id=12778