### PR TITLE
Fix for regex to be able to match long GeoTLD.

### DIFF
--- a/Kernel/System/SupportDataCollector/Plugin/OTRS/FQDN.pm
+++ b/Kernel/System/SupportDataCollector/Plugin/OTRS/FQDN.pm
@@ -38,7 +38,7 @@ sub Run {
     }
 
     # FQDN syntax check.
-    elsif ( $FQDN !~ /^([a-zA-Z0-9]([a-zA-Z0-9\-]{0,61}[a-zA-Z0-9])?\.)+[a-zA-Z]{2,6}$/ ) {
+    elsif ( $FQDN !~ /^([a-zA-Z0-9]([a-zA-Z0-9\-]{0,61}[a-zA-Z0-9])?\.)+[a-zA-Z]{2,12}$/ ) {
         $Self->AddResultProblem(
             Label   => Translatable('Domain Name'),
             Value   => $FQDN,


### PR DESCRIPTION
Currently in the proposed to be changed file we have the following regex for domain checking

( $FQDN !~ /^([a-zA-Z0-9]([a-zA-Z0-9\-]{0,61}[a-zA-Z0-9])?\.)+[a-zA-Z]{2,6}$/ ) 
since we are using a "simple" regex for matching 2-6 chars for .com .biz etc.
the problem is not being a geotld in our case but the characters being too many.
I suggest increasing this value 2,6 or 2,10 since the biggest geotld I found was vlaanderen.
The regex would then be
elsif ( $FQDN !~ /^([a-zA-Z0-9]([a-zA-Z0-9\-]{0,61}[a-zA-Z0-9])?\.)+[a-zA-Z]{2,12}$/ ) enabling a match even in the long GEOTLD domain names.
