### PR TITLE
Marked strings as translatable

### DIFF
--- a/Kernel/System/SysConfig.pm
+++ b/Kernel/System/SysConfig.pm
@@ -4333,7 +4333,7 @@ Returns:
 
     %Categories = (
         All => {
-            DisplayName => 'All Settings',
+            DisplayName => Translatable('All Settings'),
             Files => [],
         },
         OTRSFree => {
@@ -4364,7 +4364,7 @@ sub ConfigurationCategoriesGet {
     # Set framework files.
     my %Result = (
         All => {
-            DisplayName => 'All Settings',
+            DisplayName => Translatable('All Settings'),
             Files       => [],
         },
         OTRSFree => {


### PR DESCRIPTION
Hi @mgruner 
This string is not marked as translatable. The first occurrence is in the Perl doc, so I don't know, if Translatable() is necessary here. If not, please remove it.