### PR TITLE
Fix Installation failure. This break occurs, because the  user could …

### DIFF
--- a/scripts/auto_build/spec/templates/includes/redhat-systemd-base.tt
+++ b/scripts/auto_build/spec/templates/includes/redhat-systemd-base.tt
@@ -53,7 +53,7 @@ if id $OTRSUSER >/dev/null 2>&1; then
     [% '#' %] update home dir
     usermod -d /opt/otrs $OTRSUSER
 else
-    useradd $OTRSUSER -d /opt/otrs/ -s /bin/bash -g apache -c 'OTRS System User' && echo "$OTRSUSER added."
+    useradd -d /opt/otrs/ -s /bin/bash -g apache -c 'OTRS System User' $OTRSUSER && echo "$OTRSUSER added."
 fi
 
 

--- a/scripts/auto_build/spec/templates/includes/suse-systemd-base.tt
+++ b/scripts/auto_build/spec/templates/includes/suse-systemd-base.tt
@@ -55,7 +55,7 @@ if id $OTRSUSER >/dev/null 2>&1; then
     [% '#' %] update home dir
     usermod -d /opt/otrs $OTRSUSER
 else
-    useradd $OTRSUSER -d /opt/otrs/ -s /bin/bash -g www -c 'OTRS System User' && echo "$OTRSUSER added."
+    useradd -d /opt/otrs/ -s /bin/bash -g www -c 'OTRS System User' $OTRSUSER && echo "$OTRSUSER added."
 fi
 echo "Enable apache module mod_perl..."
 a2enmod perl


### PR DESCRIPTION
… not be

created.
Detail: Fixed the position of the userlogin Parameter for useradd:
Moved the userlogin parameter to the most last commandline position,
where it is expected according the POSIX standard
https://www.unix.com/man-page/posix/8/useradd/
(and  linux works mostly to that standard too)