### PR TITLE
Improved translation of processes

### DIFF
--- a/Kernel/Modules/AdminProcessManagement.pm
+++ b/Kernel/Modules/AdminProcessManagement.pm
@@ -1633,7 +1633,7 @@ sub _ShowOverview {
         Name         => 'ExampleProcess',
         Data         => \%ExampleProcessData,
         PossibleNone => 1,
-        Translation  => 0,
+        Translation  => 1,
         Class        => 'Modernize Validate_Required',
     );
     $Frontend{OTRSBusinessIsInstalled} = $Kernel::OM->Get('Kernel::System::OTRSBusiness')->OTRSBusinessIsInstalled();

--- a/Kernel/Modules/AgentTicketProcess.pm
+++ b/Kernel/Modules/AgentTicketProcess.pm
@@ -5492,7 +5492,7 @@ sub _DisplayProcessList {
         SelectedID   => $Param{ProcessEntityID},
         PossibleNone => 1,
         Sort         => 'AlphanumericValue',
-        Translation  => 0,
+        Translation  => 1,
         AutoComplete => 'off',
         TreeView     => 1,
     );

--- a/Kernel/Output/HTML/Templates/Standard/AdminProcessManagement.tt
+++ b/Kernel/Output/HTML/Templates/Standard/AdminProcessManagement.tt
@@ -149,11 +149,11 @@ SET OTRSBusinessLinkLabel = '<strong><a href="#" class="OTRSBusinessRequired">OT
 [% RenderBlockStart("ProcessRow") %]
                         <tr [% IF Data.State != "Active"%]class="Invalid"[% END %]>
                             <td>
-                                <a class="AsBlock" href="[% Env("Baselink") %]Action=[% Env("Action") %];Subaction=ProcessEdit;ID=[% Data.ID | uri %];EntityID=[% Data.EntityID | uri %]" title="[% Data.Name | html %] ([% Data.EntityID | html %])">
-                                    [% Data.Name | html %]
+                                <a class="AsBlock" href="[% Env("Baselink") %]Action=[% Env("Action") %];Subaction=ProcessEdit;ID=[% Data.ID | uri %];EntityID=[% Data.EntityID | uri %]" title="[% Translate(Data.Name) | html %] ([% Data.EntityID | html %])">
+                                    [% Translate(Data.Name) | html %]
                                 </a>
                             </td>
-                            <td title="[% Data.Description | html %]">[% Data.Description | truncate(80) | html %]</td>
+                            <td title="[% Translate(Data.Description) | html %]">[% Translate(Data.Description) | truncate(80) | html %]</td>
                             <td>[% Translate(Data.State) | html %]</td>
                             <td class="Center">
                                 <a href="[% Env("Baselink") %]Action=[% Env("Action") %];Subaction=ProcessExport;ID=[% Data.ID | uri %]" title="[% Translate("Export Process Configuration") | html %]">

--- a/Kernel/Output/HTML/Templates/Standard/ProcessManagement/ActivityDialogFooter.tt
+++ b/Kernel/Output/HTML/Templates/Standard/ProcessManagement/ActivityDialogFooter.tt
@@ -12,7 +12,7 @@
 [% RenderBlockStart("Footer") %]
                 <div class="[% Data.FooterCSSClass | html %]">
 [% RenderBlockStart("SubmitAdviceText") %]
-                    <p class="SubmitInfo">[% Data.AdviceText | html %]</p>
+                    <p class="SubmitInfo">[% Translate(Data.AdviceText) | html %]</p>
 [% RenderBlockEnd("SubmitAdviceText") %]
                     <button class="Primary CallForAction" id="[% Data.ButtonID | html %]" accesskey="g" title="[% Translate(Data.ButtonTitle) | html %] (g)" type="submit" value="[% Translate(Data.ButtonText) | html %]"><span>[% Translate(Data.ButtonText) | html %]</span></button>
                 </div>

--- a/Kernel/Output/HTML/Templates/Standard/ProcessManagement/ActivityDialogHeader.tt
+++ b/Kernel/Output/HTML/Templates/Standard/ProcessManagement/ActivityDialogHeader.tt
@@ -17,21 +17,21 @@
             <div class="Content">
                 <fieldset class="TableLike FixedLabelSmall">
                     <label>[% Translate("Process") | html %]:</label>
-                    <p class="Value FixedValueSmall" title="[% Data.Process | html %]">[% Data.Process | html %]</p>
+                    <p class="Value FixedValueSmall" title="[% Translate(Data.Process) | html %]">[% Translate(Data.Process) | html %]</p>
                     <div class="Clear"></div>
                 </fieldset>
 
                 <fieldset class="TableLike FixedLabelSmall">
                     <label>[% Translate("Activity") | html %]:</label>
-                    <p class="Value FixedValueSmall" title="[% Data.Activity | html %]">[% Data.Activity | html %]</p>
+                    <p class="Value FixedValueSmall" title="[% Translate(Data.Activity) | html %]">[% Translate(Data.Activity) | html %]</p>
                     <div class="Clear"></div>
 
                     <label>[% Translate("Dialog") | html %]:</label>
-                    <p class="Value FixedValueSmall" title="[% Data.ActivityDialog | html %]">[% Data.ActivityDialog | html %]</p>
+                    <p class="Value FixedValueSmall" title="[% Translate(Data.ActivityDialog) | html %]">[% Translate(Data.ActivityDialog) | html %]</p>
                     <div class="Clear"></div>
 [% RenderBlockStart("ProcessInfoSidebarActivityDialogDesc") %]
                     <label>[% Translate("Description") | html %]:</label>
-                    <p class="Value FixedValueSmall" title="[% Data.ActivityDialogDescription | html %]">[% Data.ActivityDialogDescription | html %]</p>
+                    <p class="Value FixedValueSmall" title="[% Translate(Data.ActivityDialogDescription) | html %]">[% Translate(Data.ActivityDialogDescription) | html %]</p>
                     <div class="Clear"></div>
 [% RenderBlockEnd("ProcessInfoSidebarActivityDialogDesc") %]
                 </fieldset>
@@ -45,7 +45,7 @@
                 <h2>[% Translate("Description") | html %]</h2>
             </div>
             <div class="Content">
-                <p class="Value FixedValueSmall">[% Data.Description | html %]</p>
+                <p class="Value FixedValueSmall">[% Translate(Data.Description) | html %]</p>
                 <div class="Clear"></div>
             </div>
         </div>
@@ -68,14 +68,14 @@
 [% RenderBlockStart("Header") %]
                 <div class="Header">
                     <h1>
-                        [% Data.Name | html %]
+                        [% Translate(Data.Name) | html %]
 [% RenderBlockStart("DescriptionShort") %]
-                        - [% Data.DescriptionShort | html %]
+                        - [% Translate(Data.DescriptionShort) | html %]
 [% RenderBlockEnd("DescriptionShort") %]
                     </h1>
                     <p>
 [% RenderBlockStart("DescriptionLong") %]
-                        [% Data.DescriptionLong | html %] -
+                        [% Translate(Data.DescriptionLong) | html %] -
 [% RenderBlockEnd("DescriptionLong") %]
 [% RenderBlockStart("CancelLink") %]
                         <a class="CancelClosePopup" href="#">[% Translate("Cancel & close") | html %]</a>

--- a/Kernel/Output/HTML/Templates/Standard/ProcessManagement/Article.tt
+++ b/Kernel/Output/HTML/Templates/Standard/ProcessManagement/Article.tt
@@ -29,7 +29,7 @@
 <div class="Clear"></div>
 
 [% RenderBlockStart("rw:Article:DescriptionShort") %]
-<div class="Field FieldExplanation">[% Data.DescriptionShort %]</div>
+<div class="Field FieldExplanation">[% Translate(Data.DescriptionShort) %]</div>
 [% RenderBlockEnd("rw:Article:DescriptionShort") %]
 
 <label class="[% Data.MandatoryClass | html %]" for="RichText">
@@ -39,7 +39,7 @@
 [% RenderBlockStart("rw:Article:DescriptionLong") %]
     <span class="FieldHelpContainer">
         <i class="fa fa-question-circle FieldHelpTrigger"></i>
-        <span>[% Data.DescriptionLong | html %]</span>
+        <span>[% Translate(Data.DescriptionLong) | html %]</span>
     </span>
 [% RenderBlockEnd("rw:Article:DescriptionLong") %]
     [% Data.LabelBody | html %]:

--- a/Kernel/Output/HTML/Templates/Standard/ProcessManagement/Customer.tt
+++ b/Kernel/Output/HTML/Templates/Standard/ProcessManagement/Customer.tt
@@ -17,7 +17,7 @@
 [% RenderBlockStart("rw:Customer:DescriptionLong") %]
     <span class="FieldHelpContainer">
         <i class="fa fa-question-circle FieldHelpTrigger"></i>
-        <span>[% Data.DescriptionLong | html %]</span>
+        <span>[% Translate(Data.DescriptionLong) | html %]</span>
     </span>
 [% RenderBlockEnd("rw:Customer:DescriptionLong") %]
     [% Data.LabelCustomerUser | html %]:

--- a/Kernel/Output/HTML/Templates/Standard/ProcessManagement/CustomerActivityDialogFooter.tt
+++ b/Kernel/Output/HTML/Templates/Standard/ProcessManagement/CustomerActivityDialogFooter.tt
@@ -13,7 +13,7 @@
                 <div class="PopupFooter">
                     <button class="Primary" id="[% Data.ButtonID | html %]" accesskey="g" title="[% Translate(Data.ButtonTitle) | html %] (g)" type="submit" value="[% Translate(Data.ButtonText) | html %]">[% Translate(Data.ButtonText) | html %]</button>
 [% RenderBlockStart("SubmitAdviceText") %]
-                    <span class="AdviceText">[% Data.AdviceText | html %]</span>
+                    <span class="AdviceText">[% Translate(Data.AdviceText) | html %]</span>
 [% RenderBlockEnd("SubmitAdviceText") %]
                 </div>
 [% RenderBlockEnd("Footer") %]

--- a/Kernel/Output/HTML/Templates/Standard/ProcessManagement/CustomerActivityDialogHeader.tt
+++ b/Kernel/Output/HTML/Templates/Standard/ProcessManagement/CustomerActivityDialogHeader.tt
@@ -22,13 +22,13 @@
 [% RenderBlockStart("Header") %]
                 <div class="PopupHeader">
                     <h1>
-                        [% Data.Name | html %]
+                        [% Translate(Data.Name) | html %]
 [% RenderBlockStart("DescriptionShort") %]
-                        - [% Data.DescriptionShort | html %]
+                        - [% Translate(Data.DescriptionShort) | html %]
 [% RenderBlockEnd("DescriptionShort") %]
                     </h1>
 [% RenderBlockStart("DescriptionLong") %]
-                    <p>[% Data.DescriptionLong | html %]</p>
+                    <p>[% Translate(Data.DescriptionLong) | html %]</p>
 [% RenderBlockEnd("DescriptionLong") %]
 [% RenderBlockStart("CancelLink") %]
                     <p>
@@ -40,8 +40,8 @@
                 <div class="Content">
                     <fieldset class="TableLike">
 [% RenderBlockStart("DescriptionShortAlt") %]
-                        <h2>[% Data.DescriptionShort | html %]</h2>
+                        <h2>[% Translate(Data.DescriptionShort) | html %]</h2>
 [% RenderBlockEnd("DescriptionShortAlt") %]
 [% RenderBlockStart("DescriptionLongAlt") %]
-                        <p class="Description">[% Data.DescriptionLong | html %]</p>
+                        <p class="Description">[% Translate(Data.DescriptionLong) | html %]</p>
 [% RenderBlockEnd("DescriptionLongAlt") %]

--- a/Kernel/Output/HTML/Templates/Standard/ProcessManagement/DynamicField.tt
+++ b/Kernel/Output/HTML/Templates/Standard/ProcessManagement/DynamicField.tt
@@ -11,14 +11,14 @@
 [% RenderBlockStart("rw:DynamicField:DescriptionLong") %]
     <span class="FieldHelpContainer">
         <i class="fa fa-question-circle FieldHelpTrigger"></i>
-        <span>[% Data.DescriptionLong | html %]</span>
+        <span>[% Translate(Data.DescriptionLong) | html %]</span>
     </span>
 [% RenderBlockEnd("rw:DynamicField:DescriptionLong") %]
     [% Data.Label %]
     <div class="Field">
         [% Data.Content %]
 [% RenderBlockStart("rw:DynamicField:DescriptionShort") %]
-        <div class="FieldExplanation">[% Data.DescriptionShort %]</div>
+        <div class="FieldExplanation">[% Translate(Data.DescriptionShort) %]</div>
 [% RenderBlockEnd("rw:DynamicField:DescriptionShort") %]
     </div>
     <div class="Clear"></div>

--- a/Kernel/Output/HTML/Templates/Standard/ProcessManagement/Lock.tt
+++ b/Kernel/Output/HTML/Templates/Standard/ProcessManagement/Lock.tt
@@ -13,7 +13,7 @@
 [% RenderBlockStart("rw:Lock:DescriptionLong") %]
     <span class="FieldHelpContainer">
         <i class="fa fa-question-circle FieldHelpTrigger"></i>
-        <span>[% Data.DescriptionLong | html %]</span>
+        <span>[% Translate(Data.DescriptionLong) | html %]</span>
     </span>
 [% RenderBlockEnd("rw:Lock:DescriptionLong") %]
     [% Data.Label | html %]:
@@ -23,7 +23,7 @@
     <div id="[% Data.FieldID | html %]Error" class="TooltipErrorMessage"><p>[% Translate("This field is required.") | html %]</p></div>
     <div id="[% Data.FieldID | html %]ServerError" class="TooltipErrorMessage"><p>[% Translate("This field is required.") | html %]</p></div>
 [% RenderBlockStart("rw:Lock:DescriptionShort") %]
-    <div class="FieldExplanation">[% Data.DescriptionShort | html %]</div>
+    <div class="FieldExplanation">[% Translate(Data.DescriptionShort) | html %]</div>
 [% RenderBlockEnd("rw:Lock:DescriptionShort") %]
 </div>
 <div class="Clear"></div>

--- a/Kernel/Output/HTML/Templates/Standard/ProcessManagement/Owner.tt
+++ b/Kernel/Output/HTML/Templates/Standard/ProcessManagement/Owner.tt
@@ -14,7 +14,7 @@
 [% RenderBlockStart("rw:Owner:DescriptionLong") %]
     <span class="FieldHelpContainer">
         <i class="fa fa-question-circle FieldHelpTrigger"></i>
-        <span>[% Data.DescriptionLong | html %]</span>
+        <span>[% Translate(Data.DescriptionLong) | html %]</span>
     </span>
 [% RenderBlockEnd("rw:Owner:DescriptionLong") %]
     [% Data.Label | html %]:
@@ -28,7 +28,7 @@
     <div id="[% Data.FieldID | html %]Error" class="TooltipErrorMessage"><p>[% Translate("This field is required.") | html %]</p></div>
     <div id="[% Data.FieldID | html %]ServerError" class="TooltipErrorMessage"><p>[% Translate("This field is required.") | html %]</p></div>
 [% RenderBlockStart("rw:Owner:DescriptionShort") %]
-    <div class="FieldExplanation">[% Data.DescriptionShort | html %]</div>
+    <div class="FieldExplanation">[% Translate(Data.DescriptionShort) | html %]</div>
 [% RenderBlockEnd("rw:Owner:DescriptionShort") %]
 </div>
 <div class="Clear"></div>

--- a/Kernel/Output/HTML/Templates/Standard/ProcessManagement/PendingTime.tt
+++ b/Kernel/Output/HTML/Templates/Standard/ProcessManagement/PendingTime.tt
@@ -10,7 +10,7 @@
 [% RenderBlockStart("rw:PendingTime:DescriptionLong") %]
     <span class="FieldHelpContainer">
         <i class="fa fa-question-circle FieldHelpTrigger"></i>
-        <span>[% Data.DescriptionLong | html %]</span>
+        <span>[% Translate(Data.DescriptionLong) | html %]</span>
     </span>
 [% RenderBlockEnd("rw:PendingTime:DescriptionLong") %]
     [% Data.Label | html %]:
@@ -20,7 +20,7 @@
     <div id="PendingTimeDayError" class="TooltipErrorMessage"><p>[% Data.PendingtTimeDayError | html %]</p></div>
     <div id="PendingTimeHourError" class="TooltipErrorMessage"><p>[% Data.PendingtTimeHourError | html %]</p></div>
 [% RenderBlockStart("rw:PendingTime:DescriptionShort") %]
-    <div class="FieldExplanation">[% Data.DescriptionShort | html %]</div>
+    <div class="FieldExplanation">[% Translate(Data.DescriptionShort) | html %]</div>
 [% RenderBlockEnd("rw:PendingTime:DescriptionShort") %]
 </div>
 <div class="Clear"></div>

--- a/Kernel/Output/HTML/Templates/Standard/ProcessManagement/Priority.tt
+++ b/Kernel/Output/HTML/Templates/Standard/ProcessManagement/Priority.tt
@@ -13,7 +13,7 @@
 [% RenderBlockStart("rw:Priority:DescriptionLong") %]
     <span class="FieldHelpContainer">
         <i class="fa fa-question-circle FieldHelpTrigger"></i>
-        <span>[% Data.DescriptionLong | html %]</span>
+        <span>[% Translate(Data.DescriptionLong) | html %]</span>
     </span>
 [% RenderBlockEnd("rw:Priority:DescriptionLong") %]
     [% Data.Label | html %]:
@@ -23,7 +23,7 @@
     <div id="[% Data.FieldID | html %]Error" class="TooltipErrorMessage"><p>[% Translate("This field is required.") | html %]</p></div>
     <div id="[% Data.FieldID | html %]ServerError" class="TooltipErrorMessage"><p>[% Translate("This field is required.") | html %]</p></div>
 [% RenderBlockStart("rw:Priority:DescriptionShort") %]
-    <div class="FieldExplanation">[% Data.DescriptionShort | html %]</div>
+    <div class="FieldExplanation">[% Translate(Data.DescriptionShort) | html %]</div>
 [% RenderBlockEnd("rw:Priority:DescriptionShort") %]
 </div>
 <div class="Clear"></div>

--- a/Kernel/Output/HTML/Templates/Standard/ProcessManagement/Queue.tt
+++ b/Kernel/Output/HTML/Templates/Standard/ProcessManagement/Queue.tt
@@ -13,7 +13,7 @@
 [% RenderBlockStart("rw:Queue:DescriptionLong") %]
     <span class="FieldHelpContainer">
         <i class="fa fa-question-circle FieldHelpTrigger"></i>
-        <span>[% Data.DescriptionLong | html %]</span>
+        <span>[% Translate(Data.DescriptionLong) | html %]</span>
     </span>
 [% RenderBlockEnd("rw:Queue:DescriptionLong") %]
     [% Data.Label | html %]:
@@ -23,7 +23,7 @@
     <div id="[% Data.FieldID | html %]Error" class="TooltipErrorMessage"><p>[% Translate("This field is required.") | html %]</p></div>
     <div id="[% Data.FieldID | html %]ServerError" class="TooltipErrorMessage"><p>[% Translate("This field is required.") | html %]</p></div>
 [% RenderBlockStart("rw:Queue:DescriptionShort") %]
-    <div class="FieldExplanation">[% Data.DescriptionShort | html %]</div>
+    <div class="FieldExplanation">[% Translate(Data.DescriptionShort) | html %]</div>
 [% RenderBlockEnd("rw:Queue:DescriptionShort") %]
 </div>
 <div class="Clear"></div>

--- a/Kernel/Output/HTML/Templates/Standard/ProcessManagement/Responsible.tt
+++ b/Kernel/Output/HTML/Templates/Standard/ProcessManagement/Responsible.tt
@@ -14,7 +14,7 @@
 [% RenderBlockStart("rw:Responsible:DescriptionLong") %]
     <span class="FieldHelpContainer">
         <i class="fa fa-question-circle FieldHelpTrigger"></i>
-        <span>[% Data.DescriptionLong | html %]</span>
+        <span>[% Translate(Data.DescriptionLong) | html %]</span>
     </span>
 [% RenderBlockEnd("rw:Responsible:DescriptionLong") %]
     [% Data.Label | html %]:
@@ -28,7 +28,7 @@
     <div id="[% Data.FieldID | html %]Error" class="TooltipErrorMessage"><p>[% Translate("This field is required.") | html %]</p></div>
     <div id="[% Data.FieldID | html %]ServerError" class="TooltipErrorMessage"><p>[% Translate("This field is required.") | html %]</p></div>
 [% RenderBlockStart("rw:Responsible:DescriptionShort") %]
-    <div class="FieldExplanation">[% Data.DescriptionShort | html %]</div>
+    <div class="FieldExplanation">[% Translate(Data.DescriptionShort) | html %]</div>
 [% RenderBlockEnd("rw:Responsible:DescriptionShort") %]
 </div>
 <div class="Clear"></div>

--- a/Kernel/Output/HTML/Templates/Standard/ProcessManagement/SLA.tt
+++ b/Kernel/Output/HTML/Templates/Standard/ProcessManagement/SLA.tt
@@ -13,7 +13,7 @@
 [% RenderBlockStart("rw:SLA:DescriptionLong") %]
     <span class="FieldHelpContainer">
         <i class="fa fa-question-circle FieldHelpTrigger"></i>
-        <span>[% Data.DescriptionLong | html %]</span>
+        <span>[% Translate(Data.DescriptionLong) | html %]</span>
     </span>
 [% RenderBlockEnd("rw:SLA:DescriptionLong") %]
     [% Data.Label | html %]:
@@ -23,7 +23,7 @@
     <div id="[% Data.FieldID | html %]Error" class="TooltipErrorMessage"><p>[% Translate("This field is required.") | html %]</p></div>
     <div id="[% Data.FieldID | html %]ServerError" class="TooltipErrorMessage"><p>[% Translate("This field is required.") | html %]</p></div>
 [% RenderBlockStart("rw:SLA:DescriptionShort") %]
-    <div class="FieldExplanation">[% Data.DescriptionShort %]</div>
+    <div class="FieldExplanation">[% Translate(Data.DescriptionShort) %]</div>
 [% RenderBlockEnd("rw:SLA:DescriptionShort") %]
 </div>
 <div class="Clear"></div>

--- a/Kernel/Output/HTML/Templates/Standard/ProcessManagement/Service.tt
+++ b/Kernel/Output/HTML/Templates/Standard/ProcessManagement/Service.tt
@@ -13,7 +13,7 @@
 [% RenderBlockStart("rw:Service:DescriptionLong") %]
     <span class="FieldHelpContainer">
         <i class="fa fa-question-circle FieldHelpTrigger"></i>
-        <span>[% Data.DescriptionLong | html %]</span>
+        <span>[% Translate(Data.DescriptionLong) | html %]</span>
     </span>
 [% RenderBlockEnd("rw:Service:DescriptionLong") %]
     [% Data.Label | html %]:
@@ -23,7 +23,7 @@
     <div id="[% Data.FieldID | html %]Error" class="TooltipErrorMessage"><p>[% Translate("This field is required.") | html %]</p></div>
     <div id="[% Data.FieldID | html %]ServerError" class="TooltipErrorMessage"><p>[% Translate("This field is required.") | html %]</p></div>
 [% RenderBlockStart("rw:Service:DescriptionShort") %]
-    <div class="FieldExplanation">[% Data.DescriptionShort | html %]</div>
+    <div class="FieldExplanation">[% Translate(Data.DescriptionShort) | html %]</div>
 [% RenderBlockEnd("rw:Service:DescriptionShort") %]
 </div>
 <div class="Clear"></div>

--- a/Kernel/Output/HTML/Templates/Standard/ProcessManagement/State.tt
+++ b/Kernel/Output/HTML/Templates/Standard/ProcessManagement/State.tt
@@ -13,7 +13,7 @@
 [% RenderBlockStart("rw:State:DescriptionLong") %]
     <span class="FieldHelpContainer">
         <i class="fa fa-question-circle FieldHelpTrigger"></i>
-        <span>[% Data.DescriptionLong | html %]</span>
+        <span>[% Translate(Data.DescriptionLong) | html %]</span>
     </span>
 [% RenderBlockEnd("rw:State:DescriptionLong") %]
     [% Data.Label | html %]:
@@ -23,7 +23,7 @@
     <div id="[% Data.FieldID | html %]Error" class="TooltipErrorMessage"><p>[% Translate("This field is required.") | html %]</p></div>
     <div id="[% Data.FieldID | html %]ServerError" class="TooltipErrorMessage"><p>[% Translate("This field is required.") | html %]</p></div>
 [% RenderBlockStart("rw:State:DescriptionShort") %]
-    <div class="FieldExplanation">[% Data.DescriptionShort | html %]</div>
+    <div class="FieldExplanation">[% Translate(Data.DescriptionShort) | html %]</div>
 [% RenderBlockEnd("rw:State:DescriptionShort") %]
 </div>
 <div class="Clear"></div>

--- a/Kernel/Output/HTML/Templates/Standard/ProcessManagement/Title.tt
+++ b/Kernel/Output/HTML/Templates/Standard/ProcessManagement/Title.tt
@@ -13,7 +13,7 @@
 [% RenderBlockStart("rw:Title:DescriptionLong") %]
     <span class="FieldHelpContainer">
         <i class="fa fa-question-circle FieldHelpTrigger"></i>
-        <span>[% Data.DescriptionLong | html %]</span>
+        <span>[% Translate(Data.DescriptionLong) | html %]</span>
     </span>
 [% RenderBlockEnd("rw:Title:DescriptionLong") %]
     [% Data.Label | html %]:
@@ -23,7 +23,7 @@
     <div id="[% Data.FieldID | html %]Error" class="TooltipErrorMessage"><p>[% Translate("This field is required.") | html %]</p></div>
     <div id="[% Data.FieldID | html %]ServerError" class="TooltipErrorMessage"><p>[% Translate("This field is required.") | html %]</p></div>
 [% RenderBlockStart("rw:Title:DescriptionShort") %]
-    <div class="FieldExplanation">[% Data.DescriptionShort | html %]</div>
+    <div class="FieldExplanation">[% Translate(Data.DescriptionShort) | html %]</div>
 [% RenderBlockEnd("rw:Title:DescriptionShort") %]
 </div>
 <div class="Clear"></div>

--- a/Kernel/Output/HTML/Templates/Standard/ProcessManagement/Type.tt
+++ b/Kernel/Output/HTML/Templates/Standard/ProcessManagement/Type.tt
@@ -13,7 +13,7 @@
 [% RenderBlockStart("rw:Type:DescriptionLong") %]
     <span class="FieldHelpContainer">
         <i class="fa fa-question-circle FieldHelpTrigger"></i>
-        <span>[% Data.DescriptionLong | html %]</span>
+        <span>[% Translate(Data.DescriptionLong) | html %]</span>
     </span>
 [% RenderBlockEnd("rw:Type:DescriptionLong") %]
     [% Data.Label | html %]:
@@ -23,7 +23,7 @@
     <div id="[% Data.FieldID | html %]Error" class="TooltipErrorMessage"><p>[% Translate("This field is required.") | html %]</p></div>
     <div id="[% Data.FieldID | html %]ServerError" class="TooltipErrorMessage"><p>[% Translate("This field is required.") | html %]</p></div>
 [% RenderBlockStart("rw:Type:DescriptionShort") %]
-    <div class="FieldExplanation">[% Data.DescriptionShort | html %]</div>
+    <div class="FieldExplanation">[% Translate(Data.DescriptionShort) | html %]</div>
 [% RenderBlockEnd("rw:Type:DescriptionShort") %]
 </div>
 <div class="Clear"></div>

--- a/var/processes/examples/Application_for_leave_post.pm
+++ b/var/processes/examples/Application_for_leave_post.pm
@@ -16,6 +16,8 @@ use parent qw(var::processes::examples::Base);
 
 our @ObjectDependencies = ();
 
+use Kernel::Language qw(Translatable);
+
 sub new {
     my ( $Type, %Param ) = @_;
 
@@ -61,7 +63,7 @@ sub Run {
     );
 
     $Response{Success} = $Self->SystemConfigurationUpdate(
-        ProcessName => 'Application For Leave',
+        ProcessName => Translatable('Application for leave'),
         Data        => \@Data,
     );
 

--- a/var/processes/examples/Application_for_leave_pre.pm
+++ b/var/processes/examples/Application_for_leave_pre.pm
@@ -16,6 +16,8 @@ use parent qw(var::processes::examples::Base);
 
 our @ObjectDependencies = ();
 
+use Kernel::Language qw(Translatable);
+
 sub new {
     my ( $Type, %Param ) = @_;
 
@@ -37,7 +39,7 @@ sub Run {
     my @DynamicFields = (
         {
             Name       => 'PreProcApplicationRecorded',
-            Label      => 'Application Recorded',
+            Label      => Translatable('Application Recorded'),
             FieldType  => 'Dropdown',
             ObjectType => 'Ticket',
             FieldOrder => 10000,
@@ -45,15 +47,15 @@ sub Run {
                 DefaultValue   => '',
                 PossibleNone   => 1,
                 PossibleValues => {
-                    'no'  => 'no',
-                    'yes' => 'yes',
+                    'no'  => Translatable('no'),
+                    'yes' => Translatable('yes'),
                 },
-                TranslatableValues => 0,
+                TranslatableValues => 1,
             },
         },
         {
             Name       => 'PreProcDaysRemaining',
-            Label      => 'Days Remaining',
+            Label      => Translatable('Days Remaining'),
             FieldType  => 'Text',
             ObjectType => 'Ticket',
             FieldOrder => 10001,
@@ -62,7 +64,7 @@ sub Run {
         },
         {
             Name       => 'PreProcVacationStart',
-            Label      => 'Vacation Start',
+            Label      => Translatable('Vacation Start'),
             FieldType  => 'Date',
             ObjectType => 'Ticket',
             FieldOrder => 10002,
@@ -72,7 +74,7 @@ sub Run {
         },
         {
             Name       => 'PreProcVacationEnd',
-            Label      => 'Vacation End',
+            Label      => Translatable('Vacation End'),
             FieldType  => 'Date',
             ObjectType => 'Ticket',
             FieldOrder => 10003,
@@ -82,7 +84,7 @@ sub Run {
         },
         {
             Name       => 'PreProcDaysUsed',
-            Label      => 'Days Used',
+            Label      => Translatable('Days Used'),
             FieldType  => 'Text',
             ObjectType => 'Ticket',
             FieldOrder => 10004,
@@ -91,7 +93,7 @@ sub Run {
         },
         {
             Name       => 'PreProcEmergencyTelephone',
-            Label      => 'Emergency Telephone',
+            Label      => Translatable('Emergency Telephone'),
             FieldType  => 'Text',
             ObjectType => 'Ticket',
             FieldOrder => 10005,
@@ -100,7 +102,7 @@ sub Run {
         },
         {
             Name       => 'PreProcRepresentationBy',
-            Label      => 'Representation By',
+            Label      => Translatable('Representation By'),
             FieldType  => 'TextArea',
             ObjectType => 'Ticket',
             FieldOrder => 10006,
@@ -111,7 +113,7 @@ sub Run {
         },
         {
             Name       => 'PreProcProcessStatus',
-            Label      => 'Process Status',
+            Label      => Translatable('Process Status'),
             FieldType  => 'Text',
             ObjectType => 'Ticket',
             FieldOrder => 10007,
@@ -120,7 +122,7 @@ sub Run {
         },
         {
             Name       => 'PreProcApprovedSuperior',
-            Label      => 'Approved Superior',
+            Label      => Translatable('Approved Superior'),
             FieldType  => 'Dropdown',
             ObjectType => 'Ticket',
             FieldOrder => 10008,
@@ -128,15 +130,15 @@ sub Run {
                 DefaultValue   => '',
                 PossibleNone   => 1,
                 PossibleValues => {
-                    'no'  => 'no',
-                    'yes' => 'yes',
+                    'no'  => Translatable('no'),
+                    'yes' => Translatable('yes'),
                 },
-                TranslatableValues => 0,
+                TranslatableValues => 1,
             },
         },
         {
             Name       => 'PreProcVacationInfo',
-            Label      => 'Vacation Info',
+            Label      => Translatable('Vacation Info'),
             FieldType  => 'TextArea',
             ObjectType => 'Ticket',
             FieldOrder => 10009,


### PR DESCRIPTION
Hello @dvuckovic 
This PR makes it possible to translate the input fields, the short and long descriptions of processes. I also marked the fields of example process "Application for leave" as translatable.