### PR TITLE
Fixed: Link to images was broken

### DIFF
--- a/Kernel/Modules/CustomerTicketArticleContent.pm
+++ b/Kernel/Modules/CustomerTicketArticleContent.pm
@@ -169,7 +169,7 @@ sub Run {
 
     # generate base url
     my $URL = 'Action=CustomerTicketAttachment;Subaction=HTMLView'
-        . ";ArticleID=$ArticleID;FileID=";
+        . ";TicketID=$TicketID;ArticleID=$ArticleID;FileID=";
 
     # replace links to inline images in html content
     my %AtmBox = $ArticleBackendObject->ArticleAttachmentIndex(


### PR DESCRIPTION
Fix for the link of inline-images in the customer-portal.
Otherwise customers can't see any images.