### PR TITLE
Fix incorrect error message in Kernel::System::PID

### DIFF
--- a/Kernel/System/PID.pm
+++ b/Kernel/System/PID.pm
@@ -103,7 +103,7 @@ sub PIDCreate {
         $Kernel::OM->Get('Kernel::System::Log')->Log(
             Priority => 'notice',
             Message  => "Removed PID ($ProcessID{Name}/$ProcessID{Host}/$ProcessID{PID}, "
-                . "because 1 hour old!",
+                . "because TTL ($TTL sec) exceeded!",
         );
     }
 


### PR DESCRIPTION
TTL is not necessary 1 hour. Error message is not valid.