### PR TITLE
Fixed translatable strings

### DIFF
--- a/Kernel/Output/HTML/ArticleCompose/Crypt.pm
+++ b/Kernel/Output/HTML/ArticleCompose/Crypt.pm
@@ -128,8 +128,7 @@ sub Run {
             Value            => $List,
             Invalid          => $InvalidMessage,
             FieldExplanation => Translatable(
-                'Keys/certificates will only be shown for recipients with more than one key/certificate.'
-                    . ' The first found key/certificate will be pre-selected. Please make sure to select the correct one.'
+                'Keys/certificates will only be shown for recipients with more than one key/certificate. The first found key/certificate will be pre-selected. Please make sure to select the correct one.'
             ),
         },
     );

--- a/Kernel/Output/HTML/ArticleCompose/Sign.pm
+++ b/Kernel/Output/HTML/ArticleCompose/Sign.pm
@@ -117,8 +117,7 @@ sub Run {
             Value            => $List,
             Invalid          => $InvalidMessage,
             FieldExplanation => Translatable(
-                'Keys/certificates will only be shown for a sender with more than one key/certificate.'
-                    . ' The first found key/certificate will be pre-selected. Please make sure to select the correct one.'
+                'Keys/certificates will only be shown for a sender with more than one key/certificate. The first found key/certificate will be pre-selected. Please make sure to select the correct one.'
             ),
         },
     );


### PR DESCRIPTION
Hi @mgruner 
The `Translatable()` function doesn't work, if the parameter contains string concatenation. Because of that now only the first part is containing in the language files.
Branch rel-6_0 and master are affected.