### PR TITLE
Set autocomplete to 'new-password' for admin interface password fields.

### DIFF
--- a/Kernel/Output/HTML/Templates/Standard/AdminCustomerUser.tt
+++ b/Kernel/Output/HTML/Templates/Standard/AdminCustomerUser.tt
@@ -279,7 +279,7 @@
 [% RenderBlockStart("Password") %]
                         <label for="[% Data.Name | html %]">[% Translate(Data.Label) | html %]:</label>
                         <div class="Field">
-                            <input id="[% Data.Name | html %]" type="password" name="[% Data.Name | html %]" class="W50pc" value="[% Data.SelectedID | html %]" autocomplete="off" />
+                            <input id="[% Data.Name | html %]" type="password" name="[% Data.Name | html %]" class="W50pc" value="[% Data.SelectedID | html %]" autocomplete="new-password" />
                             <div>[% Translate(Data.Key) | html %]</div>
                         </div>
                         <div class="Clear"></div>

--- a/Kernel/Output/HTML/Templates/Standard/AdminUser.tt
+++ b/Kernel/Output/HTML/Templates/Standard/AdminUser.tt
@@ -217,7 +217,7 @@
                             [% Translate("Password") | html %]:
                         </label>
                         <div class="Field">
-                            <input type="password" name="UserPw" id="UserPw" value="" class="W50pc [% Data.UserPwInvalid | html %] " maxlength="100" autocomplete="off" />
+                            <input type="password" name="UserPw" id="UserPw" value="" class="W50pc [% Data.UserPwInvalid | html %] " maxlength="100" autocomplete="new-password" />
 [% RenderBlockStart("ShowPasswordHint") %]
                             <p class="FieldExplanation">
                                 [% Translate("Will be auto-generated if left empty.") | html %]


### PR DESCRIPTION
This signals more accurately to password managers that this is not a
place to be putting in any existing passwords.

See: https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/autocomplete