### PR TITLE
queues RegEx and Perms settings for EventsTicketCalendar

### DIFF
--- a/Kernel/Config/Files/Ticket.xml
+++ b/Kernel/Config/Files/Ticket.xml
@@ -7183,13 +7183,21 @@
         </Setting>
     </ConfigItem>
     <ConfigItem Name="DashboardEventsTicketCalendar###Queues" Required="1" Valid="1">
-        <Description Translatable="1">Defines queues that's tickets are used for displaying as calendar events.</Description>
+        <Description Translatable="1">Defines queues that's tickets are used for displaying as calendar events, uses regular expressions case insensative. Examples: use ".*" to match all queues, use "^Sales" to match all queues starting with Sales.</Description>
         <Group>Ticket</Group>
         <SubGroup>Frontend::Agent::Dashboard::EventsTicketCalendar</SubGroup>
         <Setting>
             <Array>
-                <Item>Raw</Item>
+                <Item>^Raw$</Item>
             </Array>
+        </Setting>
+    </ConfigItem>
+    <ConfigItem Name="DashboardEventsTicketCalendar::MinimumQueuePermissionsRequirement" Required="1" Valid="1">
+        <Description Translatable="1">Minimum permission requirement on defined queues for displaying calendar events.</Description>
+        <Group>Ticket</Group>
+        <SubGroup>Frontend::Agent::Dashboard::EventsTicketCalendar</SubGroup>
+        <Setting>
+            <String>ro</String>
         </Setting>
     </ConfigItem>
     <ConfigItem Name="DashboardEventsTicketCalendar::DynamicFieldStartTime" Required="0" Valid="1">

--- a/Kernel/Output/HTML/Dashboard/EventsTicketCalendar.pm
+++ b/Kernel/Output/HTML/Dashboard/EventsTicketCalendar.pm
@@ -82,8 +82,10 @@ sub Run {
 
     $Param{CalendarWidth} = $ConfigObject->{DashboardEventsTicketCalendar}->{CalendarWidth};
 
+    my $MinimumQueuePermissionsRequirement = $ConfigObject->Get('DashboardEventsTicketCalendar::MinimumQueuePermissionsRequirement');
     my %QueuesAll = $Kernel::OM->Get('Kernel::System::Queue')->GetAllQueues(
         UserID => $Self->{UserID},
+        Type => $MinimumQueuePermissionsRequirement,
     );
 
     my $EventTicketFields  = $ConfigObject->Get('DashboardEventsTicketCalendar::TicketFieldsForEvents');
@@ -106,7 +108,7 @@ sub Run {
     my %QueuesConfigured;
     for my $Queue ( @{$Queues} ) {
         for my $QueueID ( sort keys %QueuesAll ) {
-            if ( $QueuesAll{$QueueID} eq $Queue ) {
+            if ( $QueuesAll{$QueueID} =~ /$Queue/i ) {
                 $QueuesConfigured{$QueueID} = $QueuesAll{$QueueID};
             }
         }


### PR DESCRIPTION
- Modified: Use Regular Expressions instead of exact match for defining queues
- Added: SysConfig setting, minimum required permissions to show tickets in Events Ticket Calendar for defined queues. Default: ro