### PR TITLE
More thorough fix for bug #12665

### DIFF
--- a/var/httpd/htdocs/js/Core.Agent.js
+++ b/var/httpd/htdocs/js/Core.Agent.js
@@ -586,7 +586,7 @@ Core.Agent = (function (TargetNS) {
             NavigationBarWidth += 1;
         }
 
-        $('#Navigation').css('width', NavigationBarWidth);
+        $('#Navigation').css('width', Math.ceil(NavigationBarWidth));
 
         if (NavigationBarWidth > $('#NavigationContainer').outerWidth()) {
             NavigationBarShowSlideButton('Right', parseInt($('#NavigationContainer').outerWidth(true) - NavigationBarWidth, 10));


### PR DESCRIPTION
Some Internet Explorer configurations in compatibility mode still
had some erratic behavior where menu items appeared at the left edge
of the browser window.