### PR TITLE
Fix CommunicationID matching in GenericInterfaceDebugger.js

### DIFF
--- a/var/httpd/htdocs/js/Core.Agent.Admin.GenericInterfaceDebugger.js
+++ b/var/httpd/htdocs/js/Core.Agent.Admin.GenericInterfaceDebugger.js
@@ -124,7 +124,7 @@ Core.Agent.Admin.GenericInterfaceDebugger = (function (TargetNS) {
             $('#RequestList tbody').html(HTML);
 
             $('#RequestList a').on('click', function() {
-                var CommunicationID = $(this).blur().parents('tr').find('input.CommunicationID').val();
+                var CommunicationID = $(this).blur().closest('tr').find('input.CommunicationID').val();
 
                 TargetNS.LoadCommunicationDetails(CommunicationID);
 


### PR DESCRIPTION
Changed `parents('tr')` to `closest('tr')` because in some cases click event will be fired by `<tr>` itself and parents would find some `<tr>` very far in ancestors list, then `find('input.CommunicationID')` will get the first matching `<input>` in entire document which is obviously incorrect. `closest('tr')` works correctly when click event is fired by `<tr>` or any of it's children.