### PR TITLE
enable customer users to update tickets via GenericInterface

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,4 +1,6 @@
-#6.0.24 ????-??-??
+#6.0.25 ????-??-??
+
+#6.0.24 2019-11-15
  - 2019-10-25 Fixed bug#[13651](https://bugs.otrs.org/show_bug.cgi?id=13651) - Link without Session ID when deploying settings without SessionUseCookie.
  - 2019-10-24 Updated welcome ticket text.
  - 2019-10-24 Fixed bug#[14763](https://bugs.otrs.org/show_bug.cgi?id=14763) - Invisible SysConfig settings are not removed on package deinstallation.

--- a/Kernel/GenericInterface/Operation/Ticket/Common.pm
+++ b/Kernel/GenericInterface/Operation/Ticket/Common.pm
@@ -1355,6 +1355,7 @@ sub CheckCreatePermissions {
 Tests if the user have access permissions over a ticket
 
     my $Result = $CommonObject->CheckAccessPermissions(
+        Type       => 'ro'                      # or 'rw'|'note'|...
         TicketID   => 123,
         UserID     => 123,                      # or 'CustomerLogin'
         UserType   => 'Agent',                  # or 'Customer'
@@ -1369,7 +1370,7 @@ sub CheckAccessPermissions {
     my ( $Self, %Param ) = @_;
 
     # check needed stuff
-    for my $Needed (qw(TicketID UserID UserType)) {
+    for my $Needed (qw(Type TicketID UserID UserType)) {
         if ( !$Param{$Needed} ) {
             return;
         }
@@ -1381,7 +1382,7 @@ sub CheckAccessPermissions {
     }
 
     my $Access = $Kernel::OM->Get('Kernel::System::Ticket')->$TicketPermissionFunction(
-        Type     => 'ro',
+        Type     => $Param{Type},
         TicketID => $Param{TicketID},
         UserID   => $Param{UserID},
     );

--- a/Kernel/GenericInterface/Operation/Ticket/TicketGet.pm
+++ b/Kernel/GenericInterface/Operation/Ticket/TicketGet.pm
@@ -295,6 +295,7 @@ sub Run {
     for my $TicketID (@TicketIDs) {
 
         my $Access = $Self->CheckAccessPermissions(
+            Type     => 'ro',
             TicketID => $TicketID,
             UserID   => $UserID,
             UserType => $UserType,

--- a/Kernel/GenericInterface/Operation/Ticket/TicketHistoryGet.pm
+++ b/Kernel/GenericInterface/Operation/Ticket/TicketHistoryGet.pm
@@ -145,6 +145,7 @@ sub Run {
     for my $TicketID (@TicketIDs) {
 
         my $Access = $Self->CheckAccessPermissions(
+            Type     => 'ro',
             TicketID => $TicketID,
             UserID   => $UserID,
             UserType => $UserType,

--- a/Kernel/GenericInterface/Operation/Ticket/TicketUpdate.pm
+++ b/Kernel/GenericInterface/Operation/Ticket/TicketUpdate.pm
@@ -660,6 +660,7 @@ sub Run {
         DynamicFieldList => \@DynamicFieldList,
         AttachmentList   => \@AttachmentList,
         UserID           => $UserID,
+        PermissionUserID => $PermissionUserID,
         UserType         => $UserType,
     );
 }
@@ -1308,13 +1309,14 @@ sub _CheckAttachment {
 check if user has permissions to update ticket attributes.
 
     my $Response = $OperationObject->_CheckUpdatePermissions(
-        TicketID     => 123
-        Ticket       => $Ticket,                  # all ticket parameters
-        Article      => $Ticket,                  # all attachment parameters
-        DynamicField => $Ticket,                  # all dynamic field parameters
-        Attachment   => $Ticket,                  # all attachment parameters
-        UserID       => 123,
-        UserType     => 'agent',                  # or 'customer'
+        TicketID         => 123
+        Ticket           => $Ticket,              # all ticket parameters
+        Article          => $Ticket,              # all attachment parameters
+        DynamicField     => $Ticket,              # all dynamic field parameters
+        Attachment       => $Ticket,              # all attachment parameters
+        UserID           => 123,
+        PermissionUserID => 123,
+        UserType         => 'agent',              # or 'customer'
     );
 
     returns:
@@ -1348,7 +1350,7 @@ sub _CheckUpdatePermissions {
         my $Access = $Self->CheckAccessPermissions(
             Type       => 'note',
             TicketID   => $TicketID,
-            UserID     => $Param{UserID},
+            UserID     => $Param{PermissionUserID},
             UserType   => $Param{UserType},
         );
         if ( !$Access ) {
@@ -1364,7 +1366,7 @@ sub _CheckUpdatePermissions {
         my $Access = $Self->CheckAccessPermissions(
             Type       => 'rw',
             TicketID   => $TicketID,
-            UserID     => $Param{UserID},
+            UserID     => $Param{PermissionUserID},
             UserType   => $Param{UserType},
         );
         if ( !$Access ) {
@@ -1380,7 +1382,7 @@ sub _CheckUpdatePermissions {
         my $Access = $Self->CheckAccessPermissions(
             Type       => 'move',
             TicketID   => $TicketID,
-            UserID     => $Param{UserID},
+            UserID     => $Param{PermissionUserID},
             UserType   => $Param{UserType},
         );
         if ( !$Access ) {
@@ -1396,7 +1398,7 @@ sub _CheckUpdatePermissions {
         my $Access = $Self->CheckAccessPermissions(
             Type       => 'owner',
             TicketID   => $TicketID,
-            UserID     => $Param{UserID},
+            UserID     => $Param{PermissionUserID},
             UserType   => $Param{UserType},
         );
         if ( !$Access ) {
@@ -1412,7 +1414,7 @@ sub _CheckUpdatePermissions {
         my $Access = $Self->CheckAccessPermissions(
             Type       => 'responsible',
             TicketID   => $TicketID,
-            UserID     => $Param{UserID},
+            UserID     => $Param{PermissionUserID},
             UserType   => $Param{UserType},
         );
         if ( !$Access ) {
@@ -1428,7 +1430,7 @@ sub _CheckUpdatePermissions {
         my $Access = $Self->CheckAccessPermissions(
             Type       => 'priority',
             TicketID   => $TicketID,
-            UserID     => $Param{UserID},
+            UserID     => $Param{PermissionUserID},
             UserType   => $Param{UserType},
         );
         if ( !$Access ) {
@@ -1468,7 +1470,7 @@ sub _CheckUpdatePermissions {
             $Access = $Self->CheckAccessPermissions(
                 Type       => 'close',
                 TicketID   => $TicketID,
-                UserID     => $Param{UserID},
+                UserID     => $Param{PermissionUserID},
                 UserType   => $Param{UserType},
             );
         }
@@ -1478,7 +1480,7 @@ sub _CheckUpdatePermissions {
             $Access = $Self->CheckAccessPermissions(
                 Type       => 'close',
                 TicketID   => $TicketID,
-                UserID     => $Param{UserID},
+                UserID     => $Param{PermissionUserID},
                 UserType   => $Param{UserType},
             );
         }
@@ -1500,13 +1502,14 @@ sub _CheckUpdatePermissions {
 updates a ticket and creates an article and sets dynamic fields and attachments if specified.
 
     my $Response = $OperationObject->_TicketUpdate(
-        TicketID     => 123
-        Ticket       => $Ticket,                  # all ticket parameters
-        Article      => $Article,                 # all attachment parameters
-        DynamicField => $DynamicField,            # all dynamic field parameters
-        Attachment   => $Attachment,              # all attachment parameters
-        UserID       => 123,
-        UserType     => 'Agent'                   # || 'Customer
+        TicketID         => 123
+        Ticket           => $Ticket,              # all ticket parameters
+        Article          => $Article,             # all attachment parameters
+        DynamicField     => $DynamicField,        # all dynamic field parameters
+        Attachment       => $Attachment,          # all attachment parameters
+        UserID           => 123,
+        PermissionUserID => 123,
+        UserType         => 'User'                # or 'Customer'
     );
 
     returns:

--- a/Kernel/GenericInterface/Operation/Ticket/TicketUpdate.pm
+++ b/Kernel/GenericInterface/Operation/Ticket/TicketUpdate.pm
@@ -404,6 +404,7 @@ sub Run {
 
     # check basic needed permissions
     my $Access = $Self->CheckAccessPermissions(
+        Type     => 'ro',
         TicketID => $TicketID,
         UserID   => $PermissionUserID,
         UserType => $UserType,
@@ -1313,6 +1314,7 @@ check if user has permissions to update ticket attributes.
         DynamicField => $Ticket,                  # all dynamic field parameters
         Attachment   => $Ticket,                  # all attachment parameters
         UserID       => 123,
+        UserType     => 'agent',                  # or 'customer'
     );
 
     returns:
@@ -1343,10 +1345,11 @@ sub _CheckUpdatePermissions {
 
     # check Article permissions
     if ( IsHashRefWithData($Article) ) {
-        my $Access = $TicketObject->TicketPermission(
-            Type     => 'note',
-            TicketID => $TicketID,
-            UserID   => $Param{UserID},
+        my $Access = $Self->CheckAccessPermissions(
+            Type       => 'note',
+            TicketID   => $TicketID,
+            UserID     => $Param{UserID},
+            UserType   => $Param{UserType},
         );
         if ( !$Access ) {
             return {
@@ -1358,10 +1361,11 @@ sub _CheckUpdatePermissions {
 
     # check dynamic field permissions
     if ( IsArrayRefWithData($DynamicFieldList) ) {
-        my $Access = $TicketObject->TicketPermission(
-            Type     => 'rw',
-            TicketID => $TicketID,
-            UserID   => $Param{UserID},
+        my $Access = $Self->CheckAccessPermissions(
+            Type       => 'rw',
+            TicketID   => $TicketID,
+            UserID     => $Param{UserID},
+            UserType   => $Param{UserType},
         );
         if ( !$Access ) {
             return {
@@ -1373,10 +1377,11 @@ sub _CheckUpdatePermissions {
 
     # check queue permissions
     if ( $Ticket->{Queue} || $Ticket->{QueueID} ) {
-        my $Access = $TicketObject->TicketPermission(
-            Type     => 'move',
-            TicketID => $TicketID,
-            UserID   => $Param{UserID},
+        my $Access = $Self->CheckAccessPermissions(
+            Type       => 'move',
+            TicketID   => $TicketID,
+            UserID     => $Param{UserID},
+            UserType   => $Param{UserType},
         );
         if ( !$Access ) {
             return {
@@ -1388,10 +1393,11 @@ sub _CheckUpdatePermissions {
 
     # check owner permissions
     if ( $Ticket->{Owner} || $Ticket->{OwnerID} ) {
-        my $Access = $TicketObject->TicketPermission(
-            Type     => 'owner',
-            TicketID => $TicketID,
-            UserID   => $Param{UserID},
+        my $Access = $Self->CheckAccessPermissions(
+            Type       => 'owner',
+            TicketID   => $TicketID,
+            UserID     => $Param{UserID},
+            UserType   => $Param{UserType},
         );
         if ( !$Access ) {
             return {
@@ -1403,10 +1409,11 @@ sub _CheckUpdatePermissions {
 
     # check responsible permissions
     if ( $Ticket->{Responsible} || $Ticket->{ResponsibleID} ) {
-        my $Access = $TicketObject->TicketPermission(
-            Type     => 'responsible',
-            TicketID => $TicketID,
-            UserID   => $Param{UserID},
+        my $Access = $Self->CheckAccessPermissions(
+            Type       => 'responsible',
+            TicketID   => $TicketID,
+            UserID     => $Param{UserID},
+            UserType   => $Param{UserType},
         );
         if ( !$Access ) {
             return {
@@ -1418,10 +1425,11 @@ sub _CheckUpdatePermissions {
 
     # check priority permissions
     if ( $Ticket->{Priority} || $Ticket->{PriorityID} ) {
-        my $Access = $TicketObject->TicketPermission(
-            Type     => 'priority',
-            TicketID => $TicketID,
-            UserID   => $Param{UserID},
+        my $Access = $Self->CheckAccessPermissions(
+            Type       => 'priority',
+            TicketID   => $TicketID,
+            UserID     => $Param{UserID},
+            UserType   => $Param{UserType},
         );
         if ( !$Access ) {
             return {
@@ -1457,19 +1465,21 @@ sub _CheckUpdatePermissions {
         my $Access = 1;
 
         if ( $StateData{TypeName} =~ /^close/i ) {
-            $Access = $TicketObject->TicketPermission(
-                Type     => 'close',
-                TicketID => $TicketID,
-                UserID   => $Param{UserID},
+            $Access = $Self->CheckAccessPermissions(
+                Type       => 'close',
+                TicketID   => $TicketID,
+                UserID     => $Param{UserID},
+                UserType   => $Param{UserType},
             );
         }
 
         # set pending time
         elsif ( $StateData{TypeName} =~ /^pending/i ) {
-            $Access = $TicketObject->TicketPermission(
-                Type     => 'close',
-                TicketID => $TicketID,
-                UserID   => $Param{UserID},
+            $Access = $Self->CheckAccessPermissions(
+                Type       => 'close',
+                TicketID   => $TicketID,
+                UserID     => $Param{UserID},
+                UserType   => $Param{UserType},
             );
         }
         if ( !$Access ) {


### PR DESCRIPTION
Hi,

customer users can not update tickets via GenericInterface as _CheckUpdatePermissions() in Kernel/GenericInterface/Operation/Ticket/TicketUpdate.pm does not honor $Param{UserType} at all.
CheckAccessPermission() and CheckCreatePermissions() in Common.pm do check for UserType, though.
I did not add another Check*Permission() method to Common.pm to keep it tidy. Since CheckCreatePermissions() in Common.pm is just used by TicketCreate.pm, I decided not to add a private _CheckTicketPermission() method to TicketUpdate.pm, too, but to extend CheckAccessPermissions() and let it check for $Param{UserType}. Hope that won't break any external modules that depend on Common.pm

BR,
Felix