### PR TITLE
Fixed rowspan of tables when hovering

### DIFF
--- a/Kernel/Output/HTML/Templates/Standard/AdminCommunicationLogAccounts.tt
+++ b/Kernel/Output/HTML/Templates/Standard/AdminCommunicationLogAccounts.tt
@@ -120,7 +120,7 @@
                     <tbody>
 [% RenderBlockStart("NoAccountsFound") %]
                         <tr>
-                            <td colspan="3">
+                            <td colspan="4">
                                 [% Translate("No accounts found.") | html %]
                             </td>
                         </tr>

--- a/Kernel/Output/HTML/Templates/Standard/AdminCommunicationLogZoom.tt
+++ b/Kernel/Output/HTML/Templates/Standard/AdminCommunicationLogZoom.tt
@@ -107,7 +107,7 @@
                     <tbody>
 [% RenderBlockStart("NoCommunicationObjectsFound") %]
                         <tr>
-                            <td colspan="6">
+                            <td colspan="7">
                                 [% Translate("No communication objects found.") | html %]
                             </td>
                         </tr>


### PR DESCRIPTION
Hi @mrcbnsls 
If there are no communication logs, the rowspan of the _No data found._ cell is wrong.