### PR TITLE
[ Rel-5_0 - Bug 12785 ] - Wrong convert for CustomerUser with '&' (amp) in adressbook in cc or bcc (not for 'to')

### DIFF
--- a/var/httpd/htdocs/js/Core.Agent.TicketAction.js
+++ b/var/httpd/htdocs/js/Core.Agent.TicketAction.js
@@ -111,7 +111,8 @@ Core.Agent.TicketAction = (function (TargetNS) {
             Core.Data.Get($Link.closest('tr'), 'Email')
             .replace(/&quot;/g, '"')
             .replace(/&lt;/g, '<')
-            .replace(/&gt;/g, '>');
+            .replace(/&gt;/g, '>')
+            .replace(/&amp;/g, '&');
         $Element.val(NewValue);
 
         Length = $Element.val().length;


### PR DESCRIPTION
https://bugs.otrs.org/show_bug.cgi?id=12785

Hello @dvuckovic ,

Hereby is proposal for fixing reporters issues. This fix is for Rel-5_0 since for master there is new AddressBook in which this problem is not present.

Please let me know if there are any issues or questions regarding this PR.

Regards,
Sanjin