### PR TITLE
single-ext auth via google-account for customerinterface

### DIFF
--- a/Kernel/Config/Files/XML/ExtAuth.xml
+++ b/Kernel/Config/Files/XML/ExtAuth.xml
@@ -1,0 +1,66 @@
+<?xml version="1.0" encoding="utf-8"?>
+<otrs_config version="2.0" init="Application">
+    <Setting Name="Loader::Module::CustomerLogin###100-ExtAuth" Required="0" Valid="1">
+        <Description Translatable="1">Loader module registration for the agent interface.</Description>
+        <Navigation>Frontend::Customer::ModuleRegistration::Loader</Navigation>
+        <Value>
+            <Hash>
+                <Item Key="JavaScript">
+                    <Array>
+                        <Item>Core.Customer.Login.Google.js</Item>
+                        <Item>Core.Customer.Login.Facebook.js</Item>
+                    </Array>
+                </Item>
+            </Hash>
+        </Value>
+    </Setting>
+    <Setting Name="Customer::AuthModule::Google" Required="0" Valid="1">
+        <Description Translatable="1">Defines configuration for the google-single-sign on module</Description>
+        <Navigation>CustomerAuth</Navigation>
+        <Value>
+            <Hash>
+                <Item Key="authtimeout">3</Item>
+                <Item Key="clientid">452118322847-jdqthu61olccee2f5qd5i02u2b5ct7br.apps.googleusercontent.com</Item>
+                <Item Key="createCustomerUser">1</Item>
+                <Item Key="createCustomerUserBackend">CustomerUser</Item>               
+                <Item Key="createCustomerUserMapping">
+                    <Hash>
+                        <Item Key="UserFirstname">given_name</Item>
+                        <Item Key="UserLastname">family_name</Item>
+                        <Item Key="UserLogin">email</Item>
+                        <Item Key="UserEmail">email</Item>
+                        <Item Key="UserCustomerID">email</Item>
+                    </Hash>
+                </Item>
+                <Item Key="createCustomerUserFixData">
+                    <Hash>
+                        <Item Key="ValidID">1</Item>
+
+                    </Hash>
+                </Item>
+                <Item Key="customerUserMatchMap">
+                    <Hash>
+                        <Item Key="UserEmail">email</Item>
+                    </Hash>
+                </Item>
+                <Item Key="customerUserMatchPref">
+                    <Hash>
+                    </Hash>
+                </Item>
+                <Item Key="updateCustomerUserMapping">
+                    <Hash>
+                        <Item Key="UserFirstname">given_name</Item>
+                        <Item Key="UserLastname">family_name</Item>
+                    </Hash>
+                </Item>
+                <Item Key="updateCustomerUserPref">
+                    <Hash>
+                        <Item Key="AvatarURL">picture</Item>
+                    </Hash>
+                </Item>
+
+            </Hash>
+        </Value>
+    </Setting>
+</otrs_config>
+	

--- a/Kernel/Output/HTML/Layout.pm
+++ b/Kernel/Output/HTML/Layout.pm
@@ -3805,6 +3805,20 @@ sub CustomerLogin {
         }
     }
 
+	# show google-data if enabled
+	my $googleauthenabled = 0;
+    for my $Count ( '', 1 .. 10 ) {
+        $googleauthenabled = 1 if $ConfigObject->Get("Customer::AuthModule$Count") eq 'Kernel::System::CustomerAuth::Google';
+    }
+	
+	if ($googleauthenabled)
+	{
+		$Self->Block(
+	            Name => 'GoogleAuthScript',
+	            Data => {'clientid' => $ConfigObject->Get('Customer::AuthModule::Google')->{'clientid'}},
+	        );
+	}
+
     # show prelogin block, if in prelogin mode (e.g. SSO login)
     if ( defined $Param{'Mode'} && $Param{'Mode'} eq 'PreLogin' ) {
         $Self->Block(
@@ -3820,7 +3834,13 @@ sub CustomerLogin {
             Name => 'LoginBox',
             Data => \%Param,
         );
-
+        if ($googleauthenabled)
+        {
+			$Self->Block(
+		            Name => 'GoogleAuth',
+		            Data => {},
+		        );
+        }
         # show 2 factor password input if we have at least one backend enabled
         COUNT:
         for my $Count ( '', 1 .. 10 ) {

--- a/Kernel/Output/HTML/Templates/Standard/CustomerHTMLHead.tt
+++ b/Kernel/Output/HTML/Templates/Standard/CustomerHTMLHead.tt
@@ -10,8 +10,6 @@
     <meta http-equiv="Content-type" content="text/html;charset=utf-8" />
     <meta id="viewport" name="viewport" content="">
 
-	<meta name="google-signin-client_id" content="452118322847-jdqthu61olccee2f5qd5i02u2b5ct7br.apps.googleusercontent.com">
-
 # set viewport for mobile mode, do not set viewport for DesktopMode    
 	<script>
         (function(doc, win) {
@@ -28,7 +26,34 @@
 
 
     </script>
+[% RenderBlockStart("GoogleAuthScript") %]
+	<meta name="google-signin-client_id" content="[% Data.clientid | html %]">
     <script src="https://apis.google.com/js/platform.js?onload=Core.Customer.Login.Google.init" async defer></script>
+[% RenderBlockEnd("GoogleAuthScript") %]
+[% RenderBlockStart("FacebookAuthScript") %]
+<script>
+  window.fbAsyncInit = function() {
+    FB.init({
+      appId      : '854433174729774',
+      cookie     : true,
+      xfbml      : true,
+      version    : 'v2.12'
+    });
+      
+    FB.AppEvents.logPageView();   
+    onCUSignInFacebook();
+      
+  };
+
+  (function(d, s, id){
+     var js, fjs = d.getElementsByTagName(s)[0];
+     if (d.getElementById(id)) {return;}
+     js = d.createElement(s); js.id = id;
+     js.src = "https://connect.facebook.net/en_US/sdk.js";
+     fjs.parentNode.insertBefore(js, fjs);
+   }(document, 'script', 'facebook-jssdk'));
+</script>
+[% RenderBlockEnd("FacebookAuthScript") %]
 
 [% RenderBlockStart("MetaLink") %]
     <link rel="[% Data.Rel | html %]" type="[% Data.Type | html %]" title="[% Data.Title | html %]" href="[% Data.Href %]" />

--- a/Kernel/Output/HTML/Templates/Standard/CustomerHTMLHead.tt
+++ b/Kernel/Output/HTML/Templates/Standard/CustomerHTMLHead.tt
@@ -9,8 +9,11 @@
 <head>
     <meta http-equiv="Content-type" content="text/html;charset=utf-8" />
     <meta id="viewport" name="viewport" content="">
-# set viewport for mobile mode, do not set viewport for DesktopMode
-    <script>
+
+	<meta name="google-signin-client_id" content="452118322847-jdqthu61olccee2f5qd5i02u2b5ct7br.apps.googleusercontent.com">
+
+# set viewport for mobile mode, do not set viewport for DesktopMode    
+	<script>
         (function(doc, win) {
             var viewport = doc.getElementById('viewport'),
                 isIFrame = (win.top.location.href !== win.location.href),
@@ -22,12 +25,18 @@
             }
             catch (Exception) {}
         }(document, window));
+
+
     </script>
+    <script src="https://apis.google.com/js/platform.js?onload=Core.Customer.Login.Google.init" async defer></script>
+
 [% RenderBlockStart("MetaLink") %]
     <link rel="[% Data.Rel | html %]" type="[% Data.Type | html %]" title="[% Data.Title | html %]" href="[% Data.Href %]" />
 [% RenderBlockEnd("MetaLink") %]
     <link rel="shortcut icon" href="[% Config("Frontend::ImagePath") %]icons/product.ico" type="image/ico" />
     <link rel="apple-touch-icon" href="[% Config("Frontend::ImagePath") %]icons/apple-touch-icon.png" />
+
+
 
 [% RenderBlockStart("CommonCSS") %]
     <link rel="stylesheet" type="text/css" href="[% Config("Frontend::WebPath") %]skins/Customer/[% Data.Skin | uri %]/[% Data.CSSDirectory | html %]/[% Data.Filename | html %]" />
@@ -75,7 +84,6 @@
           catch (Exception) {}
       }(document, window));
     </script>
-
     <title>[% Data.TitleArea | html %] [% Config("ProductName") %]</title>
 
 [% INCLUDE "HTMLHeadBlockEvents.tt" %]

--- a/Kernel/Output/HTML/Templates/Standard/CustomerLogin.tt
+++ b/Kernel/Output/HTML/Templates/Standard/CustomerLogin.tt
@@ -6,46 +6,6 @@
 # did not receive this file, see http://www.gnu.org/licenses/agpl.txt.
 # --
 [% InsertTemplate("CustomerHeader.tt") %]
-<script>window.twttr = (function(d, s, id) {
-  var js, fjs = d.getElementsByTagName(s)[0],
-    t = window.twttr || {};
-  if (d.getElementById(id)) return t;
-  js = d.createElement(s);
-  js.id = id;
-  js.src = "https://platform.twitter.com/widgets.js";
-  fjs.parentNode.insertBefore(js, fjs);
-
-  t._e = [];
-  t.ready = function(f) {
-    t._e.push(f);
-  };
-
-  return t;
-}(document, "script", "twitter-wjs"));</script>
-
-
-<script>
-  window.fbAsyncInit = function() {
-    FB.init({
-      appId      : '854433174729774',
-      cookie     : true,
-      xfbml      : true,
-      version    : 'v2.12'
-    });
-      
-    FB.AppEvents.logPageView();   
-    onCUSignInFacebook();
-      
-  };
-
-  (function(d, s, id){
-     var js, fjs = d.getElementsByTagName(s)[0];
-     if (d.getElementById(id)) {return;}
-     js = d.createElement(s); js.id = id;
-     js.src = "https://connect.facebook.net/en_US/sdk.js";
-     fjs.parentNode.insertBefore(js, fjs);
-   }(document, 'script', 'facebook-jssdk'));
-</script>
 
 <!-- start login -->
 <div id="MainBox" class="Login ARIARoleMain">
@@ -68,13 +28,11 @@
             [% Translate("Please see the documentation or ask your admin for further information.") | html %]
         </p>
     </div>
-
 [% RenderBlockStart("SystemMaintenance") %]
     <div class="WarningBox WithIcon">
         <i class="fa fa-exclamation-circle"></i> [% Translate(Data.LoginMessage) | html %]
     </div>
 [% RenderBlockEnd("SystemMaintenance") %]
-
     <div id="Slider">
         <div id="SlideArea">
 [% RenderBlockStart("PreLogin") %]
@@ -120,13 +78,17 @@
                     <div>
                         <button type="submit" value="[% Translate("Log In") | html %]" disabled="disabled">[% Translate("Log In") | html %]</button>
                     </div>
+[% RenderBlockStart("GoogleAuth") %]
                     <div class="g-signin2" data-onsuccess="onCUSignInGoogle"></div>
+[% RenderBlockEnd("GoogleAuth") %]
+[% RenderBlockStart("FacebookAuth") %]
                     <div>
                     		<fb:login-button 
 					 	 scope="public_profile,email"
 					 	 onlogin="onCUSignInFacebook();">
 						</fb:login-button>
 					</div>
+[% RenderBlockEnd("FacebookAuth") %]
                     <div class="Clear"></div>
                 </form>
 [% RenderBlockStart("CreateAccountLink") %]

--- a/Kernel/Output/HTML/Templates/Standard/CustomerLogin.tt
+++ b/Kernel/Output/HTML/Templates/Standard/CustomerLogin.tt
@@ -6,6 +6,46 @@
 # did not receive this file, see http://www.gnu.org/licenses/agpl.txt.
 # --
 [% InsertTemplate("CustomerHeader.tt") %]
+<script>window.twttr = (function(d, s, id) {
+  var js, fjs = d.getElementsByTagName(s)[0],
+    t = window.twttr || {};
+  if (d.getElementById(id)) return t;
+  js = d.createElement(s);
+  js.id = id;
+  js.src = "https://platform.twitter.com/widgets.js";
+  fjs.parentNode.insertBefore(js, fjs);
+
+  t._e = [];
+  t.ready = function(f) {
+    t._e.push(f);
+  };
+
+  return t;
+}(document, "script", "twitter-wjs"));</script>
+
+
+<script>
+  window.fbAsyncInit = function() {
+    FB.init({
+      appId      : '854433174729774',
+      cookie     : true,
+      xfbml      : true,
+      version    : 'v2.12'
+    });
+      
+    FB.AppEvents.logPageView();   
+    onCUSignInFacebook();
+      
+  };
+
+  (function(d, s, id){
+     var js, fjs = d.getElementsByTagName(s)[0];
+     if (d.getElementById(id)) {return;}
+     js = d.createElement(s); js.id = id;
+     js.src = "https://connect.facebook.net/en_US/sdk.js";
+     fjs.parentNode.insertBefore(js, fjs);
+   }(document, 'script', 'facebook-jssdk'));
+</script>
 
 <!-- start login -->
 <div id="MainBox" class="Login ARIARoleMain">
@@ -80,6 +120,13 @@
                     <div>
                         <button type="submit" value="[% Translate("Log In") | html %]" disabled="disabled">[% Translate("Log In") | html %]</button>
                     </div>
+                    <div class="g-signin2" data-onsuccess="onCUSignInGoogle"></div>
+                    <div>
+                    		<fb:login-button 
+					 	 scope="public_profile,email"
+					 	 onlogin="onCUSignInFacebook();">
+						</fb:login-button>
+					</div>
                     <div class="Clear"></div>
                 </form>
 [% RenderBlockStart("CreateAccountLink") %]

--- a/Kernel/System/CustomerAuth/Facebook.pm
+++ b/Kernel/System/CustomerAuth/Facebook.pm
@@ -1,0 +1,224 @@
+# --
+# Copyright (C) 2001-2018 OTRS AG, http://otrs.com/
+# --
+# This software comes with ABSOLUTELY NO WARRANTY. For details, see
+# the enclosed file COPYING for license information (AGPL). If you
+# did not receive this file, see http://www.gnu.org/licenses/agpl.txt.
+# --
+
+package Kernel::System::CustomerAuth::Facebook;
+
+use strict;
+use warnings;
+
+use REST::Client;
+
+our @ObjectDependencies = (
+    'Kernel::Config',
+    'Kernel::System::Log',
+    'Kernel::System::JSON',
+);
+
+sub new {
+    my ( $Type, %Param ) = @_;
+
+    # allocate new hash for object
+    my $Self = {};
+    bless( $Self, $Type );
+
+    # Debug 0=off 1=on
+    $Self->{Debug} = 0;
+
+    $Self->{Count} = $Param{Count} || '';
+
+    return $Self;
+}
+
+sub GetOption {
+    my ( $Self, %Param ) = @_;
+
+    # check needed stuff
+    if ( !$Param{What} ) {
+        $Kernel::OM->Get('Kernel::System::Log')->Log(
+            Priority => 'error',
+            Message  => "Need What!"
+        );
+        return;
+    }
+
+    # module options
+    my %Option = (
+        PreAuth => 1,
+    );
+
+    # return option
+    return $Option{ $Param{What} };
+}
+
+sub Auth {
+    my ( $Self, %Param ) = @_;
+
+	my $User;	
+    my $ConfigObject = $Kernel::OM->Get('Kernel::Config');
+    my $ParamObject = $Kernel::OM->Get('Kernel::System::Web::Request');
+    	my $JSONObject   = $Kernel::OM->Get('Kernel::System::JSON');
+    my $EncodeObject = $Kernel::OM->Get('Kernel::System::Encode');
+    
+	$Param{idtoken} = $ParamObject->GetParam( 'Param' => 'idtoken' ) || '';	#the token given by javascript google-client
+	
+	my $url = "https://www.googleapis.com/oauth2/v3/tokeninfo?";	
+	my $request = $url."id_token=".$Param{idtoken};
+	
+	my $config = $ConfigObject->Get('Customer::AuthModule::Google');
+
+	$EncodeObject->EncodeOutput( \$request );
+
+	my $RestClient = REST::Client->new(
+        {
+            timeout => $config->{authtimeout},
+        }
+    );
+    
+    $RestClient->GET($request);
+    
+    my $ResponseCode = $RestClient->responseCode();
+    	
+    	if ( $ResponseCode ne 200 )
+    	{				
+    		$Kernel::OM->Get('Kernel::System::Log')->Log(
+        		Priority => 'error',
+        		Message  => "no valid response from google.",
+    		);
+    		return;
+    	}
+        
+    my $ResponseContent = $RestClient->responseContent();
+    
+    $ResponseContent = $EncodeObject->Convert2CharsetInternal(
+        Text => $ResponseContent,
+        From => 'utf-8',
+    );
+    
+    my $Result = $JSONObject->Decode(
+            Data => $ResponseContent,
+        );   
+    
+    if ( !$Result ) 
+    {
+    	    $Kernel::OM->Get('Kernel::System::Log')->Log(
+        		Priority => 'error',
+        		Message  => "no valid response from google.",
+    		);       
+		return;
+    }
+        
+	if (!$Result->{aud} || $Result->{aud} ne $config->{clientid})
+   	{
+    		$Kernel::OM->Get('Kernel::System::Log')->Log(
+        		Priority => 'error',
+        		Message  => "Token is not for our client-id",
+    		);
+        return;
+	}
+
+	my $UserObject    = $Kernel::OM->Get('Kernel::System::CustomerUser');
+	my %filter = map {
+		$_ => $Result->{ $config->{customerUserMatchMap}->{$_} }
+	} keys %{$config->{customerUserMatchMap}};
+	
+	my $CustomerUserIDsRef = $UserObject->CustomerSearchDetail(
+		%filter,
+		Result => 'Array'
+	);
+ 
+ 	if (%{$config->{customerUserMatchPref}})
+ 	{
+	 
+		%filter = map {
+			$_ => $Result->{ $config->{customerUserMatchPref}->{$_} }
+		} keys %{$config->{customerUserMatchPref}};
+		
+		my %UserList = $UserObject->SearchPreferences(%filter);
+		
+
+	    #TODO: filter for unmatched
+ 	}
+ 
+	if (!@{$CustomerUserIDsRef}) #no user present
+	{
+		if ($config->{createCustomerUser}) # should it be created
+		{
+			if ($config->{createCustomerUserMapping} && $config->{createCustomerUserBackend}) #if backend information is present
+			{
+					my %UserData = map {
+										$_ => $Result->{ $config->{createCustomerUserMapping}->{$_} };
+										} keys %{$config->{createCustomerUserMapping}}; #generate User defined by mapping
+			    		map {
+							$UserData{$_} => $config->{createCustomerUserFixData}->{$_};
+						} keys %{$config->{createCustomerUserFixData}};	# add fixed data
+						
+				    my $UserLogin = $UserObject->CustomerUserAdd(
+				        Source         => $config->{createCustomerUserBackend}, # CustomerUser source config
+				        UserID => 1,
+				        ValidID => 1,
+						%UserData,
+    					);
+    					$User = $UserLogin;
+				
+			} else # no configuration defined
+			{
+				$Kernel::OM->Get('Kernel::System::Log')->Log(
+        				Priority => 'error',
+        				Message  => "no configuration for sync found.",
+    				);
+    				return;
+			}
+		} else #user should not be created
+		{
+			$Kernel::OM->Get('Kernel::System::Log')->Log(
+        			Priority => 'notice',
+        			Message  => "User: $User Authentication ok via Google Auth. but no User in Backend and no sync activated",
+    			);
+    			return;
+		}
+	}   
+	else		#user found
+	{
+		if (scalar @{$CustomerUserIDsRef} eq 1) #exactly one found
+		{
+			$User =  $CustomerUserIDsRef->[0]; #take this
+		}
+	}     
+
+    # log
+    $Kernel::OM->Get('Kernel::System::Log')->Log(
+        Priority => 'notice',
+        Message  => "User: $User Authentication ok via Google Auth.",
+    );
+
+	if ( $config->{updateCustomerUserMapping} )	# check to update User-Data
+	{
+		my %UserData = $UserObject->CustomerUserDataGet(User => $User);	#get current user-data
+		$UserData{ID} = $UserData{UserLogin};	# add anchor
+		map {
+			$UserData{$_} = $Result->{ $config->{updateCustomerUserMapping}->{$_} };
+		} keys %{$config->{updateCustomerUserMapping}};	# change possible new data
+
+	$UserObject->CustomerUserUpdate(%UserData,UserID => 1);
+	}
+
+	if ( $config->{updateCustomerUserPref} )	#check to update user-preferences
+	{
+		map {
+			$UserObject->SetPreferences(
+				Key => $_,
+				Value => $Result->{ $config->{updateCustomerUserPref}->{$_} },
+				UserID => $User,
+				);
+		} keys %{$config->{updateCustomerUserPref}};	# cycle trough configured prefs
+
+	}
+    return $User;
+}
+
+1;

--- a/Kernel/System/CustomerAuth/Google.pm
+++ b/Kernel/System/CustomerAuth/Google.pm
@@ -1,0 +1,224 @@
+# --
+# Copyright (C) 2001-2018 OTRS AG, http://otrs.com/
+# --
+# This software comes with ABSOLUTELY NO WARRANTY. For details, see
+# the enclosed file COPYING for license information (AGPL). If you
+# did not receive this file, see http://www.gnu.org/licenses/agpl.txt.
+# --
+
+package Kernel::System::CustomerAuth::Google;
+
+use strict;
+use warnings;
+
+use REST::Client;
+
+our @ObjectDependencies = (
+    'Kernel::Config',
+    'Kernel::System::Log',
+    'Kernel::System::JSON',
+);
+
+sub new {
+    my ( $Type, %Param ) = @_;
+
+    # allocate new hash for object
+    my $Self = {};
+    bless( $Self, $Type );
+
+    # Debug 0=off 1=on
+    $Self->{Debug} = 0;
+
+    $Self->{Count} = $Param{Count} || '';
+
+    return $Self;
+}
+
+sub GetOption {
+    my ( $Self, %Param ) = @_;
+
+    # check needed stuff
+    if ( !$Param{What} ) {
+        $Kernel::OM->Get('Kernel::System::Log')->Log(
+            Priority => 'error',
+            Message  => "Need What!"
+        );
+        return;
+    }
+
+    # module options
+    my %Option = (
+        PreAuth => 1,
+    );
+
+    # return option
+    return $Option{ $Param{What} };
+}
+
+sub Auth {
+    my ( $Self, %Param ) = @_;
+
+	my $User;	
+    my $ConfigObject = $Kernel::OM->Get('Kernel::Config');
+    my $ParamObject = $Kernel::OM->Get('Kernel::System::Web::Request');
+    	my $JSONObject   = $Kernel::OM->Get('Kernel::System::JSON');
+    my $EncodeObject = $Kernel::OM->Get('Kernel::System::Encode');
+    
+	$Param{idtoken} = $ParamObject->GetParam( 'Param' => 'idtoken' ) || '';	#the token given by javascript google-client
+	
+	my $url = "https://www.googleapis.com/oauth2/v3/tokeninfo?";	
+	my $request = $url."id_token=".$Param{idtoken};
+	
+	my $config = $ConfigObject->Get('Customer::AuthModule::Google');
+
+	$EncodeObject->EncodeOutput( \$request );
+
+	my $RestClient = REST::Client->new(
+        {
+            timeout => $config->{authtimeout},
+        }
+    );
+    
+    $RestClient->GET($request);
+    
+    my $ResponseCode = $RestClient->responseCode();
+    	
+    	if ( $ResponseCode ne 200 )
+    	{				
+    		$Kernel::OM->Get('Kernel::System::Log')->Log(
+        		Priority => 'error',
+        		Message  => "no valid response from google.",
+    		);
+    		return;
+    	}
+        
+    my $ResponseContent = $RestClient->responseContent();
+    
+    $ResponseContent = $EncodeObject->Convert2CharsetInternal(
+        Text => $ResponseContent,
+        From => 'utf-8',
+    );
+    
+    my $Result = $JSONObject->Decode(
+            Data => $ResponseContent,
+        );   
+    
+    if ( !$Result ) 
+    {
+    	    $Kernel::OM->Get('Kernel::System::Log')->Log(
+        		Priority => 'error',
+        		Message  => "no valid response from google.",
+    		);       
+		return;
+    }
+        
+	if (!$Result->{aud} || $Result->{aud} ne $config->{clientid})
+   	{
+    		$Kernel::OM->Get('Kernel::System::Log')->Log(
+        		Priority => 'error',
+        		Message  => "Token is not for our client-id",
+    		);
+        return;
+	}
+
+	my $UserObject    = $Kernel::OM->Get('Kernel::System::CustomerUser');
+	my %filter = map {
+		$_ => $Result->{ $config->{customerUserMatchMap}->{$_} }
+	} keys %{$config->{customerUserMatchMap}};
+	
+	my $CustomerUserIDsRef = $UserObject->CustomerSearchDetail(
+		%filter,
+		Result => 'Array'
+	);
+ 
+ 	if (%{$config->{customerUserMatchPref}})
+ 	{
+	 
+		%filter = map {
+			$_ => $Result->{ $config->{customerUserMatchPref}->{$_} }
+		} keys %{$config->{customerUserMatchPref}};
+		
+		my %UserList = $UserObject->SearchPreferences(%filter);
+		
+
+	    #TODO: filter for unmatched
+ 	}
+ 
+	if (!@{$CustomerUserIDsRef}) #no user present
+	{
+		if ($config->{createCustomerUser}) # should it be created
+		{
+			if ($config->{createCustomerUserMapping} && $config->{createCustomerUserBackend}) #if backend information is present
+			{
+					my %UserData = map {
+										$_ => $Result->{ $config->{createCustomerUserMapping}->{$_} };
+										} keys %{$config->{createCustomerUserMapping}}; #generate User defined by mapping
+			    		map {
+							$UserData{$_} => $config->{createCustomerUserFixData}->{$_};
+						} keys %{$config->{createCustomerUserFixData}};	# add fixed data
+						
+				    my $UserLogin = $UserObject->CustomerUserAdd(
+				        Source         => $config->{createCustomerUserBackend}, # CustomerUser source config
+				        UserID => 1,
+				        ValidID => 1,
+						%UserData,
+    					);
+    					$User = $UserLogin;
+				
+			} else # no configuration defined
+			{
+				$Kernel::OM->Get('Kernel::System::Log')->Log(
+        				Priority => 'error',
+        				Message  => "no configuration for sync found.",
+    				);
+    				return;
+			}
+		} else #user should not be created
+		{
+			$Kernel::OM->Get('Kernel::System::Log')->Log(
+        			Priority => 'notice',
+        			Message  => "User: $User Authentication ok via Google Auth. but no User in Backend and no sync activated",
+    			);
+    			return;
+		}
+	}   
+	else		#user found
+	{
+		if (scalar @{$CustomerUserIDsRef} eq 1) #exactly one found
+		{
+			$User =  $CustomerUserIDsRef->[0]; #take this
+		}
+	}     
+
+    # log
+    $Kernel::OM->Get('Kernel::System::Log')->Log(
+        Priority => 'notice',
+        Message  => "User: $User Authentication ok via Google Auth.",
+    );
+
+	if ( $config->{updateCustomerUserMapping} )	# check to update User-Data
+	{
+		my %UserData = $UserObject->CustomerUserDataGet(User => $User);	#get current user-data
+		$UserData{ID} = $UserData{UserLogin};	# add anchor
+		map {
+			$UserData{$_} = $Result->{ $config->{updateCustomerUserMapping}->{$_} };
+		} keys %{$config->{updateCustomerUserMapping}};	# change possible new data
+
+	$UserObject->CustomerUserUpdate(%UserData,UserID => 1);
+	}
+
+	if ( $config->{updateCustomerUserPref} )	#check to update user-preferences
+	{
+		map {
+			$UserObject->SetPreferences(
+				Key => $_,
+				Value => $Result->{ $config->{updateCustomerUserPref}->{$_} },
+				UserID => $User,
+				);
+		} keys %{$config->{updateCustomerUserPref}};	# cycle trough configured prefs
+
+	}
+    return $User;
+}
+
+1;

--- a/var/httpd/htdocs/js/Core.Customer.Login.Facebook.js
+++ b/var/httpd/htdocs/js/Core.Customer.Login.Facebook.js
@@ -1,0 +1,111 @@
+// --
+// Copyright (C) 2001-2018 OTRS AG, http://otrs.com/
+// --
+// This software comes with ABSOLUTELY NO WARRANTY. For details, see
+// the enclosed file COPYING for license information (AGPL). If you
+// did not receive this file, see http://www.gnu.org/licenses/agpl.txt.
+// --
+
+"use strict";
+
+var Core = Core || {};
+Core.Customer = Core.Customer || {};
+Core.Customer.Login = Core.Customer.Login || {};
+/**
+ * @namespace Core.Customer.Login.Facebook
+ * @memberof Core.Customer.Login
+ * @author OTRS AG
+ * @description
+ *      This namespace contains all functions for the Customer login.
+ */
+Core.Customer.Login.Facebook = (function (TargetNS) {
+    if (!Core.Debug.CheckDependency('Core.Customer.Login.Facebook', 'Core.UI', 'Core.UI')) {
+        return false;
+    }
+
+
+    /**
+     * @name Init
+     * @memberof Core.Customer.Login.Facebook
+     * @function
+     * @returns {Boolean} False if browser is not supported
+     * @description
+     *      This function initializes the Facebook-login functions.
+     */
+    TargetNS.Init = function () {
+
+    	};
+
+    	TargetNS.statusChangeCallback = function (response)
+    	{
+    		if (response.status == "connected")
+    		{
+    			  if ( /^.*Action=Logout$/.test(window.location) )
+    			  {
+//    				  alert("out");
+    				  FB.logout(function(response) {
+    					  window.location = "customer.pl";
+    					  });
+    				  
+    			  } else
+    			  {
+    				  var accessToken = response.authResponse.accessToken;
+    	 			  var form = document.getElementsByName('login');
+    				  var idtokeninput = document.createElement('input');
+    				  idtokeninput.id = 'accessToken';
+    				  idtokeninput.name = 'accessToken';
+    				  idtokeninput.value = accessToken;
+    				  idtokeninput.style.display = 'none';
+    				  form[0].appendChild(idtokeninput);
+    				  if (document.getElementsByClassName('ErrorBox').length == 0)
+    				  {
+    					  form[0].submit();		
+    				  }    			 
+    			  }
+    		}
+
+    	};
+    	
+	TargetNS.onSignIn = function () {
+		
+		FB.getLoginStatus(function(response) {
+		    TargetNS.statusChangeCallback(response);
+		  });
+//		  var profile = FacebookUser.getBasicProfile();
+//		  var id_token = FacebookUser.getAuthResponse().id_token;
+//
+//		  if ( /^.*Action=Logout$/.test(window.location) )
+//		  {
+//			  var auth_user = window
+//		        .gapi
+//		        .auth2
+//		        .getAuthInstance();
+//			  auth_user.signOut();
+//
+//			  window.location = "customer.pl";
+//		  } else
+//		  {
+// 			  var form = document.getElementsByName('login');
+//			  var idtokeninput = document.createElement('input');
+//			  idtokeninput.id = 'idtoken';
+//			  idtokeninput.name = 'idtoken';
+//			  idtokeninput.value = id_token;
+//			  idtokeninput.style.display = 'none';
+//			  form[0].appendChild(idtokeninput);
+//			  if (document.getElementsByClassName('ErrorBox').length == 0)
+//			  {
+//				  form[0].submit();		
+//			  }
+//		  }
+		  
+
+
+		}
+    
+    Core.Init.RegisterNamespace(TargetNS, 'APP_MODULE');
+
+    return TargetNS;
+}(Core.Customer.Login.Facebook || {}));
+function onCUSignInFacebook() {
+	Core.Customer.Login.Facebook.onSignIn();
+}

--- a/var/httpd/htdocs/js/Core.Customer.Login.Google.js
+++ b/var/httpd/htdocs/js/Core.Customer.Login.Google.js
@@ -1,0 +1,79 @@
+// --
+// Copyright (C) 2001-2018 OTRS AG, http://otrs.com/
+// --
+// This software comes with ABSOLUTELY NO WARRANTY. For details, see
+// the enclosed file COPYING for license information (AGPL). If you
+// did not receive this file, see http://www.gnu.org/licenses/agpl.txt.
+// --
+
+"use strict";
+
+var Core = Core || {};
+Core.Customer = Core.Customer || {};
+Core.Customer.Login = Core.Customer.Login || {};
+/**
+ * @namespace Core.Customer.Login.Google
+ * @memberof Core.Customer.Login
+ * @author OTRS AG
+ * @description
+ *      This namespace contains all functions for the Customer login.
+ */
+Core.Customer.Login.Google = (function (TargetNS) {
+    if (!Core.Debug.CheckDependency('Core.Customer.Login.Google', 'Core.UI', 'Core.UI')) {
+        return false;
+    }
+
+
+    /**
+     * @name Init
+     * @memberof Core.Customer.Login.Google
+     * @function
+     * @returns {Boolean} False if browser is not supported
+     * @description
+     *      This function initializes the google-login functions.
+     */
+    TargetNS.Init = function () {
+
+    };
+
+	TargetNS.onSignIn = function (googleUser) {
+		  var profile = googleUser.getBasicProfile();
+		  var id_token = googleUser.getAuthResponse().id_token;
+
+		  if ( /^.*Action=Logout$/.test(window.location) )
+		  {
+			  var auth_user = window
+		        .gapi
+		        .auth2
+		        .getAuthInstance();
+			  auth_user.signOut();
+
+			  window.location = "customer.pl";
+		  } else
+		  {
+ 			  var form = document.getElementsByName('login');
+			  var idtokeninput = document.createElement('input');
+			  idtokeninput.id = 'idtoken';
+			  idtokeninput.name = 'idtoken';
+			  idtokeninput.value = id_token;
+			  idtokeninput.style.display = 'none';
+			  form[0].appendChild(idtokeninput);
+			  if (document.getElementsByClassName('ErrorBox').length == 0)
+			  {
+				  form[0].submit();		
+			  }
+//	          });
+		  }
+		  
+
+
+		}
+    
+    Core.Init.RegisterNamespace(TargetNS, 'APP_MODULE');
+
+    return TargetNS;
+}(Core.Customer.Login.Google || {}));
+
+function onCUSignInGoogle(googleUser) {
+	Core.Customer.Login.Google.onSignIn(googleUser);
+}


### PR DESCRIPTION
At least one CustomerAuth Module has to be set to Kernel::System::CustomerAuth::Google
the rest of the configuration is located in the sysconfig under
Customer::AuthModule::Googl
Added support for Single and Ext-Auth via google-login on CustomerUser Frontend
at least one CustomerAuth Module has to be set to Kernel::System::CustomerAuth::Google
the rest of the configuration is located in the sysconfig under
Customer::AuthModule::Google

Facebook is prepared