### PR TITLE
Improved wording, marked error messages for translation

### DIFF
--- a/Kernel/Output/HTML/Templates/Standard/Statistics/PreviewWidget.tt
+++ b/Kernel/Output/HTML/Templates/Standard/Statistics/PreviewWidget.tt
@@ -36,7 +36,7 @@
             [% PROCESS ErrorText %]
             [% FOR Error IN Data.StatsConfigurationErrors.GeneralSpecificationFieldErrors.pairs %]
                 <p class="Error">
-                    [% Error.key | html %]: [% Error.value %]
+                    [% Error.key | html %]: [% Translate(Error.value) | html %]
                 </p>
             [% END %]
 
@@ -50,7 +50,7 @@
                 [% PROCESS ErrorText %]
                 [% FOR Error IN Data.StatsConfigurationErrors.XAxisGeneralErrors %]
                     <p class="Error">
-                        [% Error | html %]
+                        [% Translate(Error) | html %]
                     </p>
                 [% END %]
             [% ELSE %]
@@ -69,7 +69,7 @@
             [% FOR Error IN Data.StatsConfigurationErrors.XAxisFieldErrors.pairs %]
                 <p class="Error">
                     <i class="fa fa-times"></i>
-                    [% Error.key | html%]: [% Error.value %]
+                    [% Error.key | html%]: [% Translate(Error.value) | html %]
                 </p>
             [% END %]
 
@@ -81,7 +81,7 @@
             [% PROCESS ErrorText %]
             [% FOR Error IN Data.StatsConfigurationErrors.YAxisGeneralErrors %]
                 <p class="Error">
-                    [% Error | html %]
+                    [% Translate(Error) | html %]
                 </p>
             [% END %]
 
@@ -94,7 +94,7 @@
             [% PROCESS ErrorText %]
             [% FOR Error IN Data.StatsConfigurationErrors.YAxisFieldErrors.pairs %]
                 <p class="Error">
-                    [% Error.key | html%]: [% Error.value %]
+                    [% Error.key | html%]: [% Translate(Error.value) | html %]
                 </p>
             [% END %]
 
@@ -105,7 +105,7 @@
             [% PROCESS ErrorText %]
             [% FOR Error IN Data.StatsConfigurationErrors.RestrictionsFieldErrors.pairs %]
                 <p class="Error">
-                    [% Error.key | html%]: [% Error.value %]
+                    [% Error.key | html%]: [% Translate(Error.value) | html %]
                 </p>
             [% END %]
 
@@ -130,7 +130,7 @@
     [% IF Data.PreviewResult && PreviewFormats.size %]
 
         <div class="PreviewSettings">
-            [% Translate('Preview format:') | html %]
+            [% Translate('Preview format') | html %]:
             [% FOREACH Format IN PreviewFormats.sort %]
             <button class="CallForAction SwitchPreviewFormat" data-format="[% Format %]"><span>[% Translate(FormatConfig.item(Format)) | html %]</span></button>
             [% END %]

--- a/Kernel/Output/HTML/Templates/Standard/Statistics/RestrictionsWidget.tt
+++ b/Kernel/Output/HTML/Templates/Standard/Statistics/RestrictionsWidget.tt
@@ -46,7 +46,7 @@
             [% Translate("Absolute period") | html %]:
         </label>
         <div class="Field">
-            [% Translate("Between") | html %] [% Data.TimeStart %] [% Translate("and") | html %] [% Data.TimeStop %]
+            [% Translate("Between %s and %s", Data.TimeStart, Data.TimeStop) | html %]
         </div>
         <div class="Clear"></div>
 

--- a/Kernel/Output/HTML/Templates/Standard/Statistics/StatsParamsWidget.tt
+++ b/Kernel/Output/HTML/Templates/Standard/Statistics/StatsParamsWidget.tt
@@ -71,7 +71,7 @@
     <label>[% Translate(Data.Name) | html %]:</label>
     <div class="Value">
 [% RenderBlockStart("TimePeriodFixed") %]
-        [% Translate("Between") | html %] [% Data.TimeStart %] [% Translate("and") | html %] [% Data.TimeStop %]<br/>
+        [% Translate("Between %s and %s", Data.TimeStart, Data.TimeStop) | html %]<br/>
 [% RenderBlockEnd("TimePeriodFixed") %]
 [% RenderBlockStart("TimeRelativeFixed") %]
         [% Translate("The past complete %s and the current+upcoming complete %s %s", Data.TimeRelativeCount, Data.TimeRelativeUpcomingCount, Data.TimeRelativeUnit) %]<br/>
@@ -107,7 +107,7 @@
     <label><em>[% Translate("Absolute period") | html %]</em>:</label>
     <div class="Value">
         <p>
-            [% Translate('Between') | html %] [% Data.TimeStart %] [% Translate("and") | html %] [% Data.TimeStop %]<br/>
+            [% Translate("Between %s and %s", Data.TimeStart, Data.TimeStop) | html %]<br/>
         </p>
     </div>
     <div class="Clear"></div>

--- a/Kernel/Output/HTML/Templates/Standard/Statistics/XAxisWidget.tt
+++ b/Kernel/Output/HTML/Templates/Standard/Statistics/XAxisWidget.tt
@@ -28,7 +28,7 @@
             [% Translate("Absolute period") | html %]:
         </label>
         <div class="Field">
-            [% Translate("Between") | html %] [% Data.TimeStart %] [% Translate("and") | html %] [% Data.TimeStop %]
+            [% Translate("Between %s and %s", Data.TimeStart, Data.TimeStop) | html %]
         </div>
         <div class="Clear"></div>
 


### PR DESCRIPTION
Hi @mgruner 
The error messages already have been marked for translation, but the `Translate()` function was missing from the `.tt` file. I also improved the wording by concatenate the words and params into a sentence. There are many languages, where the order of the words is different from English.
Both branch rel-5_0 and master are affected!