### PR TITLE
Update AdminNotificationEvent.tt

### DIFF
--- a/Kernel/Output/HTML/Templates/Standard/AdminNotificationEvent.tt
+++ b/Kernel/Output/HTML/Templates/Standard/AdminNotificationEvent.tt
@@ -557,7 +557,7 @@
                             [% Translate("Subject") | html %]:
                                         </label>
                                         <div class="Field">
-                                            <input type="text" name="[% Data.LanguageID | html %]_Subject" id="[% Data.LanguageID | html %]_Subject" value="[% Data.Subject | html %]" class="W75pc Validate_Required [% Data.SubjectServerError | html %]" maxlength="200"/>
+                                            <input type="text" name="[% Data.LanguageID | html %]_Subject" id="[% Data.LanguageID | html %]_Subject" value="[% Data.Subject | html %]" class="W75pc Validate_Required [% Data.SubjectServerError | html %]"/>
                                             <div id="[% Data.LanguageID | html %]_SubjectError" class="TooltipErrorMessage">
                                                 <p>[% Translate("This field is required.") | html %]</p>
                                             </div>


### PR DESCRIPTION
The subject of notifications was limited to 200 characters. When lots of dynamic fields or other notification tags are in use, a small subject with only a few characters can result into a very large subject with notification tags in the notification admin interface.

Example: <OTRS_TICKET_DynamicField_123_Value> is not <OTRS_TICKET_DynamicField_234_Value> and not <OTRS_TICKET_DynamicField_345_Value> but close to <OTRS_TICKET_DynamicField_456_Value> or <OTRS_TICKET_DynamicField_567_Value>

Result: 1 is not 2 and not 3 but close to 4 or 5

Cheers, Nils