### PR TITLE
Marked AutoResponse names as translatable

### DIFF
--- a/Kernel/Output/HTML/Templates/Standard/AdminAutoResponse.tt
+++ b/Kernel/Output/HTML/Templates/Standard/AdminAutoResponse.tt
@@ -93,7 +93,7 @@
 [% RenderBlockEnd("NoDataFoundMsg") %]
 [% RenderBlockStart("OverviewResultRow") %]
                         <tr [% IF Data.ValidID != 1 %]class="Invalid"[% END %]>
-                            <td><a class="AsBlock" href="[% Env("Baselink") %]Action=[% Env("Action") %];Subaction=Change;ID=[% Data.ID | uri %]">[% Data.Name | html %]</a></td>
+                            <td><a class="AsBlock" href="[% Env("Baselink") %]Action=[% Env("Action") %];Subaction=Change;ID=[% Data.ID | uri %]">[% Translate(Data.Name) | html %]</a></td>
                             <td>[% Translate(Data.Type) | html %]</td>
                             <td title="[% Data.Comment | html %]">[% Data.Comment | truncate(20) | html %]</td>
                             <td>[% Translate(Data.Valid) | html %]</td>


### PR DESCRIPTION
Hi @mgruner
The AutoResponse names are already translated in AutoResponse <-> Queues screen, but they are still in English in the AutoResponse screen. All supported version of OTRS are affected.