### PR TITLE
Marked field explanation as translatable

### DIFF
--- a/Kernel/Output/HTML/Templates/Standard/AdminSystemConfigurationDeployment.tt
+++ b/Kernel/Output/HTML/Templates/Standard/AdminSystemConfigurationDeployment.tt
@@ -46,9 +46,9 @@
                 <h2>[% Translate("Help") | html %]</h2>
             </div>
             <div class="Content">
-                <p class="FieldExplanation">This is an overview of all settings which will be part of the deployment if you start it now. You can compare each setting to its former state by clicking the icon on the top right.</p>
-                <p class="FieldExplanation">To exclude certain settings from a deployment, click the checkbox on the header bar of a setting.</p>
-                <p class="FieldExplanation">By default, you will only deploy settings which you changed on your own. If you'd like to deploy settings changed by other users, too, please click the link on top of the screen to enter the advanced deployment mode.</p>
+                <p class="FieldExplanation">[% Translate("This is an overview of all settings which will be part of the deployment if you start it now. You can compare each setting to its former state by clicking the icon on the top right.") | html %]</p>
+                <p class="FieldExplanation">[% Translate("To exclude certain settings from a deployment, click the checkbox on the header bar of a setting.") | html %]</p>
+                <p class="FieldExplanation">[% Translate("By default, you will only deploy settings which you changed on your own. If you'd like to deploy settings changed by other users, too, please click the link on top of the screen to enter the advanced deployment mode.") | html %]</p>
             </div>
         </div>
 


### PR DESCRIPTION
Hi @mgruner 
This field explanation is not marked as translatable.