### PR TITLE
Marked headers and tooltips as translatable

### DIFF
--- a/Kernel/Output/HTML/Templates/Standard/AdminCustomerGroup.tt
+++ b/Kernel/Output/HTML/Templates/Standard/AdminCustomerGroup.tt
@@ -216,8 +216,8 @@
                             <tr>
 [% RenderBlockStart("ChangeHeader") %]
                                 <th class="[% Data.Mark | html %]">
-                                    <input type="checkbox" name="[% Data.Context | html %]_[% Data.Type | html %]" id="SelectAll[% Data.Context | html %]_[% Data.Type | html %]" title="[% Translate("Toggle %s Permission for all", Data.Type) | html %]" value="" />
-                                    [% Data.Type | html %]
+                                    <input type="checkbox" name="[% Data.Context | html %]_[% Data.Type | html %]" id="SelectAll[% Data.Context | html %]_[% Data.Type | html %]" title="[% Translate("Toggle %s Permission for all", Translate(Data.Type)) | html %]" value="" />
+                                    [% Translate(Data.Type) | html %]
                                 </th>
 [% RenderBlockEnd("ChangeHeader") %]
                             </tr>
@@ -235,7 +235,7 @@
                                 <td><a href="[% Env("Baselink") %]Action=[% Data.ActionHome | uri %];Subaction=Change;ID=[% Data.ID | uri %]">[% Data.Name | html %]</a></td>
 [% RenderBlockStart("ChangeRowItem") %]
                                 <td class="[% Data.Mark | html %]">
-                                    <input type="checkbox" name="[% Data.Context | html %]_[% Data.Type | html %]" title="[% Translate("Toggle %s permission for %s", Data.Type, Data.Name) | html %]" value="[% Data.ID | html %]" [% Data.Selected %]/>
+                                    <input type="checkbox" name="[% Data.Context | html %]_[% Data.Type | html %]" title="[% Translate("Toggle %s permission for %s", Translate(Data.Type), Data.Name) | html %]" value="[% Data.ID | html %]" [% Data.Selected %]/>
                                 </td>
 [% RenderBlockEnd("ChangeRowItem") %]
                             </tr>


### PR DESCRIPTION
Hi @mgruner and @s7design 
This PR translates the column headers and tooltips of AdminCustomerGroup screen. The strings are already translated, but the translation was not applied yet.