### PR TITLE
Configuration item fix

### DIFF
--- a/Kernel/Config/Files/XML/Ticket.xml
+++ b/Kernel/Config/Files/XML/Ticket.xml
@@ -13374,7 +13374,7 @@ Thanks for your help!
         <Navigation>Frontend::Agent::LinkObject</Navigation>
         <Value>
             <Hash>
-                <Item Key="Module">Kernel::Output::HTML::LinkObject::Ticket.pm</Item>
+                <Item Key="Module">Kernel::Output::HTML::LinkObject::Ticket</Item>
                 <Item Key="DefaultColumns">
                     <Hash>
                         <DefaultItem ValueType="Select">


### PR DESCRIPTION
&lt;Item Key="Module"&gt; usually uses package name. .pm looks needless