### PR TITLE
Improved wording for close buttons, marked strings as translatable

### DIFF
--- a/Kernel/Modules/AdminPackageManager.pm
+++ b/Kernel/Modules/AdminPackageManager.pm
@@ -549,7 +549,9 @@ sub Run {
         );
 
         if ( !$Package ) {
-            return $LayoutObject->ErrorScreen( Message => 'No such package!' );
+            return $LayoutObject->ErrorScreen(
+                Message => Translatable('No such package!'),
+            );
         }
         elsif ( substr( $Package, 0, length('ErrorMessage:') ) eq 'ErrorMessage:' ) {
 
@@ -1358,7 +1360,7 @@ sub Run {
 
         my %PackageList;
         if ( IsArrayRefWithData($InstalledPackages) ) {
-            my $DefaultStatus        = 'Not Started';
+            my $DefaultStatus        = Translatable('Not Started');
             my $DefaultStatusDisplay = $LayoutObject->{LanguageObject}->Translate($DefaultStatus);
             for my $Package ( @{$InstalledPackages} ) {
                 $PackageList{ $Package->{Name} } = {
@@ -1490,7 +1492,7 @@ sub Run {
     $Frontend{SourceList} = $LayoutObject->BuildSelection(
         Data        => { %List, %RepositoryRoot, %{$RepositoryCloudList}, },
         Name        => 'Source',
-        Title       => 'Repository List',
+        Title       => Translatable('Repository List'),
         Max         => 40,
         Translation => 0,
         SelectedID  => $Source,

--- a/Kernel/Output/HTML/Templates/Standard/AdminSMIMECertRead.tt
+++ b/Kernel/Output/HTML/Templates/Standard/AdminSMIMECertRead.tt
@@ -9,7 +9,7 @@
     <div class="Header">
         <h1>[% Translate("S/MIME Certificate") | html %]: [% Data.Filename | html %]</h1>
         <p>
-            <a class="CancelClosePopup" href="#">[% Translate("Close dialog") | html %]</a>
+            <a class="CancelClosePopup" href="#">[% Translate("Close this dialog") | html %]</a>
         </p>
     </div>
     <div class="Content">
@@ -23,6 +23,6 @@
         </div>
     </div>
     <div class="Footer">
-        <button class="CancelClosePopup" value="Close" type="button" title="[% Translate("Close dialog") | html %]" id="Close">[% Translate("Close dialog") | html %]</button>
+        <button class="CancelClosePopup" value="Close" type="button" title="[% Translate("Close this dialog") | html %]" id="Close">[% Translate("Close this dialog") | html %]</button>
     </div>
 </div>

--- a/Kernel/Output/HTML/Templates/Standard/AgentDaemonInfo.tt
+++ b/Kernel/Output/HTML/Templates/Standard/AgentDaemonInfo.tt
@@ -23,5 +23,5 @@
     <div class="Clear Spacing"></div>
 </div>
 <div class="ContentFooter Center">
-    <button id="DaemonFormCancel" class="Primary CallForAction" value="Close"><span><i class="fa fa-times"></i>[% Translate("Close dialog") | html %]</span></button>
+    <button id="DaemonFormCancel" class="Primary CallForAction" value="Close"><span><i class="fa fa-times"></i>[% Translate("Close this dialog") | html %]</span></button>
 </div>

--- a/Kernel/Output/HTML/Templates/Standard/AgentLinkObject.tt
+++ b/Kernel/Output/HTML/Templates/Standard/AgentLinkObject.tt
@@ -13,7 +13,7 @@
             [% Translate("Manage links for %s", Data.SourceObjectLong) | html %]
         </h1>
         <p>
-            <a href="[% Env("Baselink") %]Action=[% Env("Action") %];Subaction=Close" id="LinkAddCloseLink">[% Translate("Close dialog") | html %]</a>
+            <a href="[% Env("Baselink") %]Action=[% Env("Action") %];Subaction=Close" id="LinkAddCloseLink">[% Translate("Close this dialog") | html %]</a>
         </p>
     </div>
     <div class="Content">

--- a/Kernel/Output/HTML/Templates/Standard/AgentTicketHistory.tt
+++ b/Kernel/Output/HTML/Templates/Standard/AgentTicketHistory.tt
@@ -13,7 +13,7 @@
             [% Translate("History of %s%s%s", Config('Ticket::Hook'), Config('Ticket::HookDivider'), Data.TicketNumber) | html %] &mdash; [% Data.Title | html %]
         </h1>
         <p>
-            <a href="#" class="CancelClosePopup">[% Translate("Close dialog") | html %]</a>
+            <a href="#" class="CancelClosePopup">[% Translate("Close this dialog") | html %]</a>
         </p>
     </div>
 

--- a/Kernel/Output/HTML/Templates/Standard/AgentTicketPlain.tt
+++ b/Kernel/Output/HTML/Templates/Standard/AgentTicketPlain.tt
@@ -11,7 +11,7 @@
     <div class="Header">
         <h1>[% Translate("View Email Plain Text for %s%s%s", Config('Ticket::Hook'), Config('Ticket::HookDivider'), Data.TicketNumber) | html %] &mdash; [% Data.Title | html %]</h1>
         <p>
-            <a class="CancelClosePopup" href="#">[% Translate("Close dialog") | html %]</a>
+            <a class="CancelClosePopup" href="#">[% Translate("Close this dialog") | html %]</a>
         </p>
     </div>
 

--- a/var/httpd/htdocs/js/Core.Agent.Admin.SupportDataCollector.js
+++ b/var/httpd/htdocs/js/Core.Agent.Admin.SupportDataCollector.js
@@ -57,7 +57,7 @@ Core.Agent.Admin = Core.Agent.Admin || {};
                     true,
                     [
                         {
-                            Label: Core.Language.Translate('Close'),
+                            Label: Core.Language.Translate('Close this dialog'),
                             Class: 'Primary',
                             Function: function () {
                                 Core.UI.Dialog.CloseDialog($('.SendUpdateResultDialog'));
@@ -100,7 +100,7 @@ Core.Agent.Admin = Core.Agent.Admin || {};
                         true,
                         [
                             {
-                                Label: Core.Language.Translate('Close'),
+                                Label: Core.Language.Translate('Close this dialog'),
                                 Class: 'Primary',
                                 Function: function () {
                                     Core.UI.Dialog.CloseDialog($('.NoSupportBunle'));
@@ -119,7 +119,7 @@ Core.Agent.Admin = Core.Agent.Admin || {};
                         true,
                         [
                             {
-                                Label: Core.Language.Translate("Close"),
+                                Label: Core.Language.Translate("Close this dialog"),
                                 Class: 'Primary',
                                 Function: function () {
                                     Core.UI.Dialog.CloseDialog($('#SupportBundleOptionsDialog'));

--- a/var/httpd/htdocs/js/Core.Agent.AppointmentCalendar.js
+++ b/var/httpd/htdocs/js/Core.Agent.AppointmentCalendar.js
@@ -795,7 +795,7 @@ Core.Agent.AppointmentCalendar = (function (TargetNS) {
                     },
                     {
                         Type: 'Close',
-                        Label: Core.Language.Translate('Close')
+                        Label: Core.Language.Translate('Close this dialog')
                     }
                 ]
             });
@@ -929,7 +929,7 @@ Core.Agent.AppointmentCalendar = (function (TargetNS) {
                     },
                     {
                         Type: 'Close',
-                        Label: Core.Language.Translate('Close'),
+                        Label: Core.Language.Translate('Close this dialog'),
                         Function: function() {
                             Core.UI.Dialog.CloseDialog($('.Dialog:visible'));
                             AppointmentData.RevertFunc();

--- a/var/httpd/htdocs/js/Core.Agent.TicketZoom.js
+++ b/var/httpd/htdocs/js/Core.Agent.TicketZoom.js
@@ -383,7 +383,7 @@ Core.Agent.TicketZoom = (function (TargetNS) {
             Core.UI.Dialog.ShowContentDialog(ArticleViewSettingsDialogHTML, Core.Language.Translate('Settings'), '10px', 'Center', true,
                 [
                     {
-                        Label: Core.Language.Translate('Close'),
+                        Label: Core.Language.Translate('Close this dialog'),
                         Type: 'Close'
                     }
                 ], true);
@@ -545,7 +545,7 @@ Core.Agent.TicketZoom = (function (TargetNS) {
                 Buttons: [
                     {
                         Type: 'Close',
-                        Label: Core.Language.Translate("Close dialog"),
+                        Label: Core.Language.Translate("Close this dialog"),
                         Function: function() {
                             Core.UI.Dialog.CloseDialog($('.Dialog:visible'));
                             Core.Form.EnableForm($('form[name="compose"]'));

--- a/var/httpd/htdocs/js/test/Core.UI.Dialog.UnitTest.js
+++ b/var/httpd/htdocs/js/test/Core.UI.Dialog.UnitTest.js
@@ -33,7 +33,7 @@ Core.UI.Dialog = (function (Namespace) {
                         Buttons: [
                             {
                                 Type: 'Close',
-                                Label: Core.Language.Translate("Close dialog"),
+                                Label: Core.Language.Translate("Close this dialog"),
                                 Function: function() {
                                     Core.UI.Dialog.CloseDialog($('.Dialog:visible'));
                                     return false;
@@ -61,7 +61,7 @@ Core.UI.Dialog = (function (Namespace) {
                         Buttons: [
                             {
                                 Type: 'Close',
-                                Label: Core.Language.Translate("Close dialog"),
+                                Label: Core.Language.Translate("Close this dialog"),
                                 Function: function() {
                                     Core.UI.Dialog.CloseDialog($('.Dialog:visible'));
                                     return false;


### PR DESCRIPTION
Hi @mgruner 
I found some "Close" button that are ambiguous, because "Close" could mean "Close a dialog" or "Close a ticket". In Hungarian language we have two different words for them.
And I found some strings, that are not marked for translation.