### PR TITLE
Set NotificationRecipientEmail setting as non-required

### DIFF
--- a/Kernel/Config/Files/XML/Daemon.xml
+++ b/Kernel/Config/Files/XML/Daemon.xml
@@ -143,7 +143,7 @@
             </Item>
         </Value>
     </Setting>
-    <Setting Name="Daemon::SchedulerTaskWorker::NotificationRecipientEmail" Required="1" Valid="1">
+    <Setting Name="Daemon::SchedulerTaskWorker::NotificationRecipientEmail" Required="0" Valid="1">
         <Description Translatable="1">Specifies the email addresses to get notification messages from scheduler tasks.</Description>
         <Navigation>Daemon::SchedulerTaskWorker</Navigation>
         <Value>

--- a/Kernel/System/Daemon/DaemonModules/BaseTaskWorker.pm
+++ b/Kernel/System/Daemon/DaemonModules/BaseTaskWorker.pm
@@ -35,9 +35,9 @@ Creates a system error message and sends an email with the error messages form a
 
     my $Success = $TaskWorkerObject->_HandleError(
         TaskName     => 'some name',
-        TaksTye      => 'some type',
+        TaksType     => 'some type',
         LogMessage   => 'some message',       # message to set in the OTRS error log
-        ErrorMessage => 'some message',       # message to be sent ad a body of the email, usually contains
+        ErrorMessage => 'some message',       # message to be sent as a body of the email, usually contains
                                               #     all messages from STDERR including tracebacks
     );
 


### PR DESCRIPTION
There is no sense to make this setting required. It's
better to give the possibility to disable it, if you
don't want to receive mail with error messages from
Daemon.