### PR TITLE
Fixed translation of notification transport names

### DIFF
--- a/Kernel/Output/HTML/Templates/Standard/AdminAppointmentNotificationEvent.tt
+++ b/Kernel/Output/HTML/Templates/Standard/AdminAppointmentNotificationEvent.tt
@@ -376,7 +376,7 @@
                     </fieldset>
 [% RenderBlockStart("TransportRow") %]
                     <fieldset class="TableLike FixedLabel SpacingTop">
-                        <legend><span>[% Data.TransportName | html %]</span></legend>
+                        <legend><span>[% Translate(Data.TransportName) | html %]</span></legend>
 [% RenderBlockStart("TransportRowEnabled") %]
                         <label for="Transport[% Data.Transport | html %]">
                             [% Translate("Enable this notification method") | html %]:

--- a/Kernel/Output/HTML/Templates/Standard/AdminNotificationEvent.tt
+++ b/Kernel/Output/HTML/Templates/Standard/AdminNotificationEvent.tt
@@ -378,7 +378,7 @@
                         <div class="Clear"></div>
 
 [% RenderBlockStart("BackendArticleField") %]
-                        <label for="[% Data.Key %]">[% Data.Label %]:</label>
+                        <label for="[% Data.Key %]">[% Translate(Data.Label) %]:</label>
                         <div class="Field">
                             <input type="text" name="[% Data.Key %]" id="[% Data.Key %]" class="W75pc [% Data.Key %]ServerError" value="[% Data.Value | html %]"/>
                             <div id="[% Data.Key %]ServerError" class="TooltipErrorMessage">

--- a/Kernel/Output/HTML/Templates/Standard/AdminNotificationEvent.tt
+++ b/Kernel/Output/HTML/Templates/Standard/AdminNotificationEvent.tt
@@ -461,7 +461,7 @@
                     </fieldset>
 [% RenderBlockStart("TransportRow") %]
                     <fieldset class="TableLike FixedLabel SpacingTop">
-                        <legend><span>[% Data.TransportName | html %]</span></legend>
+                        <legend><span>[% Translate(Data.TransportName) | html %]</span></legend>
 [% RenderBlockStart("TransportRowEnabled") %]
                         <label for="Transport[% Data.Transport | html %]">
                             [% Translate("Enable this notification method") | html %]:


### PR DESCRIPTION
Hi @mgruner 
The transport names in the notification screens were not marked for translation yet.