### PR TITLE
[ Master - Bug 11028 ] - Owner and responsible always pre-selected in initial process screen

### DIFF
--- a/Kernel/Modules/AgentTicketProcess.pm
+++ b/Kernel/Modules/AgentTicketProcess.pm
@@ -2901,15 +2901,11 @@ sub _RenderResponsible {
         ValidateRequired => '',
     );
 
-    my $PossibleNone = 1;
-
     # if field is required put in the necessary variables for
     #    ValidateRequired class input field, Mandatory class for the label
-    #    do not allow empty selection
     if ( $Param{ActivityDialogField}->{Display} && $Param{ActivityDialogField}->{Display} == 2 ) {
         $Data{ValidateRequired} = 'Validate_Required';
         $Data{MandatoryClass}   = 'Mandatory';
-        $PossibleNone           = 0;
     }
 
     my $SelectedValue;
@@ -2949,23 +2945,18 @@ sub _RenderResponsible {
     #    (if any)
     if (
         !$SelectedValue
-        && !$PossibleNone
+        && $Param{ActivityDialogField}->{Display} == 2
         && IsHashRefWithData( $Param{Ticket} )
         )
     {
         $SelectedValue = $Param{Ticket}->{Responsible};
     }
 
-    # use current user as fallback, for all other cases where there is still no user
-    elsif ( !$SelectedValue ) {
-        $SelectedValue = $UserObject->UserLookup( UserID => $Self->{UserID} );
-    }
-
     # if we have a user already and the field is not mandatory and it is the same as in ticket, then
     #    set it to none (as it doesn't need to be changed afterall)
     elsif (
         $SelectedValue
-        && $PossibleNone
+        && $Param{ActivityDialogField}->{Display} != 2
         && IsHashRefWithData( $Param{Ticket} )
         && $SelectedValue eq $Param{Ticket}->{Responsible}
         )
@@ -2989,12 +2980,11 @@ sub _RenderResponsible {
 
     # build Responsible string
     $Data{Content} = $LayoutObject->BuildSelection(
-        Data         => $Responsibles,
-        Name         => 'ResponsibleID',
-        Translation  => 1,
-        SelectedID   => $SelectedID,
-        Class        => "Modernize $ServerError",
-        PossibleNone => $PossibleNone,
+        Data        => $Responsibles,
+        Name        => 'ResponsibleID',
+        Translation => 1,
+        SelectedID  => $SelectedID,
+        Class       => "Modernize $ServerError",
     );
 
     # send data to JS
@@ -3075,15 +3065,11 @@ sub _RenderOwner {
         ValidateRequired => '',
     );
 
-    my $PossibleNone = 1;
-
     # if field is required put in the necessary variables for
     #    ValidateRequired class input field, Mandatory class for the label
-    #    do not allow empty selection
     if ( $Param{ActivityDialogField}->{Display} && $Param{ActivityDialogField}->{Display} == 2 ) {
         $Data{ValidateRequired} = 'Validate_Required';
         $Data{MandatoryClass}   = 'Mandatory';
-        $PossibleNone           = 0;
     }
 
     my $SelectedValue;
@@ -3126,23 +3112,18 @@ sub _RenderOwner {
     #    (if any)
     if (
         !$SelectedValue
-        && !$PossibleNone
+        && $Param{ActivityDialogField}->{Display} == 2
         && IsHashRefWithData( $Param{Ticket} )
         )
     {
         $SelectedValue = $Param{Ticket}->{Owner};
     }
 
-    # use current user as fallback, for all other cases where there is still no user
-    elsif ( !$SelectedValue ) {
-        $SelectedValue = $UserObject->UserLookup( UserID => $Self->{UserID} );
-    }
-
     # if we have a user already and the field is not mandatory and it is the same as in ticket, then
     #    set it to none (as it doesn't need to be changed afterall)
     elsif (
         $SelectedValue
-        && $PossibleNone
+        && $Param{ActivityDialogField}->{Display} != 2
         && IsHashRefWithData( $Param{Ticket} )
         && $SelectedValue eq $Param{Ticket}->{Owner}
         )
@@ -3166,12 +3147,11 @@ sub _RenderOwner {
 
     # build Owner string
     $Data{Content} = $LayoutObject->BuildSelection(
-        Data         => $Owners,
-        Name         => 'OwnerID',
-        Translation  => 1,
-        SelectedID   => $SelectedID || '',
-        Class        => "Modernize $ServerError",
-        PossibleNone => $PossibleNone,
+        Data        => $Owners,
+        Name        => 'OwnerID',
+        Translation => 1,
+        SelectedID  => $SelectedID || '',
+        Class       => "Modernize $ServerError",
     );
 
     # send data to JS
@@ -5744,6 +5724,9 @@ sub _GetResponsibles {
         }
     }
 
+    # Add empty user selection.
+    $ShownUsers{''} = '-';
+
     # workflow
     my $ACL = $TicketObject->TicketAcl(
         %Param,
@@ -5837,6 +5820,9 @@ sub _GetOwners {
             }
         }
     }
+
+    # Add empty user selection.
+    $ShownUsers{''} = '-';
 
     # workflow
     my $ACL = $TicketObject->TicketAcl(


### PR DESCRIPTION
https://bugs.otrs.org/show_bug.cgi?id=11028

Hello @dvuckovic ,

Hereby is proposal for fixing reporters issues. Had to add empty selection since it was not possible to handle it via BuilsSelection() - PossibleNone param. Removed also part in which by default if there is no ticket or default values current user is pre-selected.

Please let me know if there are any issues or questions regarding this PR.

Regards,
Sanjin