### PR TITLE
Marked system types as translatable

### DIFF
--- a/Kernel/Modules/AdminRegistration.pm
+++ b/Kernel/Modules/AdminRegistration.pm
@@ -11,6 +11,8 @@ package Kernel::Modules::AdminRegistration;
 use strict;
 use warnings;
 
+use Kernel::Language qw(Translatable);
+
 our $ObjectManagerDisabled = 1;
 
 sub new {
@@ -38,7 +40,9 @@ sub Run {
 
     if ($CloudServicesDisabled) {
 
-        my $Output = $LayoutObject->Header( Title => 'Error' );
+        my $Output = $LayoutObject->Header(
+            Title => Translatable('Error'),
+        );
         $Output .= $LayoutObject->Output(
             TemplateFile => 'CloudServicesDisabled',
             Data         => \%Param
@@ -270,11 +274,16 @@ sub Run {
         );
 
         $Param{SystemTypeOption} = $LayoutObject->BuildSelection(
-            Data          => [qw( Production Test Training Development )],
+            Data => {
+                Production  => Translatable('Production'),
+                Test        => Translatable('Test'),
+                Training    => Translatable('Training'),
+                Development => Translatable('Development'),
+            }
             PossibleNone  => 1,
             Name          => 'Type',
             SelectedValue => $Param{SystemType},
-            Class         => 'Validate_Required ' . ( $Param{Errors}->{'TypeIDInvalid'} || '' ),
+            Class         => 'Modernize Validate_Required ' . ( $Param{Errors}->{'TypeIDInvalid'} || '' ),
         );
 
         my $EnvironmentObject = $Kernel::OM->Get('Kernel::System::Environment');
@@ -411,11 +420,16 @@ sub Run {
         $Param{Description} //= $RegistrationData{Description};
 
         $Param{SystemTypeOption} = $LayoutObject->BuildSelection(
-            Data          => [qw( Production Test Training Development )],
+            Data => {
+                Production  => Translatable('Production'),
+                Test        => Translatable('Test'),
+                Training    => Translatable('Training'),
+                Development => Translatable('Development'),
+            }
             PossibleNone  => 1,
             Name          => 'Type',
             SelectedValue => $Param{Type} // $RegistrationData{Type},
-            Class         => 'Validate_Required ' . ( $Param{Errors}->{'TypeIDInvalid'} || '' ),
+            Class         => 'Modernize Validate_Required ' . ( $Param{Errors}->{'TypeIDInvalid'} || '' ),
         );
 
         # fall-back for support data sending switch

--- a/Kernel/Modules/AdminRegistration.pm
+++ b/Kernel/Modules/AdminRegistration.pm
@@ -279,7 +279,7 @@ sub Run {
                 Test        => Translatable('Test'),
                 Training    => Translatable('Training'),
                 Development => Translatable('Development'),
-            }
+            },
             PossibleNone  => 1,
             Name          => 'Type',
             SelectedValue => $Param{SystemType},
@@ -425,7 +425,7 @@ sub Run {
                 Test        => Translatable('Test'),
                 Training    => Translatable('Training'),
                 Development => Translatable('Development'),
-            }
+            },
             PossibleNone  => 1,
             Name          => 'Type',
             SelectedValue => $Param{Type} // $RegistrationData{Type},

--- a/Kernel/Output/HTML/Templates/Standard/AdminRegistration.tt
+++ b/Kernel/Output/HTML/Templates/Standard/AdminRegistration.tt
@@ -100,7 +100,7 @@
                 <fieldset class="TableLike">
 
                     <label>[% Translate("System type") | html %]:</label>
-                    <div class="Value">[% Data.Type | html %]</div>
+                    <div class="Value">[% Translate(Data.Type) | html %]</div>
                     <div class="Clear"></div>
 
                     <label>[% Translate("Description") | html %]:</label>


### PR DESCRIPTION
Hi @mgruner 
The system types are not marked for translation, and the dropdown menu is not modern. Maybe this proposal can solve the problem (I couldn't try it). Both branch rel-5_0 and master are affected.