### PR TITLE
Fix email validation

### DIFF
--- a/Kernel/Modules/AgentUserSearch.pm
+++ b/Kernel/Modules/AgentUserSearch.pm
@@ -108,7 +108,7 @@ sub Run {
                 Valid  => $Param{Valid},
             );
 
-            my $UserValue = sprintf '"%s %s" <%s>',
+            my $UserValue = sprintf '"%s" <%s>',
                 $User{UserFullname},
                 $User{UserEmail};
 

--- a/Kernel/System/CheckItem.pm
+++ b/Kernel/System/CheckItem.pm
@@ -114,8 +114,9 @@ sub CheckEmail {
     # remove comment from address when checking.
     $Param{Address} =~ s{ \s* \( [^()]* \) \s* $ }{}smxg;
 
+    $Param{Address} = Email::Valid->address( $Param{Address} );
     # email address syntax check
-    if ( !Email::Valid->address( $Param{Address} ) ) {
+    if ( !$Param{Address} ) {
         $Error = "Invalid syntax";
         $Self->{ErrorType} = 'InvalidSyntax';
     }


### PR DESCRIPTION
The method `Email::Valid->address( $Param{Address} )` returns `undef` if the parameter is not a valid email, otherwise it returns the email "validated" so without spaces, for example.

If you set "test@gmail .com" as a recipient, the method returns a string so OTRS considers it valid and it fails when it's time to send the email.

With the proposed change, it will no longer fail when sending "kind of correct" email addresses as the one above.

P.S.: PR #2034 is included in this one but I'm pretty sure neither is going to be merged.