### PR TITLE
Remove useless UserID from calling TicketIDLookup

### DIFF
--- a/Kernel/GenericInterface/Operation/Ticket/TicketUpdate.pm
+++ b/Kernel/GenericInterface/Operation/Ticket/TicketUpdate.pm
@@ -374,7 +374,6 @@ sub Run {
     if ( $Param{Data}->{TicketNumber} ) {
         $TicketID = $TicketObject->TicketIDLookup(
             TicketNumber => $Param{Data}->{TicketNumber},
-            UserID       => $UserID,
         );
 
     }

--- a/Kernel/Modules/AgentTicketSearch.pm
+++ b/Kernel/Modules/AgentTicketSearch.pm
@@ -656,7 +656,6 @@ sub Run {
         {
             my $TicketID = $TicketObject->TicketIDLookup(
                 TicketNumber => $GetParam{Fulltext},
-                UserID       => $Self->{UserID},
             );
             if ($TicketID) {
                 return $LayoutObject->Redirect(

--- a/Kernel/Modules/AgentTicketZoom.pm
+++ b/Kernel/Modules/AgentTicketZoom.pm
@@ -150,7 +150,6 @@ sub new {
     if ( !$Self->{TicketID} && $ParamObject->GetParam( Param => 'TicketNumber' ) ) {
         $Self->{TicketID} = $TicketObject->TicketIDLookup(
             TicketNumber => $ParamObject->GetParam( Param => 'TicketNumber' ),
-            UserID       => $Self->{UserID},
         );
     }
 

--- a/Kernel/Modules/CustomerTicketZoom.pm
+++ b/Kernel/Modules/CustomerTicketZoom.pm
@@ -46,7 +46,6 @@ sub Run {
     if ( !$Self->{TicketID} && $TicketNumber ) {
         $Self->{TicketID} = $TicketObject->TicketIDLookup(
             TicketNumber => $ParamObject->GetParam( Param => 'TicketNumber' ),
-            UserID       => $Self->{UserID},
         );
     }
 

--- a/Kernel/System/Console/Command/Maint/Ticket/Delete.pm
+++ b/Kernel/System/Console/Command/Maint/Ticket/Delete.pm
@@ -70,7 +70,6 @@ sub Run {
         # lookup ticket id
         my $TicketID = $Kernel::OM->Get('Kernel::System::Ticket')->TicketIDLookup(
             TicketNumber => $TicketNumber,
-            UserID       => 1,
         );
 
         # error handling

--- a/Kernel/System/Ticket.pm
+++ b/Kernel/System/Ticket.pm
@@ -601,7 +601,6 @@ sub TicketCreate {
     # get ticket id
     my $TicketID = $Self->TicketIDLookup(
         TicketNumber => $Param{TN},
-        UserID       => $Param{UserID},
     );
 
     # add history entry


### PR DESCRIPTION
Kernel::System::Ticket::TicketIDLookup() doesn't use UserID param.