### PR TITLE
Fixed: I can't configure SMTP TLS of Office 365.

### DIFF
--- a/bin/otrs.CheckModules.pl
+++ b/bin/otrs.CheckModules.pl
@@ -362,6 +362,26 @@ my @NeededModules = (
                     zypper => 'perl-IO-Socket-SSL',
                 },
             },
+            {
+                Module    => 'Authen::SASL',
+                Required  => 0,
+                Comment   => 'Required for IMAP TLS connections.',
+                InstTypes => {
+                    aptget => 'libauthen-sasl-perl',
+                    emerge => 'dev-perl/Authen-SASL',
+                    zypper => 'perl-Authen-SASL',
+                },
+            },
+            {
+                Module    => 'Digest::MD5',
+                Required  => 0,
+                Comment   => 'Required for IMAP TLS connections.',
+                InstTypes => {
+                    aptget => 'libdigest-md5-perl',
+                    emerge => 'dev-perl/Digest-Perl-MD5',
+                    zypper => 'perl-Digest-MD5',
+                },
+            },
         ],
     },
     {


### PR DESCRIPTION
Hi @dvuckovic,

Herby is updated CheckModules.pl with new modules that could be required if Mail::IMAPClient is installed and used. 

There is added only Authen::SASL and Digest::MD5. I am not sure if Digest::HMAC_MD5  and/or Authen::NTLM are also required. 

I made only master branch at this moment. After your follow-up I will be able to make the same for rel-5 and rel-4.

Regards
Zoran