### PR TITLE
added option to send lostpassword-mail 

### DIFF
--- a/Kernel/System/Web/InterfaceCustomer.pm
+++ b/Kernel/System/Web/InterfaceCustomer.pm
@@ -550,7 +550,7 @@ sub Run {
         # verify customer user is valid when requesting password reset
         my @ValidIDs = $Kernel::OM->Get('Kernel::System::Valid')->ValidIDsGet();
         my $UserIsValid = grep { $UserData{ValidID} && $UserData{ValidID} == $_ } @ValidIDs;
-        if ( !$UserData{UserID} || !$UserIsValid ) {
+        if ( !$UserData{UserID} || ( !$UserIsValid  && $UserData{Config}->{CustomerValid} ) ) {
 
             # Security: pretend that password reset instructions were actually sent to
             #   make sure that users cannot find out valid usernames by


### PR DESCRIPTION
If a customeruser backend has no valid-flag currently no lost-password mail will be send. 
Now if the user in a backend without a valid-flag it will be seen as valid as in the rest of the system.
