### PR TITLE
Fixed infinite loop on filename generation

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,4 +1,5 @@
 #5.0.32 20??-??-??
+ - 2018-12-03 Fixed infinite loop on filename generation.
 
 #5.0.31 2018-11-09
  - 2018-10-26 Fixed bug#[14132](https://bugs.otrs.org/show_bug.cgi?id=14132) - After select a sub-queue the queue's field is break in the bulk window.

--- a/Kernel/System/Main.pm
+++ b/Kernel/System/Main.pm
@@ -271,8 +271,13 @@ sub FilenameCleanUp {
         my $FileName = $Param{Filename};
         my $FileExt  = '';
         if ( $Param{Filename} =~ /(.*)\.+(.*)$/ ) {
-            $FileName = $1;
-            $FileExt  = '.' . $2;
+
+            # allow extensions up to 10 chars to avoid infinite loop below
+            if (length encode('UTF-8', $2) <= 10) {
+                $FileName = $1;
+                $FileExt  = '.' . $2;
+            }
+
         }
 
         if ( length $FileName ) {
@@ -312,8 +317,14 @@ sub FilenameCleanUp {
         my $FileName = $Param{Filename};
         my $FileExt  = '';
         if ( $Param{Filename} =~ /(.*)\.+(.*)$/ ) {
-            $FileName = $1;
-            $FileExt  = '.' . $2;
+
+            # allow extensions up to 10 chars to avoid infinite loop below
+            if (length encode('UTF-8', $2) <= 10) {
+
+                $FileName = $1;
+                $FileExt  = '.' . $2;
+            }
+
         }
 
         if ( length $FileName ) {


### PR DESCRIPTION
OTRS falls into an inifinite loop on filename generation
for specific attachments.

Related: https://dev.ib.pl/ib/otrs/issues/118
Author-Change-Id: IB#1085514