### PR TITLE
Postmaster time accounting

### DIFF
--- a/Kernel/Config/Files/XML/Ticket.xml
+++ b/Kernel/Config/Files/XML/Ticket.xml
@@ -11308,6 +11308,7 @@
                 <Item>X-OTRS-CustomerUser</Item>
                 <Item>X-OTRS-SenderType</Item>
                 <Item>X-OTRS-IsVisibleForCustomer</Item>
+                <Item>X-OTRS-TimeUnit</Item>
                 <Item>X-OTRS-FollowUp-Owner</Item>
                 <Item>X-OTRS-FollowUp-OwnerID</Item>
                 <Item>X-OTRS-FollowUp-Responsible</Item>
@@ -11322,6 +11323,7 @@
                 <Item>X-OTRS-FollowUp-SLA</Item>
                 <Item>X-OTRS-FollowUp-SenderType</Item>
                 <Item>X-OTRS-FollowUp-IsVisibleForCustomer</Item>
+                <Item>X-OTRS-FollowUp-TimeUnit</Item>
                 <Item>X-OTRS-FollowUp-Title</Item>
                 <Item>X-OTRS-FollowUp-State-Keep</Item>
                 <Item>X-OTRS-BodyDecrypted</Item>

--- a/Kernel/System/PostMaster/FollowUp.pm
+++ b/Kernel/System/PostMaster/FollowUp.pm
@@ -674,6 +674,23 @@ sub Run {
         );
     }
 
+    # time accounting
+    if ( defined $GetParam{'X-OTRS-FollowUp-TimeUnit'} && $GetParam{'X-OTRS-FollowUp-TimeUnit'} =~ /^\s*\-?\d{1,10}((\.|,)\d{1,2})/ ) {
+        $TicketObject->TicketAccountTime(
+            TicketID  => $Param{TicketID},
+            ArticleID => $ArticleID,
+            TimeUnit  => $GetParam{'X-OTRS-FollowUp-TimeUnit'},
+            UserID    => $Param{InmailUserID},
+        );
+
+        $Self->{CommunicationLogObject}->ObjectLog(
+            ObjectLogType => 'Message',
+            Priority      => 'Debug',
+            Key           => 'Kernel::System::PostMaster::FollowUp',
+            Value         => "Added " . $GetParam{'X-OTRS-FollowUp-TimeUnit'} . " time units to ticket",
+        );
+    }
+
     # write log
     $Self->{CommunicationLogObject}->ObjectLog(
         ObjectLogType => 'Message',

--- a/Kernel/System/PostMaster/FollowUp.pm
+++ b/Kernel/System/PostMaster/FollowUp.pm
@@ -675,7 +675,7 @@ sub Run {
     }
 
     # time accounting
-    if ( defined $GetParam{'X-OTRS-FollowUp-TimeUnit'} && $GetParam{'X-OTRS-FollowUp-TimeUnit'} =~ /^\s*\-?\d{1,10}((\.|,)\d{1,2})/ ) {
+    if ( defined $GetParam{'X-OTRS-FollowUp-TimeUnit'} && $GetParam{'X-OTRS-FollowUp-TimeUnit'} =~ /^\s*\-?\d{1,10}((\.|,)\d{1,2})?/ ) {
         $TicketObject->TicketAccountTime(
             TicketID  => $Param{TicketID},
             ArticleID => $ArticleID,

--- a/Kernel/System/PostMaster/NewTicket.pm
+++ b/Kernel/System/PostMaster/NewTicket.pm
@@ -715,7 +715,7 @@ Message
     }
 
     # time accounting
-    if ( defined $GetParam{'X-OTRS-TimeUnit'} && $GetParam{'X-OTRS-TimeUnit'} =~ /^\s*\-?\d{1,10}((\.|,)\d{1,2})/ ) {
+    if ( defined $GetParam{'X-OTRS-TimeUnit'} && $GetParam{'X-OTRS-TimeUnit'} =~ /^\s*\-?\d{1,10}((\.|,)\d{1,2})?/ ) {
         $TicketObject->TicketAccountTime(
             TicketID  => $TicketID,
             ArticleID => $ArticleID,

--- a/Kernel/System/PostMaster/NewTicket.pm
+++ b/Kernel/System/PostMaster/NewTicket.pm
@@ -714,6 +714,23 @@ Message
         }
     }
 
+    # time accounting
+    if ( defined $GetParam{'X-OTRS-TimeUnit'} && $GetParam{'X-OTRS-TimeUnit'} =~ /^\s*\-?\d{1,10}((\.|,)\d{1,2})/ ) {
+        $TicketObject->TicketAccountTime(
+            TicketID  => $TicketID,
+            ArticleID => $ArticleID,
+            TimeUnit  => $GetParam{'X-OTRS-TimeUnit'},
+            UserID    => $Param{InmailUserID},
+        );
+
+        $Self->{CommunicationLogObject}->ObjectLog(
+            ObjectLogType => 'Message',
+            Priority      => 'Debug',
+            Key           => 'Kernel::System::PostMaster::NewTicket',
+            Value         => "Added " . $GetParam{'X-OTRS-TimeUnit'} . " time units to ticket",
+        );
+    }
+
     # write plain email to the storage
     $ArticleBackendObject->ArticleWritePlain(
         ArticleID => $ArticleID,


### PR DESCRIPTION
Hi,

this allows you to configure postmaster filters which account time units. I intentionally didn't add this to Reject.pm. A rejected follow-up should not increase time units as that email will most likely be send once again.

BR Felix