### PR TITLE
Fix linkification of fragment URLs

### DIFF
--- a/Kernel/System/HTMLUtils.pm
+++ b/Kernel/System/HTMLUtils.pm
@@ -874,7 +874,7 @@ sub LinkQuote {
             )?
             (?:                                    # link hash string
                 [\#]                               #
-                [a-zA-Z0-9&;=%\-_:\.\/]*           # hash string content, this will also catch entities like &amp;
+                [a-zA-Z0-9&;=%\-_:\.\/\?!]*        # hash string content, this will also catch entities like &amp;
             )?
         )
         (?=                                        # $4


### PR DESCRIPTION
Fix linkification of URLs used by icingaweb2 - for example:

https://icinga.company.com/icingaweb2/monitoring/service/show?host=myhost&service=myservice#!/icingaweb2/monitoring/service/history?host=myhost&service=myservice