### PR TITLE
Changed FirstnameLastnameOrder subgroup

### DIFF
--- a/Kernel/Config/Files/Framework.xml
+++ b/Kernel/Config/Files/Framework.xml
@@ -11241,7 +11241,7 @@ via the Preferences button after logging in.
     <ConfigItem Name="FirstnameLastnameOrder" Required="1" Valid="1">
         <Description Translatable="1">Specifies the order in which the firstname and the lastname of agents will be displayed.</Description>
         <Group>Framework</Group>
-        <SubGroup>Frontend::Agent</SubGroup>
+        <SubGroup>Frontend::Base</SubGroup>
         <Setting>
             <Option SelectedID="0">
                 <Item Key="0" Translatable="1">Firstname Lastname</Item>

--- a/Kernel/Config/Files/XML/Framework.xml
+++ b/Kernel/Config/Files/XML/Framework.xml
@@ -12126,7 +12126,7 @@ via the Preferences button after logging in.
     </Setting>
     <Setting Name="FirstnameLastnameOrder" Required="1" Valid="1">
         <Description Translatable="1">Specifies the order in which the firstname and the lastname of agents will be displayed.</Description>
-        <Navigation>Frontend::Agent</Navigation>
+        <Navigation>Frontend::Base</Navigation>
         <Value>
             <Item ValueType="Select" SelectedID="0">
                 <Item ValueType="Option" Value="0" Translatable="1">Firstname Lastname</Item>


### PR DESCRIPTION
Hi @mgruner 
This setting is not only applied to agents, but also to customer users, therefore the `Frontend::Base` would be better subgroup for it.