### PR TITLE
Fixed Need ObjectID! error on AgentTicketMove with article dynamic field

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,4 +1,5 @@
 #6.0.0.beta1 2017-??-??
+ - 2017-10-04 Fixed Need ObjectID! error on AgentTicketMove with article dynamic field.
  - 2017-03-26 Fixed bug#[12650](https://bugs.otrs.org/show_bug.cgi?id=12650)(PR#1636) - SendCustomerNotification does not respect newly assigned mail address. Thanks to S7!
  - 2017-03-24 Fixed bug#[12720](https://bugs.otrs.org/show_bug.cgi?id=12720)(PR#1672) - Settings window of Complex LinkObject is not translated. Thanks to S7!
  - 2017-03-24 Modernized address book. It is now possible to search for all configured custom user and customer fields.

--- a/Kernel/Modules/AgentTicketMove.pm
+++ b/Kernel/Modules/AgentTicketMove.pm
@@ -1089,13 +1089,18 @@ sub Run {
             # set the object ID (TicketID or ArticleID) depending on the field configration
             my $ObjectID = $DynamicFieldConfig->{ObjectType} eq 'Article' ? $ArticleID : $Self->{TicketID};
 
-            # set the value
-            my $Success = $DynamicFieldBackendObject->ValueSet(
-                DynamicFieldConfig => $DynamicFieldConfig,
-                ObjectID           => $ObjectID,
-                Value              => $DynamicFieldValues{ $DynamicFieldConfig->{Name} },
-                UserID             => $Self->{UserID},
-            );
+            # set dynamic field; when ObjectType=Article and no article will be created ignore
+            # this dynamic field
+            if ( $ObjectID ) {
+
+                # set the value
+                my $Success = $DynamicFieldBackendObject->ValueSet(
+                    DynamicFieldConfig => $DynamicFieldConfig,
+                    ObjectID           => $ObjectID,
+                    Value              => $DynamicFieldValues{ $DynamicFieldConfig->{Name} },
+                    UserID             => $Self->{UserID},
+                );
+            }
         }
     }
 


### PR DESCRIPTION
When there is article (ObjectType=Article) dynamic field present
on AgentTicketMove form and agent commits this form without setting
note (no article creation) OTRS will throw error "Message: Need ObjectID"
to apache error log.

This mod fixes issue described above.

Related: https://dev.ib.pl/ib/otrs/issues/112
Author-Change-Id: IB#1073020