### PR TITLE
Remove unused array

### DIFF
--- a/Kernel/System/Ticket/Event/NotificationEvent/Transport/Email.pm
+++ b/Kernel/System/Ticket/Event/NotificationEvent/Transport/Email.pm
@@ -119,9 +119,6 @@ sub SendNotification {
 
     return if $IsLocalAddress;
 
-    # create new array to prevent attachment growth (see bug#5114)
-    my @Attachments = @{ $Param{Attachments} };
-
     my %Notification = %{ $Param{Notification} };
 
     # get ticket object


### PR DESCRIPTION
Array initialized by copying attachments is not used. It can be deleted.