### PR TITLE
Update Small.pm

### DIFF
--- a/Kernel/Output/HTML/TicketOverview/Small.pm
+++ b/Kernel/Output/HTML/TicketOverview/Small.pm
@@ -1678,7 +1678,7 @@ sub Run {
                 my $ValueStrg = $DynamicFieldBackendObject->DisplayValueRender(
                     DynamicFieldConfig => $DynamicFieldConfig,
                     Value              => $Value,
-                    ValueMaxChars      => 20,
+                    ValueMaxChars      => 200,
                     LayoutObject       => $LayoutObject,
                 );
 


### PR DESCRIPTION
dynamic fields should not be stripped after 20 characters. Please consider this for version 7 as well.