### PR TITLE
Follow-up for PR1740 - fixed punctuation

### DIFF
--- a/scripts/database/otrs-initial_insert.mysql.sql
+++ b/scripts/database/otrs-initial_insert.mysql.sql
@@ -229,7 +229,7 @@ INSERT INTO follow_up_possible (id, name, comments, valid_id, create_by, create_
 # ----------------------------------------------------------
 INSERT INTO follow_up_possible (id, name, comments, valid_id, create_by, create_time, change_by, change_time)
     VALUES
-    (3, 'new ticket', 'Follow-ups for closed tickets are not possible. A new ticket will be created..', 1, 1, current_timestamp, 1, current_timestamp);
+    (3, 'new ticket', 'Follow-ups for closed tickets are not possible. A new ticket will be created.', 1, 1, current_timestamp, 1, current_timestamp);
 # ----------------------------------------------------------
 #  insert into table queue
 # ----------------------------------------------------------

--- a/scripts/database/otrs-initial_insert.oracle.sql
+++ b/scripts/database/otrs-initial_insert.oracle.sql
@@ -231,7 +231,7 @@ INSERT INTO follow_up_possible (name, comments, valid_id, create_by, create_time
 -- ----------------------------------------------------------
 INSERT INTO follow_up_possible (name, comments, valid_id, create_by, create_time, change_by, change_time)
     VALUES
-    ('new ticket', 'Follow-ups for closed tickets are not possible. A new ticket will be created..', 1, 1, current_timestamp, 1, current_timestamp);
+    ('new ticket', 'Follow-ups for closed tickets are not possible. A new ticket will be created.', 1, 1, current_timestamp, 1, current_timestamp);
 -- ----------------------------------------------------------
 --  insert into table queue
 -- ----------------------------------------------------------

--- a/scripts/database/otrs-initial_insert.postgresql.sql
+++ b/scripts/database/otrs-initial_insert.postgresql.sql
@@ -230,7 +230,7 @@ INSERT INTO follow_up_possible (name, comments, valid_id, create_by, create_time
 -- ----------------------------------------------------------
 INSERT INTO follow_up_possible (name, comments, valid_id, create_by, create_time, change_by, change_time)
     VALUES
-    ('new ticket', 'Follow-ups for closed tickets are not possible. A new ticket will be created..', 1, 1, current_timestamp, 1, current_timestamp);
+    ('new ticket', 'Follow-ups for closed tickets are not possible. A new ticket will be created.', 1, 1, current_timestamp, 1, current_timestamp);
 -- ----------------------------------------------------------
 --  insert into table queue
 -- ----------------------------------------------------------


### PR DESCRIPTION
Hi @mgruner 
This is a follow-up for https://github.com/OTRS/otrs/pull/1740 (master) and https://github.com/OTRS/otrs/pull/1741 (rel-5_0).
The superfluous dot is also present is these files. Both branch rel-5_0 and master are affected.