### PR TITLE
SupportBundleGenerator test fix

### DIFF
--- a/scripts/test/SupportBundleGenerator.t
+++ b/scripts/test/SupportBundleGenerator.t
@@ -74,7 +74,7 @@ if ( !-e $Home . '/ARCHIVE' ) {
 }
 else {
     $ArchiveExists = 1;
-    $Success       = rename( "ARCHIVE", "ARCHIVE" . $RandomNumber );
+    $Success       = rename( "$Home/ARCHIVE", "$Home/ARCHIVE" . $RandomNumber );
     $Self->True(
         $Success,
         "Found ARCHIVE file in a system, creating copy to restore it on the end of unit test."
@@ -753,7 +753,7 @@ $Self->True(
 );
 
 if ($ArchiveExists) {
-    $Success = rename( "ARCHIVE" . $RandomNumber, "ARCHIVE" );
+    $Success = rename( "$Home/ARCHIVE" . $RandomNumber, "$Home/ARCHIVE" );
     $Self->True(
         $Success,
         "Original ARCHIVE file is restored"


### PR DESCRIPTION
Fixing rename() problem:

```
$ ./otrs.CheckSum.pl -a create
Writing /opt/otrs/ARCHIVE ... done.

$ ./otrs.Console.pl Dev::UnitTest::Run --test SupportBundleGenerator
+-------------------------------------------------------------------+
/opt/otrs/scripts/test/SupportBundleGenerator.t:
+-------------------------------------------------------------------+
.
 not ok 2 - Found ARCHIVE file in a system, creating copy to restore it on the end of unit test.
...................................................
 not ok 54 - Original ARCHIVE file is restored
```