### PR TITLE
Update Medium.pm

### DIFF
--- a/Kernel/Output/HTML/TicketOverview/Medium.pm
+++ b/Kernel/Output/HTML/TicketOverview/Medium.pm
@@ -884,7 +884,7 @@ sub _Show {
         my $ValueStrg = $DynamicFieldBackendObject->DisplayValueRender(
             DynamicFieldConfig => $DynamicFieldConfig,
             Value              => $Value,
-            ValueMaxChars      => 20,
+            ValueMaxChars      => 200,
             LayoutObject       => $LayoutObject,
         );
 


### PR DESCRIPTION
dynamic fields should not be stripped after 20 characters. Please consider this for version 7 as well.