### PR TITLE
Viewable tickets page

### DIFF
--- a/Kernel/Config/Files/XML/Ticket.xml
+++ b/Kernel/Config/Files/XML/Ticket.xml
@@ -2028,13 +2028,6 @@
             <Item ValueType="Checkbox">1</Item>
         </Value>
     </Setting>
-    <Setting Name="Ticket::Frontend::AgentTicketStatusView###ViewableTicketsPage" Required="1" Valid="1">
-        <Description Translatable="1">Number of tickets to be displayed in each page.</Description>
-        <Navigation>Frontend::Agent::View::TicketStatus</Navigation>
-        <Value>
-            <Item ValueType="String" ValueRegex="^\d+$">50</Item>
-        </Value>
-    </Setting>
     <Setting Name="Ticket::Frontend::AgentTicketStatusView###SortBy::Default" UserPreferencesGroup="Advanced" UserModificationActive="1" UserModificationPossible="1" Required="1" Valid="1">
         <Description Translatable="1">Defines the default ticket attribute for ticket sorting in the status view of the agent interface.</Description>
         <Navigation>Frontend::Agent::View::TicketStatus</Navigation>
@@ -2067,13 +2060,6 @@
                 <Item ValueType="Option" Value="rw">RW</Item>
                 <Item ValueType="Option" Value="ro">RO</Item>
             </Item>
-        </Value>
-    </Setting>
-    <Setting Name="Ticket::Frontend::AgentTicketEscalationView###ViewableTicketsPage" Required="1" Valid="1">
-        <Description Translatable="1">Shows all open tickets (even if they are locked) in the escalation view of the agent interface.</Description>
-        <Navigation>Frontend::Agent::View::TicketEscalation</Navigation>
-        <Value>
-            <Item ValueType="String" ValueRegex="^\d+$">50</Item>
         </Value>
     </Setting>
     <Setting Name="Ticket::Frontend::AgentTicketEscalationView###SortBy::Default" UserPreferencesGroup="Advanced" UserModificationActive="1" UserModificationPossible="1" Required="1" Valid="1">

--- a/Kernel/Language/ar_SA.pm
+++ b/Kernel/Language/ar_SA.pm
@@ -7788,7 +7788,6 @@ Thanks for your help!
             '',
         'Number of tickets to be displayed in each page of a search result in the customer interface.' =>
             '',
-        'Number of tickets to be displayed in each page.' => '',
         'OTRS Group Services' => '',
         'OTRS News' => '',
         'OTRS can use one or more readonly mirror databases for expensive operations like fulltext search or statistics generation. Here you can specify the DSN for the first mirror database.' =>

--- a/Kernel/Language/bg.pm
+++ b/Kernel/Language/bg.pm
@@ -7787,7 +7787,6 @@ Thanks for your help!
             '',
         'Number of tickets to be displayed in each page of a search result in the customer interface.' =>
             '',
-        'Number of tickets to be displayed in each page.' => '',
         'OTRS Group Services' => '',
         'OTRS News' => 'Новини за OTRS.',
         'OTRS can use one or more readonly mirror databases for expensive operations like fulltext search or statistics generation. Here you can specify the DSN for the first mirror database.' =>

--- a/Kernel/Language/ca.pm
+++ b/Kernel/Language/ca.pm
@@ -7786,7 +7786,6 @@ Thanks for your help!
             '',
         'Number of tickets to be displayed in each page of a search result in the customer interface.' =>
             '',
-        'Number of tickets to be displayed in each page.' => '',
         'OTRS Group Services' => '',
         'OTRS News' => 'Novetats de OTRS',
         'OTRS can use one or more readonly mirror databases for expensive operations like fulltext search or statistics generation. Here you can specify the DSN for the first mirror database.' =>

--- a/Kernel/Language/cs.pm
+++ b/Kernel/Language/cs.pm
@@ -7793,7 +7793,6 @@ Thanks for your help!
             '',
         'Number of tickets to be displayed in each page of a search result in the customer interface.' =>
             '',
-        'Number of tickets to be displayed in each page.' => '',
         'OTRS Group Services' => '',
         'OTRS News' => 'Novinky OTRS',
         'OTRS can use one or more readonly mirror databases for expensive operations like fulltext search or statistics generation. Here you can specify the DSN for the first mirror database.' =>

--- a/Kernel/Language/da.pm
+++ b/Kernel/Language/da.pm
@@ -7788,7 +7788,6 @@ Thanks for your help!
             'Antallet af sager i søgeresultatet, der vises på hver side i agent-interfacet.',
         'Number of tickets to be displayed in each page of a search result in the customer interface.' =>
             'Antallet af sager i søgeresultatet, der vises på hver side i kunde-interfacet.',
-        'Number of tickets to be displayed in each page.' => '',
         'OTRS Group Services' => '',
         'OTRS News' => 'OTRS-nyheder',
         'OTRS can use one or more readonly mirror databases for expensive operations like fulltext search or statistics generation. Here you can specify the DSN for the first mirror database.' =>

--- a/Kernel/Language/de.pm
+++ b/Kernel/Language/de.pm
@@ -7796,7 +7796,6 @@ Ihr Helpdesk-Team
             'Anzahl von Tickets pro Seite in Suchergebnissen im Agentenbereich.',
         'Number of tickets to be displayed in each page of a search result in the customer interface.' =>
             'Anzahl der anzuzeigenen Tickets pro Seite in einem Suchergebnis in der Kundenoberfläche.',
-        'Number of tickets to be displayed in each page.' => 'Anzahl der angezeigten Tickets pro Seite.',
         'OTRS Group Services' => 'Dienstleistungen der OTRS Gruppe',
         'OTRS News' => 'OTRS-Neuigkeiten',
         'OTRS can use one or more readonly mirror databases for expensive operations like fulltext search or statistics generation. Here you can specify the DSN for the first mirror database.' =>

--- a/Kernel/Language/el.pm
+++ b/Kernel/Language/el.pm
@@ -7792,7 +7792,6 @@ Thanks for your help!
             '',
         'Number of tickets to be displayed in each page of a search result in the customer interface.' =>
             '',
-        'Number of tickets to be displayed in each page.' => '',
         'OTRS Group Services' => '',
         'OTRS News' => 'Νέα του OTRS',
         'OTRS can use one or more readonly mirror databases for expensive operations like fulltext search or statistics generation. Here you can specify the DSN for the first mirror database.' =>

--- a/Kernel/Language/en_CA.pm
+++ b/Kernel/Language/en_CA.pm
@@ -7792,7 +7792,6 @@ Thanks for your help!
             '',
         'Number of tickets to be displayed in each page of a search result in the customer interface.' =>
             '',
-        'Number of tickets to be displayed in each page.' => '',
         'OTRS Group Services' => '',
         'OTRS News' => '',
         'OTRS can use one or more readonly mirror databases for expensive operations like fulltext search or statistics generation. Here you can specify the DSN for the first mirror database.' =>

--- a/Kernel/Language/en_GB.pm
+++ b/Kernel/Language/en_GB.pm
@@ -7800,7 +7800,6 @@ Thanks for your help!
             'Number of tickets to be displayed in each page of a search result in the agent interface.',
         'Number of tickets to be displayed in each page of a search result in the customer interface.' =>
             'Number of tickets to be displayed in each page of a search result in the customer interface.',
-        'Number of tickets to be displayed in each page.' => '',
         'OTRS Group Services' => '',
         'OTRS News' => 'OTRS News',
         'OTRS can use one or more readonly mirror databases for expensive operations like fulltext search or statistics generation. Here you can specify the DSN for the first mirror database.' =>

--- a/Kernel/Language/es.pm
+++ b/Kernel/Language/es.pm
@@ -7809,7 +7809,6 @@ El control del acceso adicional para demostrar o no demostrar éste enlace puede
             '',
         'Number of tickets to be displayed in each page of a search result in the customer interface.' =>
             '',
-        'Number of tickets to be displayed in each page.' => '',
         'OTRS Group Services' => '',
         'OTRS News' => 'Noticias de OTRS',
         'OTRS can use one or more readonly mirror databases for expensive operations like fulltext search or statistics generation. Here you can specify the DSN for the first mirror database.' =>

--- a/Kernel/Language/es_CO.pm
+++ b/Kernel/Language/es_CO.pm
@@ -7786,7 +7786,6 @@ Thanks for your help!
             'Número de tickets desplegados en cada página del resultado de una búsqueda, en la interfaz del agente.',
         'Number of tickets to be displayed in each page of a search result in the customer interface.' =>
             'Número de tickets desplegados en cada página del resultado de una búsqueda, en la interfaz del cliente.',
-        'Number of tickets to be displayed in each page.' => '',
         'OTRS Group Services' => '',
         'OTRS News' => 'Novedades de OTRS',
         'OTRS can use one or more readonly mirror databases for expensive operations like fulltext search or statistics generation. Here you can specify the DSN for the first mirror database.' =>

--- a/Kernel/Language/es_MX.pm
+++ b/Kernel/Language/es_MX.pm
@@ -7786,7 +7786,6 @@ Thanks for your help!
             'Número de tickets desplegados en cada página del resultado de una búsqueda, en la interfaz del agente.',
         'Number of tickets to be displayed in each page of a search result in the customer interface.' =>
             'Número de tickets desplegados en cada página del resultado de una búsqueda, en la interfaz del cliente.',
-        'Number of tickets to be displayed in each page.' => '',
         'OTRS Group Services' => '',
         'OTRS News' => 'Novedades de OTRS',
         'OTRS can use one or more readonly mirror databases for expensive operations like fulltext search or statistics generation. Here you can specify the DSN for the first mirror database.' =>

--- a/Kernel/Language/et.pm
+++ b/Kernel/Language/et.pm
@@ -7786,7 +7786,6 @@ Thanks for your help!
             '',
         'Number of tickets to be displayed in each page of a search result in the customer interface.' =>
             '',
-        'Number of tickets to be displayed in each page.' => '',
         'OTRS Group Services' => '',
         'OTRS News' => 'OTRS uudised',
         'OTRS can use one or more readonly mirror databases for expensive operations like fulltext search or statistics generation. Here you can specify the DSN for the first mirror database.' =>

--- a/Kernel/Language/fa.pm
+++ b/Kernel/Language/fa.pm
@@ -7802,7 +7802,6 @@ Thanks for your help!
             'تعداد بلیط در هر صفحه از یک نتیجه جستجو در رابط عامل نمایش داده شود.',
         'Number of tickets to be displayed in each page of a search result in the customer interface.' =>
             'تعداد بلیط در هر صفحه از یک نتیجه جستجو در رابط مشتری نمایش داده می شود.',
-        'Number of tickets to be displayed in each page.' => '',
         'OTRS Group Services' => '',
         'OTRS News' => 'اخبار سامانه پشتیبانی',
         'OTRS can use one or more readonly mirror databases for expensive operations like fulltext search or statistics generation. Here you can specify the DSN for the first mirror database.' =>

--- a/Kernel/Language/fi.pm
+++ b/Kernel/Language/fi.pm
@@ -7788,7 +7788,6 @@ Thanks for your help!
             '',
         'Number of tickets to be displayed in each page of a search result in the customer interface.' =>
             '',
-        'Number of tickets to be displayed in each page.' => '',
         'OTRS Group Services' => '',
         'OTRS News' => 'OTRS uutiset',
         'OTRS can use one or more readonly mirror databases for expensive operations like fulltext search or statistics generation. Here you can specify the DSN for the first mirror database.' =>

--- a/Kernel/Language/fr.pm
+++ b/Kernel/Language/fr.pm
@@ -7794,7 +7794,6 @@ Thanks for your help!
             '',
         'Number of tickets to be displayed in each page of a search result in the customer interface.' =>
             '',
-        'Number of tickets to be displayed in each page.' => '',
         'OTRS Group Services' => 'Services du groupe OTRS',
         'OTRS News' => 'Nouvelles d\'OTRS',
         'OTRS can use one or more readonly mirror databases for expensive operations like fulltext search or statistics generation. Here you can specify the DSN for the first mirror database.' =>

--- a/Kernel/Language/fr_CA.pm
+++ b/Kernel/Language/fr_CA.pm
@@ -7793,7 +7793,6 @@ Thanks for your help!
             'Nombre de demandes affichées dans chaque page de résultats de recherche dans l\'interface agent.',
         'Number of tickets to be displayed in each page of a search result in the customer interface.' =>
             'Nombre de demandes affichées dans chaque page de résultats de recherche dans l\'interface client.',
-        'Number of tickets to be displayed in each page.' => '',
         'OTRS Group Services' => '',
         'OTRS News' => 'Nouvelles de OTRS',
         'OTRS can use one or more readonly mirror databases for expensive operations like fulltext search or statistics generation. Here you can specify the DSN for the first mirror database.' =>

--- a/Kernel/Language/gl.pm
+++ b/Kernel/Language/gl.pm
@@ -7786,7 +7786,6 @@ Thanks for your help!
             'Número de tickets para ser mostrados en cada páxina dun resultado de busca na interface de axente.',
         'Number of tickets to be displayed in each page of a search result in the customer interface.' =>
             'Número de tickets para ser mostrados en cada páxina dun resultado de busca na interface de cliente.',
-        'Number of tickets to be displayed in each page.' => '',
         'OTRS Group Services' => '',
         'OTRS News' => 'Novas do OTRS',
         'OTRS can use one or more readonly mirror databases for expensive operations like fulltext search or statistics generation. Here you can specify the DSN for the first mirror database.' =>

--- a/Kernel/Language/he.pm
+++ b/Kernel/Language/he.pm
@@ -7792,7 +7792,6 @@ Thanks for your help!
             '',
         'Number of tickets to be displayed in each page of a search result in the customer interface.' =>
             '',
-        'Number of tickets to be displayed in each page.' => '',
         'OTRS Group Services' => '',
         'OTRS News' => 'חדשות OTRS',
         'OTRS can use one or more readonly mirror databases for expensive operations like fulltext search or statistics generation. Here you can specify the DSN for the first mirror database.' =>

--- a/Kernel/Language/hi.pm
+++ b/Kernel/Language/hi.pm
@@ -7788,7 +7788,6 @@ Thanks for your help!
             'प्रतिनिधि अंतरफलक में एक खोज परिणाम के प्रत्येक पृष्ठ में प्रदर्शित होने के लिए टिकटों की संख्या।',
         'Number of tickets to be displayed in each page of a search result in the customer interface.' =>
             'ग्राहक अंतरफलक में एक खोज परिणाम के प्रत्येक पृष्ठ में प्रदर्शित होने के लिए टिकटों की संख्या।',
-        'Number of tickets to be displayed in each page.' => '',
         'OTRS Group Services' => '',
         'OTRS News' => 'OTRS समाचार',
         'OTRS can use one or more readonly mirror databases for expensive operations like fulltext search or statistics generation. Here you can specify the DSN for the first mirror database.' =>

--- a/Kernel/Language/hr.pm
+++ b/Kernel/Language/hr.pm
@@ -7790,7 +7790,6 @@ Thanks for your help!
             '',
         'Number of tickets to be displayed in each page of a search result in the customer interface.' =>
             '',
-        'Number of tickets to be displayed in each page.' => '',
         'OTRS Group Services' => '',
         'OTRS News' => 'OTRS Novosti',
         'OTRS can use one or more readonly mirror databases for expensive operations like fulltext search or statistics generation. Here you can specify the DSN for the first mirror database.' =>

--- a/Kernel/Language/hu.pm
+++ b/Kernel/Language/hu.pm
@@ -7802,7 +7802,6 @@ Az Ön segélyszolgálat csapata
             'Egy keresési eredmény minden egyes oldalán megjelenített jegyek száma az ügyintézői felületen.',
         'Number of tickets to be displayed in each page of a search result in the customer interface.' =>
             'Egy keresési eredmény minden egyes oldalán megjelenített jegyek száma az ügyfélfelületen.',
-        'Number of tickets to be displayed in each page.' => 'Az egyes oldalakon megjelenített jegyek száma.',
         'OTRS Group Services' => 'OTRS csoport szolgáltatások',
         'OTRS News' => 'OTRS hírek',
         'OTRS can use one or more readonly mirror databases for expensive operations like fulltext search or statistics generation. Here you can specify the DSN for the first mirror database.' =>

--- a/Kernel/Language/id.pm
+++ b/Kernel/Language/id.pm
@@ -7800,7 +7800,6 @@ Helpdesk Team Anda
             'Jumlah tiket yang akan ditampilkan di setiap halaman hasil pencarian di antarmuka agen.',
         'Number of tickets to be displayed in each page of a search result in the customer interface.' =>
             'Jumlah tiket yang akan ditampilkan di setiap halaman hasil pencarian di antarmuka pelanggan.',
-        'Number of tickets to be displayed in each page.' => '',
         'OTRS Group Services' => '',
         'OTRS News' => 'Berita OTRS',
         'OTRS can use one or more readonly mirror databases for expensive operations like fulltext search or statistics generation. Here you can specify the DSN for the first mirror database.' =>

--- a/Kernel/Language/it.pm
+++ b/Kernel/Language/it.pm
@@ -7794,7 +7794,6 @@ Thanks for your help!
             '',
         'Number of tickets to be displayed in each page of a search result in the customer interface.' =>
             '',
-        'Number of tickets to be displayed in each page.' => '',
         'OTRS Group Services' => '',
         'OTRS News' => 'Notizie OTRS',
         'OTRS can use one or more readonly mirror databases for expensive operations like fulltext search or statistics generation. Here you can specify the DSN for the first mirror database.' =>

--- a/Kernel/Language/ja.pm
+++ b/Kernel/Language/ja.pm
@@ -7812,7 +7812,6 @@ Contentはダイナミック・フィールドの形式によって設定内容�
             '担当者インタフェースの検索結果の各ページで、表示されるチケットの数です。',
         'Number of tickets to be displayed in each page of a search result in the customer interface.' =>
             '顧客インタフェースの検索結果の各ページで表示される、チケット数です。',
-        'Number of tickets to be displayed in each page.' => '',
         'OTRS Group Services' => 'OTRSグループ・サービス',
         'OTRS News' => 'OTRSニュース',
         'OTRS can use one or more readonly mirror databases for expensive operations like fulltext search or statistics generation. Here you can specify the DSN for the first mirror database.' =>

--- a/Kernel/Language/ko.pm
+++ b/Kernel/Language/ko.pm
@@ -7797,7 +7797,6 @@ Thanks for your help!
             '에이전트 인터페이스에서 검색 결과의 각 페이지에 표시할 티넷 수입니다.',
         'Number of tickets to be displayed in each page of a search result in the customer interface.' =>
             '고객 인터페이스에서 검색 결과의 각 페이지에 표시할 티켓 수입니다.',
-        'Number of tickets to be displayed in each page.' => '각 페이지에 표시할 티켓 수입니다.',
         'OTRS Group Services' => 'OTRS 그룹 서비스',
         'OTRS News' => 'OTRS 뉴스',
         'OTRS can use one or more readonly mirror databases for expensive operations like fulltext search or statistics generation. Here you can specify the DSN for the first mirror database.' =>

--- a/Kernel/Language/lt.pm
+++ b/Kernel/Language/lt.pm
@@ -7786,7 +7786,6 @@ Thanks for your help!
             '',
         'Number of tickets to be displayed in each page of a search result in the customer interface.' =>
             '',
-        'Number of tickets to be displayed in each page.' => '',
         'OTRS Group Services' => '',
         'OTRS News' => 'OTRS Naujienos',
         'OTRS can use one or more readonly mirror databases for expensive operations like fulltext search or statistics generation. Here you can specify the DSN for the first mirror database.' =>

--- a/Kernel/Language/lv.pm
+++ b/Kernel/Language/lv.pm
@@ -7785,7 +7785,6 @@ Thanks for your help!
             '',
         'Number of tickets to be displayed in each page of a search result in the customer interface.' =>
             '',
-        'Number of tickets to be displayed in each page.' => '',
         'OTRS Group Services' => '',
         'OTRS News' => 'OTRS jaunumi',
         'OTRS can use one or more readonly mirror databases for expensive operations like fulltext search or statistics generation. Here you can specify the DSN for the first mirror database.' =>

--- a/Kernel/Language/mk.pm
+++ b/Kernel/Language/mk.pm
@@ -7786,7 +7786,6 @@ Thanks for your help!
             '',
         'Number of tickets to be displayed in each page of a search result in the customer interface.' =>
             '',
-        'Number of tickets to be displayed in each page.' => '',
         'OTRS Group Services' => '',
         'OTRS News' => 'ОТRS Вести',
         'OTRS can use one or more readonly mirror databases for expensive operations like fulltext search or statistics generation. Here you can specify the DSN for the first mirror database.' =>

--- a/Kernel/Language/ms.pm
+++ b/Kernel/Language/ms.pm
@@ -7799,7 +7799,6 @@ Search_DynamicField_XTimeSlotStartMonth=01; Search_DynamicField_XTimeSlotStartDa
             'Jumlah tiket yang akan dipamerkan dalam setiap halaman dari hasil carian dalam paparan ejen.',
         'Number of tickets to be displayed in each page of a search result in the customer interface.' =>
             'Jumlah tiket yang akan dipamerkan dalam setiap halaman dari hasil carian dalam paparan pelanggan.',
-        'Number of tickets to be displayed in each page.' => '',
         'OTRS Group Services' => '',
         'OTRS News' => 'Berita OTRS',
         'OTRS can use one or more readonly mirror databases for expensive operations like fulltext search or statistics generation. Here you can specify the DSN for the first mirror database.' =>

--- a/Kernel/Language/nb_NO.pm
+++ b/Kernel/Language/nb_NO.pm
@@ -7794,7 +7794,6 @@ Thanks for your help!
             'Antall saker som vises per side i et søkeresultat.',
         'Number of tickets to be displayed in each page of a search result in the customer interface.' =>
             'Antall saker som vises per side i et søkeresultat i kundeportalen.',
-        'Number of tickets to be displayed in each page.' => '',
         'OTRS Group Services' => '',
         'OTRS News' => 'OTRS-nyheter',
         'OTRS can use one or more readonly mirror databases for expensive operations like fulltext search or statistics generation. Here you can specify the DSN for the first mirror database.' =>

--- a/Kernel/Language/nl.pm
+++ b/Kernel/Language/nl.pm
@@ -7803,7 +7803,6 @@ Het Helpdesk Team
             '',
         'Number of tickets to be displayed in each page of a search result in the customer interface.' =>
             '',
-        'Number of tickets to be displayed in each page.' => '',
         'OTRS Group Services' => 'OTRS Group diensten',
         'OTRS News' => 'OTRS Nieuws',
         'OTRS can use one or more readonly mirror databases for expensive operations like fulltext search or statistics generation. Here you can specify the DSN for the first mirror database.' =>

--- a/Kernel/Language/pl.pm
+++ b/Kernel/Language/pl.pm
@@ -7790,7 +7790,6 @@ Thanks for your help!
             '',
         'Number of tickets to be displayed in each page of a search result in the customer interface.' =>
             '',
-        'Number of tickets to be displayed in each page.' => '',
         'OTRS Group Services' => '',
         'OTRS News' => 'Wiadomości OTRS',
         'OTRS can use one or more readonly mirror databases for expensive operations like fulltext search or statistics generation. Here you can specify the DSN for the first mirror database.' =>

--- a/Kernel/Language/pt.pm
+++ b/Kernel/Language/pt.pm
@@ -7787,7 +7787,6 @@ Thanks for your help!
             '',
         'Number of tickets to be displayed in each page of a search result in the customer interface.' =>
             '',
-        'Number of tickets to be displayed in each page.' => '',
         'OTRS Group Services' => '',
         'OTRS News' => 'Notícias OTRS',
         'OTRS can use one or more readonly mirror databases for expensive operations like fulltext search or statistics generation. Here you can specify the DSN for the first mirror database.' =>

--- a/Kernel/Language/pt_BR.pm
+++ b/Kernel/Language/pt_BR.pm
@@ -7802,7 +7802,6 @@ Obrigado pela ajuda!
             'Número de tickets a serem exibidos em cada página de resultado de pesquisa na interface de agente.',
         'Number of tickets to be displayed in each page of a search result in the customer interface.' =>
             '',
-        'Number of tickets to be displayed in each page.' => 'Número de tickets que serão exibidos por página.',
         'OTRS Group Services' => 'Serviços do Grupo OTRS',
         'OTRS News' => 'Notícias sobre o OTRS',
         'OTRS can use one or more readonly mirror databases for expensive operations like fulltext search or statistics generation. Here you can specify the DSN for the first mirror database.' =>

--- a/Kernel/Language/ro.pm
+++ b/Kernel/Language/ro.pm
@@ -7786,7 +7786,6 @@ Thanks for your help!
             '',
         'Number of tickets to be displayed in each page of a search result in the customer interface.' =>
             '',
-        'Number of tickets to be displayed in each page.' => '',
         'OTRS Group Services' => '',
         'OTRS News' => 'Noutăți depsre OTRS',
         'OTRS can use one or more readonly mirror databases for expensive operations like fulltext search or statistics generation. Here you can specify the DSN for the first mirror database.' =>

--- a/Kernel/Language/ru.pm
+++ b/Kernel/Language/ru.pm
@@ -7808,7 +7808,6 @@ Thanks for your help!
             'Количество заявок которое показывается на каждой странице при выводе результатов поиска в интерфейсе агента.',
         'Number of tickets to be displayed in each page of a search result in the customer interface.' =>
             'Количество заявок которое показывается на каждой странице при выводе результатов поиска в интерфейсе клиента.',
-        'Number of tickets to be displayed in each page.' => 'Количество заявок, отображаемых на каждой странице.',
         'OTRS Group Services' => '',
         'OTRS News' => 'Новости OTRS',
         'OTRS can use one or more readonly mirror databases for expensive operations like fulltext search or statistics generation. Here you can specify the DSN for the first mirror database.' =>

--- a/Kernel/Language/sk_SK.pm
+++ b/Kernel/Language/sk_SK.pm
@@ -7786,7 +7786,6 @@ Thanks for your help!
             '',
         'Number of tickets to be displayed in each page of a search result in the customer interface.' =>
             '',
-        'Number of tickets to be displayed in each page.' => '',
         'OTRS Group Services' => '',
         'OTRS News' => 'OTRS novinky',
         'OTRS can use one or more readonly mirror databases for expensive operations like fulltext search or statistics generation. Here you can specify the DSN for the first mirror database.' =>

--- a/Kernel/Language/sl.pm
+++ b/Kernel/Language/sl.pm
@@ -7790,7 +7790,6 @@ Thanks for your help!
             '',
         'Number of tickets to be displayed in each page of a search result in the customer interface.' =>
             '',
-        'Number of tickets to be displayed in each page.' => '',
         'OTRS Group Services' => '',
         'OTRS News' => 'OTRS novice',
         'OTRS can use one or more readonly mirror databases for expensive operations like fulltext search or statistics generation. Here you can specify the DSN for the first mirror database.' =>

--- a/Kernel/Language/sr_Cyrl.pm
+++ b/Kernel/Language/sr_Cyrl.pm
@@ -7797,7 +7797,6 @@ Thanks for your help!
             'Број тикета који ће бити приказани на свакој страни резултата претраге у интерфејсу оператера.',
         'Number of tickets to be displayed in each page of a search result in the customer interface.' =>
             'Број тикета који ће бити приказани на свакој страни резултата претраге у интерфејсу клијента.',
-        'Number of tickets to be displayed in each page.' => 'Број тикета који ће бити приказани на свакој страни.',
         'OTRS Group Services' => 'Сервиси OTRS групе',
         'OTRS News' => 'OTRS новости',
         'OTRS can use one or more readonly mirror databases for expensive operations like fulltext search or statistics generation. Here you can specify the DSN for the first mirror database.' =>

--- a/Kernel/Language/sr_Latn.pm
+++ b/Kernel/Language/sr_Latn.pm
@@ -7803,7 +7803,6 @@ Vaša tehnička podrška
             'Broj tiketa koji će biti prikazani na svakoj strani rezultata pretrage u interfejsu operatera.',
         'Number of tickets to be displayed in each page of a search result in the customer interface.' =>
             'Broj tiketa koji će biti prikazani na svakoj strani rezultata pretrage u interfejsu klijenta.',
-        'Number of tickets to be displayed in each page.' => 'Broj tiketa koji će biti prikazani na svakoj strani.',
         'OTRS Group Services' => 'Servisi OTRS grupe',
         'OTRS News' => 'OTRS novosti',
         'OTRS can use one or more readonly mirror databases for expensive operations like fulltext search or statistics generation. Here you can specify the DSN for the first mirror database.' =>

--- a/Kernel/Language/sv.pm
+++ b/Kernel/Language/sv.pm
@@ -7788,7 +7788,6 @@ Thanks for your help!
             '',
         'Number of tickets to be displayed in each page of a search result in the customer interface.' =>
             '',
-        'Number of tickets to be displayed in each page.' => '',
         'OTRS Group Services' => '',
         'OTRS News' => 'OTRS-nyheter',
         'OTRS can use one or more readonly mirror databases for expensive operations like fulltext search or statistics generation. Here you can specify the DSN for the first mirror database.' =>

--- a/Kernel/Language/sw.pm
+++ b/Kernel/Language/sw.pm
@@ -7792,7 +7792,6 @@ Mfano:
             'Namba ta tiketi zitakazoonyeshwa katika kila ukurasa wa matokeo ya utafutaji katika kiolesura cha wakala.',
         'Number of tickets to be displayed in each page of a search result in the customer interface.' =>
             'Namba ta tiketi zitakazoonyeshwa katika kila ukurasa wa matokeo ya utafutaji katika kiolesura cha mteja.',
-        'Number of tickets to be displayed in each page.' => '',
         'OTRS Group Services' => '',
         'OTRS News' => 'OTRS Habari',
         'OTRS can use one or more readonly mirror databases for expensive operations like fulltext search or statistics generation. Here you can specify the DSN for the first mirror database.' =>

--- a/Kernel/Language/th_TH.pm
+++ b/Kernel/Language/th_TH.pm
@@ -7803,7 +7803,6 @@ Thanks for your help!
             '',
         'Number of tickets to be displayed in each page of a search result in the customer interface.' =>
             '',
-        'Number of tickets to be displayed in each page.' => '',
         'OTRS Group Services' => '',
         'OTRS News' => 'ข่าวOTRS',
         'OTRS can use one or more readonly mirror databases for expensive operations like fulltext search or statistics generation. Here you can specify the DSN for the first mirror database.' =>

--- a/Kernel/Language/tr.pm
+++ b/Kernel/Language/tr.pm
@@ -7786,7 +7786,6 @@ Thanks for your help!
             '',
         'Number of tickets to be displayed in each page of a search result in the customer interface.' =>
             '',
-        'Number of tickets to be displayed in each page.' => '',
         'OTRS Group Services' => '',
         'OTRS News' => 'OTRS Haberleri',
         'OTRS can use one or more readonly mirror databases for expensive operations like fulltext search or statistics generation. Here you can specify the DSN for the first mirror database.' =>

--- a/Kernel/Language/uk.pm
+++ b/Kernel/Language/uk.pm
@@ -7786,7 +7786,6 @@ Thanks for your help!
             '',
         'Number of tickets to be displayed in each page of a search result in the customer interface.' =>
             '',
-        'Number of tickets to be displayed in each page.' => '',
         'OTRS Group Services' => '',
         'OTRS News' => 'Новини OTRS',
         'OTRS can use one or more readonly mirror databases for expensive operations like fulltext search or statistics generation. Here you can specify the DSN for the first mirror database.' =>

--- a/Kernel/Language/vi_VN.pm
+++ b/Kernel/Language/vi_VN.pm
@@ -7785,7 +7785,6 @@ Thanks for your help!
             '',
         'Number of tickets to be displayed in each page of a search result in the customer interface.' =>
             '',
-        'Number of tickets to be displayed in each page.' => '',
         'OTRS Group Services' => '',
         'OTRS News' => 'Tin tức OTRS',
         'OTRS can use one or more readonly mirror databases for expensive operations like fulltext search or statistics generation. Here you can specify the DSN for the first mirror database.' =>

--- a/Kernel/Language/zh_CN.pm
+++ b/Kernel/Language/zh_CN.pm
@@ -7801,7 +7801,6 @@ Thanks for your help!
             '服务人员界面搜索结果每页显示的工单数。',
         'Number of tickets to be displayed in each page of a search result in the customer interface.' =>
             '客户界面搜索结果每页显示的工单数。',
-        'Number of tickets to be displayed in each page.' => '每页显示的工单数量。',
         'OTRS Group Services' => 'OTRS集团服务',
         'OTRS News' => 'OTRS新闻',
         'OTRS can use one or more readonly mirror databases for expensive operations like fulltext search or statistics generation. Here you can specify the DSN for the first mirror database.' =>

--- a/Kernel/Language/zh_TW.pm
+++ b/Kernel/Language/zh_TW.pm
@@ -7790,7 +7790,6 @@ Thanks for your help!
             '',
         'Number of tickets to be displayed in each page of a search result in the customer interface.' =>
             '',
-        'Number of tickets to be displayed in each page.' => '',
         'OTRS Group Services' => '',
         'OTRS News' => 'OTRS新聞',
         'OTRS can use one or more readonly mirror databases for expensive operations like fulltext search or statistics generation. Here you can specify the DSN for the first mirror database.' =>

--- a/Kernel/Modules/AgentTicketWatchView.pm
+++ b/Kernel/Modules/AgentTicketWatchView.pm
@@ -281,7 +281,6 @@ sub Run {
     $HeaderColumn =~ s{\A ColumnFilter }{}msxg;
     my @OriginalViewableTickets;
     my @ViewableTickets;
-    my $ViewableTicketCount = 0;
 
     # get ticket object
     my $TicketObject = $Kernel::OM->Get('Kernel::System::Ticket');

--- a/Kernel/Output/HTML/Layout/Ticket.pm
+++ b/Kernel/Output/HTML/Layout/Ticket.pm
@@ -730,7 +730,7 @@ sub TicketListShow {
     my $Object = $Backends->{$View}->{Module}->new( %{$Env} );
     return if !$Object;
 
-    # retireve filter values
+    # retrieve filter values
     if ( $Param{FilterContentOnly} ) {
         return $Object->FilterContent(
             %Param,

--- a/i18n/otrs/otrs.ar_SA.po
+++ b/i18n/otrs/otrs.ar_SA.po
@@ -23401,10 +23401,6 @@ msgid ""
 msgstr ""
 
 #. SysConfig
-msgid "Number of tickets to be displayed in each page."
-msgstr ""
-
-#. SysConfig
 msgid "OTRS Group Services"
 msgstr ""
 

--- a/i18n/otrs/otrs.bg.po
+++ b/i18n/otrs/otrs.bg.po
@@ -23653,10 +23653,6 @@ msgid ""
 msgstr ""
 
 #. SysConfig
-msgid "Number of tickets to be displayed in each page."
-msgstr ""
-
-#. SysConfig
 msgid "OTRS Group Services"
 msgstr ""
 

--- a/i18n/otrs/otrs.ca.po
+++ b/i18n/otrs/otrs.ca.po
@@ -23617,10 +23617,6 @@ msgid ""
 msgstr ""
 
 #. SysConfig
-msgid "Number of tickets to be displayed in each page."
-msgstr ""
-
-#. SysConfig
 msgid "OTRS Group Services"
 msgstr ""
 

--- a/i18n/otrs/otrs.cs.po
+++ b/i18n/otrs/otrs.cs.po
@@ -23489,10 +23489,6 @@ msgid ""
 msgstr ""
 
 #. SysConfig
-msgid "Number of tickets to be displayed in each page."
-msgstr ""
-
-#. SysConfig
 msgid "OTRS Group Services"
 msgstr ""
 

--- a/i18n/otrs/otrs.da.po
+++ b/i18n/otrs/otrs.da.po
@@ -23699,10 +23699,6 @@ msgstr ""
 "interfacet."
 
 #. SysConfig
-msgid "Number of tickets to be displayed in each page."
-msgstr ""
-
-#. SysConfig
 msgid "OTRS Group Services"
 msgstr ""
 

--- a/i18n/otrs/otrs.de.po
+++ b/i18n/otrs/otrs.de.po
@@ -26498,10 +26498,6 @@ msgstr ""
 "Kundenoberfläche."
 
 #. SysConfig
-msgid "Number of tickets to be displayed in each page."
-msgstr "Anzahl der angezeigten Tickets pro Seite."
-
-#. SysConfig
 msgid "OTRS Group Services"
 msgstr "Dienstleistungen der OTRS Gruppe"
 

--- a/i18n/otrs/otrs.el.po
+++ b/i18n/otrs/otrs.el.po
@@ -23470,10 +23470,6 @@ msgid ""
 msgstr ""
 
 #. SysConfig
-msgid "Number of tickets to be displayed in each page."
-msgstr ""
-
-#. SysConfig
 msgid "OTRS Group Services"
 msgstr ""
 

--- a/i18n/otrs/otrs.en_CA.po
+++ b/i18n/otrs/otrs.en_CA.po
@@ -23378,10 +23378,6 @@ msgid ""
 msgstr ""
 
 #. SysConfig
-msgid "Number of tickets to be displayed in each page."
-msgstr ""
-
-#. SysConfig
 msgid "OTRS Group Services"
 msgstr ""
 

--- a/i18n/otrs/otrs.en_GB.po
+++ b/i18n/otrs/otrs.en_GB.po
@@ -24902,10 +24902,6 @@ msgstr ""
 "customer interface."
 
 #. SysConfig
-msgid "Number of tickets to be displayed in each page."
-msgstr ""
-
-#. SysConfig
 msgid "OTRS Group Services"
 msgstr ""
 

--- a/i18n/otrs/otrs.es.po
+++ b/i18n/otrs/otrs.es.po
@@ -24796,10 +24796,6 @@ msgid ""
 msgstr ""
 
 #. SysConfig
-msgid "Number of tickets to be displayed in each page."
-msgstr ""
-
-#. SysConfig
 msgid "OTRS Group Services"
 msgstr ""
 

--- a/i18n/otrs/otrs.es_CO.po
+++ b/i18n/otrs/otrs.es_CO.po
@@ -24329,10 +24329,6 @@ msgstr ""
 "en la interfaz del cliente."
 
 #. SysConfig
-msgid "Number of tickets to be displayed in each page."
-msgstr ""
-
-#. SysConfig
 msgid "OTRS Group Services"
 msgstr ""
 

--- a/i18n/otrs/otrs.es_MX.po
+++ b/i18n/otrs/otrs.es_MX.po
@@ -24562,10 +24562,6 @@ msgstr ""
 "en la interfaz del cliente."
 
 #. SysConfig
-msgid "Number of tickets to be displayed in each page."
-msgstr ""
-
-#. SysConfig
 msgid "OTRS Group Services"
 msgstr ""
 

--- a/i18n/otrs/otrs.et.po
+++ b/i18n/otrs/otrs.et.po
@@ -23400,10 +23400,6 @@ msgid ""
 msgstr ""
 
 #. SysConfig
-msgid "Number of tickets to be displayed in each page."
-msgstr ""
-
-#. SysConfig
 msgid "OTRS Group Services"
 msgstr ""
 

--- a/i18n/otrs/otrs.fa.po
+++ b/i18n/otrs/otrs.fa.po
@@ -24928,10 +24928,6 @@ msgstr ""
 "تعداد بلیط در هر صفحه از یک نتیجه جستجو در رابط مشتری نمایش داده می شود."
 
 #. SysConfig
-msgid "Number of tickets to be displayed in each page."
-msgstr ""
-
-#. SysConfig
 msgid "OTRS Group Services"
 msgstr ""
 

--- a/i18n/otrs/otrs.fi.po
+++ b/i18n/otrs/otrs.fi.po
@@ -23432,10 +23432,6 @@ msgid ""
 msgstr ""
 
 #. SysConfig
-msgid "Number of tickets to be displayed in each page."
-msgstr ""
-
-#. SysConfig
 msgid "OTRS Group Services"
 msgstr ""
 

--- a/i18n/otrs/otrs.fr.po
+++ b/i18n/otrs/otrs.fr.po
@@ -23922,10 +23922,6 @@ msgid ""
 msgstr ""
 
 #. SysConfig
-msgid "Number of tickets to be displayed in each page."
-msgstr ""
-
-#. SysConfig
 msgid "OTRS Group Services"
 msgstr "Services du groupe OTRS"
 

--- a/i18n/otrs/otrs.fr_CA.po
+++ b/i18n/otrs/otrs.fr_CA.po
@@ -24460,10 +24460,6 @@ msgstr ""
 "l'interface client."
 
 #. SysConfig
-msgid "Number of tickets to be displayed in each page."
-msgstr ""
-
-#. SysConfig
 msgid "OTRS Group Services"
 msgstr ""
 

--- a/i18n/otrs/otrs.gl.po
+++ b/i18n/otrs/otrs.gl.po
@@ -24781,10 +24781,6 @@ msgstr ""
 "na interface de cliente."
 
 #. SysConfig
-msgid "Number of tickets to be displayed in each page."
-msgstr ""
-
-#. SysConfig
 msgid "OTRS Group Services"
 msgstr ""
 

--- a/i18n/otrs/otrs.he.po
+++ b/i18n/otrs/otrs.he.po
@@ -23400,10 +23400,6 @@ msgid ""
 msgstr ""
 
 #. SysConfig
-msgid "Number of tickets to be displayed in each page."
-msgstr ""
-
-#. SysConfig
 msgid "OTRS Group Services"
 msgstr ""
 

--- a/i18n/otrs/otrs.hi.po
+++ b/i18n/otrs/otrs.hi.po
@@ -23956,10 +23956,6 @@ msgstr ""
 "ग्राहक अंतरफलक में एक खोज परिणाम के प्रत्येक पृष्ठ में प्रदर्शित होने के लिए टिकटों की संख्या।"
 
 #. SysConfig
-msgid "Number of tickets to be displayed in each page."
-msgstr ""
-
-#. SysConfig
 msgid "OTRS Group Services"
 msgstr ""
 

--- a/i18n/otrs/otrs.hr.po
+++ b/i18n/otrs/otrs.hr.po
@@ -23558,10 +23558,6 @@ msgid ""
 msgstr ""
 
 #. SysConfig
-msgid "Number of tickets to be displayed in each page."
-msgstr ""
-
-#. SysConfig
 msgid "OTRS Group Services"
 msgstr ""
 

--- a/i18n/otrs/otrs.hu.po
+++ b/i18n/otrs/otrs.hu.po
@@ -26458,10 +26458,6 @@ msgstr ""
 "ügyfélfelületen."
 
 #. SysConfig
-msgid "Number of tickets to be displayed in each page."
-msgstr "Az egyes oldalakon megjelenített jegyek száma."
-
-#. SysConfig
 msgid "OTRS Group Services"
 msgstr "OTRS csoport szolgáltatások"
 

--- a/i18n/otrs/otrs.id.po
+++ b/i18n/otrs/otrs.id.po
@@ -25086,10 +25086,6 @@ msgstr ""
 "antarmuka pelanggan."
 
 #. SysConfig
-msgid "Number of tickets to be displayed in each page."
-msgstr ""
-
-#. SysConfig
 msgid "OTRS Group Services"
 msgstr ""
 

--- a/i18n/otrs/otrs.it.po
+++ b/i18n/otrs/otrs.it.po
@@ -24601,10 +24601,6 @@ msgid ""
 msgstr ""
 
 #. SysConfig
-msgid "Number of tickets to be displayed in each page."
-msgstr ""
-
-#. SysConfig
 msgid "OTRS Group Services"
 msgstr ""
 

--- a/i18n/otrs/otrs.ja.po
+++ b/i18n/otrs/otrs.ja.po
@@ -24607,10 +24607,6 @@ msgid ""
 msgstr "顧客インタフェースの検索結果の各ページで表示される、チケット数です。"
 
 #. SysConfig
-msgid "Number of tickets to be displayed in each page."
-msgstr ""
-
-#. SysConfig
 msgid "OTRS Group Services"
 msgstr "OTRSグループ・サービス"
 

--- a/i18n/otrs/otrs.ko.po
+++ b/i18n/otrs/otrs.ko.po
@@ -25145,10 +25145,6 @@ msgid ""
 msgstr "고객 인터페이스에서 검색 결과의 각 페이지에 표시할 티켓 수입니다."
 
 #. SysConfig
-msgid "Number of tickets to be displayed in each page."
-msgstr "각 페이지에 표시할 티켓 수입니다."
-
-#. SysConfig
 msgid "OTRS Group Services"
 msgstr "OTRS 그룹 서비스"
 

--- a/i18n/otrs/otrs.lt.po
+++ b/i18n/otrs/otrs.lt.po
@@ -23537,10 +23537,6 @@ msgid ""
 msgstr ""
 
 #. SysConfig
-msgid "Number of tickets to be displayed in each page."
-msgstr ""
-
-#. SysConfig
 msgid "OTRS Group Services"
 msgstr ""
 

--- a/i18n/otrs/otrs.lv.po
+++ b/i18n/otrs/otrs.lv.po
@@ -23436,10 +23436,6 @@ msgid ""
 msgstr ""
 
 #. SysConfig
-msgid "Number of tickets to be displayed in each page."
-msgstr ""
-
-#. SysConfig
 msgid "OTRS Group Services"
 msgstr ""
 

--- a/i18n/otrs/otrs.mk.po
+++ b/i18n/otrs/otrs.mk.po
@@ -23819,10 +23819,6 @@ msgid ""
 msgstr ""
 
 #. SysConfig
-msgid "Number of tickets to be displayed in each page."
-msgstr ""
-
-#. SysConfig
 msgid "OTRS Group Services"
 msgstr ""
 

--- a/i18n/otrs/otrs.ms.po
+++ b/i18n/otrs/otrs.ms.po
@@ -24971,10 +24971,6 @@ msgstr ""
 "dalam paparan pelanggan."
 
 #. SysConfig
-msgid "Number of tickets to be displayed in each page."
-msgstr ""
-
-#. SysConfig
 msgid "OTRS Group Services"
 msgstr ""
 

--- a/i18n/otrs/otrs.nb_NO.po
+++ b/i18n/otrs/otrs.nb_NO.po
@@ -23831,10 +23831,6 @@ msgid ""
 msgstr "Antall saker som vises per side i et søkeresultat i kundeportalen."
 
 #. SysConfig
-msgid "Number of tickets to be displayed in each page."
-msgstr ""
-
-#. SysConfig
 msgid "OTRS Group Services"
 msgstr ""
 

--- a/i18n/otrs/otrs.nl.po
+++ b/i18n/otrs/otrs.nl.po
@@ -24173,10 +24173,6 @@ msgid ""
 msgstr ""
 
 #. SysConfig
-msgid "Number of tickets to be displayed in each page."
-msgstr ""
-
-#. SysConfig
 msgid "OTRS Group Services"
 msgstr "OTRS Group diensten"
 

--- a/i18n/otrs/otrs.pl.po
+++ b/i18n/otrs/otrs.pl.po
@@ -24530,10 +24530,6 @@ msgid ""
 msgstr ""
 
 #. SysConfig
-msgid "Number of tickets to be displayed in each page."
-msgstr ""
-
-#. SysConfig
 msgid "OTRS Group Services"
 msgstr ""
 

--- a/i18n/otrs/otrs.pot
+++ b/i18n/otrs/otrs.pot
@@ -21006,10 +21006,6 @@ msgid "Number of tickets to be displayed in each page of a search result in the 
 msgstr ""
 
 #. SysConfig
-msgid "Number of tickets to be displayed in each page."
-msgstr ""
-
-#. SysConfig
 msgid "OTRS Group Services"
 msgstr ""
 

--- a/i18n/otrs/otrs.pt.po
+++ b/i18n/otrs/otrs.pt.po
@@ -23583,10 +23583,6 @@ msgid ""
 msgstr ""
 
 #. SysConfig
-msgid "Number of tickets to be displayed in each page."
-msgstr ""
-
-#. SysConfig
 msgid "OTRS Group Services"
 msgstr ""
 

--- a/i18n/otrs/otrs.pt_BR.po
+++ b/i18n/otrs/otrs.pt_BR.po
@@ -25890,10 +25890,6 @@ msgid ""
 msgstr ""
 
 #. SysConfig
-msgid "Number of tickets to be displayed in each page."
-msgstr "Número de tickets que serão exibidos por página."
-
-#. SysConfig
 msgid "OTRS Group Services"
 msgstr "Serviços do Grupo OTRS"
 

--- a/i18n/otrs/otrs.ro.po
+++ b/i18n/otrs/otrs.ro.po
@@ -23587,10 +23587,6 @@ msgid ""
 msgstr ""
 
 #. SysConfig
-msgid "Number of tickets to be displayed in each page."
-msgstr ""
-
-#. SysConfig
 msgid "OTRS Group Services"
 msgstr ""
 

--- a/i18n/otrs/otrs.ru.po
+++ b/i18n/otrs/otrs.ru.po
@@ -25670,10 +25670,6 @@ msgstr ""
 "результатов поиска в интерфейсе клиента."
 
 #. SysConfig
-msgid "Number of tickets to be displayed in each page."
-msgstr "Количество заявок, отображаемых на каждой странице."
-
-#. SysConfig
 msgid "OTRS Group Services"
 msgstr ""
 

--- a/i18n/otrs/otrs.sk_SK.po
+++ b/i18n/otrs/otrs.sk_SK.po
@@ -23474,10 +23474,6 @@ msgid ""
 msgstr ""
 
 #. SysConfig
-msgid "Number of tickets to be displayed in each page."
-msgstr ""
-
-#. SysConfig
 msgid "OTRS Group Services"
 msgstr ""
 

--- a/i18n/otrs/otrs.sl.po
+++ b/i18n/otrs/otrs.sl.po
@@ -23515,10 +23515,6 @@ msgid ""
 msgstr ""
 
 #. SysConfig
-msgid "Number of tickets to be displayed in each page."
-msgstr ""
-
-#. SysConfig
 msgid "OTRS Group Services"
 msgstr ""
 

--- a/i18n/otrs/otrs.sr.po
+++ b/i18n/otrs/otrs.sr.po
@@ -25830,10 +25830,6 @@ msgstr ""
 "интерфејсу клијента."
 
 #. SysConfig
-msgid "Number of tickets to be displayed in each page."
-msgstr "Број тикета који ће бити приказани на свакој страни."
-
-#. SysConfig
 msgid "OTRS Group Services"
 msgstr "Сервиси OTRS групе"
 

--- a/i18n/otrs/otrs.sv.po
+++ b/i18n/otrs/otrs.sv.po
@@ -23568,10 +23568,6 @@ msgid ""
 msgstr ""
 
 #. SysConfig
-msgid "Number of tickets to be displayed in each page."
-msgstr ""
-
-#. SysConfig
 msgid "OTRS Group Services"
 msgstr ""
 

--- a/i18n/otrs/otrs.sw.po
+++ b/i18n/otrs/otrs.sw.po
@@ -24733,10 +24733,6 @@ msgstr ""
 "katika kiolesura cha mteja."
 
 #. SysConfig
-msgid "Number of tickets to be displayed in each page."
-msgstr ""
-
-#. SysConfig
 msgid "OTRS Group Services"
 msgstr ""
 

--- a/i18n/otrs/otrs.th_TH.po
+++ b/i18n/otrs/otrs.th_TH.po
@@ -24030,10 +24030,6 @@ msgid ""
 msgstr ""
 
 #. SysConfig
-msgid "Number of tickets to be displayed in each page."
-msgstr ""
-
-#. SysConfig
 msgid "OTRS Group Services"
 msgstr ""
 

--- a/i18n/otrs/otrs.tr.po
+++ b/i18n/otrs/otrs.tr.po
@@ -23426,10 +23426,6 @@ msgid ""
 msgstr ""
 
 #. SysConfig
-msgid "Number of tickets to be displayed in each page."
-msgstr ""
-
-#. SysConfig
 msgid "OTRS Group Services"
 msgstr ""
 

--- a/i18n/otrs/otrs.uk.po
+++ b/i18n/otrs/otrs.uk.po
@@ -24049,10 +24049,6 @@ msgid ""
 msgstr ""
 
 #. SysConfig
-msgid "Number of tickets to be displayed in each page."
-msgstr ""
-
-#. SysConfig
 msgid "OTRS Group Services"
 msgstr ""
 

--- a/i18n/otrs/otrs.vi_VN.po
+++ b/i18n/otrs/otrs.vi_VN.po
@@ -23478,10 +23478,6 @@ msgid ""
 msgstr ""
 
 #. SysConfig
-msgid "Number of tickets to be displayed in each page."
-msgstr ""
-
-#. SysConfig
 msgid "OTRS Group Services"
 msgstr ""
 

--- a/i18n/otrs/otrs.zh_CN.po
+++ b/i18n/otrs/otrs.zh_CN.po
@@ -24234,10 +24234,6 @@ msgid ""
 msgstr "客户界面搜索结果每页显示的工单数。"
 
 #. SysConfig
-msgid "Number of tickets to be displayed in each page."
-msgstr "每页显示的工单数量。"
-
-#. SysConfig
 msgid "OTRS Group Services"
 msgstr "OTRS集团服务"
 

--- a/i18n/otrs/otrs.zh_TW.po
+++ b/i18n/otrs/otrs.zh_TW.po
@@ -23453,10 +23453,6 @@ msgid ""
 msgstr ""
 
 #. SysConfig
-msgid "Number of tickets to be displayed in each page."
-msgstr ""
-
-#. SysConfig
 msgid "OTRS Group Services"
 msgstr ""
 


### PR DESCRIPTION
The sysconfig setting ViewableTicketsPage seems to be no longer used. It looks like the number of displayed tickets is now taken from the user preferences.
I also removed manually the now obsolete translation. There is propably a tool for that, but I'm clueless about it.

 