### PR TITLE
Fixed UTF-8 display of help text

### DIFF
--- a/Kernel/System/Console/Command/Admin/Package/List.pm
+++ b/Kernel/System/Console/Command/Admin/Package/List.pm
@@ -9,6 +9,7 @@
 package Kernel::System::Console::Command::Admin::Package::List;
 
 use strict;
+use utf8;
 use warnings;
 
 use parent qw(Kernel::System::Console::BaseCommand);


### PR DESCRIPTION
Hi @mgruner 
This PR fixes the display of text _OTRS Verify™_ in console (`otrs.Console.pl Admin::Package::List --help`)

Before:
```
 [--show-verification-info]     - Shows package OTRS Verifyâ
                                                            ¢ status.
 [--delete-verification-cache]  - Deletes OTRS Verifyâ
                                                      ¢ cache, so verification info is fetch again from OTRS group servers.
```

After:
```
 [--show-verification-info]     - Shows package OTRS Verify™ status.
 [--delete-verification-cache]  - Deletes OTRS Verify™ cache, so verification info is fetch again from OTRS group servers.
```
OTRS 5, 6 and 7 are also affected.