### PR TITLE
[Master Bug 12802] ACL -> Process restriction does not work with a Queue Filter

### DIFF
--- a/Kernel/Modules/AgentTicketProcess.pm
+++ b/Kernel/Modules/AgentTicketProcess.pm
@@ -280,6 +280,7 @@ sub Run {
         Data          => \%ProcessListACL,
         Action        => $Self->{Action},
         UserID        => $Self->{UserID},
+        TicketID      => $TicketID,
     );
 
     if ( IsHashRefWithData($ProcessList) && $ACL ) {


### PR DESCRIPTION
Hi @dvuckovic 

This is proposal for fixing reported issue. There was missing ticket data for TicketACL if it is needed check database data.
In the report is mentioned restriction by Queue but the same problem is with other thicket properties ( State, Priority ... )

Regards
Zoran