### PR TITLE
Invalid type of comparison

### DIFF
--- a/Kernel/System/Scheduler.pm
+++ b/Kernel/System/Scheduler.pm
@@ -132,7 +132,7 @@ sub Run {
         my $TaskDueTime = $Kernel::OM->Get('Kernel::System::Time')->TimeStamp2SystemTime(
             String => $TaskItem->{DueTime},
         );
-        next TASKITEM if ( $TaskDueTime gt $SystemTime );
+        next TASKITEM if ( $TaskDueTime > $SystemTime );
 
         # get task data
         my %TaskData = $Kernel::OM->Get('Kernel::System::Scheduler::TaskManager')->TaskGet( ID => $TaskItem->{ID} );


### PR DESCRIPTION
Numerical comparison is more suitable for this place, because both scalars contain number of seconds.