### PR TITLE
Cluster suddenly dissapears in AgentTicketZoom

### DIFF
--- a/var/httpd/htdocs/skins/Agent/default/css/Core.WidgetMenu.css
+++ b/var/httpd/htdocs/skins/Agent/default/css/Core.WidgetMenu.css
@@ -243,8 +243,9 @@ ul.ContextFunctions li:last-child:hover > a {
 }
 
 .Actions li:last-child:after {
-    content: "";
-    display: none;
+    content: " | ";
+    display: block;
+    visibility: hidden;
 }
 
 .RTL .Actions li {


### PR DESCRIPTION
This bug works if cluster is the last element
![output](https://user-images.githubusercontent.com/13961674/66228312-8b02b880-e6f8-11e9-86cf-ba6385cd0da4.gif)
