### PR TITLE
Improved performance of TicketQueueOverview dashboard component.

### DIFF
--- a/Kernel/Output/HTML/Dashboard/TicketQueueOverview.pm
+++ b/Kernel/Output/HTML/Dashboard/TicketQueueOverview.pm
@@ -142,26 +142,16 @@ sub Run {
 
     my %Results;
     for my $StateOrderID ( sort { $a <=> $b } keys %ConfiguredStates ) {
-
-        # Run ticket search for all Queues and appropriate available State.
-        my @StateOrderTicketIDs = $TicketObject->TicketSearch(
-            UserID   => $Self->{UserID},
-            Result   => 'ARRAY',
-            QueueIDs => \@QueueIDs,
-            States   => [ $ConfiguredStates{$StateOrderID} ],
-            Limit    => 100_000,
-        );
-
-        # Count of tickets per QueueID.
-        my $TicketCountByQueueID = $TicketObject->TicketCountByAttribute(
-            Attribute => 'QueueID',
-            TicketIDs => \@StateOrderTicketIDs,
-        );
-
         # Gather ticket count for corresponding Queue <-> State.
         for my $QueueID (@QueueIDs) {
-            push @{ $Results{ $Queues{$QueueID} } },
-                $TicketCountByQueueID->{$QueueID} ? $TicketCountByQueueID->{$QueueID} : 0;
+            my $StateQueueTicketCount = $TicketObject->TicketSearch(
+                UserID   => $Self->{UserID},
+                Result   => 'COUNT',
+                QueueIDs => [ $QueueID ],
+                States   => [ $ConfiguredStates{$StateOrderID} ],
+            );
+
+            push @{ $Results{ $Queues{$QueueID} } }, $StateQueueTicketCount;
         }
     }
 


### PR DESCRIPTION
Running a simple COUNT query per combination of Queue and State is
a lot faster than retrieving all TicketIDs per State and
then counting these TicketIDs per QueueID, since passing in a huge
list of TicketIDs to SQL is quite slow and somewhat redundant.

We have a dashboard queue overview matrix of 24 queues in 9 states
and this solution reduces the initial load time to less than 10 %.

Also, the COUNT queries do not require an upper limit at 100.000.