### PR TITLE
[ Master - Bug 10681 ] - Fixed wrong FieldOrder default value at Dynamic Field creation

### DIFF
--- a/Kernel/Modules/AdminDynamicField.pm
+++ b/Kernel/Modules/AdminDynamicField.pm
@@ -313,8 +313,6 @@ sub _DynamicFieldsListShow {
         );
     }
 
-    my $MaxFieldOrder = 0;
-
     # check if at least 1 dynamic field is registered in the system
     if ( $Param{Total} ) {
 
@@ -374,11 +372,6 @@ sub _DynamicFieldsListShow {
                         },
                     );
                 }
-
-                # set MaxFieldOrder
-                if ( int $DynamicFieldData->{FieldOrder} > int $MaxFieldOrder ) {
-                    $MaxFieldOrder = $DynamicFieldData->{FieldOrder}
-                }
             }
         }
     }
@@ -394,7 +387,7 @@ sub _DynamicFieldsListShow {
     $LayoutObject->Block(
         Name => 'MaxFieldOrder',
         Data => {
-            MaxFieldOrder => $MaxFieldOrder,
+            MaxFieldOrder => scalar @{ $Param{DynamicFields} },
         },
     );
 

--- a/scripts/test/Selenium/Agent/Admin/DynamicField/AdminDynamicFieldCheckbox.t
+++ b/scripts/test/Selenium/Agent/Admin/DynamicField/AdminDynamicFieldCheckbox.t
@@ -12,20 +12,20 @@ use utf8;
 
 use vars (qw($Self));
 
-# get selenium object
+# Get selenium object.
 my $Selenium = $Kernel::OM->Get('Kernel::System::UnitTest::Selenium');
 
 $Selenium->RunTest(
     sub {
 
-        # get helper object
+        # Get helper object.
         my $Helper = $Kernel::OM->Get('Kernel::System::UnitTest::Helper');
 
         my %DynamicFieldsOverviewPageShownSysConfig = $Kernel::OM->Get('Kernel::System::SysConfig')->SettingGet(
             Name => 'PreferencesGroups###DynamicFieldsOverviewPageShown',
         );
 
-        # show more dynamic fields per page as the default value
+        # Show more dynamic fields per page as the default value.
         $Helper->ConfigSettingChange(
             Valid => 1,
             Key   => 'PreferencesGroups###DynamicFieldsOverviewPageShown',
@@ -35,7 +35,7 @@ $Selenium->RunTest(
             },
         );
 
-        # create test user and login
+        # Create test user and login.
         my $TestUserLogin = $Helper->TestUserCreate(
             Groups => ['admin'],
         ) || die "Did not get test user";
@@ -46,13 +46,13 @@ $Selenium->RunTest(
             Password => $TestUserLogin,
         );
 
-        # get script alias
+        # Get script alias.
         my $ScriptAlias = $Kernel::OM->Get('Kernel::Config')->Get('ScriptAlias');
 
-        # navigate to AdminDynamicField screen
+        # Navigate to AdminDynamicField screen.
         $Selenium->VerifiedGet("${ScriptAlias}index.pl?Action=AdminDynamicField");
 
-        # create and edit Ticket and Article DynamicFieldCheckbox
+        # Create and edit Ticket and Article DynamicFieldCheckbox.
         for my $Type (qw(Ticket Article)) {
 
             my $ObjectType = $Type . "DynamicField";
@@ -60,7 +60,7 @@ $Selenium->RunTest(
                 "\$('#$ObjectType').val('Checkbox').trigger('redraw.InputField').trigger('change');"
             );
 
-            # wait until page has finished loading
+            # Wait until page has finished loading.
             $Selenium->WaitFor( JavaScript => 'return typeof($) === "function" && $("#Name").length' );
 
             for my $ID (
@@ -72,7 +72,7 @@ $Selenium->RunTest(
                 $Element->is_displayed();
             }
 
-            # check client side validation
+            # Check client side validation.
             my $Element2 = $Selenium->find_element( "#Name", 'css' );
             $Element2->send_keys("");
             $Element2->VerifiedSubmit();
@@ -85,26 +85,26 @@ $Selenium->RunTest(
                 'Client side validation correctly detected missing input value',
             );
 
-            # create real text DynamicFieldCheckbox
+            # Create real text DynamicFieldCheckbox.
             my $RandomID = $Helper->GetRandomID();
 
             $Selenium->find_element( "#Name",  'css' )->send_keys($RandomID);
             $Selenium->find_element( "#Label", 'css' )->send_keys($RandomID);
             $Selenium->find_element( "#Name",  'css' )->VerifiedSubmit();
 
-            # check for test DynamicFieldCheckbox on AdminDynamicField screen
+            # Check for test DynamicFieldCheckbox on AdminDynamicField screen.
             $Self->True(
                 index( $Selenium->get_page_source(), $RandomID ) > -1,
                 "DynamicFieldCheckbox $RandomID found on table"
             ) || die;
 
-            # edit test DynamicFieldCheckbox default value and set it to invalid
+            # Edit test DynamicFieldCheckbox default value and set it to invalid.
             $Selenium->find_element( $RandomID, 'link_text' )->VerifiedClick();
 
             $Selenium->execute_script("\$('#DefaultValue').val('1').trigger('redraw.InputField').trigger('change');");
             $Selenium->execute_script("\$('#ValidID').val('2').trigger('redraw.InputField').trigger('change');");
 
-            # edit name to trigger JS and verify warning is visible
+            # Edit name to trigger JS and verify warning is visible.
             my $EditName = $RandomID . 'edit';
             $Selenium->find_element( "#Name", 'css' )->clear();
             $Selenium->find_element( "#Name", 'css' )->send_keys($EditName);
@@ -115,10 +115,10 @@ $Selenium->RunTest(
                 "Warning text is shown - JS is successful",
             );
 
-            # submit form
+            # Submit form.
             $Selenium->find_element( "#Name", 'css' )->VerifiedSubmit();
 
-            # check new and edited DynamicFieldCheckbox values
+            # Check new and edited DynamicFieldCheckbox values.
             $Selenium->find_element( $EditName, 'link_text' )->VerifiedClick();
 
             $Self->Is(
@@ -147,10 +147,7 @@ $Selenium->RunTest(
                 "#DefaultValue updated value",
             );
 
-            # go back to AdminDynamicField screen
-            $Selenium->VerifiedGet("${ScriptAlias}index.pl?Action=AdminDynamicField");
-
-            # delete DynamicFields
+            # Delete DynamicField.
             my $DynamicFieldObject = $Kernel::OM->Get('Kernel::System::DynamicField');
             my $DynamicField       = $DynamicFieldObject->DynamicFieldGet(
                 Name => $EditName,
@@ -160,15 +157,18 @@ $Selenium->RunTest(
                 UserID => 1,
             );
 
-            # sanity check
+            # Sanity check.
             $Self->True(
                 $Success,
                 "DynamicFieldDelete() - $RandomID"
             );
 
+            # Go back to AdminDynamicField screen.
+            $Selenium->VerifiedGet("${ScriptAlias}index.pl?Action=AdminDynamicField");
+
         }
 
-        # delete cache
+        # Make sure cache is correct.
         $Kernel::OM->Get('Kernel::System::Cache')->CleanUp( Type => "DynamicField" );
 
     }

--- a/scripts/test/Selenium/Agent/Admin/DynamicField/AdminDynamicFieldDateTime.t
+++ b/scripts/test/Selenium/Agent/Admin/DynamicField/AdminDynamicFieldDateTime.t
@@ -12,20 +12,20 @@ use utf8;
 
 use vars (qw($Self));
 
-# get selenium object
+# Get selenium object.
 my $Selenium = $Kernel::OM->Get('Kernel::System::UnitTest::Selenium');
 
 $Selenium->RunTest(
     sub {
 
-        # get helper object
+        # Get helper object.
         my $Helper = $Kernel::OM->Get('Kernel::System::UnitTest::Helper');
 
         my %DynamicFieldsOverviewPageShownSysConfig = $Kernel::OM->Get('Kernel::System::SysConfig')->SettingGet(
             Name => 'PreferencesGroups###DynamicFieldsOverviewPageShown',
         );
 
-        # show more dynamic fields per page as the default value
+        # Show more dynamic fields per page as the default value.
         $Helper->ConfigSettingChange(
             Valid => 1,
             Key   => 'PreferencesGroups###DynamicFieldsOverviewPageShown',
@@ -35,7 +35,7 @@ $Selenium->RunTest(
             },
         );
 
-        # create test user and login
+        # Create test user and login.
         my $TestUserLogin = $Helper->TestUserCreate(
             Groups => ['admin'],
         ) || die "Did not get test user";
@@ -46,19 +46,19 @@ $Selenium->RunTest(
             Password => $TestUserLogin,
         );
 
-        # get script alias
+        # Get script alias.
         my $ScriptAlias = $Kernel::OM->Get('Kernel::Config')->Get('ScriptAlias');
 
-        # navigate to AdminDynamicField
+        # Navigate to AdminDynamicField.
         $Selenium->VerifiedGet("${ScriptAlias}index.pl?Action=AdminDynamicField");
 
-        # create and edit Ticket and Article DynamicFieldCheckbox
+        # Create and edit Ticket and Article DynamicFieldCheckbox.
         for my $Type (qw(Ticket Article)) {
 
             my $ObjectType = $Type . "DynamicField";
             $Selenium->execute_script("\$('#$ObjectType').val('Date').trigger('redraw.InputField').trigger('change');");
 
-            # wait until page has finished loading
+            # Wait until page has finished loading.
             $Selenium->WaitFor( JavaScript => 'return typeof($) === "function" && $("#Name").length' );
 
             for my $ID (
@@ -70,7 +70,7 @@ $Selenium->RunTest(
                 $Element->is_displayed();
             }
 
-            # check client side validation
+            # Check client side validation.
             my $Element = $Selenium->find_element( "#Name", 'css' );
             $Element->send_keys("");
             $Element->VerifiedSubmit();
@@ -83,7 +83,7 @@ $Selenium->RunTest(
                 'Client side validation correctly detected missing input value',
             );
 
-            # check default values
+            # Check default values.
             $Selenium->execute_script("\$('#YearsPeriod').val('1').trigger('redraw.InputField').trigger('change');");
 
             $Self->Is(
@@ -102,20 +102,20 @@ $Selenium->RunTest(
                 "#YearsInFuture updated value",
             );
 
-            # create real text DynamicFieldDate
+            # Create real text DynamicFieldDate.
             my $RandomID = $Helper->GetRandomID();
 
             $Selenium->find_element( "#Name",  'css' )->send_keys($RandomID);
             $Selenium->find_element( "#Label", 'css' )->send_keys($RandomID);
             $Selenium->find_element( "#Name",  'css' )->VerifiedSubmit();
 
-            # check for test DynamicFieldCheckbox on AdminDynamicField screen
+            # Check for test DynamicFieldCheckbox on AdminDynamicField screen.
             $Self->True(
                 index( $Selenium->get_page_source(), $RandomID ) > -1,
                 "DynamicFieldDate $RandomID found on table"
             ) || die;
 
-            # edit test DynamicFieldDate years period, default value and set it to invalid
+            # Edit test DynamicFieldDate years period, default value and set it to invalid.
             $Selenium->find_element( $RandomID, 'link_text' )->VerifiedClick();
 
             $Selenium->find_element( "#DefaultValue",  'css' )->clear();
@@ -127,7 +127,7 @@ $Selenium->RunTest(
             $Selenium->execute_script("\$('#ValidID').val('2').trigger('redraw.InputField').trigger('change');");
             $Selenium->find_element( "#Name", 'css' )->VerifiedSubmit();
 
-            # check new and edited DynamicFieldDateTime values
+            # Check new and edited DynamicFieldDateTime values.
             $Selenium->find_element( $RandomID, 'link_text' )->VerifiedClick();
 
             $Self->Is(
@@ -166,10 +166,7 @@ $Selenium->RunTest(
                 "#ValidID updated value",
             );
 
-            # go back to AdminDynamicField screen
-            $Selenium->VerifiedGet("${ScriptAlias}index.pl?Action=AdminDynamicField");
-
-            # delete DynamicFields
+            # Delete DynamicField.
             my $DynamicFieldObject = $Kernel::OM->Get('Kernel::System::DynamicField');
             my $DynamicField       = $DynamicFieldObject->DynamicFieldGet(
                 Name => $RandomID,
@@ -179,15 +176,18 @@ $Selenium->RunTest(
                 UserID => 1,
             );
 
-            # sanity check
+            # Sanity check.
             $Self->True(
                 $Success,
                 "DynamicFieldDelete() - $RandomID"
             );
 
+            # Go back to AdminDynamicField screen.
+            $Selenium->VerifiedGet("${ScriptAlias}index.pl?Action=AdminDynamicField");
+
         }
 
-        # make sure cache is correct
+        # Make sure cache is correct.
         $Kernel::OM->Get('Kernel::System::Cache')->CleanUp( Type => "DynamicField" );
 
     }

--- a/scripts/test/Selenium/Agent/Admin/DynamicField/AdminDynamicFieldDropdown.t
+++ b/scripts/test/Selenium/Agent/Admin/DynamicField/AdminDynamicFieldDropdown.t
@@ -12,20 +12,20 @@ use utf8;
 
 use vars (qw($Self));
 
-# get selenium object
+# Get selenium object.
 my $Selenium = $Kernel::OM->Get('Kernel::System::UnitTest::Selenium');
 
 $Selenium->RunTest(
     sub {
 
-        # get helper object
+        # Get helper object.
         my $Helper = $Kernel::OM->Get('Kernel::System::UnitTest::Helper');
 
         my %DynamicFieldsOverviewPageShownSysConfig = $Kernel::OM->Get('Kernel::System::SysConfig')->SettingGet(
             Name => 'PreferencesGroups###DynamicFieldsOverviewPageShown',
         );
 
-        # show more dynamic fields per page as the default value
+        # Show more dynamic fields per page as the default value.
         $Helper->ConfigSettingChange(
             Valid => 1,
             Key   => 'PreferencesGroups###DynamicFieldsOverviewPageShown',
@@ -35,7 +35,7 @@ $Selenium->RunTest(
             },
         );
 
-        # create test user and login
+        # Create test user and login.
         my $TestUserLogin = $Helper->TestUserCreate(
             Groups => ['admin'],
         ) || die "Did not get test user";
@@ -46,21 +46,21 @@ $Selenium->RunTest(
             Password => $TestUserLogin,
         );
 
-        # get script alias
+        # Get script alias.
         my $ScriptAlias = $Kernel::OM->Get('Kernel::Config')->Get('ScriptAlias');
 
-        # navigate to AdminDynamicField screen
+        # Navigate to AdminDynamicField screen.
         $Selenium->VerifiedGet("${ScriptAlias}index.pl?Action=AdminDynamicField");
 
-        # create and edit Ticket and Article DynamicFieldDropdown
+        # Create and edit Ticket and Article DynamicFieldDropdown.
         for my $Type (qw(Ticket Article)) {
 
             my $ObjectType = $Type . "DynamicField";
 
-            # add dynamic field of type Dropdown
+            # Add dynamic field of type Dropdown.
             $Selenium->execute_script("\$('#$ObjectType').val('Dropdown').trigger('change');");
 
-            # wait until page has finished loading
+            # Wait until page has finished loading.
             $Selenium->WaitFor( JavaScript => 'return typeof($) === "function" && $("#Name").length' );
 
             for my $ID (
@@ -72,7 +72,7 @@ $Selenium->RunTest(
                 $Element->is_displayed();
             }
 
-            # check client side validation
+            # Check client side validation.
             my $Element = $Selenium->find_element( "#Name", 'css' );
             $Element->send_keys("");
             $Element->VerifiedSubmit();
@@ -85,7 +85,7 @@ $Selenium->RunTest(
                 'Client side validation correctly detected missing input value',
             );
 
-            # create real text DynamicFieldDropdown
+            # Create real text DynamicFieldDropdown.
             my $RandomID = $Helper->GetRandomID();
 
             $Selenium->find_element( "#Name",     'css' )->send_keys($RandomID);
@@ -94,22 +94,22 @@ $Selenium->RunTest(
             $Selenium->find_element( "#Key_1",    'css' )->send_keys("Key1");
             $Selenium->find_element( "#Value_1",  'css' )->send_keys("Value1");
 
-            # check default value
+            # Check default value.
             $Self->Is(
                 $Selenium->find_element( "#DefaultValue option[value='Key1']", 'css' )->is_enabled(),
                 1,
                 "Key1 is possible #DefaultValue",
             );
 
-            # add another possible value
+            # Add another possible value.
             $Selenium->find_element( "#AddValue", 'css' )->VerifiedClick();
             $Selenium->find_element( "#Key_2",    'css' )->send_keys("Key2");
             $Selenium->find_element( "#Value_2",  'css' )->send_keys("Value2");
 
-            # add another possible value
+            # Add another possible value.
             $Selenium->find_element( "#AddValue", 'css' )->VerifiedClick();
 
-            # submit form, expecting validation check
+            # Submit form, expecting validation check.
             $Selenium->find_element("//button[\@value='Save'][\@type='submit']")->VerifiedClick();
 
             $Self->Is(
@@ -120,42 +120,42 @@ $Selenium->RunTest(
                 'Client side validation correctly detected missing input value for added possible value',
             );
 
-            # input possible value
+            # Input possible value.
             $Selenium->find_element( "#Key_3",   'css' )->send_keys("Key3");
             $Selenium->find_element( "#Value_3", 'css' )->send_keys("Value3");
 
-            # select default value
+            # Select default value.
             $Selenium->execute_script(
                 "\$('#DefaultValue').val('Key3').trigger('redraw.InputField').trigger('change');"
             );
 
-            # verify default value
+            # Verify default value.
             $Self->Is(
                 $Selenium->find_element( "#DefaultValue", 'css' )->get_value(),
                 'Key3',
                 "Key3 is possible #DefaultValue",
             );
 
-            # remove added possible value
+            # Remove added possible value.
             $Selenium->find_element( "#RemoveValue__3", 'css' )->VerifiedClick();
 
-            # verify default value is changed
+            # Verify default value is changed.
             $Self->Is(
                 $Selenium->find_element( "#DefaultValue", 'css' )->get_value(),
                 '',
                 "DefaultValue is removed",
             );
 
-            # submit form
+            # Submit form.
             $Selenium->find_element( "#Name", 'css' )->VerifiedSubmit();
 
-            # check for test DynamicFieldDropdown on AdminDynamicField screen
+            # Check for test DynamicFieldDropdown on AdminDynamicField screen.
             $Self->True(
                 index( $Selenium->get_page_source(), $RandomID ) > -1,
                 "DynamicFieldDropdown $RandomID found on table"
             ) || die;
 
-            # edit test DynamicFieldDropdown possible none, treeview, default value and set it to invalid
+            # Edit test DynamicFieldDropdown possible none, treeview, default value and set it to invalid.
             $Selenium->find_element( $RandomID, 'link_text' )->VerifiedClick();
 
             $Selenium->execute_script(
@@ -166,7 +166,7 @@ $Selenium->RunTest(
             $Selenium->execute_script("\$('#ValidID').val('2').trigger('redraw.InputField').trigger('change');");
             $Selenium->find_element( "#Name", 'css' )->VerifiedSubmit();
 
-            # check new and edited DynamicFieldDropdown values
+            # Check new and edited DynamicFieldDropdown values.
             $Selenium->find_element( $RandomID, 'link_text' )->VerifiedClick();
 
             $Self->Is(
@@ -220,10 +220,7 @@ $Selenium->RunTest(
                 "#ValidID updated value",
             );
 
-            # go back to AdminDynamicField screen
-            $Selenium->VerifiedGet("${ScriptAlias}index.pl?Action=AdminDynamicField");
-
-            # delete DynamicFields
+            # Delete DynamicField.
             my $DynamicFieldObject = $Kernel::OM->Get('Kernel::System::DynamicField');
             my $DynamicField       = $DynamicFieldObject->DynamicFieldGet(
                 Name => $RandomID,
@@ -233,15 +230,18 @@ $Selenium->RunTest(
                 UserID => 1,
             );
 
-            # sanity check
+            # Sanity check.
             $Self->True(
                 $Success,
                 "DynamicFieldDelete() - $RandomID"
             );
 
+            # Go back to AdminDynamicField screen.
+            $Selenium->VerifiedGet("${ScriptAlias}index.pl?Action=AdminDynamicField");
+
         }
 
-        # make sure cache is correct
+        # Make sure cache is correct.
         $Kernel::OM->Get('Kernel::System::Cache')->CleanUp( Type => "DynamicField" );
 
     }

--- a/scripts/test/Selenium/Agent/Admin/DynamicField/AdminDynamicFieldMultiselect.t
+++ b/scripts/test/Selenium/Agent/Admin/DynamicField/AdminDynamicFieldMultiselect.t
@@ -12,20 +12,20 @@ use utf8;
 
 use vars (qw($Self));
 
-# get selenium object
+# Get selenium object.
 my $Selenium = $Kernel::OM->Get('Kernel::System::UnitTest::Selenium');
 
 $Selenium->RunTest(
     sub {
 
-        # get helper object
+        # Get helper object.
         my $Helper = $Kernel::OM->Get('Kernel::System::UnitTest::Helper');
 
         my %DynamicFieldsOverviewPageShownSysConfig = $Kernel::OM->Get('Kernel::System::SysConfig')->SettingGet(
             Name => 'PreferencesGroups###DynamicFieldsOverviewPageShown',
         );
 
-        # show more dynamic fields per page as the default value
+        # Show more dynamic fields per page as the default value.
         $Helper->ConfigSettingChange(
             Valid => 1,
             Key   => 'PreferencesGroups###DynamicFieldsOverviewPageShown',
@@ -35,7 +35,7 @@ $Selenium->RunTest(
             },
         );
 
-        # create test user and login
+        # Create test user and login.
         my $TestUserLogin = $Helper->TestUserCreate(
             Groups => ['admin'],
         ) || die "Did not get test user";
@@ -46,13 +46,13 @@ $Selenium->RunTest(
             Password => $TestUserLogin,
         );
 
-        # get script alias
+        # Get script alias.
         my $ScriptAlias = $Kernel::OM->Get('Kernel::Config')->Get('ScriptAlias');
 
-        # navigate to AdminDynamicField screen
+        # Navigate to AdminDynamicField screen.
         $Selenium->VerifiedGet("${ScriptAlias}index.pl?Action=AdminDynamicField");
 
-        # create and edit Ticket and Article DynamicFieldMultiselect
+        # Create and edit Ticket and Article DynamicFieldMultiselect.
         for my $Type (qw(Ticket Article)) {
 
             my $ObjectType = $Type . "DynamicField";
@@ -60,7 +60,7 @@ $Selenium->RunTest(
                 "\$('#$ObjectType').val('Multiselect').trigger('redraw.InputField').trigger('change');"
             );
 
-            # wait until page has finished loading
+            # Wait until page has finished loading.
             $Selenium->WaitFor( JavaScript => 'return typeof($) === "function" && $("#Name").length' );
 
             for my $ID (
@@ -72,7 +72,7 @@ $Selenium->RunTest(
                 $Element->is_displayed();
             }
 
-            # check client side validation
+            # Check client side validation.
             my $Element2 = $Selenium->find_element( "#Name", 'css' );
             $Element2->send_keys("");
             $Element2->VerifiedSubmit();
@@ -85,7 +85,7 @@ $Selenium->RunTest(
                 'Client side validation correctly detected missing input value',
             );
 
-            # create real text DynamicFieldMultiselect
+            # Create real text DynamicFieldMultiselect.
             my $RandomID = $Helper->GetRandomID();
 
             $Selenium->find_element( "#Name",     'css' )->send_keys($RandomID);
@@ -94,22 +94,22 @@ $Selenium->RunTest(
             $Selenium->find_element( "#Key_1",    'css' )->send_keys("Key1");
             $Selenium->find_element( "#Value_1",  'css' )->send_keys("Value1");
 
-            # check default value
+            # Check default value.
             $Self->Is(
                 $Selenium->find_element( "#DefaultValue option[value='Key1']", 'css' )->get_value(),
                 'Key1',
                 "Key1 is possible #DefaultValue",
             );
 
-            # add another possible value
+            # Add another possible value.
             $Selenium->find_element( "#AddValue", 'css' )->VerifiedClick();
             $Selenium->find_element( "#Key_2",    'css' )->send_keys("Key2");
             $Selenium->find_element( "#Value_2",  'css' )->send_keys("Value2");
 
-            # add another possible value
+            # Add another possible value.
             $Selenium->find_element( "#AddValue", 'css' )->VerifiedClick();
 
-            # submit form, expecting validation check
+            # Submit form, expecting validation check.
             $Selenium->find_element("//button[\@type='submit']")->VerifiedClick();
 
             $Self->Is(
@@ -120,26 +120,26 @@ $Selenium->RunTest(
                 'Client side validation correctly detected missing input value for added possible value',
             );
 
-            # input possible value
+            # Input possible value.
             $Selenium->find_element( "#Key_3",   'css' )->send_keys("Key3");
             $Selenium->find_element( "#Value_3", 'css' )->send_keys("Value3");
 
-            # select default value
+            # Select default value.
             $Selenium->execute_script(
                 "\$('#DefaultValue').val('Key3').trigger('redraw.InputField').trigger('change');"
             );
 
-            # verify default value
+            # Verify default value.
             $Self->Is(
                 $Selenium->find_element( "#DefaultValue", 'css' )->get_value(),
                 'Key3',
                 "Key3 is possible #DefaultValue",
             );
 
-            # remove added possible value
+            # Remove added possible value.
             $Selenium->find_element( "#RemoveValue__3", 'css' )->VerifiedClick();
 
-            # verify default value is changed
+            # Verify default value is changed.
             $Self->Is(
                 $Selenium->find_element( "#DefaultValue", 'css' )->get_value(),
                 '',
@@ -151,19 +151,19 @@ $Selenium->RunTest(
                 "\$('#DefaultValue').val(['Key1', 'Key2']).trigger('redraw.InputField').trigger('change');"
             );
 
-            # submit form
+            # Submit form.
             $Selenium->find_element( "#Name", 'css' )->VerifiedSubmit();
 
-            # check for test DynamicFieldMultiselect on AdminDynamicField screen
+            # Check for test DynamicFieldMultiselect on AdminDynamicField screen.
             $Self->True(
                 index( $Selenium->get_page_source(), $RandomID ) > -1,
                 "DynamicFieldMultiselect $RandomID found on table"
             ) || die;
 
-            # click on created dynamic field
+            # Click on created dynamic field.
             $Selenium->find_element( $RandomID, 'link_text' )->VerifiedClick();
 
-            # check for saved 'defaul values' on creation, expecting both values to be present
+            # Check for saved 'defaul values' on creation, expecting both values to be present.
             $Self->IsDeeply(
                 $Selenium->execute_script(
                     "return \$('#DefaultValue').val();"
@@ -172,13 +172,13 @@ $Selenium->RunTest(
                 'Found default values after creation',
             );
 
-            # edit test DynamicFieldMultiselect possible none, default value, treeview and set it to invalid
+            # Edit test DynamicFieldMultiselect possible none, default value, treeview and set it to invalid.
             $Selenium->execute_script("\$('#PossibleNone').val('1').trigger('redraw.InputField').trigger('change');");
             $Selenium->execute_script("\$('#TreeView').val('1').trigger('redraw.InputField').trigger('change');");
             $Selenium->execute_script("\$('#ValidID').val('2').trigger('redraw.InputField').trigger('change');");
             $Selenium->find_element( "#Name", 'css' )->VerifiedSubmit();
 
-            # check new and edited DynamicFieldMultiselect values
+            # Check new and edited DynamicFieldMultiselect values.
             $Selenium->find_element( $RandomID, 'link_text' )->VerifiedClick();
 
             $Self->Is(
@@ -227,10 +227,7 @@ $Selenium->RunTest(
                 "#ValidID updated value",
             );
 
-            # go back to AdminDynamicField screen
-            $Selenium->VerifiedGet("${ScriptAlias}index.pl?Action=AdminDynamicField");
-
-            # delete DynamicFields
+            # Delete DynamicField.
             my $DynamicFieldObject = $Kernel::OM->Get('Kernel::System::DynamicField');
             my $DynamicField       = $DynamicFieldObject->DynamicFieldGet(
                 Name => $RandomID,
@@ -240,15 +237,18 @@ $Selenium->RunTest(
                 UserID => 1,
             );
 
-            # sanity check
+            # Sanity check.
             $Self->True(
                 $Success,
                 "DynamicFieldDelete() - $RandomID"
             );
 
+            # Go back to AdminDynamicField screen.
+            $Selenium->VerifiedGet("${ScriptAlias}index.pl?Action=AdminDynamicField");
+
         }
 
-        # make sure cache is correct
+        # Make sure cache is correct.
         $Kernel::OM->Get('Kernel::System::Cache')->CleanUp( Type => "DynamicField" );
 
     }

--- a/scripts/test/Selenium/Agent/Admin/DynamicField/AdminDynamicFieldTextArea.t
+++ b/scripts/test/Selenium/Agent/Admin/DynamicField/AdminDynamicFieldTextArea.t
@@ -12,20 +12,20 @@ use utf8;
 
 use vars (qw($Self));
 
-# get selenium object
+# Get selenium object.
 my $Selenium = $Kernel::OM->Get('Kernel::System::UnitTest::Selenium');
 
 $Selenium->RunTest(
     sub {
 
-        # get helper object
+        # Get helper object.
         my $Helper = $Kernel::OM->Get('Kernel::System::UnitTest::Helper');
 
         my %DynamicFieldsOverviewPageShownSysConfig = $Kernel::OM->Get('Kernel::System::SysConfig')->SettingGet(
             Name => 'PreferencesGroups###DynamicFieldsOverviewPageShown',
         );
 
-        # show more dynamic fields per page as the default value
+        # Show more dynamic fields per page as the default value.
         $Helper->ConfigSettingChange(
             Valid => 1,
             Key   => 'PreferencesGroups###DynamicFieldsOverviewPageShown',
@@ -35,7 +35,7 @@ $Selenium->RunTest(
             },
         );
 
-        # create test user and login
+        # Create test user and login.
         my $TestUserLogin = $Helper->TestUserCreate(
             Groups => ['admin'],
         ) || die "Did not get test user";
@@ -46,13 +46,13 @@ $Selenium->RunTest(
             Password => $TestUserLogin,
         );
 
-        # get script alias
+        # Get script alias.
         my $ScriptAlias = $Kernel::OM->Get('Kernel::Config')->Get('ScriptAlias');
 
-        # navigate to AdminDynamicField screen
+        # Navigate to AdminDynamicField screen.
         $Selenium->VerifiedGet("${ScriptAlias}index.pl?Action=AdminDynamicField");
 
-        # create and edit Ticket and Article DynamicFieldTextArea
+        # Create and edit Ticket and Article DynamicFieldTextArea.
         for my $Type (qw(Ticket Article)) {
 
             my $ObjectType = $Type . "DynamicField";
@@ -60,7 +60,7 @@ $Selenium->RunTest(
                 "\$('#$ObjectType').val('TextArea').trigger('redraw.InputField').trigger('change');"
             );
 
-            # wait until page has finished loading
+            # Wait until page has finished loading.
             $Selenium->WaitFor( JavaScript => 'return typeof($) === "function" && $("#Name").length' );
 
             for my $ID (
@@ -72,7 +72,7 @@ $Selenium->RunTest(
                 $Element->is_displayed();
             }
 
-            # check client side validation
+            # Check client side validation.
             my $Element2 = $Selenium->find_element( "#Name", 'css' );
             $Element2->send_keys("");
             $Element2->VerifiedSubmit();
@@ -85,7 +85,7 @@ $Selenium->RunTest(
                 'Client side validation correctly detected missing input value',
             );
 
-            # create real text DynamicFieldTextArea
+            # Create real text DynamicFieldTextArea.
             my $RandomID      = $Helper->GetRandomID();
             my $RegEx         = '^[0-9]$';
             my $RegExErrorTxt = "Please remove this entry and enter a new one with the correct value.";
@@ -99,13 +99,13 @@ $Selenium->RunTest(
             $Selenium->find_element( "#CustomerRegExErrorMessage_1", 'css' )->send_keys($RegExErrorTxt);
             $Selenium->find_element( "#Name",                        'css' )->VerifiedSubmit();
 
-            # check for test DynamicFieldTextArea on AdminDynamicField screen
+            # Check for test DynamicFieldTextArea on AdminDynamicField screen.
             $Self->True(
                 index( $Selenium->get_page_source(), $RandomID ) > -1,
                 "DynamicFieldTextArea $RandomID found on table"
             ) || die;
 
-            # edit test DynamicFieldTextArea name, default value and set it to invalid
+            # Edit test DynamicFieldTextArea name, default value and set it to invalid.
             $Selenium->find_element( $RandomID, 'link_text' )->VerifiedClick();
 
             $Selenium->find_element( "#Name",         'css' )->clear();
@@ -114,7 +114,7 @@ $Selenium->RunTest(
             $Selenium->execute_script("\$('#ValidID').val('2').trigger('redraw.InputField').trigger('change');");
             $Selenium->find_element( "#Name", 'css' )->VerifiedSubmit();
 
-            # check new and edited DynamicFieldTextArea values
+            # Check new and edited DynamicFieldTextArea values.
             $Selenium->find_element( $RandomID, 'link_text' )->VerifiedClick();
 
             $Self->Is(
@@ -158,10 +158,7 @@ $Selenium->RunTest(
                 "#ValidID updated value",
             );
 
-            # go back to AdminDynamicField screen
-            $Selenium->VerifiedGet("${ScriptAlias}index.pl?Action=AdminDynamicField");
-
-            # delete DynamicFields
+            # Delete DynamicField.
             my $DynamicFieldObject = $Kernel::OM->Get('Kernel::System::DynamicField');
             my $DynamicField       = $DynamicFieldObject->DynamicFieldGet(
                 Name => $RandomID,
@@ -171,15 +168,18 @@ $Selenium->RunTest(
                 UserID => 1,
             );
 
-            # sanity check
+            # Sanity check.
             $Self->True(
                 $Success,
                 "DynamicFieldDelete() - $RandomID"
             );
 
+            # Go back to AdminDynamicField screen.
+            $Selenium->VerifiedGet("${ScriptAlias}index.pl?Action=AdminDynamicField");
+
         }
 
-        # make sure cache is correct
+        # Make sure cache is correct.
         $Kernel::OM->Get('Kernel::System::Cache')->CleanUp( Type => "DynamicField" );
 
     }


### PR DESCRIPTION
https://bugs.otrs.org/show_bug.cgi?id=10681

Hello @dvuckovic,

It is a proposal for reported bug fix. By default, when dynamic fields were created, they were added to the bottom of the page, not to the bottom of the list. Because of that, MaxFieldOrder value for 'MaxFieldOrder' block is changed.

Selenium tests are modified. Tested dynamic field was deleted by backend function after re-navigating to DynamicField overview screen and because of that default FieldOrder value was not correct in the next adding screen.

Also, check for default FieldOrder value is added to Selenium test AdminDynamicField.t.

If you have any comment about this PR, please let me know.

Regards,
Milan