### PR TITLE
[ Rel-5_0 - Follow-up Bug 12773 ] - In case of big screen resolution the Subject field is too long

### DIFF
--- a/var/httpd/htdocs/skins/Customer/default/css/Core.Form.css
+++ b/var/httpd/htdocs/skins/Customer/default/css/Core.Form.css
@@ -241,7 +241,7 @@ fieldset select {
 
 .TicketCompose fieldset #Subject {
     width: 50%;
-    max-width: 614px;
+    max-width: 620px;
 }
 
 fieldset.Columns .Column {


### PR DESCRIPTION
https://bugs.otrs.org/show_bug.cgi?id=12773

Hello @mrcbnsls ,

Hereby is just short fix for rel-5_0 in which max-width for Subject field is increased so it match default RichText editor width.

Regards,
Sanjin