### PR TITLE
Fix warnings about uninitialized value in logs

### DIFF
--- a/Kernel/System/Ticket/Article/Backend/MIMEBase.pm
+++ b/Kernel/System/Ticket/Article/Backend/MIMEBase.pm
@@ -360,7 +360,7 @@ sub ArticleCreate {
     # Check if there are additional To's from InvolvedAgent and InformAgent.
     #   See bug#13422 (https://bugs.otrs.org/show_bug.cgi?id=13422).
     if ( $Param{ForceNotificationToUserID} && ref $Param{ForceNotificationToUserID} eq 'ARRAY' ) {
-        my $NewTo;
+        my $NewTo = '';
         USER:
         for my $UserID ( @{ $Param{ForceNotificationToUserID} } ) {
 


### PR DESCRIPTION
Inittialize $NewTo with empty value to prevent warnings about uninitialized values in concatention

```
[Mon Jul 23 15:52:04 2018] -e: Use of uninitialized value $NewTo in concatenation (.) or string at /opt/otrs/Kernel/System/Ticket/Article/Backend/MIMEBase.pm line 383.
```