### PR TITLE
Removed translatable attribute

### DIFF
--- a/Kernel/Config/Files/Framework.xml
+++ b/Kernel/Config/Files/Framework.xml
@@ -886,7 +886,7 @@
         <Setting>
             <Option SelectedID="Gravatar">
                 <Item Key="None" Translatable="1">None</Item>
-                <Item Key="Gravatar" Translatable="1">Gravatar.com</Item>
+                <Item Key="Gravatar">Gravatar.com</Item>
             </Option>
         </Setting>
     </ConfigItem>

--- a/Kernel/Config/Files/XML/Framework.xml
+++ b/Kernel/Config/Files/XML/Framework.xml
@@ -754,7 +754,7 @@
         <Value>
             <Item ValueType="Select" SelectedID="Gravatar">
                 <Item ValueType="Option" Value="None" Translatable="1">None</Item>
-                <Item ValueType="Option" Value="Gravatar" Translatable="1">Gravatar.com</Item>
+                <Item ValueType="Option" Value="Gravatar">Gravatar.com</Item>
             </Item>
         </Value>
     </Setting>


### PR DESCRIPTION
Hi @mrcbnsls 
You have added a new SysConfig in https://github.com/OTRS/otrs/commit/dcfe3c0438b98da1edb1f47a458293f90179978e. The name of the Gravatar website shouldn't be translatable.