### PR TITLE
Marked strings as translatable

### DIFF
--- a/Kernel/Config/Files/XML/Ticket.xml
+++ b/Kernel/Config/Files/XML/Ticket.xml
@@ -8587,8 +8587,8 @@
         <Navigation>Frontend::Agent::View::TicketMove</Navigation>
         <Value>
             <Item ValueType="Select" SelectedID="TicketZoom">
-                <Item ValueType="Option" Value="TicketZoom">TicketZoom</Item>
-                <Item ValueType="Option" Value="LastScreenOverview">LastScreenOverview</Item>
+                <Item ValueType="Option" Value="TicketZoom" Translatable="1">Ticket Zoom</Item>
+                <Item ValueType="Option" Value="LastScreenOverview" Translatable="1">Last Screen Overview</Item>
             </Item>
         </Value>
     </Setting>


### PR DESCRIPTION
Hi @mgruner 
These string are displayed in the Advanced personal settings of OTRS Business Solution. All others are translated, only these are untranslated.