### PR TITLE
Update Article.tt

### DIFF
--- a/Kernel/Output/HTML/Templates/Standard/ProcessManagement/Article.tt
+++ b/Kernel/Output/HTML/Templates/Standard/ProcessManagement/Article.tt
@@ -7,8 +7,6 @@
 # --
 [% RenderBlockStart("rw:Article") %]
 
-<div class="FieldSeparator"></div>
-
 [% RenderBlockStart("rw:Article:InformAgent") %]
 <label for="InformUserID">[% Translate("Inform Agent") | html %]:</label>
 <div class="Field">
@@ -75,5 +73,4 @@
 </div>
 <div class="Clear"></div>
 [% RenderBlockEnd("TimeUnits") %]
-<div class="FieldSeparator"></div>
 [% RenderBlockEnd("rw:Article") %]


### PR DESCRIPTION
Removed confusing field separator. This was only used for the article field and confused several users.

Instead of this static field separator it would be nice to have some kind of pseudo elements available for process dialogs to add field separator, free text information, etc.

Cheers, Nils