### PR TITLE
Fix search for dynamic field that contains an asterisk (*)

### DIFF
--- a/Kernel/System/Ticket/TicketSearch.pm
+++ b/Kernel/System/Ticket/TicketSearch.pm
@@ -1393,10 +1393,12 @@ sub TicketSearch {
             for my $Text (@SearchParams) {
                 next TEXT if ( !defined $Text || $Text eq '' );
 
-                $Text =~ s/\*/%/gi;
+                if ( $Operator eq 'Like' ) {
+                    $Text =~ s/\*/%/gi;
 
-                # check search attribute, we do not need to search for *
-                next TEXT if $Text =~ /^\%{1,3}$/;
+                    # check search attribute, we do not need to search for *
+                    next TEXT if $Text =~ /^\%{1,3}$/;
+                }
 
                 # skip validation for empty values
                 if ( $Operator ne 'Empty' ) {

--- a/scripts/test/Ticket/TicketDynamicFieldSearch.t
+++ b/scripts/test/Ticket/TicketDynamicFieldSearch.t
@@ -878,6 +878,34 @@ $Self->IsDeeply(
     'Search for two values in a same field, match one ticket using an array ',
 );
 
+# Check that we can use an Equals-Search for a value that contains a *
+my $ValueWithAsterisk = '* is an asterisk';
+$BackendObject->ValueSet(
+    DynamicFieldConfig => $FieldConfig[0],
+    ObjectID           => $TicketData[0]{TicketID},
+    Value              => $ValueWithAsterisk,
+    UserID             => 1,
+);
+
+my $DynamicFieldName = $FieldConfig[0]->{Name};
+
+@TicketResultSearch = $TicketObject->TicketSearch(
+    Result                       => 'ARRAY',
+    Limit                        => 100,
+    "DynamicField_$DynamicFieldName" => {
+        Equals => $ValueWithAsterisk,
+    },
+    UserID     => 1,
+    Permission => 'r0',
+);
+
+$Self->IsDeeply(
+    \@TicketResultSearch,
+    [ $TicketData[0]{TicketID} ],
+    "can do an 'Equals' search with a dynamic field value that contain an asterisk",
+);
+
+
 # Check that searching for non-existing dynamic fields is an error
 my $Result = $TicketObject->TicketSearch(
     Result                                    => 'COUNT',


### PR DESCRIPTION
The TicketSearch code uncondtionally replaced every `*` with a `%`, but then
used the "=" operator for comparison, where `%` is not a wildcard. So
it was impossible to search for a dynamic field value which contains a `*`.

This commit does the substitution of `*` by `%` only if the operator is
"Like", where `%` is actually a wildcard.