### PR TITLE
Fixed incorrect postmaster filter matching

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,4 +1,5 @@
 #6.0.0.beta1 2017-??-??
+ - 2017-11-13 Fixed incorrect postmaster filter matching.
  - 2017-03-26 Fixed bug#[12650](https://bugs.otrs.org/show_bug.cgi?id=12650)(PR#1636) - SendCustomerNotification does not respect newly assigned mail address. Thanks to S7!
  - 2017-03-24 Fixed bug#[12720](https://bugs.otrs.org/show_bug.cgi?id=12720)(PR#1672) - Settings window of Complex LinkObject is not translated. Thanks to S7!
  - 2017-03-24 Modernized address book. It is now possible to search for all configured custom user and customer fields.

--- a/Kernel/System/PostMaster/Filter/MatchDBSource.pm
+++ b/Kernel/System/PostMaster/Filter/MatchDBSource.pm
@@ -84,7 +84,7 @@ sub Run {
                 my @EmailAddresses = $Self->{ParserObject}->SplitAddressLine(
                     Line => $Param{GetParam}->{$_},
                 );
-                my $LocalMatched;
+                my $LocalMatched = 0;
                 RECIPIENT:
                 for my $Recipients (@EmailAddresses) {
                     my $Email = $Self->{ParserObject}->GetEmailAddress( Email => $Recipients );
@@ -105,6 +105,12 @@ sub Run {
                         last RECIPIENT;
                     }
                 }
+
+                # negate result if configured
+                if ( $Config{Not}->{$_} ) {
+                    $LocalMatched ^= 1 ;
+                }
+
                 if ( !$LocalMatched ) {
                     $MatchedNot = 1;
                 }
@@ -112,11 +118,6 @@ sub Run {
                     $Matched = 1;
                 }
 
-                # switch MatchedNot and $Matched
-                if ( $Config{Not}->{$_} ) {
-                    $MatchedNot ^= 1;
-                    $Matched    ^= 1;
-                }
             }
 
             # match string


### PR DESCRIPTION
Postmaster filter with conditions like

    Body: non-existing-text
    From: EMAILADDRESS:non-existing-mail@test.com (negation checked here)
    To: EMAILADDRESS:matching-mail@test.com

matches message like

    From: <test@test.com>
    To: <matching-mail@test.com>
    Subject: test
    Message-ID: <test12345678@test.com>
    Content-Type: text/plain; charset="UTF-8"
    Mime-Version: 1.0
    Content-Transfer-Encoding: 8bit

    test

but should not. This mod fixes issue described above.

Related: https://dev.ib.pl/ib/otrs/issues/115
Author-Change-Id: IB#1074203