### PR TITLE
[ Rel-5_0 ] - JS improvements for multiple LinkTable widgets.

### DIFF
--- a/var/httpd/htdocs/js/Core.Agent.LinkObject.js
+++ b/var/httpd/htdocs/js/Core.Agent.LinkObject.js
@@ -38,7 +38,7 @@ Core.Agent.LinkObject = (function (TargetNS) {
                 Core.AJAX.ContentUpdate($('#' + ElementID), URL, function () {
                     Core.UI.ToggleTwoContainer($('#linkobject' + ElementID + '-setting'), $('#' + ElementID));
                     Core.UI.InitWidgetActionToggle();
-                    Core.Agent.TableFilters.SetAllocationList();
+                    Core.Agent.TableFilters.SetAllocationList(ElementID);
                 });
             });
         }

--- a/var/httpd/htdocs/js/Core.Agent.TableFilters.js
+++ b/var/httpd/htdocs/js/Core.Agent.TableFilters.js
@@ -252,10 +252,11 @@ Core.Agent.TableFilters = (function (TargetNS) {
      * @name SetAllocationList
      * @memberof Core.Agent.TableFilters
      * @function
+     * @param {String} ElementID - The ID of the element whose content should be updated with the server answer.
      * @description
      *      Initialize allocation list.
      */
-    TargetNS.SetAllocationList = function () {
+    TargetNS.SetAllocationList = function (ElementID) {
         $('.AllocationListContainer').each(function() {
 
             var $ContainerObj = $(this),
@@ -265,7 +266,17 @@ Core.Agent.TableFilters = (function (TargetNS) {
                 DataAvailable,
                 Translation,
                 $FieldObj,
-                IDString = '#' + $ContainerObj.find('.AssignedFields').attr('id') + ', #' + $ContainerObj.find('.AvailableFields').attr('id');
+                IDString = '#' + $ContainerObj.find('.AssignedFields').attr('id') + ', #' + $ContainerObj.find('.AvailableFields').attr('id'),
+                RegEx;
+
+            // Skip to the next container if content shouldn't be updated.
+            if (typeof ElementID !== 'undefined') {
+                RegEx = new RegExp(ElementID.replace('Widget','') + '$');
+
+                if (!IDString.match(RegEx)) {
+                    return true;
+                }
+            }
 
             if (DataEnabledJSON) {
                 DataEnabled = Core.JSON.Parse(DataEnabledJSON);

--- a/var/httpd/htdocs/js/Core.UI.js
+++ b/var/httpd/htdocs/js/Core.UI.js
@@ -160,7 +160,7 @@ Core.UI = (function (TargetNS) {
      */
     TargetNS.RegisterToggleTwoContainer = function ($ClickedElement, $Element1, $Element2) {
         if (isJQueryObject($ClickedElement) && $ClickedElement.length) {
-            $ClickedElement.click(function () {
+            $ClickedElement.off('click.UI').on('click.UI', function () {
                 if ($Element1.is(':visible')) {
                     TargetNS.ToggleTwoContainer($Element1, $Element2);
                 }


### PR DESCRIPTION
Hello @dvuckovic ,

Hereby is proposal for fixing JS issues when having multiple different link object tables. Sending new parameter to Core.Agent.TableFilter.SetAllocationList() function. With this param we then on 'Save changes' on widget preference setting update just that specific widget excluding other from the update which resulted in multiplication of allocation lists.

Additionally, added off / on when creating events for registering toggle between containers.

Please let me know if there are any issues or questions regarding this PR.

Regards,
Sanjin