### PR TITLE
Mark string as translatable

### DIFF
--- a/Kernel/Modules/AdminRoleUser.pm
+++ b/Kernel/Modules/AdminRoleUser.pm
@@ -11,6 +11,8 @@ package Kernel::Modules::AdminRoleUser;
 use strict;
 use warnings;
 
+use Kernel::Language qw(Translatable);
+
 our $ObjectManagerDisabled = 1;
 
 sub new {
@@ -214,8 +216,8 @@ sub _Change {
     my $NeType = $Type eq 'Role' ? 'User' : 'Role';
 
     my %VisibleType = (
-        Role => 'Role',
-        User => 'Agent'
+        Role => Translatable('Role'),
+        User => Translatable('Agent'),
     );
 
     my $LayoutObject = $Kernel::OM->Get('Kernel::Output::HTML::Layout');


### PR DESCRIPTION
Hi @mgruner 
I found 2 strings, that are not marked as translatable. These strings are displayed in the table header of AdminRoleUser screen, when clicking on an agent.
Unfortunately all supported branches are affected: rel-4_0, rel-5_0, rel-6_0 and master. Can you please apply this PR in all branches?