### PR TITLE
[rel-5_0] Marked error messages for translation

### DIFF
--- a/Kernel/Output/HTML/Templates/Standard/Statistics/PreviewWidget.tt
+++ b/Kernel/Output/HTML/Templates/Standard/Statistics/PreviewWidget.tt
@@ -36,7 +36,7 @@
             [% PROCESS ErrorText %]
             [% FOR Error IN Data.StatsConfigurationErrors.GeneralSpecificationFieldErrors.pairs %]
                 <p class="Error">
-                    [% Error.key | html %]: [% Error.value %]
+                    [% Error.key | html %]: [% Translate(Error.value) | html %]
                 </p>
             [% END %]
 
@@ -50,7 +50,7 @@
                 [% PROCESS ErrorText %]
                 [% FOR Error IN Data.StatsConfigurationErrors.XAxisGeneralErrors %]
                     <p class="Error">
-                        [% Error | html %]
+                        [% Translate(Error) | html %]
                     </p>
                 [% END %]
             [% ELSE %]
@@ -69,7 +69,7 @@
             [% FOR Error IN Data.StatsConfigurationErrors.XAxisFieldErrors.pairs %]
                 <p class="Error">
                     <i class="fa fa-times"></i>
-                    [% Error.key | html%]: [% Error.value %]
+                    [% Error.key | html%]: [% Translate(Error.value) | html %]
                 </p>
             [% END %]
 
@@ -81,7 +81,7 @@
             [% PROCESS ErrorText %]
             [% FOR Error IN Data.StatsConfigurationErrors.YAxisGeneralErrors %]
                 <p class="Error">
-                    [% Error | html %]
+                    [% Translate(Error) | html %]
                 </p>
             [% END %]
 
@@ -94,7 +94,7 @@
             [% PROCESS ErrorText %]
             [% FOR Error IN Data.StatsConfigurationErrors.YAxisFieldErrors.pairs %]
                 <p class="Error">
-                    [% Error.key | html%]: [% Error.value %]
+                    [% Error.key | html%]: [% Translate(Error.value) | html %]
                 </p>
             [% END %]
 
@@ -105,7 +105,7 @@
             [% PROCESS ErrorText %]
             [% FOR Error IN Data.StatsConfigurationErrors.RestrictionsFieldErrors.pairs %]
                 <p class="Error">
-                    [% Error.key | html%]: [% Error.value %]
+                    [% Error.key | html%]: [% Translate(Error.value) | html %]
                 </p>
             [% END %]
 
@@ -130,7 +130,7 @@
     [% IF Data.PreviewResult && PreviewFormats.size %]
 
         <div class="PreviewSettings">
-            [% Translate('Preview format:') | html %]
+            [% Translate('Preview format') | html %]:
             [% FOREACH Format IN PreviewFormats.sort %]
             <button class="CallForAction SwitchPreviewFormat" data-format="[% Format %]"><span>[% Translate(FormatConfig.item(Format)) | html %]</span></button>
             [% END %]


### PR DESCRIPTION
Hi @mgruner 
This is the backport version of https://github.com/OTRS/otrs/pull/1744 for branach rel-5_0.
You wrote, you don't want to make changes to the strings in OTRS 5. This PR changes a little bit (remove a colon from the string), but the other changes doesn't affect the existing translation, because the translated strings are already in the language files.
If you don't agree with my minor string change, then feel free to remove it from this proposal.