### PR TITLE
Fix bug in _UserCacheClear in Kernel::System::User

### DIFF
--- a/Kernel/System/User.pm
+++ b/Kernel/System/User.pm
@@ -1284,7 +1284,7 @@ sub _UserCacheClear {
     my @CacheKeys;
 
     # Delete cache for all possible FirstnameLastNameOrder settings as this might be overridden by users.
-    for my $FirstnameLastNameOrder ( 0 .. 8 ) {
+    for my $FirstnameLastNameOrder ( 0 .. 9 ) {
         for my $ActiveLevel1 ( 0 .. 1 ) {
             for my $ActiveLevel2 ( 0 .. 1 ) {
                 push @CacheKeys, (


### PR DESCRIPTION
FirstnameLastnameOrder setting value can be in range from 0 to 9.