### PR TITLE
Improved AdminCustomerUserService screen

### DIFF
--- a/Kernel/Modules/AdminCustomerUserService.pm
+++ b/Kernel/Modules/AdminCustomerUserService.pm
@@ -363,10 +363,10 @@ sub _Change {
     my $LayoutObject = $Kernel::OM->Get('Kernel::Output::HTML::Layout');
 
     if ( $VisibleType{$NeType} eq 'Customer' ) {
-        $Param{BreadcrumbTitle} = "Allocate Customers to Service";
+        $Param{BreadcrumbTitle} = Translatable('Allocate Customer Users to Service');
     }
     else {
-        $Param{BreadcrumbTitle} = "Allocate Services to Customer";
+        $Param{BreadcrumbTitle} = Translatable('Allocate Services to Customer User');
     }
 
     # overview

--- a/Kernel/Modules/AdminCustomerUserService.pm
+++ b/Kernel/Modules/AdminCustomerUserService.pm
@@ -11,6 +11,8 @@ package Kernel::Modules::AdminCustomerUserService;
 use strict;
 use warnings;
 
+use Kernel::Language qw(Translatable);
+
 our $ObjectManagerDisabled = 1;
 
 sub new {

--- a/Kernel/Output/HTML/Templates/Standard/AdminCustomerUserService.tt
+++ b/Kernel/Output/HTML/Templates/Standard/AdminCustomerUserService.tt
@@ -9,11 +9,11 @@
 [% RenderBlockStart("Overview") %]
 <div class="MainBox ARIARoleMain LayoutFixedSidebar SidebarFirst">
 
-    <h1 class="InvisibleText">[% Translate("Manage Customer-Services Relations") | html %]</h1>
+    <h1 class="InvisibleText">[% Translate("Manage Customer User-Services Relations") | html %]</h1>
 
     [% BreadcrumbPath = [
             {
-                Name => Translate('Manage Customer-Services Relations'),
+                Name => Translate('Manage Customer User-Services Relations'),
                 Link => Data.OverviewLink,
             },
         ]
@@ -22,7 +22,7 @@
     [% IF Data.Type %]
             [% USE EditTitle = String(Translate(Data.BreadcrumbTitle)) %]
             [% IF Data.Name %]
-                [% BreadcrumbPath.push({ Name => EditTitle.append(" '", Data.Name , "'") }) %]
+                [% BreadcrumbPath.push({ Name => EditTitle.append(": ", Data.Name) }) %]
             [% ELSE %]
                 [% BreadcrumbPath.push({ Name => EditTitle.append("") }) %]
             [% END %]
@@ -103,7 +103,7 @@
                 <div class="Size1of2">
                     <ul class="Tablelike" id="Customers">
                         <li class="FilterMessage Hidden">[% Translate("No matches found.") | html %]</li>
-                        <li class="Header">[% Translate("Customers") | html %]
+                        <li class="Header">[% Translate("Customer Users") | html %]
 [% RenderBlockStart("ResultCustomerUserCount") %]
                             ([% Data.CustomerUserCount | html %])
 [% RenderBlockEnd("ResultCustomerUserCount") %]
@@ -138,7 +138,7 @@
 [% RenderBlockStart("AllocateItem") %]
             <div class="Header">
                 <h2>
-                    [% Translate(Data.BreadcrumbTitle) | html %]
+                    [% Translate(Data.BreadcrumbTitle) | html %]:
                     <a href="[% Env("Baselink") %]Action=[% Data.ActionHome | uri %];Subaction=[% Data.SubactionHeader | uri %];[% Data.IDHeaderStrg | uri %]=[% Data.ID | uri %]">[% Data.Name | html %]</a>
                 </h2>
             </div>


### PR DESCRIPTION
Hi @mgruner 
This PR changes the following:
- replaced "Customer" with "Customer User"
- marked breadcrumb title as translatable
- replaced apostrophe with colon, as some languages (e. g. Hungarian) uses other character for quotation, but colon is the same in all language (maybe it can be ndash instead of colon)