### PR TITLE
Update Preview.pm

### DIFF
--- a/Kernel/Output/HTML/TicketOverview/Preview.pm
+++ b/Kernel/Output/HTML/TicketOverview/Preview.pm
@@ -979,7 +979,7 @@ sub _Show {
         my $ValueStrg = $DynamicFieldBackendObject->DisplayValueRender(
             DynamicFieldConfig => $DynamicFieldConfig,
             Value              => $Value,
-            ValueMaxChars      => 20,
+            ValueMaxChars      => 200,
             LayoutObject       => $LayoutObject,
         );
 


### PR DESCRIPTION
dynamic fields should not be stripped after 20 characters. Please consider this for version 7 as well.