### PR TITLE
Fixed: script name returned by mod_perl is a directory

### DIFF
--- a/scripts/apache2-perl-startup.pl
+++ b/scripts/apache2-perl-startup.pl
@@ -31,7 +31,7 @@ BEGIN {
     # set $0 to index.pl if it is not an existing file:
     # on Fedora, $0 is not a path which would break OTRS.
     # see bug # 8533
-    if ( !-e $0 ) {
+    if ( !-e $0 or -d $0 ) {
         $0 = '/opt/otrs/bin/cgi-bin/index.pl';    ## no critic
     }
 }


### PR DESCRIPTION
Hi,

As explain here : https://bugs.otrs.org/show_bug.cgi?id=8533#c17 on some linux distro the script returned by mod_perl is limited to the sized of original process name. This is the case for alpine linux.

In this case the apache2 process is named `httpd` (5 char). `$0` will contain `/opt/`.

As you can see the patch for bug 8533 us `-e $0`. If `$0` contain a folder name the test will be true.

This PR test if the `$0` var contain is a directory path.

Regards
