### PR TITLE
Adaptive Height of the Article Boxes

### DIFF
--- a/var/httpd/htdocs/js/Core.Agent.TicketZoom.js
+++ b/var/httpd/htdocs/js/Core.Agent.TicketZoom.js
@@ -117,19 +117,22 @@ Core.Agent.TicketZoom = (function (TargetNS) {
      */
     TargetNS.IframeAutoHeight = function ($Iframe) {
         var NewHeight;
-
+        var IframBodyHeight;
         if (isJQueryObject($Iframe)) {
-
+            $Iframe.width($Iframe.width() - 2);
+            IframBodyHeight = $Iframe.contents().find("body").height();
             NewHeight = $Iframe.contents().height();
             if (!NewHeight || isNaN(NewHeight)) {
                 NewHeight = Core.Config.Get('Ticket::Frontend::HTMLArticleHeightDefault');
             }
             else {
-                if (NewHeight > Core.Config.Get('Ticket::Frontend::HTMLArticleHeightMax')) {
+                if (IframBodyHeight > Core.Config.Get('Ticket::Frontend::HTMLArticleHeightMax')) {
                     NewHeight = Core.Config.Get('Ticket::Frontend::HTMLArticleHeightMax');
                 }
+                else {
+                    NewHeight = IframBodyHeight;
+                }
             }
-
             // add delta for scrollbar
             NewHeight = parseInt(NewHeight, 10) + 25;
             $Iframe.height(NewHeight + 'px');


### PR DESCRIPTION
The height of the article boxes is adapted to the content, for example, if there is a line of text in the box, the height of the box is also the height of the line.