### PR TITLE
Do not update passwort to prevent rehashing

### DIFF
--- a/Kernel/System/Auth.pm
+++ b/Kernel/System/Auth.pm
@@ -288,6 +288,7 @@ sub Auth {
             %User,
             ValidID      => $ValidID,
             ChangeUserID => 1,
+            UserPw       => '',
         );
 
         return if !$Update;


### PR DESCRIPTION
# Problem:
If `PasswordMaxLoginFailed` is set and an agent logs in more times than allowed, the status is changed to `invalid-temporarily`. The whole `%User` hash is passed to `UserUpdate`  - including the already hashed password.
This changes the password by hashing it again. 
# Solution:
This problem can be prevented by not passing the hashed password.