### PR TITLE
Do not truncate title in TicketTitleUpdate

### DIFF
--- a/Kernel/System/Ticket.pm
+++ b/Kernel/System/Ticket.pm
@@ -1493,15 +1493,11 @@ sub TicketTitleUpdate {
     # clear ticket cache
     $Self->_TicketCacheClear( TicketID => $Param{TicketID} );
 
-    # truncate title
-    my $Title = substr( $Param{Title}, 0, 50 );
-    $Title .= '...' if length($Title) == 50;
-
     # history insert
     $Self->HistoryAdd(
         TicketID     => $Param{TicketID},
         HistoryType  => 'TitleUpdate',
-        Name         => "\%\%$Ticket{Title}\%\%$Title",
+        Name         => "\%\%$Ticket{Title}\%\%$Param{Title}",
         CreateUserID => $Param{UserID},
     );
 


### PR DESCRIPTION
Hello,

I am currently developing an OTRS module for Apache Kafka integration to stream ticket events to other services. For this purpose, I heavily use ticket events, and especially the "HistoryAdd" event. When the latter is caught, I parse its content (which can be found in the `ticket_history.name` column basically) and send it to our Kafka instance.

One weird behaviour I've noticed, is when a ticket's title is updated. For reminder, the content of the the history is as such: `%%{OldTitle}%%{NewTitle}`.
In a situation where we have a long title (more than 50 chars), the `OldTitle` field is actually complete but the `NewTitle` field is truncated to 50 chars and OTRS will add "..." at the end.

This is annoying to me as I will have to do a new request to the database to get the complete new title. Furthermore, I don't understand why the first field is truncated but not the other. Hence, I propose this pull request.

Thank you!

Edit: an explanation about the truncate or a better idea to get the events changes are welcome.