### PR TITLE
Add total count of links in block to block header

### DIFF
--- a/Kernel/Output/HTML/Layout/LinkObject.pm
+++ b/Kernel/Output/HTML/Layout/LinkObject.pm
@@ -413,7 +413,7 @@ sub LinkObjectTableCreateComplex {
             Name => 'TableComplexBlock',
             Data => {
                 BlockDescription => $BlockDescription,
-                Blockname        => $Block->{Blockname} || '',
+                Blockname        => $Block->{Blockname} . ' (' . scalar @{ $Block->{ItemList} } . ')' || '',
                 Name             => $Block->{Blockname},
                 NameForm         => $Block->{Blockname},
                 AJAX             => $Param{AJAX},


### PR DESCRIPTION
This PR adds the count of links for a block (e.g. number of linked tickets) to the block header.

Before:
![otrs_link_count_before](https://user-images.githubusercontent.com/6499251/34895221-f76c0652-f7e4-11e7-9d75-7cac3658c6df.png)

After:
![otrs_link_count_after](https://user-images.githubusercontent.com/6499251/34895223-faf75222-f7e4-11e7-8cec-214639d7ce13.png)

The reason for this change is that we sometimes have tickets that really have many linked tickets (e.g. a "master ticket") and it would be great to see at one glance how many tickets are linked in total.
