### PR TITLE
Text templates selection list is not presented when creating ticket

### DIFF
--- a/Kernel/Modules/AgentTicketEmail.pm
+++ b/Kernel/Modules/AgentTicketEmail.pm
@@ -2575,10 +2575,10 @@ sub _MaskEmailNew {
     # build text template string
     if ( IsHashRefWithData( \%StandardTemplates ) ) {
         $Param{StandardTemplateStrg} = $LayoutObject->BuildSelection(
-            Data       => $Param{StandardTemplates}  || {},
-            Name       => 'StandardTemplateID',
-            SelectedID => $Param{StandardTemplateID} || '',
-            Class      => 'Modernize',
+            Data         => \%StandardTemplates,
+            Name         => 'StandardTemplateID',
+            SelectedID   => $Param{StandardTemplateID} || '',
+            Class        => 'Modernize',
             PossibleNone => 1,
             Sort         => 'AlphanumericValue',
             Translation  => 1,

--- a/Kernel/Modules/AgentTicketPhone.pm
+++ b/Kernel/Modules/AgentTicketPhone.pm
@@ -2522,10 +2522,10 @@ sub _MaskPhoneNew {
     # build text template string
     if ( IsHashRefWithData( \%StandardTemplates ) ) {
         $Param{StandardTemplateStrg} = $LayoutObject->BuildSelection(
-            Data       => $Param{StandardTemplates}  || {},
-            Name       => 'StandardTemplateID',
-            SelectedID => $Param{StandardTemplateID} || '',
-            Class      => 'Modernize',
+            Data         => \%StandardTemplates,
+            Name         => 'StandardTemplateID',
+            SelectedID   => $Param{StandardTemplateID} || '',
+            Class        => 'Modernize',
             PossibleNone => 1,
             Sort         => 'AlphanumericValue',
             Translation  => 1,

--- a/Kernel/Modules/AgentTicketPhoneCommon.pm
+++ b/Kernel/Modules/AgentTicketPhoneCommon.pm
@@ -1149,9 +1149,9 @@ sub _MaskPhone {
     # build text template string
     if ( IsHashRefWithData( \%StandardTemplates ) ) {
         $Param{StandardTemplateStrg} = $LayoutObject->BuildSelection(
-            Data       => $Param{StandardTemplates}  || {},
-            Name       => 'StandardTemplateID',
-            SelectedID => $Param{StandardTemplateID} || '',
+            Data         => \%StandardTemplates},
+            Name         => 'StandardTemplateID',
+            SelectedID   => $Param{StandardTemplateID} || '',
             PossibleNone => 1,
             Sort         => 'AlphanumericValue',
             Translation  => 0,


### PR DESCRIPTION
In OTRS-4.0.20, when creating an email or phone ticket the list of valid templates of type "Create" is always empty.

The related code is the same in branch "master"

The commit in this PR fixes the issue.

BEFORE COMMIT 9c0ea56:
=================

![image](https://user-images.githubusercontent.com/8179031/27342870-a9d6f28a-55e1-11e7-8454-eb2b0558d844.png)

AFTER COMMIT 9c0ea56:
================

![image](https://user-images.githubusercontent.com/8179031/27342950-d843df2a-55e1-11e7-83cf-20efe1e5e0b3.png)


best regards,

Cyrille