### PR TITLE
Bigfix in Small.pm (broken key for CustomerUserLogin)

### DIFF
--- a/Kernel/Output/HTML/TicketOverview/Small.pm
+++ b/Kernel/Output/HTML/TicketOverview/Small.pm
@@ -1830,7 +1830,7 @@ sub FilterContent {
     if ( $HeaderColumn eq 'CustomerUserID' ) {
         $SelectedColumn = 'CustomerUserLogin';
     }
-    if ( $HeaderColumn eq 'CustomerID' ) {
+    elsif ( $HeaderColumn eq 'CustomerID' ) {
         $SelectedColumn = 'CustomerID';
     }
     elsif ( $HeaderColumn !~ m{ \A DynamicField_ }xms ) {


### PR DESCRIPTION
In #1833 used "if" while looks like "elsif" must be here.
Because of "if" usage $SelectedColumn (for CustomerUserLogin) is suffixed later with 'IDs' and $SelectedColumn becomes broken key for $Self->{StoredFilters} (CustomerUserLoginIDs although correct key is CustomerUserLogin)