### PR TITLE
Update de.pm - typo in german translation

### DIFF
--- a/Kernel/Language/de.pm
+++ b/Kernel/Language/de.pm
@@ -1766,7 +1766,7 @@ sub Data {
         'Title or salutation' => 'Titel oder Anrede',
         'Firstname' => 'Vorname',
         'Lastname' => 'Nachname',
-        'A user with this username already exists!' => 'Es existiert bereits ein Nuter mit diesem Benutzernamen!',
+        'A user with this username already exists!' => 'Es existiert bereits ein Nutzer mit diesem Benutzernamen!',
         'Will be auto-generated if left empty.' => 'Wird für ein leeres Feld automatisch generiert.',
         'Mobile' => 'Mobiltelefon',
         'On' => 'Ein',


### PR DESCRIPTION
Line 1769: The word "Nuter" doesn't exists in german, "Nutzer" will be much better ;-)