### PR TITLE
fixed packagedescription html insertion issue in packagemanager

### DIFF
--- a/Kernel/Output/HTML/Templates/Standard/AdminPackageManager.tt
+++ b/Kernel/Output/HTML/Templates/Standard/AdminPackageManager.tt
@@ -534,7 +534,7 @@
 [% RenderBlockStart("FeatureAddonData") %]
                             <tr>
                                 <td><a href="[% Data.Link | html %]" target="_feature_addon_details">[% Data.Title | html %]</a></td>
-                                <td>[% Data.Description | html %]</td>
+                                <td>[% Data.Description %]</td>
                             </tr>
 [% RenderBlockEnd("FeatureAddonData") %]
                         </tbody>


### PR DESCRIPTION
before: 
![grafik](https://user-images.githubusercontent.com/36455093/38732982-8b61c2b6-3f20-11e8-9618-7ebc5ed1109c.png)

after: 
![grafik](https://user-images.githubusercontent.com/36455093/38732943-6291c96c-3f20-11e8-928b-1a66654a0f8a.png)
