### PR TITLE
[ Master - Bug 7958 ] - Agent email-address is visible in CustomerTicketZoom on note-external

### DIFF
--- a/Kernel/Modules/CustomerTicketZoom.pm
+++ b/Kernel/Modules/CustomerTicketZoom.pm
@@ -1561,25 +1561,16 @@ sub _Mask {
             );
         }
 
-        # do some strips && quoting
-        my $RecipientDisplayType = $ConfigObject->Get('Ticket::Frontend::DefaultRecipientDisplayType') || 'Realname';
-        my $SenderDisplayType    = $ConfigObject->Get('Ticket::Frontend::DefaultSenderDisplayType')    || 'Realname';
         KEY:
         for my $Key (qw(From To Cc)) {
 
             next KEY if !$Article{$Key};
 
-            my $DisplayType = $Key eq 'From'             ? $SenderDisplayType : $RecipientDisplayType;
-            my $HiddenType  = $DisplayType eq 'Realname' ? 'Value'            : 'Realname';
-
             $LayoutObject->Block(
                 Name => 'ArticleRow',
                 Data => {
-                    Key                  => $Key,
-                    Value                => $Article{$Key},
-                    Realname             => $Article{ $Key . 'Realname' },
-                    ArticleID            => $Article{ArticleID},
-                    $HiddenType . Hidden => 'Hidden',
+                    Key      => $Key,
+                    Realname => $Article{ $Key . 'Realname' },
                 },
             );
         }

--- a/Kernel/Output/HTML/Templates/Standard/CustomerTicketZoom.tt
+++ b/Kernel/Output/HTML/Templates/Standard/CustomerTicketZoom.tt
@@ -81,11 +81,8 @@
                         <div class="Details SeperatorRow">
 [% RenderBlockStart("ArticleRow") %]
                             <div>
-                                <div class="Label Switchable">[% Translate(Data.Key) | html %]:</div>
-                                <span title="[% Data.Value | html %]">
-                                    <span class="Switch [% Data.ValueHidden | html %]">[% Data.Value | html %]</span>
-                                    <span class="Switch [% Data.RealnameHidden | html %]">[% Data.Realname | html %]</span>
-                                </span>
+                                <div class="Label">[% Translate(Data.Key) | html %]:</div>
+                                <span title="[% Data.Realname | html %]">[% Data.Realname | html %]</span>
                                 <div class="Clear"></div>
                             </div>
 [% RenderBlockEnd("ArticleRow") %]

--- a/var/httpd/htdocs/js/Core.Customer.TicketZoom.js
+++ b/var/httpd/htdocs/js/Core.Customer.TicketZoom.js
@@ -226,11 +226,6 @@ Core.Customer.TicketZoom = (function (TargetNS) {
             ResizeIframe($VisibleIframe.get(0));
         }
 
-        // add switchable toggle
-        $('div.Label.Switchable').off('click.Switch').on('click.Switch', function() {
-            $(this).next('span').find('.Switch').toggleClass('Hidden');
-        });
-
         // init browser link message close button
         if ($('.MessageBrowser').length) {
             $('.MessageBrowser a.Close').on('click', function () {

--- a/var/httpd/htdocs/skins/Customer/default/css/Core.TicketZoom.css
+++ b/var/httpd/htdocs/skins/Customer/default/css/Core.TicketZoom.css
@@ -264,10 +264,6 @@
     height: auto;
 }
 
-#Messages .MessageBody div.Label.Switchable {
-    cursor: pointer;
-}
-
 #NoArticles {
     border: 1px solid #E9E9E9;
     border-bottom: 1px solid #DDD;


### PR DESCRIPTION
https://bugs.otrs.org/show_bug.cgi?id=7958

Hello @dvuckovic ,

Hereby is proposal for fixing reporters issue. Removed showing email address in customer interface for article To, From and Cc. With this change also removed option to toggle type of showing data ( RealName / RealName <email> ) when clicking on label. These changes only affect customer interface, agent interface remains intact.

Please let me know if you have any questions or issues regarding this PR.

Regards,
Sanjin