### PR TITLE
Refer to ArticleBackendObject in Kernel/Output/HTML/ArticleCheck/PGP.pm

### DIFF
--- a/Kernel/Output/HTML/ArticleCheck/PGP.pm
+++ b/Kernel/Output/HTML/ArticleCheck/PGP.pm
@@ -180,7 +180,7 @@ sub Check {
     if ( $Param{Article}->{Body} =~ m{ ^\s* -----BEGIN [ ] PGP [ ] SIGNED [ ] MESSAGE----- }xms ) {
 
         # get original message
-        my $Message = $TicketObject->ArticlePlain(
+        my $Message = $TicketBackendObject->ArticlePlain(
             ArticleID => $Self->{ArticleID},
             UserID    => $Self->{UserID},
         );


### PR DESCRIPTION
ArticleObject is non-existant, use ArticleBackendObject instead

Fixes error:
Can't locate object method "ArticlePlain" via package "Kernel::System::Ticket::Article" at /opt/otrs/Kernel/Output/HTML/ArticleCheck/PGP.pm line 189.
When using Search