### PR TITLE
Fix for http 500 Error when downloading Attachment

### DIFF
--- a/Kernel/Modules/AgentTicketAttachment.pm
+++ b/Kernel/Modules/AgentTicketAttachment.pm
@@ -148,7 +148,10 @@ sub Run {
             Sandbox     => 1,
         );
     }
-
+    
+    #When the FileName has Invalid HTTP Characters the file can't get downloaded. That Regex removes that Characters
+    $Data{Filename} =~ s/[^A-Za-z0-9\-\.]//g;
+    
     # download it AttachmentDownloadType is configured
     return $LayoutObject->Attachment(
         %Data,

--- a/Kernel/Modules/AgentTicketAttachment.pm
+++ b/Kernel/Modules/AgentTicketAttachment.pm
@@ -150,7 +150,7 @@ sub Run {
     }
     
     #When the FileName has Invalid HTTP Characters the file can't get downloaded. That Regex removes that Characters
-    $Data{Filename} =~ s/[^A-Za-z0-9\-\.]//g;
+    $Data{Filename} =~ s/[^A-Za-z0-9\-\.\#\_]//g;
     
     # download it AttachmentDownloadType is configured
     return $LayoutObject->Attachment(


### PR DESCRIPTION
On our Systems we got an 500 Error when we tried to download a file that had invalid HTTP Chatacters in the file name.
With this Regex it worked on our Systems ..
It's not an ideal Solution i know that.

Error on our Site:
[Thu Mar 08 13:55:26.372324 2018] [http:error] [pid 13122] [client <ip>] AH02430: Response header 'Content-Disposition' value of 'attachment;  filename="WG___#___AR$AKSS_Ticket_-_NT-Zugriffsrechte\r_beantragen.eml"; filename*=utf-8''WG___%<number>___AR%24AKSS__Ticket_-_NT-Zugriffsrechte%0D_beantragen.eml' contains invalid characters, aborting request, referer: <link>