### PR TITLE
Fix bad regexp for PGP detection, causes backtracking

### DIFF
--- a/Kernel/Modules/AgentTicketArticleContent.pm
+++ b/Kernel/Modules/AgentTicketArticleContent.pm
@@ -146,9 +146,9 @@ sub Run {
     # see bug#9672
     if (
         $Data{Content} =~ m{
-        ^ .* -----BEGIN [ ] PGP [ ] MESSAGE-----  .* $      # grep PGP begin tag
-        .+                                                  # PGP parts may be nested in html
-        ^ .* -----END [ ] PGP [ ] MESSAGE-----  .* $        # grep PGP end tag
+        ^ [^\n]* -----BEGIN [ ] PGP [ ] MESSAGE-----  [^\n]* $      # grep PGP begin tag
+        .+                                                          # PGP parts may be nested in html
+        ^ [^\n]* -----END   [ ] PGP [ ] MESSAGE-----  [^\n]* $      # grep PGP end tag
     }xms
         )
     {


### PR DESCRIPTION
The regexp contained several greedy matches, which cause backtracking.
The time needed to match grows exponentially with the length of the
string. An 8K string takes about 2 seconds to process, 10K takes over
7 seconds, and 20K more than 15 minutes.