### PR TITLE
SelectSingleRow() for DB.pm

### DIFF
--- a/Kernel/System/DB.pm
+++ b/Kernel/System/DB.pm
@@ -886,6 +886,49 @@ sub SelectAll {
     return \@Records;
 }
 
+=head2 SelectSingleRow()
+
+returns single row from a SELECT statement.
+In essence, this calls Prepare() and FetchrowArray() to get single record.
+
+    my $ResultAsArrayRef = $DBObject->SelectSingleRow(
+        SQL  => 'SELECT id, name FROM table WHERE name = ?',
+        Bind => [ \$ItemName ],
+    );
+
+You can pass the same arguments as to the Prepare() method.
+
+Returns undef (if query failed), or an array ref (if query was successful):
+
+    my $ResultAsArrayRef = [ 4, 'ItemFour' ];
+
+Method has extra checks - only one row should be returned.
+
+=cut
+
+sub SelectSingleRow {
+    my ( $Self, %Param ) = @_;
+
+    return if !$Self->Prepare(%Param);
+
+    my @Record;
+    my $RowCount = 0;
+    while ( my @Row = $Self->FetchrowArray() ) {
+        $RowCount++;
+
+        @Record = @Row if $RowCount == 1;
+    }
+
+    if ( $RowCount > 1 ) {
+        $Kernel::OM->Get('Kernel::System::Log')->Log(
+            Priority => 'Error',
+            Message  => "Returned $RowCount rows instead of 1! SQL: $Param{SQL}",
+        );
+        return;
+    }
+    return \@Record;
+}
+
 =head2 GetDatabaseFunction()
 
 to get database functions like


### PR DESCRIPTION
Hello!

A situation when we need only one row is rather common, and I think that special method for such cases is a good idea.
Following the style [guide](https://doc.otrs.com/doc/manual/developer/6.0/en/html/code-style-guide.html#database-using-while-loop), we have built-in while loop (there is some places where `FetchrowArray() `not wrapped with loop). But regardless [guide](https://doc.otrs.com/doc/manual/developer/6.0/en/html/code-style-guide.html#database-using-limit), I considered to omit hardcoded  `Limit => 1` in new method.
I think it will help to track weird bugs:
```
$Self->{DBObject}->Prepare(
    SQL   => 'SELECT id FROM foo WHERE name = ?',
    Bind  => [ \$Username ],
    Limit => 1,
);
```
If name somehow not unique, we will have random id from call to call. So, `Limit => 1` makes sense only with `ORDER BY`

Thank you for your attention!
