### PR TITLE
[Master - Bug 12801] Set Role validity state to invalid, doesn't effect permissions.

### DIFF
--- a/Kernel/System/Group.pm
+++ b/Kernel/System/Group.pm
@@ -1652,7 +1652,7 @@ sub PermissionGroupRoleGet {
     }
 
     # get valid role list
-    my %RoleList = $Self->RoleList();
+    my %RoleList = $Self->RoleList( Valid => 1 );
 
     # calculate roles
     my %Roles;
@@ -1849,7 +1849,7 @@ sub PermissionRoleUserGet {
     }
 
     # get valid role list
-    my %RoleList = $Self->RoleList();
+    my %RoleList = $Self->RoleList( Valid => 1 );
 
     return if !$RoleList{ $Param{RoleID} };
 
@@ -1930,7 +1930,7 @@ sub PermissionUserRoleGet {
     my $RolesRaw = $Permissions{ $Param{UserID} } || [];
 
     # get valid role list
-    my %RoleList = $Self->RoleList();
+    my %RoleList = $Self->RoleList( Valid => 1 );
 
     # calculate roles
     my %Roles;


### PR DESCRIPTION
Hi @dvuckovic 

Hereby is solved issue with permission by role if role is set on invalid. There was a problem here
https://github.com/OTRS/otrs/blob/master/Kernel/System/Group.pm#L1933 for the reported issue. 

However, I fixed it on the another two place in Group.pm. I checked the test Role.t and AdminRole.t. These changes doesn't have influence on them. 

Regards
Zoran 