### PR TITLE
added --follow-Outside-symlinks to otrs.SetPermissions.pl

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,7 @@
 #7.0.0.alpha1 2018-??-??
 
 #6.0.2 2017-??-??
+ - 2017-11-17 Added --follow-outside-symlinks and error for skipping directory to otrs.SetPermissions 
  - 2017-11-17 Fixed bug#[13343](https://bugs.otrs.org/show_bug.cgi?id=13343) - LDAP customer user backends should be implicitly read only.
  - 2017-11-17 Fixed bug#[13348](https://bugs.otrs.org/show_bug.cgi?id=13348) - User specific settings do not reset when set to the default value.
  - 2017-11-16 Fixed bug#[13331](https://bugs.otrs.org/show_bug.cgi?id=13331) - Ticket Age is shown not updated on customer interface.


### PR DESCRIPTION
Recently we moved our FS article data to a different partition and symlinked the var/article dir the right location.

It turned out that the SetPermission script skipped  directories that are outside the otrs/ basedir.

- We added a warning notice that a directory is skipped so this doesn't happen unseen
- added a script switch to skip/change the behaviour and follow symlinks outside the basedir.

With kind regards,

Thomas