### PR TITLE
Inconsistent naming of the BackendObject

### DIFF
--- a/Kernel/System/DynamicField/Backend.pm
+++ b/Kernel/System/DynamicField/Backend.pm
@@ -38,7 +38,7 @@ DynamicFields backend interface
 
 create a DynamicField backend object. Do not use it directly, instead use:
 
-    my $DynamicFieldObject = $Kernel::OM->Get('Kernel::System::DynamicField::Backend');
+    my $BackendObject = $Kernel::OM->Get('Kernel::System::DynamicField::Backend');
 
 =cut
 


### PR DESCRIPTION
All the other functions use $BackendObject, but the new-POD description declares it as $DynamicFieldObject (which collides with the actual DynamicFieldObject).