### PR TITLE
[WIP] add sort for link tables

### DIFF
--- a/Kernel/Output/HTML/Layout/LinkObject.pm
+++ b/Kernel/Output/HTML/Layout/LinkObject.pm
@@ -514,6 +514,7 @@ sub LinkObjectTableCreateComplex {
                     Data => {
                         %{$Column},
                         Content => $Content,
+                        ContentRaw => $Column->{Content},
                     },
                 );
             }

--- a/Kernel/Output/HTML/Templates/Standard/LinkObject.tt
+++ b/Kernel/Output/HTML/Templates/Standard/LinkObject.tt
@@ -161,11 +161,15 @@
         </div>
 [% RenderBlockEnd("ContentLargePreferencesForm") %]
         <div id="[% Data.Name | html %]">
-            <table class="DataTable">
+            <table id="LinkObjectTable-[% Data.Name | html %]" class="DataTable">
                 <thead>
                     <tr>
 [% RenderBlockStart("TableComplexBlockColumn") %]
-                        <th> [% Translate(Data.Content) | html %] </th>
+                        [% IF Data.Content == 'Delete' %]
+                            <th>[% Translate(Data.Content) | html %] </th>
+                        [% ELSE %]
+                            <th class="Sortable"><a href="#"> [% Translate(Data.Content) | html %] </a> </th>
+                        [% END %]
 [% RenderBlockEnd("TableComplexBlockColumn") %]
                     </tr>
                 </thead>
@@ -175,6 +179,10 @@
 [% RenderBlockStart("TableComplexBlockRowColumn") %]
                         <td class="[% Data.CssClass | html %]">
                             [% Data.Content %]
+
+                            [% IF Data.Type != 'CheckboxDelete' %]
+                                <input type="hidden" class="SortData" value="[% Data.ContentRaw %]" /> 
+                            [% END %]
                         </td>
 [% RenderBlockEnd("TableComplexBlockRowColumn") %]
                     </tr>

--- a/var/httpd/htdocs/js/Core.Agent.TicketZoom.js
+++ b/var/httpd/htdocs/js/Core.Agent.TicketZoom.js
@@ -689,6 +689,11 @@ Core.Agent.TicketZoom = (function (TargetNS) {
         // Table sorting
         Core.UI.Table.Sort.Init($('#ArticleTable'));
 
+        // Table sorting for Linked Objects
+        Core.UI.Table.Sort.Init($('#LinkObjectTable-Appointment'));
+        Core.UI.Table.Sort.Init($('#LinkObjectTable-FAQ'));
+        Core.UI.Table.Sort.Init($('#LinkObjectTable-Ticket'));
+
         // load another article, if in "show one article" mode and article id is provided by location hash
         if (!ZoomExpand) {
             URLHash = location.hash.replace(/#/, '');


### PR DESCRIPTION
This PR adds the possibility to sort the table of linked objects (e.g. Tickets, FAQs) in AgentTicketZoom.

I would like to get some feedback on my implementation of this because I have not done a lot of coding for OTRS yet. 
I already noticed that this is not working in "index.pl?Action=AgentLinkObject" screens, so this will need to be fixed (or excluded) before it makes sense to merge this PR.