### PR TITLE
[ Rel-5_0 - Bug 11243 ] - Wrong escalation time if response time set to 60 or less minutes

### DIFF
--- a/Kernel/System/Time.pm
+++ b/Kernel/System/Time.pm
@@ -731,8 +731,8 @@ sub DestinationTime {
 
                 # Check if we have a working hour
                 if ( grep { $H == $_ } @{ $TimeWorkingHours->{ $LDay{$WDay} } } ) {
-                    if ( $Param{Time} > 60 * 60 ) {
-                        my $RestOfHour = 3600 - ( $Minute * 60 + $Second );
+                    my $RestOfHour = 3600 - ( $Minute * 60 + $Second );
+                    if ( $Param{Time} > $RestOfHour ) {
                         $DestinationTime += $RestOfHour;
                         $Param{Time} -= $RestOfHour;
                     }


### PR DESCRIPTION
https://bugs.otrs.org/show_bug.cgi?id=11243

Hi @dvuckovic 

It is a proposal for fix of reported bug which does not exist on master branch because of Time object changes.
Bug appeared every time when escalation time is set to less than 60 minutes and is greater than the rest of a day working time. Because of that, IF clause is modified.
Unit test Escalations.t is extended for inspecting of described case.
If you have any comment please let me know.

Regards,
Milan