### PR TITLE
Add Search Attribute by Single Click

### DIFF
--- a/var/httpd/htdocs/js/Core.Agent.Search.js
+++ b/var/httpd/htdocs/js/Core.Agent.Search.js
@@ -387,7 +387,9 @@ Core.Agent.Search = (function (TargetNS) {
                 }
 
                 Core.UI.InputFields.Activate($('.Dialog:visible'));
-
+                $('#Attribute').on('change', function () {
+                    $('.AddButton').trigger('click');
+                });
                 // register add of attribute
                 $('.AddButton').on('click', function () {
                     var Attribute = $('#Attribute').val();


### PR DESCRIPTION
Currently if a search attribute need to be added, this attribute should be selected first and then the + button has to be clicked. This feature supports, if the search attribute is selected, it will be automatically added.