### PR TITLE
[rel-5_0] Fixed translations of webservice screen

### DIFF
--- a/Kernel/Modules/AdminGenericInterfaceWebservice.pm
+++ b/Kernel/Modules/AdminGenericInterfaceWebservice.pm
@@ -1088,18 +1088,18 @@ sub _ShowEdit {
     # meta configuration for output blocks
     my %CommTypeConfig = (
         Provider => {
-            Title             => $LayoutObject->{LanguageObject}->Translate('OTRS as provider'),
+            Title             => Translatable('OTRS as provider'),
             SelectedTransport => $ProviderData->{Transport}->{Type},
             ActionType        => 'Operation',
-            ActionsTitle      => 'Operations',
+            ActionsTitle      => Translatable('Operations'),
             ActionsConfig     => $ProviderData->{Operation},
             ControllerData    => \%GIOperations,
         },
         Requester => {
-            Title             => $LayoutObject->{LanguageObject}->Translate('OTRS as requester'),
+            Title             => Translatable('OTRS as requester'),
             SelectedTransport => $RequesterData->{Transport}->{Type},
             ActionType        => 'Invoker',
-            ActionsTitle      => 'Invokers',
+            ActionsTitle      => Translatable('Invokers'),
             ActionsConfig     => $RequesterData->{Invoker},
             ControllerData    => \%GIInvokers,
         },

--- a/Kernel/Output/HTML/Templates/Standard/AdminGenericInterfaceWebservice.tt
+++ b/Kernel/Output/HTML/Templates/Standard/AdminGenericInterfaceWebservice.tt
@@ -18,12 +18,12 @@ SET OTRSBusinessLinkLabelWithContractLevel = '<strong><a href="#" class="OTRSBus
         <li>[% Translate("You are here") | html %]:</li>
 [% RenderBlockStart("WebservicePathElement") %]
         <li>
-            <a href="[% Env("Baselink") %][% Data.Link %];Nav=[% Data.Nav | uri %]">[% Data.Name | html %]</a>
+            <a href="[% Env("Baselink") %][% Data.Link %];Nav=[% Data.Nav | uri %]">[% Translate(Data.Name) | html %]</a>
         </li>
 [% RenderBlockEnd("WebservicePathElement") %]
 [% RenderBlockStart("WebservicePathElementNoLink") %]
         <li>
-            [% Data.Name | html %]
+            [% Translate(Data.Name) | html %]
         </li>
 [% RenderBlockEnd("WebservicePathElementNoLink") %]
     </ul>


### PR DESCRIPTION
Hi @mgruner 
This pull request makes it possible to apply the existing translation in web service breadcrumb. I also marked two titles as translatable. Please merge it, and sync translations with Transifex. You said, that you wouldn't change translation of OTRS 5, but these titles are missing from language files.
This PR is only for branch rel-5_0. I will create a separate PR for branch master.