### PR TITLE
Fixed: Net::SSLGlue issues warnings on modern systems (bug#12334).

### DIFF
--- a/Kernel/System/Email/SMTPS.pm
+++ b/Kernel/System/Email/SMTPS.pm
@@ -11,7 +11,7 @@ package Kernel::System::Email::SMTPS;
 use strict;
 use warnings;
 
-use Net::SSLGlue::SMTP;
+use Net::SMTP;
 
 use parent qw(Kernel::System::Email::SMTP);
 


### PR DESCRIPTION
fixed [bug#12334](https://bugs.otrs.org/show_bug.cgi?id=12334#c20) and tested pass in Ubuntu 16.04.

