### PR TITLE
Marked strings as translatable

### DIFF
--- a/Kernel/Output/HTML/Templates/Standard/CustomerAccept.tt
+++ b/Kernel/Output/HTML/Templates/Standard/CustomerAccept.tt
@@ -9,13 +9,13 @@
 <!-- start form -->
 <div id="MainBox" class="Login">
     <div class="Content">
-        <h2>[% Translate("Info") | html %]</h2>
+        <h2>[% Translate("Information") | html %]</h2>
         <p>
-            Dear Customer,<br/>
-            thank you for using our services.
+            [% Translate("Dear Customer,") | html %]<br/>
+            [% Translate("thank you for using our services.") | html %]
         </p>
         <p>
-            <a href="[% Env("Baselink") %]Action=[% Env("Action") %];Accept=1">Yes, I accepted your license.</a>
+            <a href="[% Env("Baselink") %]Action=[% Env("Action") %];Accept=1">[% Translate("Yes, I accepted your license.") | html %]</a>
         </p>
     </div>
 </div>


### PR DESCRIPTION
Hi @mgruner 
I found some strings in the customer frontend, which are not marked for translation. I don't know, that my proposal would be the best way to translate multiline HTML strings. Please feel free to modify it, if there is a better solution available.
OTRS 5 is also affected, a back port would be needed.