### PR TITLE
otrs.Console.pl Maint::Ticket::InvalidUserCleanup eats 100% cpu and throws errors

### DIFF
--- a/Kernel/System/Console/Command/Maint/Ticket/InvalidUserCleanup.pm
+++ b/Kernel/System/Console/Command/Maint/Ticket/InvalidUserCleanup.pm
@@ -205,7 +205,7 @@ sub _CleanupFlags {
 
         return if !$DBObject->Prepare(
             SQL => "
-                SELECT DISTINCT(article.id)
+                SELECT DISTINCT(article.id), article.ticket_id
                 FROM article
                     INNER JOIN ticket ON ticket.id = article.ticket_id
                     INNER JOIN article_flag ON article.id = article_flag.article_id
@@ -216,13 +216,14 @@ sub _CleanupFlags {
 
         my @ArticleIDs;
         while ( my @Row = $DBObject->FetchrowArray() ) {
-            push @ArticleIDs, $Row[0];
+            push @ArticleIDs, [ $Row[0], $Row[1] ];
         }
 
         $Count = 0;
         for my $ArticleID (@ArticleIDs) {
             $ArticleObject->ArticleFlagDelete(
-                ArticleID => $ArticleID,
+                ArticleID => $ArticleID->[0],
+                TicketID  => $ArticleID->[1],
                 Key       => 'Seen',
                 UserID    => $User->{UserID},
             );


### PR DESCRIPTION
otrs.Console.pl Maint::Ticket::InvalidUserCleanup from latest 6.0.20 eats 100% cpu and throws a lot of errors like this one:

 Message: Need TicketID!

 Traceback (5127):
   Module: Kernel::System::Ticket::Article::ArticleFlagDelete Line: 436
   Module: Kernel::System::Console::Command::Maint::Ticket::InvalidUserCleanup::_CleanupFlags Line: 228
   Module: Kernel::System::Console::Command::Maint::Ticket::InvalidUserCleanup::Run Line: 96
   Module: (eval) Line: 460
   Module: Kernel::System::Console::BaseCommand::Execute Line: 454
   Module: Kernel::System::Console::InterfaceConsole::Run Line: 80
   Module: /opt/otrs/bin/otrs.Console.pl Line: 36

Trivial patch attached to pass TicketID to ArticleFlagDelete().