### PR TITLE
Test for checking bug in StandardTemplateLookup()

### DIFF
--- a/scripts/test/StandardTemplate.t
+++ b/scripts/test/StandardTemplate.t
@@ -128,6 +128,15 @@ for my $Test (@Tests) {
         $LookupID,
         "StandardTemplateLookup()",
     );
+    
+    # second lookup of non-existing template name AFTER successful lookup by Name (previous test)
+    my $WrongLookupID = $StandardTemplateObject->StandardTemplateLookup(
+        StandardTemplate => $Test->{Add}->{Name} . $RandomID, # wrong name
+    );
+    $Self->False(
+        $WrongLookupID,
+        "StandardTemplateLookup() - try to find template by wrong name AFTER previous SUCCESSFUL lookup",
+    );
 
     # update
     my $Update = $StandardTemplateObject->StandardTemplateUpdate(


### PR DESCRIPTION
Second call of StandardTemplateLookup() with unexisting parameter after successful call with existing parameter returns the value of previous call although we expect undef.