### PR TITLE
Fixed translation mechanism in AdminCommunicationLog

### DIFF
--- a/Kernel/Modules/AdminCommunicationLog.pm
+++ b/Kernel/Modules/AdminCommunicationLog.pm
@@ -28,7 +28,8 @@ sub new {
 sub Run {
     my ( $Self, %Param ) = @_;
 
-    my $ParamObject = $Kernel::OM->Get('Kernel::System::Web::Request');
+    my $LayoutObject = $Kernel::OM->Get('Kernel::Output::HTML::Layout');
+    my $ParamObject  = $Kernel::OM->Get('Kernel::System::Web::Request');
 
     my %GetParam;
     for my $Param (
@@ -49,9 +50,8 @@ sub Run {
         );
 
         if ( !IsHashRefWithData($Communication) ) {
-            my $LayoutObject = $Kernel::OM->Get('Kernel::Output::HTML::Layout');
             return $LayoutObject->FatalError(
-                Message => Translatable('Invalid CommunicationID '),
+                Message => Translatable('Invalid CommunicationID!'),
             );
         }
     }
@@ -76,10 +76,8 @@ sub Run {
     $GetParam{StartTime} //= 86400;
 
     if ( $GetParam{StartTime} && $GetParam{StartTime} !~ m{^\d+$} ) {
-        my $LayoutObject = $Kernel::OM->Get('Kernel::Output::HTML::Layout');
-
         return $LayoutObject->FatalError(
-            Message => sprintf( Translatable('Invalid StartTime: %s!'), $GetParam{StartTime} ),
+            Message => $LayoutObject->{LanguageObject}->Translate( 'Invalid StartTime: %s!', $GetParam{StartTime} ),
         );
     }
     else {
@@ -89,9 +87,8 @@ sub Run {
         );
 
         if ( !$ValidDate ) {
-            my $LayoutObject = $Kernel::OM->Get('Kernel::Output::HTML::Layout');
             return $LayoutObject->FatalError(
-                Message => sprintf( Translatable("Invalid StartTime: %s!"), $GetParam{StartTime} ),
+                Message => $LayoutObject->{LanguageObject}->Translate( 'Invalid StartTime: %s!', $GetParam{StartTime} ),
             );
         }
         $GetParam{DateTime} = $DateTimeObject->ToString();
@@ -145,7 +142,7 @@ sub _ShowOverview {
         },
     );
 
-    # get personal page shown count
+    # Get personal page shown count.
     my $PageShownPreferencesKey = 'AdminCommunicationLogPageShown';
     my $PageShown               = $Self->{$PageShownPreferencesKey} || 25;
     my $Group                   = 'CommunicationLogPageShown';
@@ -195,7 +192,7 @@ sub _ShowOverview {
 
     if ( !$Filters{ $Param{Filter} } ) {
         return $LayoutObject->FatalError(
-            Message => sprintf( Translatable('Invalid Filter: %s!'), $Param{Filter} ),
+            Message => $LayoutObject->{LanguageObject}->Translate( 'Invalid Filter: %s!', $Param{Filter} ),
         );
     }
 
@@ -225,7 +222,7 @@ sub _ShowOverview {
         },
     );
 
-    # generate human readable average processing time
+    # Generate human readable average processing time.
     my $AverageSeconds = $CommunicationLogDBObj->CommunicationList(
         StartDate => $Param{DateTime},
         Result    => 'AVERAGE',
@@ -233,7 +230,7 @@ sub _ShowOverview {
 
     my $AverageString = $AverageSeconds >= 1
         ? $Self->_HumanReadableAverage( Seconds => $AverageSeconds )
-        : Translatable('Less than a second');
+        : $LayoutObject->{LanguageObject}->Translate('Less than a second');
 
     my %Accounts = $Self->_AccountStatus(
         StartDate => $Param{DateTime},
@@ -288,7 +285,7 @@ sub _ShowOverview {
             Failed           => $Filters{Failed}->{Count},
             StatusFilter     => $StatusFilter,
             StartTime        => $Param{StartTime} || 0,
-            TimeRange        => $Param{TimeRanges}->{ $Param{StartTime} },
+            TimeRange        => $LayoutObject->{LanguageObject}->Translate( $Param{TimeRanges}->{ $Param{StartTime} } ),
             AverageString    => $AverageString,
             AccountsStatus   => $Status,
             AccountsOverview => \%AccountsOverview,
@@ -297,14 +294,14 @@ sub _ShowOverview {
 
     my $Total = scalar @CommunicationData;
 
-    # get data selection
+    # Get data selection.
     my %Data;
     my $Config = $Kernel::OM->Get('Kernel::Config')->Get('PreferencesGroups');
     if ( $Config && $Config->{$Group} && $Config->{$Group}->{Data} ) {
         %Data = %{ $Config->{$Group}->{Data} };
     }
 
-    # calculate max. shown per page
+    # Calculate max. shown per page.
     if ( $Param{StartHit} > $Total ) {
         my $Pages = int( ( $Total / $PageShown ) + 0.99999 );
         $Param{StartHit} = ( ( $Pages - 1 ) * $PageShown ) + 1;
@@ -316,7 +313,7 @@ sub _ShowOverview {
         $URLExtension .= "$URLPart=$Param{$URLPart};";
     }
 
-    # build nav bar
+    # Build nav bar.
     my $Limit = $Param{Limit} || 20_000;
     my %PageNav = $LayoutObject->PageNavBar(
         Limit     => $Limit,
@@ -328,7 +325,7 @@ sub _ShowOverview {
         IDPrefix  => $LayoutObject->{Action},
     );
 
-    # build shown dynamic fields per page
+    # Build shown dynamic fields per page.
     $Param{RequestedURL} = "Action=$Self->{Action};$URLExtension";
 
     for my $URLPart (qw(Filter SortBy OrderBy StartTime)) {
@@ -413,8 +410,8 @@ sub _ShowOverview {
 
     for my $TableHeader (@TableHeaders) {
 
-        my $CSS   = $TableHeader->{Class};
-        my $Title = $TableHeader->{HeaderName};
+        my $CSS             = $TableHeader->{Class};
+        my $TranslatedTitle = $LayoutObject->{LanguageObject}->Translate( $TableHeader->{HeaderName} );
         my $OrderBy;
 
         if ( $Param{SortBy} eq $TableHeader->{SortByName} ) {
@@ -427,9 +424,11 @@ sub _ShowOverview {
                 $CSS .= ' SortDescendingLarge';
             }
 
-            # set title description
-            my $TitleDesc = $OrderBy eq 'Up' ? Translatable('sorted descending') : Translatable('sorted ascending');
-            $Title .= ', ' . $TitleDesc;
+            # Set title description.
+            my $TitleDesc = $OrderBy eq 'Up'
+                ? $LayoutObject->{LanguageObject}->Translate('sorted descending')
+                : $LayoutObject->{LanguageObject}->Translate('sorted ascending');
+            $TranslatedTitle .= ', ' . $TitleDesc;
         }
 
         $LayoutObject->Block(
@@ -439,7 +438,7 @@ sub _ShowOverview {
                 SortByName => $TableHeader->{SortByName},
                 OrderBy    => $OrderBy,
                 CSS        => $CSS,
-                Title      => $Title,
+                Title      => $TranslatedTitle,
                 HeaderLink => $HeaderURL,
             },
         );
@@ -501,7 +500,7 @@ sub _ZoomView {
     my $Output = $LayoutObject->Header();
     $Output .= $LayoutObject->NavigationBar();
 
-    # call all needed template blocks
+    # Call all needed template blocks.
     $LayoutObject->Block(
         Name => 'Main',
         Data => \%Param,
@@ -572,13 +571,13 @@ sub _ZoomView {
         Class        => 'Modernize W75pc',
     );
 
-    # send CommunicationID to JS
+    # Send CommunicationID to JS.
     $LayoutObject->AddJSData(
         Key   => 'CommunicationID',
         Value => $Param{CommunicationID},
     );
 
-    # send ObjectLogID to JS
+    # Send ObjectLogID to JS.
     $LayoutObject->AddJSData(
         Key   => 'ObjectLogID',
         Value => $Param{ObjectLogID},
@@ -679,7 +678,7 @@ sub _AccountsView {
             # Generate human readable average processing time.
             my $AverageString = $AverageSeconds >= 1
                 ? $Self->_HumanReadableAverage( Seconds => $AverageSeconds )
-                : Translatable('Less than a second');
+                : $LayoutObject->{LanguageObject}->Translate('Less than a second');
 
             my $HealthStatus = $Self->_CheckHealth($Account);
 
@@ -723,7 +722,7 @@ sub _AccountsView {
         Data         => {
             %Param,
             CommunicationLogCount => $CommunicationLogCount,
-            TimeRange             => $Param{TimeRanges}->{ $Param{StartTime} },
+            TimeRange             => $LayoutObject->{LanguageObject}->Translate( $Param{TimeRanges}->{ $Param{StartTime} } ),
         },
     );
 
@@ -785,7 +784,7 @@ sub _GetCommunicationLog {
         StartDate => $Param{DateTime},
     );
 
-    # get personal page shown count
+    # Get personal page shown count.
     my $PageShownPreferencesKey = 'AdminCommunicationLogPageShown';
     my $PageShown               = $Self->{$PageShownPreferencesKey} || 25;
     my $Group                   = 'CommunicationLogPageShown';
@@ -832,14 +831,14 @@ sub _GetCommunicationLog {
 
     my $Total = scalar keys %CommunicationIDs;
 
-    # get data selection
+    # Get data selection.
     my %Data;
     my $Config = $Kernel::OM->Get('Kernel::Config')->Get('PreferencesGroups');
     if ( $Config && $Config->{$Group} && $Config->{$Group}->{Data} ) {
         %Data = %{ $Config->{$Group}->{Data} };
     }
 
-    # calculate max. shown per page
+    # Calculate max. shown per page.
     if ( $Param{StartHit} > $Total ) {
         my $Pages = int( ( $Total / $PageShown ) + 0.99999 );
         $Param{StartHit} = ( ( $Pages - 1 ) * $PageShown ) + 1;
@@ -851,7 +850,7 @@ sub _GetCommunicationLog {
         $URLExtension .= "$URLPart=$Param{$URLPart};";
     }
 
-    # build nav bar
+    # Build nav bar.
     my $Limit = $Param{Limit} || 20_000;
     my %PageNav = $LayoutObject->PageNavBar(
         Limit     => $Limit,
@@ -862,7 +861,7 @@ sub _GetCommunicationLog {
         Link      => $URLExtension,
     );
 
-    # build shown dynamic fields per page
+    # Build shown dynamic fields per page.
     $Param{RequestedURL} = "Action=$Self->{Action};$URLExtension";
 
     for my $URLPart (qw(SortBy OrderBy StartTime)) {
@@ -904,6 +903,8 @@ sub _GetCommunicationLog {
 sub _HumanReadableAverage {
     my ( $Self, %Param ) = @_;
 
+    my $LayoutObject = $Kernel::OM->Get('Kernel::Output::HTML::Layout');
+
     my $DateTimeAverageStart = $Kernel::OM->Create('Kernel::System::DateTime');
     my $DateTimeAverageStop  = $Kernel::OM->Create('Kernel::System::DateTime');
 
@@ -918,8 +919,8 @@ sub _HumanReadableAverage {
             "$AverageDelta->{Days} " .
             (
             $AverageDelta->{Days} > 1
-            ? Translatable('days')
-            : Translatable('day')
+            ? $LayoutObject->{LanguageObject}->Translate('days')
+            : $LayoutObject->{LanguageObject}->Translate('day')
             );
     }
 
@@ -928,8 +929,8 @@ sub _HumanReadableAverage {
             "$AverageDelta->{Hours} " .
             (
             $AverageDelta->{Hours} > 1
-            ? Translatable('hours')
-            : Translatable('hour')
+            ? $LayoutObject->{LanguageObject}->Translate('hours')
+            : $LayoutObject->{LanguageObject}->Translate('hour')
             );
     }
 
@@ -938,8 +939,8 @@ sub _HumanReadableAverage {
             "$AverageDelta->{Minutes} " .
             (
             $AverageDelta->{Minutes} > 1
-            ? Translatable('minutes')
-            : Translatable('minute')
+            ? $LayoutObject->{LanguageObject}->Translate('minutes')
+            : $LayoutObject->{LanguageObject}->Translate('minute')
             );
     }
 
@@ -948,8 +949,8 @@ sub _HumanReadableAverage {
             "$AverageDelta->{Seconds} " .
             (
             $AverageDelta->{Seconds} > 1
-            ? Translatable('seconds')
-            : Translatable('second')
+            ? $LayoutObject->{LanguageObject}->Translate('seconds')
+            : $LayoutObject->{LanguageObject}->Translate('second')
             );
     }
 


### PR DESCRIPTION
Hi @mgruner 
The AdminCommunicationLog screen contains many untranslated strings. This PR fixes the translation mechanism of this screen.