### PR TITLE
[rel-5_0] Improved output message

### DIFF
--- a/Kernel/System/Console/Command/Maint/Ticket/InvalidUserCleanup.pm
+++ b/Kernel/System/Console/Command/Maint/Ticket/InvalidUserCleanup.pm
@@ -190,8 +190,9 @@ sub Run {
                     UserID      => 1,
                 );
                 $Count++;
-                print
-                    "    Removing ticket watcher entries of ticket <yellow>$TicketID</yellow> for user <yellow>$User{UserLogin}</yellow>\n";
+                $Self->Print(
+                    "    Removing ticket watcher entries of ticket <yellow>$TicketID</yellow> for user <yellow>$User{UserLogin}</yellow>\n"
+                );
                 Time::HiRes::usleep($MicroSleep) if $MicroSleep;
             }
 


### PR DESCRIPTION
Hi @mgruner 
This output message is generated by `print` method, so the colourize is not working:
![console](https://user-images.githubusercontent.com/1006118/28200998-4c16e5c4-686f-11e7-8ec0-1056edb5bf3f.png)

This output message is missing from branch master. Intentionally or accidentally?