### PR TITLE
Add needed param to check

### DIFF
--- a/Kernel/System/CustomerUser.pm
+++ b/Kernel/System/CustomerUser.pm
@@ -977,12 +977,14 @@ sub CustomerUserUpdate {
     my ( $Self, %Param ) = @_;
 
     # check needed stuff
-    if ( !$Param{UserLogin} ) {
-        $Kernel::OM->Get('Kernel::System::Log')->Log(
-            Priority => 'error',
-            Message  => "Need UserLogin!"
-        );
-        return;
+    for (qw(UserLogin UserLogin)) {
+        if ( !$Param{$_} ) {
+            $Kernel::OM->Get('Kernel::System::Log')->Log(
+                Priority => 'error',
+                Message  => "Need $_!"
+            );
+            return;
+        }
     }
 
     # check for UserLogin-renaming and if new UserLogin already exists...


### PR DESCRIPTION
Otherwise the DB update fails because of a foreign key constraint.

Note: Would be great if the Objects are named and used consistently.
Example: For User.pm the changing user is passed as "ChangeUserID", here it's named "UserID".
Or: to get detailed data for agents, the function is called "GetUserData" (Verb -> Object), for customerusers it's called "CustomerUserDataGet" (Object -> Verb).