### PR TITLE
CREATE USER in MySQL 8

### DIFF
--- a/Kernel/Modules/Installer.pm
+++ b/Kernel/Modules/Installer.pm
@@ -505,8 +505,8 @@ sub Run {
 
                 @Statements = (
                     "CREATE DATABASE `$DB{DBName}` charset utf8",
-                    "GRANT ALL PRIVILEGES ON `$DB{DBName}`.* TO `$DB{OTRSDBUser}`\@`$DB{Host}` IDENTIFIED BY '$DB{OTRSDBPassword}' WITH GRANT OPTION",
-                    "FLUSH PRIVILEGES",
+                    "CREATE USER `$DB{OTRSDBUser}`\@`$Host` IDENTIFIED BY '$DB{OTRSDBPassword}'",
+                    "GRANT ALL PRIVILEGES ON `$DB{DBName}`.* TO `$DB{OTRSDBUser}`\@`$Host` WITH GRANT OPTION",
                 );
             }
 

--- a/Kernel/System/UnitTest/Driver.pm
+++ b/Kernel/System/UnitTest/Driver.pm
@@ -514,6 +514,11 @@ sub _Print {
     }
 
     if ( $Self->{Verbose} || !$ResultOk ) {
+
+        # Work around problem with leading \0 bytes in the output buffer
+        #   which breaks the unicode output. The reason is not certain, maybe because of
+        #   Perl's exception handling.
+        $Self->{OutputBuffer} =~ s{\0}{}g;
         print { $Self->{OriginalSTDOUT} } $Self->{OutputBuffer};
     }
     $Self->{OutputBuffer} = '';


### PR DESCRIPTION
Hi, I tried to install ((OTRS)) Community Edition on Ubuntu 20.04 runnint MySQL 8.0.20-0ubuntu0.20.04.1.
In this setup `Kernel::Modules::Installer` complained because of `GRANT ALL PRIVILEGES` statement. Ich changes the user creation statement such that it works with MySQL 8. This should also work with MySQL 5.7 and MariaDB.

Note that FLUSH PRIVILEGES is not needed unless there are direct manipulations of the ,ysql.user table.