### PR TITLE
Configurable access to archive searching in agent panel

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,4 +1,5 @@
 #6.0.0.beta1 2017-??-??
+ - 2017-10-05 Configurable access to archive searching in agent panel.
  - 2017-03-26 Fixed bug#[12650](https://bugs.otrs.org/show_bug.cgi?id=12650)(PR#1636) - SendCustomerNotification does not respect newly assigned mail address. Thanks to S7!
  - 2017-03-24 Fixed bug#[12720](https://bugs.otrs.org/show_bug.cgi?id=12720)(PR#1672) - Settings window of Complex LinkObject is not translated. Thanks to S7!
  - 2017-03-24 Modernized address book. It is now possible to search for all configured custom user and customer fields.

--- a/Kernel/Config/Files/Ticket.xml
+++ b/Kernel/Config/Files/Ticket.xml
@@ -217,6 +217,17 @@
             </Option>
         </Setting>
     </ConfigItem>
+    <ConfigItem Name="Ticket::AgentArchiveSystem" Required="1" Valid="1">
+        <Description Translatable="1">Activates the ticket archive system search in the agent interface (does not affect generic agent nor statistics modules).</Description>
+        <Group>Ticket</Group>
+        <SubGroup>Core::Ticket</SubGroup>
+        <Setting>
+            <Option SelectedID="1">
+                <Item Key="0">No</Item>
+                <Item Key="1">Yes</Item>
+            </Option>
+        </Setting>
+    </ConfigItem>
     <ConfigItem Name="Ticket::CustomerArchiveSystem" Required="1" Valid="1">
         <Description Translatable="1">Activates the ticket archive system search in the customer interface.</Description>
         <Group>Ticket</Group>

--- a/Kernel/Config/Files/XML/Ticket.xml
+++ b/Kernel/Config/Files/XML/Ticket.xml
@@ -162,6 +162,13 @@
             <Item ValueType="Checkbox">1</Item>
         </Value>
     </Setting>
+    <Setting Name="Ticket::AgentArchiveSystem" Required="1" Valid="1">
+        <Description Translatable="1">Activates the ticket archive system search in the agent interface (does not affect generic agent nor statistics modules).</Description>
+        <Navigation>Core::Ticket</Navigation>
+        <Value>
+            <Item ValueType="Checkbox">1</Item>
+        </Value>
+    </Setting>
     <Setting Name="Ticket::CustomerArchiveSystem" Required="1" Valid="1">
         <Description Translatable="1">Activates the ticket archive system search in the customer interface.</Description>
         <Navigation>Core::Ticket</Navigation>

--- a/Kernel/Modules/AgentTicketSearch.pm
+++ b/Kernel/Modules/AgentTicketSearch.pm
@@ -1479,7 +1479,8 @@ sub Run {
             },
         );
 
-        if ( $ConfigObject->Get('Ticket::ArchiveSystem') ) {
+        if ( $ConfigObject->Get('Ticket::ArchiveSystem')
+            && $ConfigObject->Get('Ticket::AgentArchiveSystem') ) {
             push @Attributes, (
                 {
                     Key   => 'SearchInArchive',
@@ -1798,7 +1799,8 @@ sub Run {
             Class      => 'Modernize',
         );
 
-        if ( $ConfigObject->Get('Ticket::ArchiveSystem') ) {
+        if ( $ConfigObject->Get('Ticket::ArchiveSystem')
+            && $ConfigObject->Get('Ticket::AgentArchiveSystem') ) {
 
             $Param{SearchInArchiveStrg} = $LayoutObject->BuildSelection(
                 Data => {

--- a/Kernel/Output/HTML/LinkObject/Ticket.pm
+++ b/Kernel/Output/HTML/LinkObject/Ticket.pm
@@ -755,7 +755,8 @@ sub SearchOptionList {
             };
     }
 
-    if ( $Kernel::OM->Get('Kernel::Config')->Get('Ticket::ArchiveSystem') ) {
+    if ( $Kernel::OM->Get('Kernel::Config')->Get('Ticket::ArchiveSystem')
+        && $Kernel::OM->Get('Kernel::Config')->Get('Ticket::AgentArchiveSystem') ) {
         push @SearchOptionList,
             {
             Key  => 'ArchiveID',


### PR DESCRIPTION
This mod introduces new SysConfig parameter Ticket::AgentArchiveSystem
that allows admin to disable access for archive searches in agent panel
(does not affect generic agent nor statistics modules). This may help
in protection against overloads in bigger OTRS setups (i.e. fulltext
searches in archive by agents).

Related: https://dev.ib.pl/ib/otrs/issues/113
Author-Change-Id: IB#1073066