### PR TITLE
Fixes bug #13205

### DIFF
--- a/Kernel/Modules/AgentTicketActionCommon.pm
+++ b/Kernel/Modules/AgentTicketActionCommon.pm
@@ -1549,6 +1549,7 @@ sub Run {
                     SelectedID   => $GetParam{NewQueueID},
                     PossibleNone => 1,
                     Translation  => 0,
+                    TreeView     => $TreeView,
                     Max          => 100,
                 },
                 @DynamicFieldAJAX,


### PR DESCRIPTION
No TreeView Queue selection in AgentTicketActionCommon after AjaxUpdate.

See: https://bugs.otrs.org/show_bug.cgi?id=13205