### PR TITLE
Fixed SaveButtons widgets

### DIFF
--- a/Kernel/Output/HTML/Templates/Standard/AdminACLEdit.tt
+++ b/Kernel/Output/HTML/Templates/Standard/AdminACLEdit.tt
@@ -234,11 +234,8 @@
                 </div>
             </div>
 
-            <div class="WidgetSimple ScreenXL">
-                <div class="Header Expanded">
-                    <div class="WidgetAction Toggle">
-                        <a href="#" title="[% Translate("Save settings") | html %]"></a>
-                    </div>
+            <div class="WidgetSimple">
+                <div class="Header">
                     <h2>[% Translate("Save ACL") | html %]</h2>
                 </div>
                 <div class="Content">

--- a/Kernel/Output/HTML/Templates/Standard/AdminProcessManagementProcessEdit.tt
+++ b/Kernel/Output/HTML/Templates/Standard/AdminProcessManagementProcessEdit.tt
@@ -254,11 +254,8 @@
                 </div>
             </div>
 
-            <div class="WidgetSimple ScreenXL">
-                <div class="Header Expanded">
-                    <div class="WidgetAction Toggle">
-                        <a href="#" title="[% Translate("Save settings") | html %]"></a>
-                    </div>
+            <div class="WidgetSimple">
+                <div class="Header">
                     <h2>[% Translate("Save Activities, Activity Dialogs and Transitions") | html %]</h2>
                 </div>
                 <div class="Content">


### PR DESCRIPTION
Hi @mgruner 
The SaveButtons widget of ACL and Process Management is collapsible, but they shouldn't be collapsible. This PR fixes the layout.
All supported branches (rel-5_0, rel-6_0 and master) are affected.