### PR TITLE
UTF-8 encode user/pass for radius authentication

### DIFF
--- a/Kernel/System/Auth/Radius.pm
+++ b/Kernel/System/Auth/Radius.pm
@@ -123,6 +123,10 @@ sub Auth {
             return;
         }
     }
+    #utf8 encode user and password
+    utf8::encode($Pw);
+    utf8::encode($User);
+
     my $AuthResult = $Radius->check_pwd( $User, $Pw );
 
     # login note


### PR DESCRIPTION
UTF-8 encode Username/Password for radius authentication. Otherwise non-ascii characters aren't permitted in user/pass when using radius authentication.