### PR TITLE
New module Kernel::System::Log::Screen and Kernel::System::Log improvement

### DIFF
--- a/Kernel/System/Log/Screen.pm
+++ b/Kernel/System/Log/Screen.pm
@@ -1,0 +1,73 @@
+## nofilter(TidyAll::Plugin::OTRS::Perl::Time)
+
+package Kernel::System::Log::Screen;
+
+use strict;
+use warnings;
+
+use Term::ANSIColor;
+
+our @ObjectDependencies = ();
+
+sub new {
+    my ( $Type, %Param ) = @_;
+
+    # allocate new hash for object
+    my $Self = {};
+    bless( $Self, $Type );
+
+    # colorize output
+    $Self->{Colorize} ||= -t STDOUT ? 1 : 0;
+
+    # Enable autoflush, otherwise color will not be reset properly.
+    # More see https://rt.cpan.org/Public/Bug/Display.html?id=121974
+    if ( $Self->{Colorize} ) {
+        $|++;
+    }
+
+    # default colors
+    $Self->{Color} = {
+        info    => 'bold white',
+        notice  => 'bold cyan',
+        error   => 'bold red',
+    };
+    
+    return $Self;
+}
+
+sub Log {
+    my ( $Self, %Param ) = @_;
+
+    my $Color = $Self->{Color}{ $Param{Priority} };
+    if ( $Self->{Colorize} && $Color ) {
+        print color($Color);
+    }
+
+    print '[' . localtime() . ']';    ## no critic
+
+    if ( lc $Param{Priority} eq 'debug' ) {
+        print "[Debug][$Param{Module}][$Param{Line}] $Param{Message}\n";
+    }
+    elsif ( lc $Param{Priority} eq 'info' ) {
+        print "[Info][$Param{Module}] $Param{Message}\n";
+    }
+    elsif ( lc $Param{Priority} eq 'notice' ) {
+        print "[Notice][$Param{Module}] $Param{Message}\n";
+    }
+    elsif ( lc $Param{Priority} eq 'error' ) {
+        print "[Error][$Param{Module}][$Param{Line}] $Param{Message}\n";
+    }
+    else {
+        # print error messages to STDERR
+        print STDERR
+            "[Error][$Param{Module}] Priority: '$Param{Priority}' not defined! Message: $Param{Message}\n";
+    }
+
+    if ( $Self->{Colorize} && $Color ) {
+        print color('reset');
+    }
+    
+    return 1;
+}
+
+1;


### PR DESCRIPTION
These two commits increase the convenience for scripting. Now you can override configured minimum log level and used log module in runtime for your scripts.

Generally speaking it's just shortcuts for `$ConfigObject->Set( Key => 'MinimumLogLevel', Value => $Value )` and `$ConfigObject->Set( Key => 'LogModule', Value => $Value )`, but now log objects can be constructed in more pleasant manner:

```perl
local $Kernel::OM = Kernel::System::ObjectManager->new(
    'Kernel::System::Log' => {
	LogModule       => 'Kernel::System::Log::Screen',
        LogPrefix       => 'OTRS-otrs.Test.pl',
	MinimumLogLevel => 'debug',
    },
);
```

Also for scripting I've added new backend `Kernel::System::Log::Screen`, that just puts messages to stdout and colorize them (unless stdout was not redirected to some file). Now you don't need do something like `tail -f /var/log/otrs/otrs.log` and it looks pretty nice: :)

![screenshot](https://user-images.githubusercontent.com/1090420/61331049-2854fb80-a832-11e9-82e2-2b00e09f25df.png)