### PR TITLE
Make userAttr in ldap-sync actually user selectable

### DIFF
--- a/Kernel/System/Auth/Sync/LDAP.pm
+++ b/Kernel/System/Auth/Sync/LDAP.pm
@@ -167,8 +167,10 @@ sub Sync {
 
     # get whole user dn
     my $UserDN;
+    my $UserAttr;
     for my $Entry ( $Result->all_entries() ) {
         $UserDN = $Entry->dn();
+        $UserAttr = $Entry->get_value($Self->{UserAttr});
     }
 
     # log if there is no LDAP user entry
@@ -369,7 +371,7 @@ sub Sync {
                 $Filter = "($Self->{AccessAttr}=" . escape_filter_value($UserDN) . ')';
             }
             else {
-                $Filter = "($Self->{AccessAttr}=" . escape_filter_value( $Param{User} ) . ')';
+                $Filter = "($Self->{AccessAttr}=" . escape_filter_value( $UserAttr ) . ')';
             }
             my $Result = $LDAP->search(
                 base   => $GroupDN,


### PR DESCRIPTION
You can define the UserAttr in the LDAP-Sync Module. But the module doesn't really look up the actual value of the user ldap entry.

This plays a role when you login to otrs using your mail address. Otrs now maps the mail address internally to the UID-Attribute. When syncing groups it uses the internal uid to filter the member attributes.

With this patch, the actual value of the user ldap entry is looked up and used to filter the group membershift.