### PR TITLE
Add missing dependency (Sys::Syslog) in otrs.CheckModules.pl

### DIFF
--- a/bin/otrs.CheckModules.pl
+++ b/bin/otrs.CheckModules.pl
@@ -444,6 +444,16 @@ my @NeededModules = (
         },
     },
     {
+        Module    => 'Log::Syslog',
+        Required  => 0,
+        Comment   => 'Required for logging with Log::SysLog OTRS backend.',
+        InstTypes => {
+            aptget => 'libsys-syslog-perl',
+            emerge => 'perl-core/Sys-Syslog',
+            ports  => 'sysutils/p5-Sys-Syslog',
+        },
+    },
+    {
         Module    => 'Template',
         Required  => 1,
         Comment   => 'Template::Toolkit, the rendering engine of OTRS.',

--- a/bin/otrs.CheckModules.pl
+++ b/bin/otrs.CheckModules.pl
@@ -444,7 +444,7 @@ my @NeededModules = (
         },
     },
     {
-        Module    => 'Log::Syslog',
+        Module    => 'Sys::Syslog',
         Required  => 0,
         Comment   => 'Required for logging with Log::SysLog OTRS backend.',
         InstTypes => {


### PR DESCRIPTION
OTRS Log::SysLog log backend uses Sys::Syslog module. Without it I've got the following error message (from Apache logs):

```
[Thu Dec 07 13:41:32.599880 2017] [:error] [pid 27689] [Thu Dec  7 13:41:32 2017] -e: Can't load log backend module Kernel::System::Log::SysLog! Can't locate Sys/Syslog.pm in @INC (@INC contains: /usr/Custom /us
r/Kernel/cpan-lib /usr /usr/sbin/../../Custom /usr/sbin/../../Kernel/cpan-lib /usr/sbin/../.. /opt/otrs/Custom /opt/otrs/Kernel/cpan-lib /opt/otrs/ /usr/local/lib64/perl5 /usr/local/share/perl5 /usr/lib64/perl5/
vendor_perl /usr/share/perl5/vendor_perl /usr/lib64/perl5 /usr/share/perl5 . /etc/httpd) at /opt/otrs//Kernel/System/Log/SysLog.pm line 14.\n[Thu Dec  7 13:41:32 2017] -e: BEGIN failed--compilation aborted at /o
pt/otrs//Kernel/System/Log/SysLog.pm line 14.\n[Thu Dec  7 13:41:32 2017] -e: Compilation failed in require at (eval 67) line 2.\n
```

Where /opt/otrs//Kernel/System/Log/SysLog.pm line 14:

`use Sys::Syslog qw();`